### PR TITLE
fix GasUsed bug

### DIFF
--- a/libethcore/BlockInfo.cpp
+++ b/libethcore/BlockInfo.cpp
@@ -157,8 +157,8 @@ void BlockInfo::verifyInternals(bytesConstRef _block) const
 	{
 		bytes k = rlp(i);
 		t.insert(&k, tr.data());
-		u256 gp = tr[1].toInt<u256>();
-		mgp = min(mgp, gp);
+		u256 gasprice = tr[1].toInt<u256>();
+		mgp = min(mgp, gasprice); // the minimum gas price is not used for anything //TODO delete?
 		++i;
 	}
 	if (transactionsRoot != t.root())

--- a/libethcore/Exceptions.h
+++ b/libethcore/Exceptions.h
@@ -51,6 +51,7 @@ struct UncleTooOld: virtual dev::Exception {};
 class UncleInChain: virtual public dev::Exception { public: UncleInChain(h256Set _uncles, h256 _block): m_uncles(_uncles), m_block(_block) {} h256Set m_uncles; h256 m_block; virtual const char* what() const noexcept; };
 struct DuplicateUncleNonce: virtual dev::Exception {};
 struct InvalidStateRoot: virtual dev::Exception {};
+struct InvalidGasUsed: virtual dev::Exception {};
 class InvalidTransactionsHash: virtual public dev::Exception { public: InvalidTransactionsHash(h256 _head, h256 _real): m_head(_head), m_real(_real) {} h256 m_head; h256 m_real; virtual const char* what() const noexcept; };
 struct InvalidTransaction: virtual dev::Exception {};
 struct InvalidDifficulty: virtual dev::Exception {};

--- a/libethereum/State.cpp
+++ b/libethereum/State.cpp
@@ -600,6 +600,13 @@ u256 State::enact(bytesConstRef _block, BlockChain const& _bc, bool _checkNonce)
 		BOOST_THROW_EXCEPTION(InvalidStateRoot());
 	}
 
+	if (m_currentBlock.gasUsed != gasUsed())
+	{
+		// Rollback the trie.
+		m_db.rollback();
+		BOOST_THROW_EXCEPTION(InvalidGasUsed() << RequirementError(bigint(gasUsed()), bigint(m_currentBlock.gasUsed)));
+	}
+
 	return tdIncrease;
 }
 


### PR DESCRIPTION
When receiving a block, the gasUsed parameter is not checked at all. One could easily create a consensus fork by sending a block with a wrong gasUsed value (but otherwise correct block). Assuming the other clients do check this paramter, the cpp will accept the block and the other clients don't.