### PR TITLE
fixed unknow buildtype

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ function(createBuildInfo)
 	if (CMAKE_BUILD_TYPE)
 		set(_cmake_build_type ${CMAKE_BUILD_TYPE})
 	else()
-		set(_cmake_build_type "undefined")
+		set(_cmake_build_type "${CMAKE_CFG_INTDIR}")
 	endif()
 
 	# Generate header file containing useful build information

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,7 @@ function(createBuildInfo)
 	endif ()
 
 	#cmake build type may be not specified when using msvc
-	if (${CMAKE_BUILD_TYPE})
+	if (CMAKE_BUILD_TYPE)
 		set(_cmake_build_type ${CMAKE_BUILD_TYPE})
 	else()
 		set(_cmake_build_type "undefined")


### PR DESCRIPTION
for mac && linux ETH_BUILD_TYPE has proper value again
for multi-configuration generators (eg. windows) we check dynamically switched configuration

read more here:
http://www.cmake.org/cmake/help/v3.0/variable/CMAKE_BUILD_TYPE.html
http://www.cmake.org/Wiki/CMake_Useful_Variables