### PR TITLE
Fix Natspec tagless bug

### DIFF
--- a/libsolidity/InterfaceHandler.cpp
+++ b/libsolidity/InterfaceHandler.cpp
@@ -349,8 +349,13 @@ void InterfaceHandler::parseDocString(std::string const& _string, CommentOwner _
 		}
 		else if (m_lastTag != DocTagType::NONE) // continuation of the previous tag
 			currPos = appendDocTag(currPos, end, _owner);
-		else if (currPos != end) // skip the line if a newline was found
+		else if (currPos != end)
+		{
+			if (nlPos == end) //end of text
+				return;
+			// else skip the line if a newline was found
 			currPos = nlPos + 1;
+		}
 	}
 }
 

--- a/test/SolidityNatspecJSON.cpp
+++ b/test/SolidityNatspecJSON.cpp
@@ -510,6 +510,19 @@ BOOST_AUTO_TEST_CASE(dev_title_at_function_error)
 	BOOST_CHECK_THROW(checkNatspec(sourceCode, natspec, false), DocstringParsingError);
 }
 
+// test for bug where having no tags in docstring would cause infinite loop
+BOOST_AUTO_TEST_CASE(natspec_no_tags)
+{
+	char const* sourceCode = "contract test {\n"
+	"  /// I do something awesome\n"
+	"  function mul(uint a, uint second) returns(uint d) { return a * 7 + second; }\n"
+	"}\n";
+
+	char const* natspec = "{\"methods\": {}}";
+
+	checkNatspec(sourceCode, natspec, false);
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 }


### PR DESCRIPTION
Fixing bug where empty tagless docstring in Natspec would result in an infinite loop