### PR TITLE
Reverse order of inheritance in base list.

### DIFF
--- a/test/SolidityEndToEndTest.cpp
+++ b/test/SolidityEndToEndTest.cpp
@@ -1545,7 +1545,7 @@ BOOST_AUTO_TEST_CASE(single_copy_with_multiple_inheritance)
 		}
 		contract A is Base { function setViaA(uint i) { setData(i); } }
 		contract B is Base { function getViaB() returns (uint i) { return getViaBase(); } }
-		contract Derived is A, B, Base { }
+		contract Derived is Base, B, A { }
 	)";
 	compileAndRun(sourceCode, 0, "Derived");
 	BOOST_CHECK(callContractFunction("getViaB()") == encodeArgs(0));
@@ -1642,7 +1642,7 @@ BOOST_AUTO_TEST_CASE(constructor_argument_overriding)
 			}
 		}
 		contract Base is BaseBase(2) { }
-		contract Derived is Base, BaseBase(3) {
+		contract Derived is BaseBase(3), Base {
 			function getA() returns (uint r) { return m_a; }
 		}
 	)";

--- a/test/SolidityNameAndTypeResolution.cpp
+++ b/test/SolidityNameAndTypeResolution.cpp
@@ -386,7 +386,7 @@ BOOST_AUTO_TEST_CASE(inheritance_diamond_basic)
 		contract root { function rootFunction() {} }
 		contract inter1 is root { function f() {} }
 		contract inter2 is root { function f() {} }
-		contract derived is inter1, inter2, root {
+		contract derived is root, inter2, inter1 {
 			function g() { f(); rootFunction(); }
 		}
 	)";


### PR DESCRIPTION
After this change, in `contract A is B1, B2, B3 { ... }`, the bases `B1`, `B2` and `B3` are given in base to derived order.