### PR TITLE
fix libsolidity's warning on Mac

### DIFF
--- a/libsolidity/Parser.cpp
+++ b/libsolidity/Parser.cpp
@@ -180,7 +180,7 @@ ASTPointer<InheritanceSpecifier> Parser::parseInheritanceSpecifier()
 
 Declaration::Visibility Parser::parseVisibilitySpecifier(Token::Value _token)
 {
-	Declaration::Visibility visibility;
+	Declaration::Visibility visibility = Declaration::Visibility::DEFAULT;
 	if (_token == Token::PUBLIC)
 		visibility = Declaration::Visibility::PUBLIC;
 	else if (_token == Token::PROTECTED)


### PR DESCRIPTION
    /Users/q/Repos/cpp-ethereum/libsolidity/Parser.cpp:188:11: warning: variable 'visibility' is used uninitialized whenever 'if'
          condition is false [-Wsometimes-uninitialized]
            else if (_token == Token::PRIVATE)
                     ^~~~~~~~~~~~~~~~~~~~~~~~
    /Users/q/Repos/cpp-ethereum/libsolidity/Parser.cpp:193:9: note: uninitialized use occurs here
            return visibility;
                   ^~~~~~~~~~
    /Users/q/Repos/cpp-ethereum/libsolidity/Parser.cpp:188:7: note: remove the 'if' if its condition is always true
            else if (_token == Token::PRIVATE)
                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    /Users/q/Repos/cpp-ethereum/libsolidity/Parser.cpp:183:2: note: variable 'visibility' is declared here
            Declaration::Visibility visibility;
            ^
    1 warning generated.