### PR TITLE
Arbitrary parameters for call() and all hash functions.

### DIFF
--- a/libsolidity/AST.cpp
+++ b/libsolidity/AST.cpp
@@ -497,20 +497,21 @@ void FunctionCall::checkTypeRequirements()
 		// and then ask if that is implicitly convertible to the struct represented by the
 		// function parameters
 		TypePointers const& parameterTypes = functionType->getParameterTypes();
-		if (functionType->getLocation() != FunctionType::Location::SHA3 && parameterTypes.size() != m_arguments.size())
+		if (!functionType->takesArbitraryParameters() && parameterTypes.size() != m_arguments.size())
 			BOOST_THROW_EXCEPTION(createTypeError("Wrong argument count for function call."));
 
 		if (m_names.empty())
 		{
 			for (size_t i = 0; i < m_arguments.size(); ++i)
-				if (functionType->getLocation() != FunctionType::Location::SHA3 &&
+				if (!functionType->takesArbitraryParameters() &&
 						!m_arguments[i]->getType()->isImplicitlyConvertibleTo(*parameterTypes[i]))
 					BOOST_THROW_EXCEPTION(m_arguments[i]->createTypeError("Invalid type for argument in function call."));
 		}
 		else
 		{
-			if (functionType->getLocation() == FunctionType::Location::SHA3)
-				BOOST_THROW_EXCEPTION(createTypeError("Named arguments cannnot be used for SHA3."));
+			if (functionType->takesArbitraryParameters())
+				BOOST_THROW_EXCEPTION(createTypeError("Named arguments cannnot be used for functions "
+													  "that take arbitrary parameters."));
 			auto const& parameterNames = functionType->getParameterNames();
 			if (parameterNames.size() != m_names.size())
 				BOOST_THROW_EXCEPTION(createTypeError("Some argument names are missing."));

--- a/libsolidity/ExpressionCompiler.h
+++ b/libsolidity/ExpressionCompiler.h
@@ -97,7 +97,8 @@ private:
 	unsigned appendArgumentsCopyToMemory(std::vector<ASTPointer<Expression const>> const& _arguments,
 										 TypePointers const& _types = {},
 										 unsigned _memoryOffset = 0,
-										 bool _padToWordBoundaries = true);
+										 bool _padToWordBoundaries = true,
+										 bool _padExceptionIfFourBytes = false);
 	/// Appends code that moves a stack element of the given type to memory
 	/// @returns the number of bytes moved to memory
 	unsigned appendTypeMoveToMemory(Type const& _type, Location const& _location, unsigned _memoryOffset,

--- a/libsolidity/GlobalContext.cpp
+++ b/libsolidity/GlobalContext.cpp
@@ -40,7 +40,7 @@ m_magicVariables(vector<shared_ptr<MagicVariableDeclaration const>>{make_shared<
 					make_shared<MagicVariableDeclaration>("suicide",
 							make_shared<FunctionType>(strings{"address"}, strings{}, FunctionType::Location::Suicide)),
 					make_shared<MagicVariableDeclaration>("sha3",
-							make_shared<FunctionType>(strings{"hash"}, strings{"hash"}, FunctionType::Location::SHA3)),
+							make_shared<FunctionType>(strings(), strings{"hash"}, FunctionType::Location::SHA3, true)),
 					make_shared<MagicVariableDeclaration>("log0",
 							make_shared<FunctionType>(strings{"hash"},strings{}, FunctionType::Location::Log0)),
 					make_shared<MagicVariableDeclaration>("log1",
@@ -52,11 +52,11 @@ m_magicVariables(vector<shared_ptr<MagicVariableDeclaration const>>{make_shared<
 					make_shared<MagicVariableDeclaration>("log4",
 							make_shared<FunctionType>(strings{"hash", "hash", "hash", "hash", "hash"},strings{}, FunctionType::Location::Log4)),
 					make_shared<MagicVariableDeclaration>("sha256",
-							make_shared<FunctionType>(strings{"hash"}, strings{"hash"}, FunctionType::Location::SHA256)),
+							make_shared<FunctionType>(strings(), strings{"hash"}, FunctionType::Location::SHA256, true)),
 					make_shared<MagicVariableDeclaration>("ecrecover",
 							make_shared<FunctionType>(strings{"hash", "hash8", "hash", "hash"}, strings{"address"}, FunctionType::Location::ECRecover)),
 					make_shared<MagicVariableDeclaration>("ripemd160",
-							make_shared<FunctionType>(strings{"hash"}, strings{"hash160"}, FunctionType::Location::RIPEMD160))})
+							make_shared<FunctionType>(strings(), strings{"hash160"}, FunctionType::Location::RIPEMD160, true))})
 {
 }
 

--- a/libsolidity/Types.h
+++ b/libsolidity/Types.h
@@ -367,14 +367,15 @@ public:
 	explicit FunctionType(VariableDeclaration const& _varDecl);
 	explicit FunctionType(EventDefinition const& _event);
 	FunctionType(strings const& _parameterTypes, strings const& _returnParameterTypes,
-				 Location _location = Location::Internal):
+				 Location _location = Location::Internal, bool _arbitraryParameters = false):
 		FunctionType(parseElementaryTypeVector(_parameterTypes), parseElementaryTypeVector(_returnParameterTypes),
-					 _location) {}
+					 _location, _arbitraryParameters) {}
 	FunctionType(TypePointers const& _parameterTypes, TypePointers const& _returnParameterTypes,
 				 Location _location = Location::Internal,
-				 bool _gasSet = false, bool _valueSet = false):
+				 bool _arbitraryParameters = false, bool _gasSet = false, bool _valueSet = false):
 		m_parameterTypes(_parameterTypes), m_returnParameterTypes(_returnParameterTypes),
-		m_location(_location), m_gasSet(_gasSet), m_valueSet(_valueSet) {}
+		m_location(_location),
+		m_arbitraryParameters(_arbitraryParameters), m_gasSet(_gasSet), m_valueSet(_valueSet) {}
 
 	TypePointers const& getParameterTypes() const { return m_parameterTypes; }
 	std::vector<std::string> const& getParameterNames() const { return m_parameterNames; }
@@ -407,6 +408,9 @@ public:
 	/// Can contain a nullptr in which case indicates absence of documentation
 	ASTPointer<ASTString> getDocumentation() const;
 
+	/// true iff arguments are to be padded to multiples of 32 bytes for external calls
+	bool padArguments() const { return !(m_location == Location::SHA3 || m_location == Location::SHA256 || m_location == Location::RIPEMD160); }
+	bool takesArbitraryParameters() const { return m_arbitraryParameters; }
 	bool gasSet() const { return m_gasSet; }
 	bool valueSet() const { return m_valueSet; }
 
@@ -422,6 +426,8 @@ private:
 	std::vector<std::string> m_parameterNames;
 	std::vector<std::string> m_returnParameterNames;
 	Location const m_location;
+	/// true iff the function takes an arbitrary number of arguments of arbitrary types
+	bool const m_arbitraryParameters = false;
 	bool const m_gasSet = false; ///< true iff the gas value to be used is on the stack
 	bool const m_valueSet = false; ///< true iff the value to be sent is on the stack
 	bool m_isConstant;


### PR DESCRIPTION
This allows manual calls to other contracts. It contains something that might be considered a hack: If the first argument to `call` is a type of exactly four bytes, it is not padded to 32 bytes, allowing to use
`call(string4(string32("f(uint256,bool)")), 2, 3)` to call a specific ABI function.