### PR TITLE
Sol source libraries

### DIFF
--- a/libsolidity/CompilerStack.cpp
+++ b/libsolidity/CompilerStack.cpp
@@ -65,7 +65,7 @@ bool CompilerStack::addSource(string const& _name, string const& _content, bool 
 {
 	bool existed = m_sources.count(_name) != 0;
 	reset(true);
-	m_sources[_name].scanner = make_shared<Scanner>(CharStream(expanded(_content)), _name);
+	m_sources[_name].scanner = make_shared<Scanner>(CharStream(_content), _name);
 	m_sources[_name].isLibrary = _isLibrary;
 	return existed;
 }
@@ -73,7 +73,7 @@ bool CompilerStack::addSource(string const& _name, string const& _content, bool 
 void CompilerStack::setSource(string const& _sourceCode)
 {
 	reset();
-	addSource("", expanded(_sourceCode));
+	addSource("", _sourceCode);
 }
 
 void CompilerStack::parse()
@@ -127,57 +127,6 @@ vector<string> CompilerStack::getContractNames() const
 	return contractNames;
 }
 
-////// BEGIN: TEMPORARY ONLY
-///
-/// NOTE: THIS INVALIDATES SOURCE POINTERS AND CAN CRASH THE COMPILER
-///
-/// remove once import works properly and we have genesis contracts
-
-string CompilerStack::expanded(string const& _sourceCode)
-{
-	const map<string, string> c_standardSources = map<string, string>{
-		{ "Config", "contract Config{function lookup(uint256 service)constant returns(address a){}function kill(){}function unregister(uint256 id){}function register(uint256 id,address service){}}" },
-		{ "Coin", "contract Coin{function isApprovedFor(address _target,address _proxy)constant returns(bool _r){}function isApproved(address _proxy)constant returns(bool _r){}function sendCoinFrom(address _from,uint256 _val,address _to){}function coinBalanceOf(address _a)constant returns(uint256 _r){}function sendCoin(uint256 _val,address _to){}function coinBalance()constant returns(uint256 _r){}function approve(address _a){}}"},
-		{ "CoinReg", "contract CoinReg{function count()constant returns(uint256 r){}function info(uint256 i)constant returns(address addr,string3 name,uint256 denom){}function register(string3 name,uint256 denom){}function unregister(){}}" },
-		{ "coin", "#require CoinReg\ncontract coin {function coin(string3 name, uint denom) {CoinReg(Config().lookup(3)).register(name, denom);}}" },
-		{ "service", "#require Config\ncontract service{function service(uint _n){Config().register(_n, this);}}" },
-		{ "owned", "contract owned{function owned(){owner = msg.sender;}modifier onlyowner(){if(msg.sender==owner)_}address owner;}" },
-		{ "mortal", "#require owned\ncontract mortal is owned {function kill() { if (msg.sender == owner) suicide(owner); }}" },
-		{ "NameReg", "contract NameReg{function register(string32 name){}function addressOf(string32 name)constant returns(address addr){}function unregister(){}function nameOf(address addr)constant returns(string32 name){}}" },
-		{ "named", "#require Config NameReg\ncontract named {function named(string32 name) {NameReg(Config().lookup(1)).register(name);}}" },
-		{ "std", "#require owned mortal Config NameReg named" },
-	};
-
-	string sub;
-	set<string> got;
-	function<string(string const&)> localExpanded;
-	localExpanded = [&](string const& s) -> string
-	{
-		string ret = s;
-		for (size_t p = 0; p != string::npos;)
-			if ((p = ret.find("#require ")) != string::npos)
-			{
-				string n = ret.substr(p + 9, ret.find_first_of('\n', p + 9) - p - 9);
-				ret.replace(p, n.size() + 9, "");
-				vector<string> rs;
-				boost::split(rs, n, boost::is_any_of(" \t,"), boost::token_compress_on);
-				for (auto const& r: rs)
-					if (!got.count(r))
-					{
-						if (c_standardSources.count(r))
-							sub.append("\n" + localExpanded(c_standardSources.at(r)) + "\n");
-						got.insert(r);
-					}
-			}
-			// TODO: remove once we have genesis contracts.
-			else if ((p = ret.find("Config()")) != string::npos)
-				ret.replace(p, 8, "Config(0xc6d9d2cd449a754c494264e1809c50e34d64562b)");
-		return ret;
-	};
-	return sub + localExpanded(_sourceCode);
-}
-
-////// END: TEMPORARY ONLY
 
 void CompilerStack::compile(bool _optimize)
 {

--- a/libsolidity/CompilerStack.cpp
+++ b/libsolidity/CompilerStack.cpp
@@ -58,14 +58,15 @@ CompilerStack::CompilerStack(bool _addStandardSources):
 	m_addStandardSources(_addStandardSources), m_parseSuccessful(false)
 {
 	if (m_addStandardSources)
-		addSources(StandardSources);
+		addSources(StandardSources, true); // add them as libraries
 }
 
-bool CompilerStack::addSource(string const& _name, string const& _content)
+bool CompilerStack::addSource(string const& _name, string const& _content, bool _isLibrary)
 {
 	bool existed = m_sources.count(_name) != 0;
 	reset(true);
 	m_sources[_name].scanner = make_shared<Scanner>(CharStream(expanded(_content)), _name);
+	m_sources[_name].isLibrary = _isLibrary;
 	return existed;
 }
 
@@ -328,7 +329,8 @@ void CompilerStack::resolveImports()
 	};
 
 	for (auto const& sourcePair: m_sources)
-		toposort(&sourcePair.second);
+		if (!sourcePair.second.isLibrary)
+			toposort(&sourcePair.second);
 
 	swap(m_sourceOrder, sourceOrder);
 }

--- a/libsolidity/CompilerStack.h
+++ b/libsolidity/CompilerStack.h
@@ -64,8 +64,8 @@ public:
 
 	/// Adds a source object (e.g. file) to the parser. After this, parse has to be called again.
 	/// @returns true if a source object by the name already existed and was replaced.
-	void addSources(std::map<std::string, std::string> const& _nameContents) { for (auto const& i: _nameContents) addSource(i.first, i.second); }
-	bool addSource(std::string const& _name, std::string const& _content);
+	void addSources(std::map<std::string, std::string> const& _nameContents, bool _isLibrary = false) { for (auto const& i: _nameContents) addSource(i.first, i.second, _isLibrary); }
+	bool addSource(std::string const& _name, std::string const& _content, bool _isLibrary = false);
 	void setSource(std::string const& _sourceCode);
 	/// Parses all source units that were added
 	void parse();
@@ -125,7 +125,8 @@ private:
 		std::shared_ptr<Scanner> scanner;
 		std::shared_ptr<SourceUnit> ast;
 		std::string interface;
-		void reset() { scanner.reset(); ast.reset(); interface.clear(); }
+		bool isLibrary;
+		void reset() { scanner.reset(); ast.reset(); interface.clear(); isLibrary = false;}
 	};
 
 	struct Contract

--- a/libsolidity/CompilerStack.h
+++ b/libsolidity/CompilerStack.h
@@ -125,7 +125,7 @@ private:
 		std::shared_ptr<Scanner> scanner;
 		std::shared_ptr<SourceUnit> ast;
 		std::string interface;
-		bool isLibrary;
+		bool isLibrary = false;
 		void reset() { scanner.reset(); ast.reset(); interface.clear(); isLibrary = false;}
 	};
 

--- a/libsolidity/CompilerStack.h
+++ b/libsolidity/CompilerStack.h
@@ -144,10 +144,6 @@ private:
 		Contract();
 	};
 
-	/// Expand source code with preprocessor-like includes.
-	/// @todo Replace with better framework.
-	std::string expanded(std::string const& _sourceCode);
-
 	void reset(bool _keepSources = false);
 	void resolveImports();
 


### PR DESCRIPTION
Turned out to be smaller than expected.

Some source units can be added as Libraries. If that is so, they they are compiled iff they are requested by an import statement.

Removed the temporary `#require Contract` preprocessor hack. Those contracts are now be added as libraries.

There already are some tests in the `EndToEndTests` which check for usage of the std library so this should actually already be tested.
