### PR TITLE
Changes required for upgrade to jsonrpccpp 0.4.2

### DIFF
--- a/cmake/EthDependencies.cmake
+++ b/cmake/EthDependencies.cmake
@@ -59,6 +59,10 @@ if (JSONRPC)
 	message (" - json-rpc-cpp lib   : ${JSON_RPC_CPP_LIBRARIES}")
 	add_definitions(-DETH_JSONRPC)
 
+ 	find_package(MHD) 
+	message(" - microhttpd header: ${MHD_INCLUDE_DIRS}")
+	message(" - microhttpd lib   : ${MHD_LIBRARIES}")
+
 endif() #JSONRPC
 
 # TODO readline package does not yet check for correct version number

--- a/cmake/FindMHD.cmake
+++ b/cmake/FindMHD.cmake
@@ -1,0 +1,47 @@
+# Find microhttpd 
+#
+# Find the microhttpd includes and library
+# 
+# if you nee to add a custom library search path, do it via via CMAKE_PREFIX_PATH 
+# 
+# This module defines
+#  MHD_INCLUDE_DIRS, where to find header, etc.
+#  MHD_LIBRARIES, the libraries needed to use jsoncpp.
+#  MHD_FOUND, If false, do not try to use jsoncpp.
+
+find_path(
+	MHD_INCLUDE_DIR 
+	NAMES microhttpd.h
+	DOC "microhttpd include dir"
+)
+
+find_library(
+	MHD_LIBRARY
+	NAMES microhttpd microhttpd-10 libmicrohttpd libmicrohttpd-dll
+	DOC "microhttpd library"
+)
+
+set(MHD_INCLUDE_DIRS ${MHD_INCLUDE_DIR})
+set(MHD_LIBRARIES ${MHD_LIBRARY})
+
+# debug library on windows
+# same naming convention as in qt (appending debug library with d)
+# boost is using the same "hack" as us with "optimized" and "debug"
+# official MHD project actually uses _d suffix
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+	find_library(
+		MHD_LIBRARY_DEBUG
+		NAMES microhttpd_d microhttpd-10_d libmicrohttpd_d libmicrohttpd-dll_d
+		DOC "mhd debug library"
+	)
+
+	set(MHD_LIBRARIES optimized ${MHD_LIBRARIES} debug ${MHD_LIBRARY_DEBUG})
+
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(mhd DEFAULT_MSG
+	MHD_INCLUDE_DIR MHD_LIBRARY)
+
+mark_as_advanced(MHD_INCLUDE_DIR MHD_LIBRARY)
+

--- a/cmake/FindMHD.cmake
+++ b/cmake/FindMHD.cmake
@@ -1,16 +1,16 @@
-# Find microhttpd 
+# Find microhttpd
 #
 # Find the microhttpd includes and library
-# 
-# if you nee to add a custom library search path, do it via via CMAKE_PREFIX_PATH 
-# 
+#
+# if you need to add a custom library search path, do it via via CMAKE_PREFIX_PATH
+#
 # This module defines
 #  MHD_INCLUDE_DIRS, where to find header, etc.
 #  MHD_LIBRARIES, the libraries needed to use jsoncpp.
 #  MHD_FOUND, If false, do not try to use jsoncpp.
 
 find_path(
-	MHD_INCLUDE_DIR 
+	MHD_INCLUDE_DIR
 	NAMES microhttpd.h
 	DOC "microhttpd include dir"
 )
@@ -25,7 +25,7 @@ set(MHD_INCLUDE_DIRS ${MHD_INCLUDE_DIR})
 set(MHD_LIBRARIES ${MHD_LIBRARY})
 
 # debug library on windows
-# same naming convention as in qt (appending debug library with d)
+# same naming convention as in QT (appending debug library with d)
 # boost is using the same "hack" as us with "optimized" and "debug"
 # official MHD project actually uses _d suffix
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")

--- a/extdep/CMakeLists.txt
+++ b/extdep/CMakeLists.txt
@@ -35,7 +35,10 @@ if (ETH_COMPILE)
 	include(compile/boost.cmake)
 else()	
 	eth_download(jsoncpp)
-	eth_download(json-rpc-cpp OSX_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/scripts/json-rpc-cpp_osx.sh)
+	eth_download(json-rpc-cpp
+		VERSION 4.2
+		OSX_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/scripts/json-rpc-cpp_osx.sh
+	)
 	
 	if (APPLE)
 		eth_download(snappy OSX_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/scripts/snappy_osx.sh)

--- a/extdep/CMakeLists.txt
+++ b/extdep/CMakeLists.txt
@@ -35,6 +35,7 @@ if (ETH_COMPILE)
 	include(compile/boost.cmake)
 else()	
 	eth_download(jsoncpp)
+	eth_download(microhttpd)
 	eth_download(json-rpc-cpp
 		VERSION 4.2
 		OSX_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/scripts/json-rpc-cpp_osx.sh

--- a/libweb3jsonrpc/CMakeLists.txt
+++ b/libweb3jsonrpc/CMakeLists.txt
@@ -9,9 +9,11 @@ set(CMAKE_AUTOMOC OFF)
 
 aux_source_directory(. SRC_LIST)
 
+include_directories(..)
+include_directories(${JSONCPP_INCLUDE_DIRS})
+include_directories(${MHD_INCLUDE_DIRS})
 include_directories(${JSON_RPC_CPP_INCLUDE_DIRS})
 include_directories(${LEVELDB_INCLUDE_DIRS})
-include_directories(..)
 
 set(EXECUTABLE web3jsonrpc)
 
@@ -26,6 +28,7 @@ endif()
 target_link_libraries(${EXECUTABLE} ${LEVELDB_LIBRARIES})
 target_link_libraries(${EXECUTABLE} ${JSONCPP_LIBRARIES})
 target_link_libraries(${EXECUTABLE} ${JSON_RPC_CPP_SERVER_LIBRARIES})
+target_link_libraries(${EXECUTABLE} ${MHD_LIBRARIES})
 
 target_link_libraries(${EXECUTABLE} webthree)
 target_link_libraries(${EXECUTABLE} secp256k1)

--- a/libweb3jsonrpc/WebThreeStubServerBase.cpp
+++ b/libweb3jsonrpc/WebThreeStubServerBase.cpp
@@ -264,7 +264,7 @@ Json::Value WebThreeStubServerBase::eth_blockByHash(std::string const& _hash)
 	return toJson(client()->blockInfo(jsToFixed<32>(_hash)));
 }
 
-Json::Value WebThreeStubServerBase::eth_blockByNumber(int const& _number)
+Json::Value WebThreeStubServerBase::eth_blockByNumber(int _number)
 {
 	return toJson(client()->blockInfo(client()->hashFromNumber(_number)));
 }
@@ -342,7 +342,7 @@ std::string WebThreeStubServerBase::eth_call(Json::Value const& _json)
 	return ret;
 }
 
-Json::Value WebThreeStubServerBase::eth_changed(int const& _id)
+Json::Value WebThreeStubServerBase::eth_changed(int _id)
 {
 	auto entries = client()->checkWatch(_id);
 	if (entries.size())
@@ -381,7 +381,7 @@ std::string WebThreeStubServerBase::db_get(std::string const& _name, std::string
 	return toJS(dev::asBytes(ret));
 }
 
-Json::Value WebThreeStubServerBase::eth_filterLogs(int const& _id)
+Json::Value WebThreeStubServerBase::eth_filterLogs(int _id)
 {
 	return toJson(client()->logs(_id));
 }
@@ -563,13 +563,13 @@ bool WebThreeStubServerBase::eth_setCoinbase(std::string const& _address)
 	return true;
 }
 
-bool WebThreeStubServerBase::eth_setDefaultBlock(int const& _block)
+bool WebThreeStubServerBase::eth_setDefaultBlock(int _block)
 {
 	client()->setDefault(_block);
 	return true;
 }
 
-bool WebThreeStubServerBase::eth_setListening(bool const& _listening)
+bool WebThreeStubServerBase::eth_setListening(bool _listening)
 {
 	if (_listening)
 		network()->startNetwork();
@@ -578,7 +578,7 @@ bool WebThreeStubServerBase::eth_setListening(bool const& _listening)
 	return true;
 }
 
-bool WebThreeStubServerBase::eth_setMining(bool const& _mining)
+bool WebThreeStubServerBase::eth_setMining(bool _mining)
 {
 	if (_mining)
 		client()->startMining();
@@ -587,7 +587,7 @@ bool WebThreeStubServerBase::eth_setMining(bool const& _mining)
 	return true;
 }
 
-Json::Value WebThreeStubServerBase::shh_changed(int const& _id)
+Json::Value WebThreeStubServerBase::shh_changed(int _id)
 {
 	Json::Value ret(Json::arrayValue);
 	auto pub = m_shhWatches[_id];
@@ -619,7 +619,7 @@ int WebThreeStubServerBase::shh_newFilter(Json::Value const& _json)
 	return ret;
 }
 
-bool WebThreeStubServerBase::shh_uninstallFilter(int const& _id)
+bool WebThreeStubServerBase::shh_uninstallFilter(int _id)
 {
 	face()->uninstallWatch(_id);
 	return true;
@@ -671,27 +671,27 @@ bool WebThreeStubServerBase::authenticate(TransactionSkeleton const& _t)
 	return true;
 }
 
-Json::Value WebThreeStubServerBase::eth_transactionByHash(std::string const& _hash, int const& _i)
+Json::Value WebThreeStubServerBase::eth_transactionByHash(std::string const& _hash, int _i)
 {
 	return toJson(client()->transaction(jsToFixed<32>(_hash), _i));
 }
 
-Json::Value WebThreeStubServerBase::eth_transactionByNumber(int const& _number, int const& _i)
+Json::Value WebThreeStubServerBase::eth_transactionByNumber(int _number, int _i)
 {
 	return toJson(client()->transaction(client()->hashFromNumber(_number), _i));
 }
 
-Json::Value WebThreeStubServerBase::eth_uncleByHash(std::string const& _hash, int const& _i)
+Json::Value WebThreeStubServerBase::eth_uncleByHash(std::string const& _hash, int _i)
 {
 	return toJson(client()->uncle(jsToFixed<32>(_hash), _i));
 }
 
-Json::Value WebThreeStubServerBase::eth_uncleByNumber(int const& _number, int const& _i)
+Json::Value WebThreeStubServerBase::eth_uncleByNumber(int _number, int _i)
 {
 	return toJson(client()->uncle(client()->hashFromNumber(_number), _i));
 }
 
-bool WebThreeStubServerBase::eth_uninstallFilter(int const& _id)
+bool WebThreeStubServerBase::eth_uninstallFilter(int _id)
 {
 	client()->uninstallWatch(_id);
 	return true;

--- a/libweb3jsonrpc/WebThreeStubServerBase.h
+++ b/libweb3jsonrpc/WebThreeStubServerBase.h
@@ -69,16 +69,16 @@ public:
 	virtual Json::Value eth_accounts();
 	virtual std::string eth_balanceAt(std::string const& _address);
 	virtual Json::Value eth_blockByHash(std::string const& _hash);
-	virtual Json::Value eth_blockByNumber(int const& _number);
+	virtual Json::Value eth_blockByNumber(int _number);
 	virtual std::string eth_call(Json::Value const& _json);
-	virtual Json::Value eth_changed(int const& _id);
+	virtual Json::Value eth_changed(int _id);
 	virtual std::string eth_codeAt(std::string const& _address);
 	virtual std::string eth_coinbase();
 	virtual Json::Value eth_compilers();
 	virtual double eth_countAt(std::string const& _address);
 	virtual int eth_defaultBlock();
 	virtual std::string eth_gasPrice();
-	virtual Json::Value eth_filterLogs(int const& _id);
+	virtual Json::Value eth_filterLogs(int _id);
 	virtual bool eth_flush();
 	virtual Json::Value eth_logs(Json::Value const& _json);
 	virtual bool eth_listening();
@@ -88,20 +88,20 @@ public:
 	virtual int eth_number();
 	virtual int eth_peerCount();
 	virtual bool eth_setCoinbase(std::string const& _address);
-	virtual bool eth_setDefaultBlock(int const& _block);
-	virtual bool eth_setListening(bool const& _listening);
+	virtual bool eth_setDefaultBlock(int _block);
+	virtual bool eth_setListening(bool _listening);
 	virtual std::string eth_lll(std::string const& _s);
 	virtual std::string eth_serpent(std::string const& _s);
-	virtual bool eth_setMining(bool const& _mining);
+	virtual bool eth_setMining(bool _mining);
 	virtual std::string eth_solidity(std::string const& _code);
 	virtual std::string eth_stateAt(std::string const& _address, std::string const& _storage);
 	virtual Json::Value eth_storageAt(std::string const& _address);
 	virtual std::string eth_transact(Json::Value const& _json);
-	virtual Json::Value eth_transactionByHash(std::string const& _hash, int const& _i);
-	virtual Json::Value eth_transactionByNumber(int const& _number, int const& _i);
-	virtual Json::Value eth_uncleByHash(std::string const& _hash, int const& _i);
-	virtual Json::Value eth_uncleByNumber(int const& _number, int const& _i);
-	virtual bool eth_uninstallFilter(int const& _id);
+	virtual Json::Value eth_transactionByHash(std::string const& _hash, int _i);
+	virtual Json::Value eth_transactionByNumber(int  _number, int _i);
+	virtual Json::Value eth_uncleByHash(std::string const& _hash, int _i);
+	virtual Json::Value eth_uncleByNumber(int _number, int _i);
+	virtual bool eth_uninstallFilter(int _id);
 
 	virtual Json::Value eth_getWork();
 	virtual bool eth_submitWork(std::string const& _nonce);
@@ -112,13 +112,13 @@ public:
 	virtual bool db_putString(std::string const& _name, std::string const& _key, std::string const& _value);
 
 	virtual std::string shh_addToGroup(std::string const& _group, std::string const& _who);
-	virtual Json::Value shh_changed(int const& _id);
+	virtual Json::Value shh_changed(int _id);
 	virtual bool shh_haveIdentity(std::string const& _id);
 	virtual int shh_newFilter(Json::Value const& _json);
 	virtual std::string shh_newGroup(std::string const& _id, std::string const& _who);
 	virtual std::string shh_newIdentity();
 	virtual bool shh_post(Json::Value const& _json);
-	virtual bool shh_uninstallFilter(int const& _id);
+	virtual bool shh_uninstallFilter(int _id);
 
 	void setAccounts(std::vector<dev::KeyPair> const& _accounts);
 	void setIdentities(std::vector<dev::KeyPair> const& _ids);

--- a/libweb3jsonrpc/abstractwebthreestubserver.h
+++ b/libweb3jsonrpc/abstractwebthreestubserver.h
@@ -10,59 +10,59 @@
 class AbstractWebThreeStubServer : public jsonrpc::AbstractServer<AbstractWebThreeStubServer>
 {
     public:
-        AbstractWebThreeStubServer(jsonrpc::AbstractServerConnector &conn) : jsonrpc::AbstractServer<AbstractWebThreeStubServer>(conn)
+        AbstractWebThreeStubServer(jsonrpc::AbstractServerConnector &conn, jsonrpc::serverVersion_t type = jsonrpc::JSONRPC_SERVER_V2) : jsonrpc::AbstractServer<AbstractWebThreeStubServer>(conn, type)
         {
-            this->bindAndAddMethod(new jsonrpc::Procedure("web3_sha3", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_STRING, "param1",jsonrpc::JSON_STRING, NULL), &AbstractWebThreeStubServer::web3_sha3I);
-            this->bindAndAddMethod(new jsonrpc::Procedure("eth_coinbase", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_STRING,  NULL), &AbstractWebThreeStubServer::eth_coinbaseI);
-            this->bindAndAddMethod(new jsonrpc::Procedure("eth_setCoinbase", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_BOOLEAN, "param1",jsonrpc::JSON_STRING, NULL), &AbstractWebThreeStubServer::eth_setCoinbaseI);
-            this->bindAndAddMethod(new jsonrpc::Procedure("eth_listening", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_BOOLEAN,  NULL), &AbstractWebThreeStubServer::eth_listeningI);
-            this->bindAndAddMethod(new jsonrpc::Procedure("eth_setListening", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_BOOLEAN, "param1",jsonrpc::JSON_BOOLEAN, NULL), &AbstractWebThreeStubServer::eth_setListeningI);
-            this->bindAndAddMethod(new jsonrpc::Procedure("eth_mining", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_BOOLEAN,  NULL), &AbstractWebThreeStubServer::eth_miningI);
-            this->bindAndAddMethod(new jsonrpc::Procedure("eth_setMining", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_BOOLEAN, "param1",jsonrpc::JSON_BOOLEAN, NULL), &AbstractWebThreeStubServer::eth_setMiningI);
-            this->bindAndAddMethod(new jsonrpc::Procedure("eth_gasPrice", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_STRING,  NULL), &AbstractWebThreeStubServer::eth_gasPriceI);
-            this->bindAndAddMethod(new jsonrpc::Procedure("eth_accounts", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_ARRAY,  NULL), &AbstractWebThreeStubServer::eth_accountsI);
-            this->bindAndAddMethod(new jsonrpc::Procedure("eth_peerCount", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_INTEGER,  NULL), &AbstractWebThreeStubServer::eth_peerCountI);
-            this->bindAndAddMethod(new jsonrpc::Procedure("eth_defaultBlock", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_INTEGER,  NULL), &AbstractWebThreeStubServer::eth_defaultBlockI);
-            this->bindAndAddMethod(new jsonrpc::Procedure("eth_setDefaultBlock", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_BOOLEAN, "param1",jsonrpc::JSON_INTEGER, NULL), &AbstractWebThreeStubServer::eth_setDefaultBlockI);
-            this->bindAndAddMethod(new jsonrpc::Procedure("eth_number", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_INTEGER,  NULL), &AbstractWebThreeStubServer::eth_numberI);
-            this->bindAndAddMethod(new jsonrpc::Procedure("eth_balanceAt", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_STRING, "param1",jsonrpc::JSON_STRING, NULL), &AbstractWebThreeStubServer::eth_balanceAtI);
-            this->bindAndAddMethod(new jsonrpc::Procedure("eth_stateAt", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_STRING, "param1",jsonrpc::JSON_STRING,"param2",jsonrpc::JSON_STRING, NULL), &AbstractWebThreeStubServer::eth_stateAtI);
-            this->bindAndAddMethod(new jsonrpc::Procedure("eth_storageAt", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_OBJECT, "param1",jsonrpc::JSON_STRING, NULL), &AbstractWebThreeStubServer::eth_storageAtI);
-            this->bindAndAddMethod(new jsonrpc::Procedure("eth_countAt", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_REAL, "param1",jsonrpc::JSON_STRING, NULL), &AbstractWebThreeStubServer::eth_countAtI);
-            this->bindAndAddMethod(new jsonrpc::Procedure("eth_codeAt", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_STRING, "param1",jsonrpc::JSON_STRING, NULL), &AbstractWebThreeStubServer::eth_codeAtI);
-            this->bindAndAddMethod(new jsonrpc::Procedure("eth_transact", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_STRING, "param1",jsonrpc::JSON_OBJECT, NULL), &AbstractWebThreeStubServer::eth_transactI);
-            this->bindAndAddMethod(new jsonrpc::Procedure("eth_call", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_STRING, "param1",jsonrpc::JSON_OBJECT, NULL), &AbstractWebThreeStubServer::eth_callI);
-            this->bindAndAddMethod(new jsonrpc::Procedure("eth_flush", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_BOOLEAN,  NULL), &AbstractWebThreeStubServer::eth_flushI);
-            this->bindAndAddMethod(new jsonrpc::Procedure("eth_blockByHash", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_OBJECT, "param1",jsonrpc::JSON_STRING, NULL), &AbstractWebThreeStubServer::eth_blockByHashI);
-            this->bindAndAddMethod(new jsonrpc::Procedure("eth_blockByNumber", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_OBJECT, "param1",jsonrpc::JSON_INTEGER, NULL), &AbstractWebThreeStubServer::eth_blockByNumberI);
-            this->bindAndAddMethod(new jsonrpc::Procedure("eth_transactionByHash", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_OBJECT, "param1",jsonrpc::JSON_STRING,"param2",jsonrpc::JSON_INTEGER, NULL), &AbstractWebThreeStubServer::eth_transactionByHashI);
-            this->bindAndAddMethod(new jsonrpc::Procedure("eth_transactionByNumber", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_OBJECT, "param1",jsonrpc::JSON_INTEGER,"param2",jsonrpc::JSON_INTEGER, NULL), &AbstractWebThreeStubServer::eth_transactionByNumberI);
-            this->bindAndAddMethod(new jsonrpc::Procedure("eth_uncleByHash", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_OBJECT, "param1",jsonrpc::JSON_STRING,"param2",jsonrpc::JSON_INTEGER, NULL), &AbstractWebThreeStubServer::eth_uncleByHashI);
-            this->bindAndAddMethod(new jsonrpc::Procedure("eth_uncleByNumber", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_OBJECT, "param1",jsonrpc::JSON_INTEGER,"param2",jsonrpc::JSON_INTEGER, NULL), &AbstractWebThreeStubServer::eth_uncleByNumberI);
-            this->bindAndAddMethod(new jsonrpc::Procedure("eth_compilers", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_ARRAY,  NULL), &AbstractWebThreeStubServer::eth_compilersI);
-            this->bindAndAddMethod(new jsonrpc::Procedure("eth_lll", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_STRING, "param1",jsonrpc::JSON_STRING, NULL), &AbstractWebThreeStubServer::eth_lllI);
-            this->bindAndAddMethod(new jsonrpc::Procedure("eth_solidity", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_STRING, "param1",jsonrpc::JSON_STRING, NULL), &AbstractWebThreeStubServer::eth_solidityI);
-            this->bindAndAddMethod(new jsonrpc::Procedure("eth_serpent", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_STRING, "param1",jsonrpc::JSON_STRING, NULL), &AbstractWebThreeStubServer::eth_serpentI);
-            this->bindAndAddMethod(new jsonrpc::Procedure("eth_newFilter", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_INTEGER, "param1",jsonrpc::JSON_OBJECT, NULL), &AbstractWebThreeStubServer::eth_newFilterI);
-            this->bindAndAddMethod(new jsonrpc::Procedure("eth_newFilterString", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_INTEGER, "param1",jsonrpc::JSON_STRING, NULL), &AbstractWebThreeStubServer::eth_newFilterStringI);
-            this->bindAndAddMethod(new jsonrpc::Procedure("eth_uninstallFilter", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_BOOLEAN, "param1",jsonrpc::JSON_INTEGER, NULL), &AbstractWebThreeStubServer::eth_uninstallFilterI);
-            this->bindAndAddMethod(new jsonrpc::Procedure("eth_changed", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_ARRAY, "param1",jsonrpc::JSON_INTEGER, NULL), &AbstractWebThreeStubServer::eth_changedI);
-            this->bindAndAddMethod(new jsonrpc::Procedure("eth_filterLogs", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_ARRAY, "param1",jsonrpc::JSON_INTEGER, NULL), &AbstractWebThreeStubServer::eth_filterLogsI);
-            this->bindAndAddMethod(new jsonrpc::Procedure("eth_logs", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_ARRAY, "param1",jsonrpc::JSON_OBJECT, NULL), &AbstractWebThreeStubServer::eth_logsI);
-            this->bindAndAddMethod(new jsonrpc::Procedure("eth_getWork", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_ARRAY,  NULL), &AbstractWebThreeStubServer::eth_getWorkI);
-            this->bindAndAddMethod(new jsonrpc::Procedure("eth_submitWork", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_BOOLEAN, "param1",jsonrpc::JSON_STRING, NULL), &AbstractWebThreeStubServer::eth_submitWorkI);
-            this->bindAndAddMethod(new jsonrpc::Procedure("db_put", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_BOOLEAN, "param1",jsonrpc::JSON_STRING,"param2",jsonrpc::JSON_STRING,"param3",jsonrpc::JSON_STRING, NULL), &AbstractWebThreeStubServer::db_putI);
-            this->bindAndAddMethod(new jsonrpc::Procedure("db_get", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_STRING, "param1",jsonrpc::JSON_STRING,"param2",jsonrpc::JSON_STRING, NULL), &AbstractWebThreeStubServer::db_getI);
-            this->bindAndAddMethod(new jsonrpc::Procedure("db_putString", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_BOOLEAN, "param1",jsonrpc::JSON_STRING,"param2",jsonrpc::JSON_STRING,"param3",jsonrpc::JSON_STRING, NULL), &AbstractWebThreeStubServer::db_putStringI);
-            this->bindAndAddMethod(new jsonrpc::Procedure("db_getString", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_STRING, "param1",jsonrpc::JSON_STRING,"param2",jsonrpc::JSON_STRING, NULL), &AbstractWebThreeStubServer::db_getStringI);
-            this->bindAndAddMethod(new jsonrpc::Procedure("shh_post", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_BOOLEAN, "param1",jsonrpc::JSON_OBJECT, NULL), &AbstractWebThreeStubServer::shh_postI);
-            this->bindAndAddMethod(new jsonrpc::Procedure("shh_newIdentity", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_STRING,  NULL), &AbstractWebThreeStubServer::shh_newIdentityI);
-            this->bindAndAddMethod(new jsonrpc::Procedure("shh_haveIdentity", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_BOOLEAN, "param1",jsonrpc::JSON_STRING, NULL), &AbstractWebThreeStubServer::shh_haveIdentityI);
-            this->bindAndAddMethod(new jsonrpc::Procedure("shh_newGroup", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_STRING, "param1",jsonrpc::JSON_STRING,"param2",jsonrpc::JSON_STRING, NULL), &AbstractWebThreeStubServer::shh_newGroupI);
-            this->bindAndAddMethod(new jsonrpc::Procedure("shh_addToGroup", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_STRING, "param1",jsonrpc::JSON_STRING,"param2",jsonrpc::JSON_STRING, NULL), &AbstractWebThreeStubServer::shh_addToGroupI);
-            this->bindAndAddMethod(new jsonrpc::Procedure("shh_newFilter", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_INTEGER, "param1",jsonrpc::JSON_OBJECT, NULL), &AbstractWebThreeStubServer::shh_newFilterI);
-            this->bindAndAddMethod(new jsonrpc::Procedure("shh_uninstallFilter", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_BOOLEAN, "param1",jsonrpc::JSON_INTEGER, NULL), &AbstractWebThreeStubServer::shh_uninstallFilterI);
-            this->bindAndAddMethod(new jsonrpc::Procedure("shh_changed", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_ARRAY, "param1",jsonrpc::JSON_INTEGER, NULL), &AbstractWebThreeStubServer::shh_changedI);
+            this->bindAndAddMethod(jsonrpc::Procedure("web3_sha3", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_STRING, "param1",jsonrpc::JSON_STRING, NULL), &AbstractWebThreeStubServer::web3_sha3I);
+            this->bindAndAddMethod(jsonrpc::Procedure("eth_coinbase", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_STRING,  NULL), &AbstractWebThreeStubServer::eth_coinbaseI);
+            this->bindAndAddMethod(jsonrpc::Procedure("eth_setCoinbase", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_BOOLEAN, "param1",jsonrpc::JSON_STRING, NULL), &AbstractWebThreeStubServer::eth_setCoinbaseI);
+            this->bindAndAddMethod(jsonrpc::Procedure("eth_listening", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_BOOLEAN,  NULL), &AbstractWebThreeStubServer::eth_listeningI);
+            this->bindAndAddMethod(jsonrpc::Procedure("eth_setListening", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_BOOLEAN, "param1",jsonrpc::JSON_BOOLEAN, NULL), &AbstractWebThreeStubServer::eth_setListeningI);
+            this->bindAndAddMethod(jsonrpc::Procedure("eth_mining", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_BOOLEAN,  NULL), &AbstractWebThreeStubServer::eth_miningI);
+            this->bindAndAddMethod(jsonrpc::Procedure("eth_setMining", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_BOOLEAN, "param1",jsonrpc::JSON_BOOLEAN, NULL), &AbstractWebThreeStubServer::eth_setMiningI);
+            this->bindAndAddMethod(jsonrpc::Procedure("eth_gasPrice", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_STRING,  NULL), &AbstractWebThreeStubServer::eth_gasPriceI);
+            this->bindAndAddMethod(jsonrpc::Procedure("eth_accounts", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_ARRAY,  NULL), &AbstractWebThreeStubServer::eth_accountsI);
+            this->bindAndAddMethod(jsonrpc::Procedure("eth_peerCount", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_INTEGER,  NULL), &AbstractWebThreeStubServer::eth_peerCountI);
+            this->bindAndAddMethod(jsonrpc::Procedure("eth_defaultBlock", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_INTEGER,  NULL), &AbstractWebThreeStubServer::eth_defaultBlockI);
+            this->bindAndAddMethod(jsonrpc::Procedure("eth_setDefaultBlock", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_BOOLEAN, "param1",jsonrpc::JSON_INTEGER, NULL), &AbstractWebThreeStubServer::eth_setDefaultBlockI);
+            this->bindAndAddMethod(jsonrpc::Procedure("eth_number", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_INTEGER,  NULL), &AbstractWebThreeStubServer::eth_numberI);
+            this->bindAndAddMethod(jsonrpc::Procedure("eth_balanceAt", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_STRING, "param1",jsonrpc::JSON_STRING, NULL), &AbstractWebThreeStubServer::eth_balanceAtI);
+            this->bindAndAddMethod(jsonrpc::Procedure("eth_stateAt", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_STRING, "param1",jsonrpc::JSON_STRING,"param2",jsonrpc::JSON_STRING, NULL), &AbstractWebThreeStubServer::eth_stateAtI);
+            this->bindAndAddMethod(jsonrpc::Procedure("eth_storageAt", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_OBJECT, "param1",jsonrpc::JSON_STRING, NULL), &AbstractWebThreeStubServer::eth_storageAtI);
+            this->bindAndAddMethod(jsonrpc::Procedure("eth_countAt", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_REAL, "param1",jsonrpc::JSON_STRING, NULL), &AbstractWebThreeStubServer::eth_countAtI);
+            this->bindAndAddMethod(jsonrpc::Procedure("eth_codeAt", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_STRING, "param1",jsonrpc::JSON_STRING, NULL), &AbstractWebThreeStubServer::eth_codeAtI);
+            this->bindAndAddMethod(jsonrpc::Procedure("eth_transact", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_STRING, "param1",jsonrpc::JSON_OBJECT, NULL), &AbstractWebThreeStubServer::eth_transactI);
+            this->bindAndAddMethod(jsonrpc::Procedure("eth_call", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_STRING, "param1",jsonrpc::JSON_OBJECT, NULL), &AbstractWebThreeStubServer::eth_callI);
+            this->bindAndAddMethod(jsonrpc::Procedure("eth_flush", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_BOOLEAN,  NULL), &AbstractWebThreeStubServer::eth_flushI);
+            this->bindAndAddMethod(jsonrpc::Procedure("eth_blockByHash", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_OBJECT, "param1",jsonrpc::JSON_STRING, NULL), &AbstractWebThreeStubServer::eth_blockByHashI);
+            this->bindAndAddMethod(jsonrpc::Procedure("eth_blockByNumber", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_OBJECT, "param1",jsonrpc::JSON_INTEGER, NULL), &AbstractWebThreeStubServer::eth_blockByNumberI);
+            this->bindAndAddMethod(jsonrpc::Procedure("eth_transactionByHash", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_OBJECT, "param1",jsonrpc::JSON_STRING,"param2",jsonrpc::JSON_INTEGER, NULL), &AbstractWebThreeStubServer::eth_transactionByHashI);
+            this->bindAndAddMethod(jsonrpc::Procedure("eth_transactionByNumber", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_OBJECT, "param1",jsonrpc::JSON_INTEGER,"param2",jsonrpc::JSON_INTEGER, NULL), &AbstractWebThreeStubServer::eth_transactionByNumberI);
+            this->bindAndAddMethod(jsonrpc::Procedure("eth_uncleByHash", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_OBJECT, "param1",jsonrpc::JSON_STRING,"param2",jsonrpc::JSON_INTEGER, NULL), &AbstractWebThreeStubServer::eth_uncleByHashI);
+            this->bindAndAddMethod(jsonrpc::Procedure("eth_uncleByNumber", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_OBJECT, "param1",jsonrpc::JSON_INTEGER,"param2",jsonrpc::JSON_INTEGER, NULL), &AbstractWebThreeStubServer::eth_uncleByNumberI);
+            this->bindAndAddMethod(jsonrpc::Procedure("eth_compilers", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_ARRAY,  NULL), &AbstractWebThreeStubServer::eth_compilersI);
+            this->bindAndAddMethod(jsonrpc::Procedure("eth_lll", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_STRING, "param1",jsonrpc::JSON_STRING, NULL), &AbstractWebThreeStubServer::eth_lllI);
+            this->bindAndAddMethod(jsonrpc::Procedure("eth_solidity", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_STRING, "param1",jsonrpc::JSON_STRING, NULL), &AbstractWebThreeStubServer::eth_solidityI);
+            this->bindAndAddMethod(jsonrpc::Procedure("eth_serpent", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_STRING, "param1",jsonrpc::JSON_STRING, NULL), &AbstractWebThreeStubServer::eth_serpentI);
+            this->bindAndAddMethod(jsonrpc::Procedure("eth_newFilter", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_INTEGER, "param1",jsonrpc::JSON_OBJECT, NULL), &AbstractWebThreeStubServer::eth_newFilterI);
+            this->bindAndAddMethod(jsonrpc::Procedure("eth_newFilterString", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_INTEGER, "param1",jsonrpc::JSON_STRING, NULL), &AbstractWebThreeStubServer::eth_newFilterStringI);
+            this->bindAndAddMethod(jsonrpc::Procedure("eth_uninstallFilter", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_BOOLEAN, "param1",jsonrpc::JSON_INTEGER, NULL), &AbstractWebThreeStubServer::eth_uninstallFilterI);
+            this->bindAndAddMethod(jsonrpc::Procedure("eth_changed", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_ARRAY, "param1",jsonrpc::JSON_INTEGER, NULL), &AbstractWebThreeStubServer::eth_changedI);
+            this->bindAndAddMethod(jsonrpc::Procedure("eth_filterLogs", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_ARRAY, "param1",jsonrpc::JSON_INTEGER, NULL), &AbstractWebThreeStubServer::eth_filterLogsI);
+            this->bindAndAddMethod(jsonrpc::Procedure("eth_logs", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_ARRAY, "param1",jsonrpc::JSON_OBJECT, NULL), &AbstractWebThreeStubServer::eth_logsI);
+            this->bindAndAddMethod(jsonrpc::Procedure("eth_getWork", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_ARRAY,  NULL), &AbstractWebThreeStubServer::eth_getWorkI);
+            this->bindAndAddMethod(jsonrpc::Procedure("eth_submitWork", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_BOOLEAN, "param1",jsonrpc::JSON_STRING, NULL), &AbstractWebThreeStubServer::eth_submitWorkI);
+            this->bindAndAddMethod(jsonrpc::Procedure("db_put", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_BOOLEAN, "param1",jsonrpc::JSON_STRING,"param2",jsonrpc::JSON_STRING,"param3",jsonrpc::JSON_STRING, NULL), &AbstractWebThreeStubServer::db_putI);
+            this->bindAndAddMethod(jsonrpc::Procedure("db_get", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_STRING, "param1",jsonrpc::JSON_STRING,"param2",jsonrpc::JSON_STRING, NULL), &AbstractWebThreeStubServer::db_getI);
+            this->bindAndAddMethod(jsonrpc::Procedure("db_putString", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_BOOLEAN, "param1",jsonrpc::JSON_STRING,"param2",jsonrpc::JSON_STRING,"param3",jsonrpc::JSON_STRING, NULL), &AbstractWebThreeStubServer::db_putStringI);
+            this->bindAndAddMethod(jsonrpc::Procedure("db_getString", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_STRING, "param1",jsonrpc::JSON_STRING,"param2",jsonrpc::JSON_STRING, NULL), &AbstractWebThreeStubServer::db_getStringI);
+            this->bindAndAddMethod(jsonrpc::Procedure("shh_post", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_BOOLEAN, "param1",jsonrpc::JSON_OBJECT, NULL), &AbstractWebThreeStubServer::shh_postI);
+            this->bindAndAddMethod(jsonrpc::Procedure("shh_newIdentity", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_STRING,  NULL), &AbstractWebThreeStubServer::shh_newIdentityI);
+            this->bindAndAddMethod(jsonrpc::Procedure("shh_haveIdentity", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_BOOLEAN, "param1",jsonrpc::JSON_STRING, NULL), &AbstractWebThreeStubServer::shh_haveIdentityI);
+            this->bindAndAddMethod(jsonrpc::Procedure("shh_newGroup", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_STRING, "param1",jsonrpc::JSON_STRING,"param2",jsonrpc::JSON_STRING, NULL), &AbstractWebThreeStubServer::shh_newGroupI);
+            this->bindAndAddMethod(jsonrpc::Procedure("shh_addToGroup", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_STRING, "param1",jsonrpc::JSON_STRING,"param2",jsonrpc::JSON_STRING, NULL), &AbstractWebThreeStubServer::shh_addToGroupI);
+            this->bindAndAddMethod(jsonrpc::Procedure("shh_newFilter", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_INTEGER, "param1",jsonrpc::JSON_OBJECT, NULL), &AbstractWebThreeStubServer::shh_newFilterI);
+            this->bindAndAddMethod(jsonrpc::Procedure("shh_uninstallFilter", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_BOOLEAN, "param1",jsonrpc::JSON_INTEGER, NULL), &AbstractWebThreeStubServer::shh_uninstallFilterI);
+            this->bindAndAddMethod(jsonrpc::Procedure("shh_changed", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_ARRAY, "param1",jsonrpc::JSON_INTEGER, NULL), &AbstractWebThreeStubServer::shh_changedI);
         }
 
         inline virtual void web3_sha3I(const Json::Value &request, Json::Value &response)
@@ -71,6 +71,7 @@ class AbstractWebThreeStubServer : public jsonrpc::AbstractServer<AbstractWebThr
         }
         inline virtual void eth_coinbaseI(const Json::Value &request, Json::Value &response)
         {
+            (void)request;
             response = this->eth_coinbase();
         }
         inline virtual void eth_setCoinbaseI(const Json::Value &request, Json::Value &response)
@@ -79,6 +80,7 @@ class AbstractWebThreeStubServer : public jsonrpc::AbstractServer<AbstractWebThr
         }
         inline virtual void eth_listeningI(const Json::Value &request, Json::Value &response)
         {
+            (void)request;
             response = this->eth_listening();
         }
         inline virtual void eth_setListeningI(const Json::Value &request, Json::Value &response)
@@ -87,6 +89,7 @@ class AbstractWebThreeStubServer : public jsonrpc::AbstractServer<AbstractWebThr
         }
         inline virtual void eth_miningI(const Json::Value &request, Json::Value &response)
         {
+            (void)request;
             response = this->eth_mining();
         }
         inline virtual void eth_setMiningI(const Json::Value &request, Json::Value &response)
@@ -95,18 +98,22 @@ class AbstractWebThreeStubServer : public jsonrpc::AbstractServer<AbstractWebThr
         }
         inline virtual void eth_gasPriceI(const Json::Value &request, Json::Value &response)
         {
+            (void)request;
             response = this->eth_gasPrice();
         }
         inline virtual void eth_accountsI(const Json::Value &request, Json::Value &response)
         {
+            (void)request;
             response = this->eth_accounts();
         }
         inline virtual void eth_peerCountI(const Json::Value &request, Json::Value &response)
         {
+            (void)request;
             response = this->eth_peerCount();
         }
         inline virtual void eth_defaultBlockI(const Json::Value &request, Json::Value &response)
         {
+            (void)request;
             response = this->eth_defaultBlock();
         }
         inline virtual void eth_setDefaultBlockI(const Json::Value &request, Json::Value &response)
@@ -115,6 +122,7 @@ class AbstractWebThreeStubServer : public jsonrpc::AbstractServer<AbstractWebThr
         }
         inline virtual void eth_numberI(const Json::Value &request, Json::Value &response)
         {
+            (void)request;
             response = this->eth_number();
         }
         inline virtual void eth_balanceAtI(const Json::Value &request, Json::Value &response)
@@ -147,6 +155,7 @@ class AbstractWebThreeStubServer : public jsonrpc::AbstractServer<AbstractWebThr
         }
         inline virtual void eth_flushI(const Json::Value &request, Json::Value &response)
         {
+            (void)request;
             response = this->eth_flush();
         }
         inline virtual void eth_blockByHashI(const Json::Value &request, Json::Value &response)
@@ -175,6 +184,7 @@ class AbstractWebThreeStubServer : public jsonrpc::AbstractServer<AbstractWebThr
         }
         inline virtual void eth_compilersI(const Json::Value &request, Json::Value &response)
         {
+            (void)request;
             response = this->eth_compilers();
         }
         inline virtual void eth_lllI(const Json::Value &request, Json::Value &response)
@@ -215,6 +225,7 @@ class AbstractWebThreeStubServer : public jsonrpc::AbstractServer<AbstractWebThr
         }
         inline virtual void eth_getWorkI(const Json::Value &request, Json::Value &response)
         {
+            (void)request;
             response = this->eth_getWork();
         }
         inline virtual void eth_submitWorkI(const Json::Value &request, Json::Value &response)
@@ -243,6 +254,7 @@ class AbstractWebThreeStubServer : public jsonrpc::AbstractServer<AbstractWebThr
         }
         inline virtual void shh_newIdentityI(const Json::Value &request, Json::Value &response)
         {
+            (void)request;
             response = this->shh_newIdentity();
         }
         inline virtual void shh_haveIdentityI(const Json::Value &request, Json::Value &response)
@@ -273,14 +285,14 @@ class AbstractWebThreeStubServer : public jsonrpc::AbstractServer<AbstractWebThr
         virtual std::string eth_coinbase() = 0;
         virtual bool eth_setCoinbase(const std::string& param1) = 0;
         virtual bool eth_listening() = 0;
-        virtual bool eth_setListening(const bool& param1) = 0;
+        virtual bool eth_setListening(bool param1) = 0;
         virtual bool eth_mining() = 0;
-        virtual bool eth_setMining(const bool& param1) = 0;
+        virtual bool eth_setMining(bool param1) = 0;
         virtual std::string eth_gasPrice() = 0;
         virtual Json::Value eth_accounts() = 0;
         virtual int eth_peerCount() = 0;
         virtual int eth_defaultBlock() = 0;
-        virtual bool eth_setDefaultBlock(const int& param1) = 0;
+        virtual bool eth_setDefaultBlock(int param1) = 0;
         virtual int eth_number() = 0;
         virtual std::string eth_balanceAt(const std::string& param1) = 0;
         virtual std::string eth_stateAt(const std::string& param1, const std::string& param2) = 0;
@@ -291,20 +303,20 @@ class AbstractWebThreeStubServer : public jsonrpc::AbstractServer<AbstractWebThr
         virtual std::string eth_call(const Json::Value& param1) = 0;
         virtual bool eth_flush() = 0;
         virtual Json::Value eth_blockByHash(const std::string& param1) = 0;
-        virtual Json::Value eth_blockByNumber(const int& param1) = 0;
-        virtual Json::Value eth_transactionByHash(const std::string& param1, const int& param2) = 0;
-        virtual Json::Value eth_transactionByNumber(const int& param1, const int& param2) = 0;
-        virtual Json::Value eth_uncleByHash(const std::string& param1, const int& param2) = 0;
-        virtual Json::Value eth_uncleByNumber(const int& param1, const int& param2) = 0;
+        virtual Json::Value eth_blockByNumber(int param1) = 0;
+        virtual Json::Value eth_transactionByHash(const std::string& param1, int param2) = 0;
+        virtual Json::Value eth_transactionByNumber(int param1, int param2) = 0;
+        virtual Json::Value eth_uncleByHash(const std::string& param1, int param2) = 0;
+        virtual Json::Value eth_uncleByNumber(int param1, int param2) = 0;
         virtual Json::Value eth_compilers() = 0;
         virtual std::string eth_lll(const std::string& param1) = 0;
         virtual std::string eth_solidity(const std::string& param1) = 0;
         virtual std::string eth_serpent(const std::string& param1) = 0;
         virtual int eth_newFilter(const Json::Value& param1) = 0;
         virtual int eth_newFilterString(const std::string& param1) = 0;
-        virtual bool eth_uninstallFilter(const int& param1) = 0;
-        virtual Json::Value eth_changed(const int& param1) = 0;
-        virtual Json::Value eth_filterLogs(const int& param1) = 0;
+        virtual bool eth_uninstallFilter(int param1) = 0;
+        virtual Json::Value eth_changed(int param1) = 0;
+        virtual Json::Value eth_filterLogs(int param1) = 0;
         virtual Json::Value eth_logs(const Json::Value& param1) = 0;
         virtual Json::Value eth_getWork() = 0;
         virtual bool eth_submitWork(const std::string& param1) = 0;
@@ -318,8 +330,8 @@ class AbstractWebThreeStubServer : public jsonrpc::AbstractServer<AbstractWebThr
         virtual std::string shh_newGroup(const std::string& param1, const std::string& param2) = 0;
         virtual std::string shh_addToGroup(const std::string& param1, const std::string& param2) = 0;
         virtual int shh_newFilter(const Json::Value& param1) = 0;
-        virtual bool shh_uninstallFilter(const int& param1) = 0;
-        virtual Json::Value shh_changed(const int& param1) = 0;
+        virtual bool shh_uninstallFilter(int param1) = 0;
+        virtual Json::Value shh_changed(int param1) = 0;
 };
 
-#endif //JSONRPC_CPP_ABSTRACTWEBTHREESTUBSERVER_H_
+#endif //JSONRPC_CPP_STUB_ABSTRACTWEBTHREESTUBSERVER_H_

--- a/mix/Web3Server.cpp
+++ b/mix/Web3Server.cpp
@@ -55,7 +55,7 @@ void Web3Server::put(std::string const& _name, std::string const& _key, std::str
 	m_db[k] = _value;
 }
 
-Json::Value Web3Server::eth_changed(int const& _id)
+Json::Value Web3Server::eth_changed(int _id)
 {
 	return WebThreeStubServerBase::eth_changed(_id);
 }

--- a/mix/Web3Server.h
+++ b/mix/Web3Server.h
@@ -44,7 +44,7 @@ signals:
 	void newTransaction();
 
 protected:
-	virtual Json::Value eth_changed(int const& _id) override;
+	virtual Json::Value eth_changed(int _id) override;
 	virtual std::string eth_transact(Json::Value const& _json) override;
 	virtual std::string eth_call(Json::Value const& _json) override;
 

--- a/test/webthreestubclient.h
+++ b/test/webthreestubclient.h
@@ -10,7 +10,7 @@
 class WebThreeStubClient : public jsonrpc::Client
 {
     public:
-        WebThreeStubClient(jsonrpc::IClientConnector &conn) : jsonrpc::Client(conn) {}
+        WebThreeStubClient(jsonrpc::IClientConnector &conn, jsonrpc::clientVersion_t type = jsonrpc::JSONRPC_CLIENT_V2) : jsonrpc::Client(conn, type) {}
 
         std::string web3_sha3(const std::string& param1) throw (jsonrpc::JsonRpcException)
         {
@@ -52,7 +52,7 @@ class WebThreeStubClient : public jsonrpc::Client
             else
                 throw jsonrpc::JsonRpcException(jsonrpc::Errors::ERROR_CLIENT_INVALID_RESPONSE, result.toStyledString());
         }
-        bool eth_setListening(const bool& param1) throw (jsonrpc::JsonRpcException)
+        bool eth_setListening(bool param1) throw (jsonrpc::JsonRpcException)
         {
             Json::Value p;
             p.append(param1);
@@ -72,7 +72,7 @@ class WebThreeStubClient : public jsonrpc::Client
             else
                 throw jsonrpc::JsonRpcException(jsonrpc::Errors::ERROR_CLIENT_INVALID_RESPONSE, result.toStyledString());
         }
-        bool eth_setMining(const bool& param1) throw (jsonrpc::JsonRpcException)
+        bool eth_setMining(bool param1) throw (jsonrpc::JsonRpcException)
         {
             Json::Value p;
             p.append(param1);
@@ -122,7 +122,7 @@ class WebThreeStubClient : public jsonrpc::Client
             else
                 throw jsonrpc::JsonRpcException(jsonrpc::Errors::ERROR_CLIENT_INVALID_RESPONSE, result.toStyledString());
         }
-        bool eth_setDefaultBlock(const int& param1) throw (jsonrpc::JsonRpcException)
+        bool eth_setDefaultBlock(int param1) throw (jsonrpc::JsonRpcException)
         {
             Json::Value p;
             p.append(param1);
@@ -233,7 +233,7 @@ class WebThreeStubClient : public jsonrpc::Client
             else
                 throw jsonrpc::JsonRpcException(jsonrpc::Errors::ERROR_CLIENT_INVALID_RESPONSE, result.toStyledString());
         }
-        Json::Value eth_blockByNumber(const int& param1) throw (jsonrpc::JsonRpcException)
+        Json::Value eth_blockByNumber(int param1) throw (jsonrpc::JsonRpcException)
         {
             Json::Value p;
             p.append(param1);
@@ -243,7 +243,7 @@ class WebThreeStubClient : public jsonrpc::Client
             else
                 throw jsonrpc::JsonRpcException(jsonrpc::Errors::ERROR_CLIENT_INVALID_RESPONSE, result.toStyledString());
         }
-        Json::Value eth_transactionByHash(const std::string& param1, const int& param2) throw (jsonrpc::JsonRpcException)
+        Json::Value eth_transactionByHash(const std::string& param1, int param2) throw (jsonrpc::JsonRpcException)
         {
             Json::Value p;
             p.append(param1);
@@ -254,7 +254,7 @@ class WebThreeStubClient : public jsonrpc::Client
             else
                 throw jsonrpc::JsonRpcException(jsonrpc::Errors::ERROR_CLIENT_INVALID_RESPONSE, result.toStyledString());
         }
-        Json::Value eth_transactionByNumber(const int& param1, const int& param2) throw (jsonrpc::JsonRpcException)
+        Json::Value eth_transactionByNumber(int param1, int param2) throw (jsonrpc::JsonRpcException)
         {
             Json::Value p;
             p.append(param1);
@@ -265,7 +265,7 @@ class WebThreeStubClient : public jsonrpc::Client
             else
                 throw jsonrpc::JsonRpcException(jsonrpc::Errors::ERROR_CLIENT_INVALID_RESPONSE, result.toStyledString());
         }
-        Json::Value eth_uncleByHash(const std::string& param1, const int& param2) throw (jsonrpc::JsonRpcException)
+        Json::Value eth_uncleByHash(const std::string& param1, int param2) throw (jsonrpc::JsonRpcException)
         {
             Json::Value p;
             p.append(param1);
@@ -276,7 +276,7 @@ class WebThreeStubClient : public jsonrpc::Client
             else
                 throw jsonrpc::JsonRpcException(jsonrpc::Errors::ERROR_CLIENT_INVALID_RESPONSE, result.toStyledString());
         }
-        Json::Value eth_uncleByNumber(const int& param1, const int& param2) throw (jsonrpc::JsonRpcException)
+        Json::Value eth_uncleByNumber(int param1, int param2) throw (jsonrpc::JsonRpcException)
         {
             Json::Value p;
             p.append(param1);
@@ -347,7 +347,7 @@ class WebThreeStubClient : public jsonrpc::Client
             else
                 throw jsonrpc::JsonRpcException(jsonrpc::Errors::ERROR_CLIENT_INVALID_RESPONSE, result.toStyledString());
         }
-        bool eth_uninstallFilter(const int& param1) throw (jsonrpc::JsonRpcException)
+        bool eth_uninstallFilter(int param1) throw (jsonrpc::JsonRpcException)
         {
             Json::Value p;
             p.append(param1);
@@ -357,7 +357,7 @@ class WebThreeStubClient : public jsonrpc::Client
             else
                 throw jsonrpc::JsonRpcException(jsonrpc::Errors::ERROR_CLIENT_INVALID_RESPONSE, result.toStyledString());
         }
-        Json::Value eth_changed(const int& param1) throw (jsonrpc::JsonRpcException)
+        Json::Value eth_changed(int param1) throw (jsonrpc::JsonRpcException)
         {
             Json::Value p;
             p.append(param1);
@@ -367,7 +367,7 @@ class WebThreeStubClient : public jsonrpc::Client
             else
                 throw jsonrpc::JsonRpcException(jsonrpc::Errors::ERROR_CLIENT_INVALID_RESPONSE, result.toStyledString());
         }
-        Json::Value eth_filterLogs(const int& param1) throw (jsonrpc::JsonRpcException)
+        Json::Value eth_filterLogs(int param1) throw (jsonrpc::JsonRpcException)
         {
             Json::Value p;
             p.append(param1);
@@ -515,7 +515,7 @@ class WebThreeStubClient : public jsonrpc::Client
             else
                 throw jsonrpc::JsonRpcException(jsonrpc::Errors::ERROR_CLIENT_INVALID_RESPONSE, result.toStyledString());
         }
-        bool shh_uninstallFilter(const int& param1) throw (jsonrpc::JsonRpcException)
+        bool shh_uninstallFilter(int param1) throw (jsonrpc::JsonRpcException)
         {
             Json::Value p;
             p.append(param1);
@@ -525,7 +525,7 @@ class WebThreeStubClient : public jsonrpc::Client
             else
                 throw jsonrpc::JsonRpcException(jsonrpc::Errors::ERROR_CLIENT_INVALID_RESPONSE, result.toStyledString());
         }
-        Json::Value shh_changed(const int& param1) throw (jsonrpc::JsonRpcException)
+        Json::Value shh_changed(int param1) throw (jsonrpc::JsonRpcException)
         {
             Json::Value p;
             p.append(param1);
@@ -537,4 +537,4 @@ class WebThreeStubClient : public jsonrpc::Client
         }
 };
 
-#endif //JSONRPC_CPP_WEBTHREESTUBCLIENT_H_
+#endif //JSONRPC_CPP_STUB_WEBTHREESTUBCLIENT_H_


### PR DESCRIPTION
This has been tested by Marek at MacosX in #970 and by me in ArchLinux.

 This is kind of a duplicate of that PR but it's actually based on the latest develop and I will constantly be rebasing on it since I am now forced to use the latest jsonrpccpp and need this to build.

This will need to be merged as soon as jsonrpccpp 0.4.2 (the latest) is used by all platforms.
(Before that happens the buildbot will of course report build failure)