### PR TITLE
zero sized init code in creation not using gas

### DIFF
--- a/libethereum/ExtVM.cpp
+++ b/libethereum/ExtVM.cpp
@@ -50,8 +50,9 @@ h160 ExtVM::create(u256 _endowment, u256& io_gas, bytesConstRef _code, OnOpFunc 
 	{
 		e.go(_onOp);
 		e.accrueSubState(sub);
+		io_gas = e.endGas();
 	}
-	io_gas = e.endGas();
+
 	return e.newAddress();
 }
 


### PR DESCRIPTION
This a suggestion. This would lead to a zombie account without code beeing created instead of leaving CREATE with 0 gas left.