### PR TITLE
Solidity multiple arg sha3

### DIFF
--- a/libsolidity/AST.cpp
+++ b/libsolidity/AST.cpp
@@ -493,19 +493,9 @@ void FunctionCall::checkTypeRequirements()
 		if (m_names.empty())
 		{
 			for (size_t i = 0; i < m_arguments.size(); ++i)
-			{
-				if (functionType->getLocation() == FunctionType::Location::SHA3)
-				{
-#if 0 // are we sure we want that? Literal constant nums can't live outside storage and so sha3(42) will fail
-					if (!m_arguments[i]->getType()->canLiveOutsideStorage())
-						BOOST_THROW_EXCEPTION(createTypeError("SHA3 called with argument that can't live outside storage"));
-#endif
-					if (!m_arguments[i]->getType()->isImplicitlyConvertibleTo(*parameterTypes[0]))
-						BOOST_THROW_EXCEPTION(m_arguments[i]->createTypeError("SHA3 argument can't be converted to hash"));
-
-				} else if (!m_arguments[i]->getType()->isImplicitlyConvertibleTo(*parameterTypes[i]))
+				if (functionType->getLocation() != FunctionType::Location::SHA3 &&
+					!m_arguments[i]->getType()->isImplicitlyConvertibleTo(*parameterTypes[i]))
 					BOOST_THROW_EXCEPTION(createTypeError("Invalid type for argument in function call."));
-			}
 		}
 		else if (functionType->getLocation() == FunctionType::Location::SHA3)
 			BOOST_THROW_EXCEPTION(createTypeError("Named arguments can't be used for SHA3."));

--- a/libsolidity/AST.cpp
+++ b/libsolidity/AST.cpp
@@ -487,7 +487,7 @@ void FunctionCall::checkTypeRequirements()
 		// and then ask if that is implicitly convertible to the struct represented by the
 		// function parameters
 		TypePointers const& parameterTypes = functionType->getParameterTypes();
-		if (functionType->getLocation() !=FunctionType::Location::SHA3 && parameterTypes.size() != m_arguments.size())
+		if (functionType->getLocation() != FunctionType::Location::SHA3 && parameterTypes.size() != m_arguments.size())
 			BOOST_THROW_EXCEPTION(createTypeError("Wrong argument count for function call."));
 
 		if (m_names.empty())  // LTODO: Totally ignoring sha3 case for named arguments for now just for the rebase to work

--- a/libsolidity/AST.cpp
+++ b/libsolidity/AST.cpp
@@ -490,7 +490,7 @@ void FunctionCall::checkTypeRequirements()
 		if (functionType->getLocation() != FunctionType::Location::SHA3 && parameterTypes.size() != m_arguments.size())
 			BOOST_THROW_EXCEPTION(createTypeError("Wrong argument count for function call."));
 
-		if (m_names.empty())  // LTODO: Totally ignoring sha3 case for named arguments for now just for the rebase to work
+		if (m_names.empty())
 		{
 			for (size_t i = 0; i < m_arguments.size(); ++i)
 			{
@@ -501,14 +501,14 @@ void FunctionCall::checkTypeRequirements()
 						BOOST_THROW_EXCEPTION(createTypeError("SHA3 called with argument that can't live outside storage"));
 #endif
 					if (!m_arguments[i]->getType()->isImplicitlyConvertibleTo(*parameterTypes[0]))
-						BOOST_THROW_EXCEPTION(createTypeError(std::string("SHA3 argument ") +
-															  boost::lexical_cast<std::string>(i + 1) +
-															  std::string("can't be converted to hash")));
+						BOOST_THROW_EXCEPTION(m_arguments[i]->createTypeError("SHA3 argument can't be converted to hash"));
 
 				} else if (!m_arguments[i]->getType()->isImplicitlyConvertibleTo(*parameterTypes[i]))
 					BOOST_THROW_EXCEPTION(createTypeError("Invalid type for argument in function call."));
 			}
 		}
+		else if (functionType->getLocation() == FunctionType::Location::SHA3)
+			BOOST_THROW_EXCEPTION(createTypeError("Named arguments can't be used for SHA3."));
 		else
 		{
 			auto const& parameterNames = functionType->getParameterNames();

--- a/libsolidity/AST.cpp
+++ b/libsolidity/AST.cpp
@@ -502,7 +502,7 @@ void FunctionCall::checkTypeRequirements()
 #endif
 					if (!m_arguments[i]->getType()->isImplicitlyConvertibleTo(*parameterTypes[0]))
 						BOOST_THROW_EXCEPTION(createTypeError(std::string("SHA3 argument ") +
-															  boost::lexical_cast<std::string>(i) +
+															  boost::lexical_cast<std::string>(i + 1) +
 															  std::string("can't be converted to hash")));
 
 				} else if (!m_arguments[i]->getType()->isImplicitlyConvertibleTo(*parameterTypes[i]))

--- a/libsolidity/ExpressionCompiler.cpp
+++ b/libsolidity/ExpressionCompiler.cpp
@@ -852,7 +852,7 @@ unsigned ExpressionCompiler::appendArgumentsCopyToMemory(vector<ASTPointer<Expre
 	for (unsigned i = 0; i < _arguments.size(); ++i)
 	{
 		_arguments[i]->accept(*this);
-		length += moveTypeToMemory(*_arguments[i]->getType(), _arguments[i]->getLocation(), _memoryOffset + length);
+		length += moveTypeToMemory(*_arguments[i]->getType()->getRealType(), _arguments[i]->getLocation(), _memoryOffset + length);
 	}
 	return length;
 }

--- a/libsolidity/ExpressionCompiler.cpp
+++ b/libsolidity/ExpressionCompiler.cpp
@@ -856,8 +856,8 @@ unsigned ExpressionCompiler::appendSameTypeArgumentsCopyToMemory(TypePointer con
 	return length;
 }
 
-unsigned ExpressionCompiler::appendExpressionCopyToMemory(Type const& _expectedType,
-														  Expression const& _expression, unsigned _memoryOffset)
+unsigned ExpressionCompiler::appendTypeConversionAndMoveToMemory(Type const& _expectedType, Type const& _type,
+																 Location const& _location, unsigned _memoryOffset)
 {
 	appendTypeConversion(_type, _expectedType, true);
 	unsigned const c_numBytes = CompilerUtils::getPaddedSize(_expectedType.getCalldataEncodedSize());

--- a/libsolidity/ExpressionCompiler.cpp
+++ b/libsolidity/ExpressionCompiler.cpp
@@ -851,7 +851,7 @@ unsigned ExpressionCompiler::appendArgumentsCopyToMemory(vector<ASTPointer<Expre
 	// without type conversion
 	for (unsigned i = 0; i < _arguments.size(); ++i)
 	{
-		bool wantPadding = (_arguments[i]->getType()->getCategory() == Type::Category::STRING) ? false : true;
+		const bool wantPadding = false;
 		_arguments[i]->accept(*this);
 		length += moveTypeToMemory(*_arguments[i]->getType()->getRealType(), _arguments[i]->getLocation(), _memoryOffset + length, wantPadding);
 	}

--- a/libsolidity/ExpressionCompiler.cpp
+++ b/libsolidity/ExpressionCompiler.cpp
@@ -860,8 +860,8 @@ unsigned ExpressionCompiler::appendArgumentsCopyToMemory(vector<ASTPointer<Expre
 
 unsigned ExpressionCompiler::moveTypeToMemory(Type const& _type, Location const& _location, unsigned _memoryOffset, bool _padToWordBoundaries)
 {
-	unsigned const encodedSize = _type.getCalldataEncodedSize();
-	unsigned const c_numBytes = _padToWordBoundaries ? CompilerUtils::getPaddedSize(encodedSize) : encodedSize;
+	unsigned const c_encodedSize = _type.getCalldataEncodedSize();
+	unsigned const c_numBytes = _padToWordBoundaries ? CompilerUtils::getPaddedSize(c_encodedSize) : c_encodedSize;
 	if (c_numBytes == 0 || c_numBytes > 32)
 		BOOST_THROW_EXCEPTION(CompilerError()
 							  << errinfo_sourceLocation(_location)

--- a/libsolidity/ExpressionCompiler.cpp
+++ b/libsolidity/ExpressionCompiler.cpp
@@ -275,7 +275,7 @@ bool ExpressionCompiler::visit(FunctionCall const& _functionCall)
 			m_context << u256(0) << eth::Instruction::CODECOPY;
 
 			unsigned length = bytecode.size();
-			length += appendArgumentCopyToMemory(function.getParameterTypes(), arguments, length);
+			length += appendArgumentsCopyToMemory(function.getParameterTypes(), arguments, length);
 			// size, offset, endowment
 			m_context << u256(length) << u256(0);
 			if (function.valueSet())
@@ -800,7 +800,7 @@ void ExpressionCompiler::appendExternalFunctionCall(FunctionType const& _functio
 
 	// reserve space for the function identifier
 	unsigned dataOffset = bare ? 0 : CompilerUtils::dataStartOffset;
-	dataOffset += appendArgumentCopyToMemory(_functionType.getParameterTypes(), _arguments, dataOffset);
+	dataOffset += appendArgumentsCopyToMemory(_functionType.getParameterTypes(), _arguments, dataOffset);
 
 	//@todo only return the first return value for now
 	Type const* firstType = _functionType.getReturnParameterTypes().empty() ? nullptr :
@@ -836,9 +836,9 @@ void ExpressionCompiler::appendExternalFunctionCall(FunctionType const& _functio
 	}
 }
 
-unsigned ExpressionCompiler::appendArgumentCopyToMemory(TypePointers const& _types,
-														vector<ASTPointer<Expression const>> const& _arguments,
-														unsigned _memoryOffset)
+unsigned ExpressionCompiler::appendArgumentsCopyToMemory(TypePointers const& _types,
+														 vector<ASTPointer<Expression const>> const& _arguments,
+														 unsigned _memoryOffset)
 {
 	unsigned length = 0;
 	for (unsigned i = 0; i < _arguments.size(); ++i)

--- a/libsolidity/ExpressionCompiler.h
+++ b/libsolidity/ExpressionCompiler.h
@@ -94,19 +94,16 @@ private:
 									bool bare = false);
 	/// Appends code that copies the given arguments to memory (with optional offset).
 	/// @returns the number of bytes copied to memory
-	unsigned appendArgumentsCopyToMemory(TypePointers const& _types,
-										 std::vector<ASTPointer<Expression const>> const& _arguments,
+	unsigned appendArgumentsCopyToMemory(std::vector<ASTPointer<Expression const>> const& _arguments,
+										 TypePointers const& _types = {},
 										 unsigned _memoryOffset = 0);
 	/// Appends code that copies a type to memory.
 	/// @returns the number of bytes copied to memory
 	unsigned appendTypeConversionAndMoveToMemory(Type const& _expectedType, Type const& _type,
 												 Location const& _location, unsigned _memoryOffset = 0);
-	/// Appends code that copies the given arguments that should all have the
-	/// same @a _type to memory (with optional offset).
+	/// Appends code that moves a type to memory
 	/// @returns the number of bytes copied to memory
-	unsigned appendSameTypeArgumentsCopyToMemory(TypePointer const& _type,
-												 std::vector<ASTPointer<Expression const>> const& _arguments,
-												 unsigned _memoryOffset = 0);
+	unsigned moveTypeToMemory(Type const& _type, Location const& _location, unsigned _memoryOffset);
 	/// Appends code that evaluates a single expression and copies it to memory (with optional offset).
 	/// @returns the number of bytes copied to memory
 	unsigned appendExpressionCopyToMemory(Type const& _expectedType, Expression const& _expression,

--- a/libsolidity/ExpressionCompiler.h
+++ b/libsolidity/ExpressionCompiler.h
@@ -94,9 +94,9 @@ private:
 									bool bare = false);
 	/// Appends code that copies the given arguments to memory (with optional offset).
 	/// @returns the number of bytes copied to memory
-	unsigned appendArgumentCopyToMemory(TypePointers const& _types,
-										std::vector<ASTPointer<Expression const>> const& _arguments,
-										unsigned _memoryOffset = 0);
+	unsigned appendArgumentsCopyToMemory(TypePointers const& _types,
+										 std::vector<ASTPointer<Expression const>> const& _arguments,
+										 unsigned _memoryOffset = 0);
 	/// Appends code that copies the given arguments that should all have the
 	/// same @a _type to memory (with optional offset).
 	/// @returns the number of bytes copied to memory

--- a/libsolidity/ExpressionCompiler.h
+++ b/libsolidity/ExpressionCompiler.h
@@ -103,7 +103,7 @@ private:
 												 Location const& _location, unsigned _memoryOffset = 0);
 	/// Appends code that moves a type to memory
 	/// @returns the number of bytes copied to memory
-	unsigned moveTypeToMemory(Type const& _type, Location const& _location, unsigned _memoryOffset);
+	unsigned moveTypeToMemory(Type const& _type, Location const& _location, unsigned _memoryOffset, bool _padToWordBoundaries = true);
 	/// Appends code that evaluates a single expression and copies it to memory (with optional offset).
 	/// @returns the number of bytes copied to memory
 	unsigned appendExpressionCopyToMemory(Type const& _expectedType, Expression const& _expression,

--- a/libsolidity/ExpressionCompiler.h
+++ b/libsolidity/ExpressionCompiler.h
@@ -97,6 +97,10 @@ private:
 	unsigned appendArgumentsCopyToMemory(TypePointers const& _types,
 										 std::vector<ASTPointer<Expression const>> const& _arguments,
 										 unsigned _memoryOffset = 0);
+	/// Appends code that copies a type to memory.
+	/// @returns the number of bytes copied to memory
+	unsigned appendTypeConversionAndMoveToMemory(Type const& _expectedType, Type const& _type,
+												 Location const& _location, unsigned _memoryOffset = 0);
 	/// Appends code that copies the given arguments that should all have the
 	/// same @a _type to memory (with optional offset).
 	/// @returns the number of bytes copied to memory

--- a/libsolidity/ExpressionCompiler.h
+++ b/libsolidity/ExpressionCompiler.h
@@ -97,10 +97,12 @@ private:
 	unsigned appendArgumentCopyToMemory(TypePointers const& _types,
 										std::vector<ASTPointer<Expression const>> const& _arguments,
 										unsigned _memoryOffset = 0);
-	/// Appends code that copies a type to memory.
+	/// Appends code that copies the given arguments that should all have the
+	/// same @a _type to memory (with optional offset).
 	/// @returns the number of bytes copied to memory
-	unsigned appendTypeConversionAndMoveToMemory(Type const& _expectedType, Type const& _type,
-												 Location const& _location, unsigned _memoryOffset = 0);
+	unsigned appendSameTypeArgumentsCopyToMemory(TypePointer const& _type,
+												 std::vector<ASTPointer<Expression const>> const& _arguments,
+												 unsigned _memoryOffset = 0);
 	/// Appends code that evaluates a single expression and copies it to memory (with optional offset).
 	/// @returns the number of bytes copied to memory
 	unsigned appendExpressionCopyToMemory(Type const& _expectedType, Expression const& _expression,

--- a/libsolidity/Types.cpp
+++ b/libsolidity/Types.cpp
@@ -364,8 +364,7 @@ u256 IntegerConstantType::literalValue(Literal const* _literal) const
 TypePointer IntegerConstantType::getRealType() const
 {
 	auto intType = getIntegerType();
-	if (!intType)
-		BOOST_THROW_EXCEPTION(InternalCompilerError() << errinfo_comment("getRealType called with invalid integer constant" + toString()));
+	solAssert(!!intType, std::string("getRealType called with invalid integer constant") + toString());
 	return intType;
 }
 

--- a/libsolidity/Types.cpp
+++ b/libsolidity/Types.cpp
@@ -361,6 +361,14 @@ u256 IntegerConstantType::literalValue(Literal const* _literal) const
 	return value;
 }
 
+TypePointer IntegerConstantType::getRealType() const
+{
+	auto intType = getIntegerType();
+	if (!intType)
+		BOOST_THROW_EXCEPTION(InternalCompilerError() << errinfo_comment("getRealType called with invalid integer constant" + toString()));
+	return intType;
+}
+
 shared_ptr<IntegerType const> IntegerConstantType::getIntegerType() const
 {
 	bigint value = m_value;

--- a/libsolidity/Types.h
+++ b/libsolidity/Types.h
@@ -130,6 +130,8 @@ public:
 	/// i.e. it behaves differently in lvalue context and in value context.
 	virtual bool isValueType() const { return false; }
 	virtual unsigned getSizeOnStack() const { return 1; }
+	/// @returns the real type of some types, like e.g: IntegerConstant
+	virtual TypePointer getRealType() const { return TypePointer(); }
 
 	/// Returns the list of all members of this type. Default implementation: no members.
 	virtual MemberList const& getMembers() const { return EmptyMemberList; }
@@ -140,7 +142,7 @@ public:
 	virtual u256 literalValue(Literal const*) const
 	{
 		BOOST_THROW_EXCEPTION(InternalCompilerError() << errinfo_comment("Literal value requested "
-																		  "for type without literals."));
+																		 "for type without literals."));
 	}
 
 protected:
@@ -175,6 +177,7 @@ public:
 	virtual MemberList const& getMembers() const { return isAddress() ? AddressMemberList : EmptyMemberList; }
 
 	virtual std::string toString() const override;
+	virtual TypePointer getRealType() const { return std::make_shared<IntegerType>(m_bits, m_modifier); }
 
 	int getNumBits() const { return m_bits; }
 	bool isHash() const { return m_modifier == Modifier::HASH || m_modifier == Modifier::ADDRESS; }
@@ -214,6 +217,7 @@ public:
 
 	virtual std::string toString() const override;
 	virtual u256 literalValue(Literal const* _literal) const override;
+	virtual TypePointer getRealType() const override;
 
 	/// @returns the smallest integer type that can hold the value or an empty pointer if not possible.
 	std::shared_ptr<IntegerType const> getIntegerType() const;

--- a/libsolidity/Types.h
+++ b/libsolidity/Types.h
@@ -131,7 +131,7 @@ public:
 	virtual bool isValueType() const { return false; }
 	virtual unsigned getSizeOnStack() const { return 1; }
 	/// @returns the real type of some types, like e.g: IntegerConstant
-	virtual TypePointer getRealType() const { return TypePointer(); }
+	virtual TypePointer getRealType() const { return shared_from_this(); }
 
 	/// Returns the list of all members of this type. Default implementation: no members.
 	virtual MemberList const& getMembers() const { return EmptyMemberList; }

--- a/libsolidity/Types.h
+++ b/libsolidity/Types.h
@@ -249,6 +249,7 @@ public:
 
 	virtual std::string toString() const override { return "string" + dev::toString(m_bytes); }
 	virtual u256 literalValue(Literal const* _literal) const override;
+	virtual TypePointer getRealType() const override { return std::make_shared<StaticStringType>(m_bytes); }
 
 	int getNumBytes() const { return m_bytes; }
 

--- a/test/SolidityEndToEndTest.cpp
+++ b/test/SolidityEndToEndTest.cpp
@@ -2107,7 +2107,7 @@ BOOST_AUTO_TEST_CASE(sha3_multiple_arguments)
 		})";
 	compileAndRun(sourceCode);
 
-	BOOST_CHECK(callContractFunction("foo(uint256,uint256,uint256)", 10 , 12, 13) == encodeArgs(
+	BOOST_CHECK(callContractFunction("foo(uint256,uint256,uint256)", 10, 12, 13) == encodeArgs(
 					dev::sha3(
 						toBigEndian(u256(10)) +
 						toBigEndian(u256(12)) +

--- a/test/SolidityEndToEndTest.cpp
+++ b/test/SolidityEndToEndTest.cpp
@@ -576,7 +576,7 @@ BOOST_AUTO_TEST_CASE(simple_mapping)
 							 "  }\n"
 							 "}";
 	compileAndRun(sourceCode);
-	
+
 	BOOST_CHECK(callContractFunction("get(uint8)", byte(0)) == encodeArgs(byte(0x00)));
 	BOOST_CHECK(callContractFunction("get(uint8)", byte(0x01)) == encodeArgs(byte(0x00)));
 	BOOST_CHECK(callContractFunction("get(uint8)", byte(0xa7)) == encodeArgs(byte(0x00)));
@@ -933,7 +933,7 @@ BOOST_AUTO_TEST_CASE(multiple_elementary_accessors)
 	compileAndRun(sourceCode);
 	BOOST_CHECK(callContractFunction("data()") == encodeArgs(8));
 	BOOST_CHECK(callContractFunction("name()") == encodeArgs("Celina"));
-	BOOST_CHECK(callContractFunction("a_hash()") == encodeArgs(dev::sha3(toBigEndian(u256(123)))));
+	BOOST_CHECK(callContractFunction("a_hash()") == encodeArgs(dev::sha3(bytes({0x7b}))));
 	BOOST_CHECK(callContractFunction("an_address()") == encodeArgs(toBigEndian(u160(0x1337))));
 	BOOST_CHECK(callContractFunction("super_secret_data()") == bytes());
 }
@@ -2127,8 +2127,8 @@ BOOST_AUTO_TEST_CASE(sha3_multiple_arguments_with_numeric_literals)
 	BOOST_CHECK(callContractFunction("foo(uint256,uint16)", 10, 12) == encodeArgs(
 					dev::sha3(
 						toBigEndian(u256(10)) +
-						toBigEndian(u256(12)) +
-						toBigEndian(u256(145)))));
+						bytes({0x0, 0xc}) +
+						bytes({0x91}))));
 }
 
 BOOST_AUTO_TEST_CASE(sha3_multiple_arguments_with_string_literals)
@@ -2147,14 +2147,13 @@ BOOST_AUTO_TEST_CASE(sha3_multiple_arguments_with_string_literals)
 	compileAndRun(sourceCode);
 
 	BOOST_CHECK(callContractFunction("foo()") == encodeArgs(dev::sha3("foo")));
-#if 0 // work in progress
+
 	BOOST_CHECK(callContractFunction("bar(uint256,uint16)", 10, 12) == encodeArgs(
 					dev::sha3(
 						toBigEndian(u256(10)) +
-						toBigEndian(u256(12)) +
-						toBigEndian(u256(145)) +
-						asBytes("foo")))));
-#endif
+						bytes({0x0, 0xc}) +
+						bytes({0x91}) +
+						bytes({0x66, 0x6f, 0x6f}))));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/SolidityEndToEndTest.cpp
+++ b/test/SolidityEndToEndTest.cpp
@@ -2099,7 +2099,6 @@ BOOST_AUTO_TEST_CASE(sha3_multiple_arguments)
 {
 	char const* sourceCode = R"(
 		contract c {
-			// function foo(uint a) returns (hash d)
 			function foo(uint a, uint b, uint c) returns (hash d)
 			{
 				d = sha3(a, b, c);
@@ -2112,6 +2111,50 @@ BOOST_AUTO_TEST_CASE(sha3_multiple_arguments)
 						toBigEndian(u256(10)) +
 						toBigEndian(u256(12)) +
 						toBigEndian(u256(13)))));
+}
+
+BOOST_AUTO_TEST_CASE(sha3_multiple_arguments_with_numeric_literals)
+{
+	char const* sourceCode = R"(
+		contract c {
+			function foo(uint a, uint16 b) returns (hash d)
+			{
+				d = sha3(a, b, 145);
+			}
+		})";
+	compileAndRun(sourceCode);
+
+	BOOST_CHECK(callContractFunction("foo(uint256,uint16)", 10, 12) == encodeArgs(
+					dev::sha3(
+						toBigEndian(u256(10)) +
+						toBigEndian(u256(12)) +
+						toBigEndian(u256(145)))));
+}
+
+BOOST_AUTO_TEST_CASE(sha3_multiple_arguments_with_string_literals)
+{
+	char const* sourceCode = R"(
+		contract c {
+			function foo() returns (hash d)
+			{
+				d = sha3("foo");
+			}
+			function bar(uint a, uint16 b) returns (hash d)
+			{
+				d = sha3(a, b, 145, "foo");
+			}
+		})";
+	compileAndRun(sourceCode);
+
+	BOOST_CHECK(callContractFunction("foo()") == encodeArgs(dev::sha3("foo")));
+#if 0 // work in progress
+	BOOST_CHECK(callContractFunction("bar(uint256,uint16)", 10, 12) == encodeArgs(
+					dev::sha3(
+						toBigEndian(u256(10)) +
+						toBigEndian(u256(12)) +
+						toBigEndian(u256(145)) +
+						asBytes("foo")))));
+#endif
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/SolidityEndToEndTest.cpp
+++ b/test/SolidityEndToEndTest.cpp
@@ -2095,6 +2095,25 @@ BOOST_AUTO_TEST_CASE(event_lots_of_data)
 	BOOST_CHECK_EQUAL(m_logs[0].topics[0], dev::sha3(string("Deposit(address,hash256,uint256,bool)")));
 }
 
+BOOST_AUTO_TEST_CASE(sha3_multiple_arguments)
+{
+	char const* sourceCode = R"(
+		contract c {
+			// function foo(uint a) returns (hash d)
+			function foo(uint a, uint b, uint c) returns (hash d)
+			{
+				d = sha3(a, b, c);
+			}
+		})";
+	compileAndRun(sourceCode);
+
+	BOOST_CHECK(callContractFunction("foo(uint256,uint256,uint256)", 10 , 12, 13) == encodeArgs(
+					dev::sha3(
+						toBigEndian(u256(10)) +
+						toBigEndian(u256(12)) +
+						toBigEndian(u256(13)))));
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 }


### PR DESCRIPTION
It currently works for multiple arguments of the same type that can be converted to hash.
And here comes the question. Do we have, or if we don't have do we want to introduce, a FunctionType attribute that states it can take any arbitrary number of arguments of any type? Because that would be a much cleaner solution.

