### PR TITLE
p2p: NodeTable fixes for Go interoperability

### DIFF
--- a/libp2p/NodeTable.h
+++ b/libp2p/NodeTable.h
@@ -286,7 +286,7 @@ struct PingNode: RLPXDatagram<PingNode>
 /**
  * Pong packet: response to ping
  *
- * RLP Encoded Items: 1
+ * RLP Encoded Items: 2
  * Minimum Encoded Size: 33 bytes
  * Maximum Encoded Size: 33 bytes
  */
@@ -299,8 +299,8 @@ struct Pong: RLPXDatagram<Pong>
 	h256 echo;				///< MCD of PingNode
 	unsigned expiration;
 	
-	void streamRLP(RLPStream& _s) const { _s.appendList(1); _s << echo; }
-	void interpretRLP(bytesConstRef _bytes) { RLP r(_bytes); echo = (h256)r[0]; }
+	void streamRLP(RLPStream& _s) const { _s.appendList(2); _s << echo << expiration; }
+	void interpretRLP(bytesConstRef _bytes) { RLP r(_bytes); echo = (h256)r[0]; expiration = r[1].toInt<unsigned>(); }
 };
 
 /**

--- a/libp2p/NodeTable.h
+++ b/libp2p/NodeTable.h
@@ -272,7 +272,7 @@ struct PingNode: RLPXDatagram<PingNode>
 	PingNode(bi::udp::endpoint _ep): RLPXDatagram<PingNode>(_ep) {}
 	PingNode(bi::udp::endpoint _ep, std::string _src, uint16_t _srcPort, std::chrono::seconds _expiration = std::chrono::seconds(60)): RLPXDatagram<PingNode>(_ep), ipAddress(_src), port(_srcPort), expiration(futureFromEpoch(_expiration)) {}
 
-	uint8_t packetType() { return 1; }
+	static const uint8_t type = 1;
 	
 	unsigned version = 1;
 	std::string ipAddress;
@@ -294,7 +294,8 @@ struct Pong: RLPXDatagram<Pong>
 {
 	Pong(bi::udp::endpoint _ep): RLPXDatagram<Pong>(_ep), expiration(futureFromEpoch(std::chrono::seconds(60))) {}
 
-	uint8_t packetType() { return 2; }
+	static const uint8_t type = 2;
+
 	h256 echo;				///< MCD of PingNode
 	unsigned expiration;
 	
@@ -319,8 +320,9 @@ struct FindNode: RLPXDatagram<FindNode>
 {
 	FindNode(bi::udp::endpoint _ep): RLPXDatagram<FindNode>(_ep) {}
 	FindNode(bi::udp::endpoint _ep, NodeId _target, std::chrono::seconds _expiration = std::chrono::seconds(30)): RLPXDatagram<FindNode>(_ep), target(_target), expiration(futureFromEpoch(_expiration)) {}
+
+	static const uint8_t type = 3;
 	
-	uint8_t packetType() { return 3; }
 	h512 target;
 	unsigned expiration;
 	
@@ -361,7 +363,7 @@ struct Neighbours: RLPXDatagram<Neighbours>
 		}
 	}
 	
-	uint8_t packetType() { return 4; }
+	static const uint8_t type = 4;
 	std::list<Node> nodes;
 	unsigned expiration = 1;
 

--- a/libp2p/UDP.h
+++ b/libp2p/UDP.h
@@ -60,8 +60,8 @@ protected:
  */
 struct RLPXDatagramFace: public UDPDatagram
 {
-	static uint64_t futureFromEpoch(std::chrono::milliseconds _ms) { return std::chrono::duration_cast<std::chrono::milliseconds>((std::chrono::system_clock::now() + _ms).time_since_epoch()).count(); }
-	static uint64_t futureFromEpoch(std::chrono::seconds _sec) { return std::chrono::duration_cast<std::chrono::milliseconds>((std::chrono::system_clock::now() + _sec).time_since_epoch()).count(); }
+	static uint64_t futureFromEpoch(std::chrono::milliseconds _ms) { return std::chrono::duration_cast<std::chrono::seconds>((std::chrono::system_clock::now() + _ms).time_since_epoch()).count(); }
+	static uint64_t futureFromEpoch(std::chrono::seconds _sec) { return std::chrono::duration_cast<std::chrono::seconds>((std::chrono::system_clock::now() + _sec).time_since_epoch()).count(); }
 	static Public authenticate(bytesConstRef _sig, bytesConstRef _rlp);
 	
 	virtual uint8_t packetType() =0;

--- a/libp2p/UDP.h
+++ b/libp2p/UDP.h
@@ -77,6 +77,7 @@ struct RLPXDatagram: public RLPXDatagramFace
 {
 	RLPXDatagram(bi::udp::endpoint const& _ep): RLPXDatagramFace(_ep) {}
 	static T fromBytesConstRef(bi::udp::endpoint const& _ep, bytesConstRef _bytes) { T t(_ep); t.interpretRLP(_bytes); return std::move(t); }
+	uint8_t packetType() { return T::type; }
 };
 
 /**


### PR DESCRIPTION
These changes are necessary for interoperability with the node discovery implementation in go-ethereum.

This is for @subtly. It goes to his p2p branch, which is being reviewed in #656.