### PR TITLE
CLI flag to set number of mining threads

### DIFF
--- a/eth/main.cpp
+++ b/eth/main.cpp
@@ -119,6 +119,7 @@ void help()
         << "    -p,--port <port>  Connect to remote port (default: 30303)." << endl
         << "    -r,--remote <host>  Connect to remote host (default: none)." << endl
         << "    -s,--secret <secretkeyhex>  Set the secret key for use with send command (default: auto)." << endl
+        << "    -t,--miners <number>  Number of mining threads to start (Default: " << thread::hardware_concurrency() << ")" << endl
         << "    -u,--public-ip <ip>  Force public ip to given (default; auto)." << endl
         << "    -v,--verbosity <0 - 9>  Set the log verbosity from 0 to 9 (Default: 8)." << endl
         << "    -x,--peers <number>  Attempt to connect to given number of peers (Default: 5)." << endl
@@ -195,6 +196,7 @@ int main(int argc, char** argv)
 	unsigned mining = ~(unsigned)0;
 	NodeMode mode = NodeMode::Full;
 	unsigned peers = 5;
+    int miners = -1;
 	bool interactive = false;
 #if ETH_JSONRPC
 	int jsonrpc = -1;
@@ -295,6 +297,8 @@ int main(int argc, char** argv)
 			g_logVerbosity = atoi(argv[++i]);
 		else if ((arg == "-x" || arg == "--peers") && i + 1 < argc)
 			peers = atoi(argv[++i]);
+        else if ((arg == "-t" || arg == "--miners") && i + 1 < argc)
+            miners = atoi(argv[++i]);
 		else if ((arg == "-o" || arg == "--mode") && i + 1 < argc)
 		{
 			string m = argv[++i];
@@ -337,7 +341,8 @@ int main(int argc, char** argv)
 		dbPath,
 		false,
 		mode == NodeMode::Full ? set<string>{"eth", "shh"} : set<string>(),
-		netPrefs
+		netPrefs,
+        miners
 		);
 	web3.setIdealPeerCount(peers);
 	eth::Client* c = mode == NodeMode::Full ? web3.ethereum() : nullptr;

--- a/eth/main.cpp
+++ b/eth/main.cpp
@@ -119,7 +119,7 @@ void help()
         << "    -p,--port <port>  Connect to remote port (default: 30303)." << endl
         << "    -r,--remote <host>  Connect to remote host (default: none)." << endl
         << "    -s,--secret <secretkeyhex>  Set the secret key for use with send command (default: auto)." << endl
-        << "    -t,--miners <number>  Number of mining threads to start (Default: " << thread::hardware_concurrency() << ")" << endl
+		<< "    -t,--miners <number>  Number of mining threads to start (Default: " << thread::hardware_concurrency() << ")" << endl
         << "    -u,--public-ip <ip>  Force public ip to given (default; auto)." << endl
         << "    -v,--verbosity <0 - 9>  Set the log verbosity from 0 to 9 (Default: 8)." << endl
         << "    -x,--peers <number>  Attempt to connect to given number of peers (Default: 5)." << endl
@@ -196,7 +196,7 @@ int main(int argc, char** argv)
 	unsigned mining = ~(unsigned)0;
 	NodeMode mode = NodeMode::Full;
 	unsigned peers = 5;
-    int miners = -1;
+	int miners = -1;
 	bool interactive = false;
 #if ETH_JSONRPC
 	int jsonrpc = -1;
@@ -297,8 +297,8 @@ int main(int argc, char** argv)
 			g_logVerbosity = atoi(argv[++i]);
 		else if ((arg == "-x" || arg == "--peers") && i + 1 < argc)
 			peers = atoi(argv[++i]);
-        else if ((arg == "-t" || arg == "--miners") && i + 1 < argc)
-            miners = atoi(argv[++i]);
+		else if ((arg == "-t" || arg == "--miners") && i + 1 < argc)
+			miners = atoi(argv[++i]);
 		else if ((arg == "-o" || arg == "--mode") && i + 1 < argc)
 		{
 			string m = argv[++i];
@@ -342,7 +342,7 @@ int main(int argc, char** argv)
 		false,
 		mode == NodeMode::Full ? set<string>{"eth", "shh"} : set<string>(),
 		netPrefs,
-        miners
+		miners
 		);
 	web3.setIdealPeerCount(peers);
 	eth::Client* c = mode == NodeMode::Full ? web3.ethereum() : nullptr;

--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -59,7 +59,7 @@ void VersionChecker::setOk()
 	}
 }
 
-Client::Client(p2p::Host* _extNet, std::string const& _dbPath, bool _forceClean, u256 _networkId):
+Client::Client(p2p::Host* _extNet, std::string const& _dbPath, bool _forceClean, u256 _networkId, int miners):
 	Worker("eth"),
 	m_vc(_dbPath),
 	m_bc(_dbPath, !m_vc.ok() || _forceClean),
@@ -69,7 +69,10 @@ Client::Client(p2p::Host* _extNet, std::string const& _dbPath, bool _forceClean,
 {
 	m_host = _extNet->registerCapability(new EthereumHost(m_bc, m_tq, m_bq, _networkId));
 
-	setMiningThreads();
+    if(miners > -1)
+        setMiningThreads(miners);
+    else
+        setMiningThreads();
 	if (_dbPath.size())
 		Defaults::setDBPath(_dbPath);
 	m_vc.setOk();

--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -69,10 +69,10 @@ Client::Client(p2p::Host* _extNet, std::string const& _dbPath, bool _forceClean,
 {
 	m_host = _extNet->registerCapability(new EthereumHost(m_bc, m_tq, m_bq, _networkId));
 
-    if(miners > -1)
-        setMiningThreads(miners);
-    else
-        setMiningThreads();
+	if(miners > -1)
+		setMiningThreads(miners);
+	else
+		setMiningThreads();
 	if (_dbPath.size())
 		Defaults::setDBPath(_dbPath);
 	m_vc.setOk();

--- a/libethereum/Client.h
+++ b/libethereum/Client.h
@@ -166,7 +166,7 @@ class Client: public MinerHost, public Interface, Worker
 
 public:
 	/// New-style Constructor.
-	explicit Client(p2p::Host* _host, std::string const& _dbPath = std::string(), bool _forceClean = false, u256 _networkId = 0);
+	explicit Client(p2p::Host* _host, std::string const& _dbPath = std::string(), bool _forceClean = false, u256 _networkId = 0, int miners = -1);
 
 	/// Destructor.
 	virtual ~Client();

--- a/libwebthree/WebThree.cpp
+++ b/libwebthree/WebThree.cpp
@@ -35,15 +35,15 @@ using namespace dev::p2p;
 using namespace dev::eth;
 using namespace dev::shh;
 
-WebThreeDirect::WebThreeDirect(std::string const& _clientVersion, std::string const& _dbPath, bool _forceClean, std::set<std::string> const& _interfaces, NetworkPreferences const& _n):
+WebThreeDirect::WebThreeDirect(std::string const& _clientVersion, std::string const& _dbPath, bool _forceClean, std::set<std::string> const& _interfaces, NetworkPreferences const& _n, int miners):
 	m_clientVersion(_clientVersion),
 	m_net(_clientVersion, _n)
 {
 	if (_dbPath.size())
 		Defaults::setDBPath(_dbPath);
-
-	if (_interfaces.count("eth"))
-		m_ethereum.reset(new eth::Client(&m_net, _dbPath, _forceClean));
+    if (_interfaces.count("eth"))
+        m_ethereum.reset(new eth::Client(&m_net, _dbPath, _forceClean, 0, miners));
+		
 
 	if (_interfaces.count("shh"))
 		m_whisper = m_net.registerCapability<WhisperHost>(new WhisperHost);

--- a/libwebthree/WebThree.cpp
+++ b/libwebthree/WebThree.cpp
@@ -41,8 +41,8 @@ WebThreeDirect::WebThreeDirect(std::string const& _clientVersion, std::string co
 {
 	if (_dbPath.size())
 		Defaults::setDBPath(_dbPath);
-    if (_interfaces.count("eth"))
-        m_ethereum.reset(new eth::Client(&m_net, _dbPath, _forceClean, 0, miners));
+	if (_interfaces.count("eth"))
+		m_ethereum.reset(new eth::Client(&m_net, _dbPath, _forceClean, 0, miners));
 		
 
 	if (_interfaces.count("shh"))

--- a/libwebthree/WebThree.h
+++ b/libwebthree/WebThree.h
@@ -106,7 +106,7 @@ class WebThreeDirect : public WebThreeNetworkFace
 public:
 	/// Constructor for private instance. If there is already another process on the machine using @a _dbPath, then this will throw an exception.
 	/// ethereum() may be safely static_cast()ed to a eth::Client*.
-	WebThreeDirect(std::string const& _clientVersion, std::string const& _dbPath, bool _forceClean = false, std::set<std::string> const& _interfaces = {"eth", "shh"}, p2p::NetworkPreferences const& _n = p2p::NetworkPreferences());
+	WebThreeDirect(std::string const& _clientVersion, std::string const& _dbPath, bool _forceClean = false, std::set<std::string> const& _interfaces = {"eth", "shh"}, p2p::NetworkPreferences const& _n = p2p::NetworkPreferences(), int miners = -1);
 
 	/// Destructor.
 	~WebThreeDirect();

--- a/neth/main.cpp
+++ b/neth/main.cpp
@@ -81,7 +81,7 @@ void help()
 		<< "    -p,--port <port>  Connect to remote port (default: 30303)." << endl
 		<< "    -r,--remote <host>  Connect to remote host (default: none)." << endl
 		<< "    -s,--secret <secretkeyhex>  Set the secret key for use with send command (default: auto)." << endl
-        << "    -t,--miners <number>  Number of mining threads to start (Default: " << thread::hardware_concurrency() << ")" << endl
+		<< "    -t,--miners <number>  Number of mining threads to start (Default: " << thread::hardware_concurrency() << ")" << endl
 		<< "    -u,--public-ip <ip>  Force public ip to given (default; auto)." << endl
 		<< "    -v,--verbosity <0..9>  Set the log verbosity from 0 to 9 (tmp forced to 1)." << endl
 		<< "    -x,--peers <number>  Attempt to connect to given number of peers (default: 5)." << endl
@@ -308,7 +308,7 @@ int main(int argc, char** argv)
 	unsigned mining = ~(unsigned)0;
 	NodeMode mode = NodeMode::Full;
 	unsigned peers = 5;
-    int miners = -1;
+	int miners = -1;
 #if ETH_JSONRPC
 	int jsonrpc = 8080;
 #endif
@@ -403,8 +403,8 @@ int main(int argc, char** argv)
 			g_logVerbosity = atoi(argv[++i]);
 		else if ((arg == "-x" || arg == "--peers") && i + 1 < argc)
 			peers = atoi(argv[++i]);
-        else if ((arg == "-t" || arg == "--miners") && i + 1 < argc)
-            miners = atoi(argv[++i]);
+		else if ((arg == "-t" || arg == "--miners") && i + 1 < argc)
+			miners = atoi(argv[++i]);
 		else if (arg == "-h" || arg == "--help")
 			help();
 		else if (arg == "-V" || arg == "--version")
@@ -425,7 +425,7 @@ int main(int argc, char** argv)
 		false,
 		mode == NodeMode::Full ? set<string>{"eth", "shh"} : set<string>(),
 		netPrefs,
-        miners
+		miners
 		);
 	web3.setIdealPeerCount(peers);
 	eth::Client* c = mode == NodeMode::Full ? web3.ethereum() : nullptr;

--- a/neth/main.cpp
+++ b/neth/main.cpp
@@ -81,6 +81,7 @@ void help()
 		<< "    -p,--port <port>  Connect to remote port (default: 30303)." << endl
 		<< "    -r,--remote <host>  Connect to remote host (default: none)." << endl
 		<< "    -s,--secret <secretkeyhex>  Set the secret key for use with send command (default: auto)." << endl
+        << "    -t,--miners <number>  Number of mining threads to start (Default: " << thread::hardware_concurrency() << ")" << endl
 		<< "    -u,--public-ip <ip>  Force public ip to given (default; auto)." << endl
 		<< "    -v,--verbosity <0..9>  Set the log verbosity from 0 to 9 (tmp forced to 1)." << endl
 		<< "    -x,--peers <number>  Attempt to connect to given number of peers (default: 5)." << endl
@@ -307,6 +308,7 @@ int main(int argc, char** argv)
 	unsigned mining = ~(unsigned)0;
 	NodeMode mode = NodeMode::Full;
 	unsigned peers = 5;
+    int miners = -1;
 #if ETH_JSONRPC
 	int jsonrpc = 8080;
 #endif
@@ -401,6 +403,8 @@ int main(int argc, char** argv)
 			g_logVerbosity = atoi(argv[++i]);
 		else if ((arg == "-x" || arg == "--peers") && i + 1 < argc)
 			peers = atoi(argv[++i]);
+        else if ((arg == "-t" || arg == "--miners") && i + 1 < argc)
+            miners = atoi(argv[++i]);
 		else if (arg == "-h" || arg == "--help")
 			help();
 		else if (arg == "-V" || arg == "--version")
@@ -420,7 +424,8 @@ int main(int argc, char** argv)
 		dbPath,
 		false,
 		mode == NodeMode::Full ? set<string>{"eth", "shh"} : set<string>(),
-		netPrefs
+		netPrefs,
+        miners
 		);
 	web3.setIdealPeerCount(peers);
 	eth::Client* c = mode == NodeMode::Full ? web3.ethereum() : nullptr;


### PR DESCRIPTION
Added optional flag -t / --miners to eth and neth, which sets the number of CPU threads to use for mining (the default is the previous behavior of using all available CPU cores). By allowing the user to set only a single mining thread, the InvalidTimestamp exception can be avoided (see #994). It is also helpful to control the number of mining threads to manage CPU and energy usage and to aid in debugging.