### PR TITLE
update windows precompiled qt version 5.3 -> 5.4

### DIFF
--- a/extdep/CMakeLists.txt
+++ b/extdep/CMakeLists.txt
@@ -42,7 +42,7 @@ else()
 	endif()
 
 	eth_download(leveldb OSX_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/scripts/leveldb_osx.sh)
-	eth_download(qt)
+	eth_download(qt VERSION 5.4)
 	eth_download(cryptopp)
 	eth_download(boost)
 	eth_download(curl)


### PR DESCRIPTION
Downloading qt-5.4 from [here](http://build.ethdev.com/builds/windows-precompiled/). Mix working on windows.