### PR TITLE
Bugfix for functions override

### DIFF
--- a/libsolidity/AST.h
+++ b/libsolidity/AST.h
@@ -448,7 +448,7 @@ public:
 
 	virtual bool isLValue() const override;
 	bool isLocalVariable() const { return !!dynamic_cast<FunctionDefinition const*>(getScope()); }
-	bool isFunctionParameter() const;
+	bool isExternalFunctionParameter() const;
 	bool isStateVariable() const { return m_isStateVariable; }
 	bool isIndexed() const { return m_isIndexed; }
 

--- a/libsolidity/NameAndTypeResolver.cpp
+++ b/libsolidity/NameAndTypeResolver.cpp
@@ -333,7 +333,13 @@ void ReferencesResolver::endVisit(VariableDeclaration& _variable)
 	// or mapping
 	if (_variable.getTypeName())
 	{
-		_variable.setType(_variable.getTypeName()->toType());
+		TypePointer type = _variable.getTypeName()->toType();
+		// All byte array parameter types should point to call data
+		if (_variable.isExternalFunctionParameter())
+			if (auto const* byteArrayType = dynamic_cast<ByteArrayType const*>(type.get()))
+				type = byteArrayType->copyForLocation(ByteArrayType::Location::CallData);
+		_variable.setType(type);
+
 		if (!_variable.getType())
 			BOOST_THROW_EXCEPTION(_variable.getTypeName()->createTypeError("Invalid type name"));
 	}

--- a/test/SolidityNameAndTypeResolution.cpp
+++ b/test/SolidityNameAndTypeResolution.cpp
@@ -1163,6 +1163,19 @@ BOOST_AUTO_TEST_CASE(external_argument_delete)
 	BOOST_CHECK_THROW(parseTextAndResolveNames(sourceCode), TypeError);
 }
 
+BOOST_AUTO_TEST_CASE(test_for_bug_override_function_with_bytearray_type)
+{
+	char const* sourceCode = R"(
+		contract Vehicle {
+			function f(bytes _a) external returns (uint256 r) {r = 1;}
+		}
+		contract Bike is Vehicle {
+			function f(bytes _a) external returns (uint256 r) {r = 42;}
+		}
+		)";
+	BOOST_CHECK_NO_THROW(parseTextAndResolveNamesWithChecks(sourceCode));
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 }


### PR DESCRIPTION
- Functions with byte array type parameters can now be safely
  overriden. Parameter location is now set at the right place.

- Also made a test for the fix