### PR TITLE
JSON-RPC transactionCount && uncleCount, fixed #1027

### DIFF
--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -714,6 +714,20 @@ BlockInfo Client::uncle(h256 _blockHash, unsigned _i) const
 		return BlockInfo();
 }
 
+unsigned Client::transactionCount(h256 _blockHash) const
+{
+	auto bl = m_bc.block(_blockHash);
+	RLP b(bl);
+	return b[1].itemCount();
+}
+
+unsigned Client::uncleCount(h256 _blockHash) const
+{
+	auto bl = m_bc.block(_blockHash);
+	RLP b(bl);
+	return b[2].itemCount();
+}
+
 LocalisedLogEntries Client::logs(LogFilter const& _f) const
 {
 	LocalisedLogEntries ret;

--- a/libethereum/Client.h
+++ b/libethereum/Client.h
@@ -229,6 +229,8 @@ public:
 	virtual BlockDetails blockDetails(h256 _hash) const { return m_bc.details(_hash); }
 	virtual Transaction transaction(h256 _blockHash, unsigned _i) const;
 	virtual BlockInfo uncle(h256 _blockHash, unsigned _i) const;
+	virtual unsigned transactionCount(h256 _blockHash) const;
+	virtual unsigned uncleCount(h256 _blockHash) const;
 
 	/// Differences between transactions.
 	using Interface::diff;

--- a/libethereum/Interface.h
+++ b/libethereum/Interface.h
@@ -103,6 +103,8 @@ public:
 	virtual BlockDetails blockDetails(h256 _hash) const = 0;
 	virtual Transaction transaction(h256 _blockHash, unsigned _i) const = 0;
 	virtual BlockInfo uncle(h256 _blockHash, unsigned _i) const = 0;
+	virtual unsigned transactionCount(h256 _blockHash) const = 0;
+	virtual unsigned uncleCount(h256 _blockHash) const = 0;
 
 	// [EXTRA API]:
 

--- a/libweb3jsonrpc/WebThreeStubServerBase.cpp
+++ b/libweb3jsonrpc/WebThreeStubServerBase.cpp
@@ -367,6 +367,26 @@ double WebThreeStubServerBase::eth_countAt(string const& _address)
 	return (double)(uint64_t)client()->countAt(jsToAddress(_address), client()->getDefault());
 }
 
+double WebThreeStubServerBase::eth_transactionCountByHash(std::string const& _hash)
+{
+	return client()->transactionCount(jsToFixed<32>(_hash));
+}
+
+double WebThreeStubServerBase::eth_transactionCountByNumber(int _number)
+{
+	return client()->transactionCount(client()->hashFromNumber(_number));
+}
+
+double WebThreeStubServerBase::eth_uncleCountByHash(std::string const& _hash)
+{
+	return client()->transactionCount(jsToFixed<32>(_hash));
+}
+
+double WebThreeStubServerBase::eth_uncleCountByNumber(int _number)
+{
+	return client()->transactionCount(client()->hashFromNumber(_number));
+}
+
 int WebThreeStubServerBase::eth_defaultBlock()
 {
 	return client()->getDefault();

--- a/libweb3jsonrpc/WebThreeStubServerBase.h
+++ b/libweb3jsonrpc/WebThreeStubServerBase.h
@@ -76,6 +76,10 @@ public:
 	virtual std::string eth_coinbase();
 	virtual Json::Value eth_compilers();
 	virtual double eth_countAt(std::string const& _address);
+	virtual double eth_transactionCountByHash(std::string const& _hash);
+	virtual double eth_transactionCountByNumber(int _number);
+	virtual double eth_uncleCountByHash(std::string const& _hash);
+	virtual double eth_uncleCountByNumber(int _number);
 	virtual int eth_defaultBlock();
 	virtual std::string eth_gasPrice();
 	virtual Json::Value eth_filterLogs(int _id);

--- a/libweb3jsonrpc/abstractwebthreestubserver.h
+++ b/libweb3jsonrpc/abstractwebthreestubserver.h
@@ -29,6 +29,10 @@ class AbstractWebThreeStubServer : public jsonrpc::AbstractServer<AbstractWebThr
             this->bindAndAddMethod(jsonrpc::Procedure("eth_stateAt", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_STRING, "param1",jsonrpc::JSON_STRING,"param2",jsonrpc::JSON_STRING, NULL), &AbstractWebThreeStubServer::eth_stateAtI);
             this->bindAndAddMethod(jsonrpc::Procedure("eth_storageAt", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_OBJECT, "param1",jsonrpc::JSON_STRING, NULL), &AbstractWebThreeStubServer::eth_storageAtI);
             this->bindAndAddMethod(jsonrpc::Procedure("eth_countAt", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_REAL, "param1",jsonrpc::JSON_STRING, NULL), &AbstractWebThreeStubServer::eth_countAtI);
+            this->bindAndAddMethod(jsonrpc::Procedure("eth_transactionCountByHash", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_REAL, "param1",jsonrpc::JSON_STRING, NULL), &AbstractWebThreeStubServer::eth_transactionCountByHashI);
+            this->bindAndAddMethod(jsonrpc::Procedure("eth_transactionCountByNumber", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_REAL, "param1",jsonrpc::JSON_INTEGER, NULL), &AbstractWebThreeStubServer::eth_transactionCountByNumberI);
+            this->bindAndAddMethod(jsonrpc::Procedure("eth_uncleCountByHash", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_REAL, "param1",jsonrpc::JSON_STRING, NULL), &AbstractWebThreeStubServer::eth_uncleCountByHashI);
+            this->bindAndAddMethod(jsonrpc::Procedure("eth_uncleCountByNumber", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_REAL, "param1",jsonrpc::JSON_INTEGER, NULL), &AbstractWebThreeStubServer::eth_uncleCountByNumberI);
             this->bindAndAddMethod(jsonrpc::Procedure("eth_codeAt", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_STRING, "param1",jsonrpc::JSON_STRING, NULL), &AbstractWebThreeStubServer::eth_codeAtI);
             this->bindAndAddMethod(jsonrpc::Procedure("eth_transact", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_STRING, "param1",jsonrpc::JSON_OBJECT, NULL), &AbstractWebThreeStubServer::eth_transactI);
             this->bindAndAddMethod(jsonrpc::Procedure("eth_call", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_STRING, "param1",jsonrpc::JSON_OBJECT, NULL), &AbstractWebThreeStubServer::eth_callI);
@@ -140,6 +144,22 @@ class AbstractWebThreeStubServer : public jsonrpc::AbstractServer<AbstractWebThr
         inline virtual void eth_countAtI(const Json::Value &request, Json::Value &response)
         {
             response = this->eth_countAt(request[0u].asString());
+        }
+        inline virtual void eth_transactionCountByHashI(const Json::Value &request, Json::Value &response)
+        {
+            response = this->eth_transactionCountByHash(request[0u].asString());
+        }
+        inline virtual void eth_transactionCountByNumberI(const Json::Value &request, Json::Value &response)
+        {
+            response = this->eth_transactionCountByNumber(request[0u].asInt());
+        }
+        inline virtual void eth_uncleCountByHashI(const Json::Value &request, Json::Value &response)
+        {
+            response = this->eth_uncleCountByHash(request[0u].asString());
+        }
+        inline virtual void eth_uncleCountByNumberI(const Json::Value &request, Json::Value &response)
+        {
+            response = this->eth_uncleCountByNumber(request[0u].asInt());
         }
         inline virtual void eth_codeAtI(const Json::Value &request, Json::Value &response)
         {
@@ -298,6 +318,10 @@ class AbstractWebThreeStubServer : public jsonrpc::AbstractServer<AbstractWebThr
         virtual std::string eth_stateAt(const std::string& param1, const std::string& param2) = 0;
         virtual Json::Value eth_storageAt(const std::string& param1) = 0;
         virtual double eth_countAt(const std::string& param1) = 0;
+        virtual double eth_transactionCountByHash(const std::string& param1) = 0;
+        virtual double eth_transactionCountByNumber(int param1) = 0;
+        virtual double eth_uncleCountByHash(const std::string& param1) = 0;
+        virtual double eth_uncleCountByNumber(int param1) = 0;
         virtual std::string eth_codeAt(const std::string& param1) = 0;
         virtual std::string eth_transact(const Json::Value& param1) = 0;
         virtual std::string eth_call(const Json::Value& param1) = 0;

--- a/libweb3jsonrpc/spec.json
+++ b/libweb3jsonrpc/spec.json
@@ -18,6 +18,10 @@
             { "name": "eth_stateAt", "params": ["", ""], "order": [], "returns": ""},
             { "name": "eth_storageAt", "params": [""], "order": [], "returns": {}},
             { "name": "eth_countAt", "params": [""], "order": [], "returns" : 0.0},
+            { "name": "eth_transactionCountByHash", "params": [""], "order": [], "returns" : 0.0},
+            { "name": "eth_transactionCountByNumber", "params": [0], "order": [], "returns" : 0.0},
+            { "name": "eth_uncleCountByHash", "params": [""], "order": [], "returns" : 0.0},
+            { "name": "eth_uncleCountByNumber", "params": [0], "order": [], "returns" : 0.0},
             { "name": "eth_codeAt", "params": [""], "order": [], "returns": ""},
 
             { "name": "eth_transact", "params": [{}], "order": [], "returns": ""},

--- a/mix/MixClient.cpp
+++ b/mix/MixClient.cpp
@@ -463,6 +463,20 @@ eth::BlockInfo MixClient::uncle(h256 _blockHash, unsigned _i) const
 		return BlockInfo();
 }
 
+unsigned MixClient::transactionCount(h256 _blockHash) const
+{
+	auto bl = bc().block(_blockHash);
+	RLP b(bl);
+	return b[1].itemCount();
+}
+
+unsigned MixClient::uncleCount(h256 _blockHash) const
+{
+	auto bl = bc().block(_blockHash);
+	RLP b(bl);
+	return b[2].itemCount();
+}
+
 unsigned MixClient::number() const
 {
 	return bc().number();

--- a/mix/MixClient.h
+++ b/mix/MixClient.h
@@ -71,6 +71,8 @@ public:
 	eth::BlockDetails blockDetails(h256 _hash) const override;
 	eth::Transaction transaction(h256 _blockHash, unsigned _i) const override;
 	eth::BlockInfo uncle(h256 _blockHash, unsigned _i) const override;
+	unsigned transactionCount(h256 _blockHash) const override;
+	unsigned uncleCount(h256 _blockHash) const override;
 	unsigned number() const override;
 	eth::Transactions pending() const override;
 	eth::StateDiff diff(unsigned _txi, h256 _block) const override;

--- a/test/webthreestubclient.h
+++ b/test/webthreestubclient.h
@@ -183,6 +183,46 @@ class WebThreeStubClient : public jsonrpc::Client
             else
                 throw jsonrpc::JsonRpcException(jsonrpc::Errors::ERROR_CLIENT_INVALID_RESPONSE, result.toStyledString());
         }
+        double eth_transactionCountByHash(const std::string& param1) throw (jsonrpc::JsonRpcException)
+        {
+            Json::Value p;
+            p.append(param1);
+            Json::Value result = this->CallMethod("eth_transactionCountByHash",p);
+            if (result.isDouble())
+                return result.asDouble();
+            else
+                throw jsonrpc::JsonRpcException(jsonrpc::Errors::ERROR_CLIENT_INVALID_RESPONSE, result.toStyledString());
+        }
+        double eth_transactionCountByNumber(int param1) throw (jsonrpc::JsonRpcException)
+        {
+            Json::Value p;
+            p.append(param1);
+            Json::Value result = this->CallMethod("eth_transactionCountByNumber",p);
+            if (result.isDouble())
+                return result.asDouble();
+            else
+                throw jsonrpc::JsonRpcException(jsonrpc::Errors::ERROR_CLIENT_INVALID_RESPONSE, result.toStyledString());
+        }
+        double eth_uncleCountByHash(const std::string& param1) throw (jsonrpc::JsonRpcException)
+        {
+            Json::Value p;
+            p.append(param1);
+            Json::Value result = this->CallMethod("eth_uncleCountByHash",p);
+            if (result.isDouble())
+                return result.asDouble();
+            else
+                throw jsonrpc::JsonRpcException(jsonrpc::Errors::ERROR_CLIENT_INVALID_RESPONSE, result.toStyledString());
+        }
+        double eth_uncleCountByNumber(int param1) throw (jsonrpc::JsonRpcException)
+        {
+            Json::Value p;
+            p.append(param1);
+            Json::Value result = this->CallMethod("eth_uncleCountByNumber",p);
+            if (result.isDouble())
+                return result.asDouble();
+            else
+                throw jsonrpc::JsonRpcException(jsonrpc::Errors::ERROR_CLIENT_INVALID_RESPONSE, result.toStyledString());
+        }
         std::string eth_codeAt(const std::string& param1) throw (jsonrpc::JsonRpcException)
         {
             Json::Value p;


### PR DESCRIPTION
added 4 JSON-RPC methods:
* eth_transactionCountByHash
* eth_transactionCountByNumber
* eth_uncleCountByHash
* eth_uncleCountByNumber

fixes #1027 