### PR TITLE
Fixed microhttpd deployment

### DIFF
--- a/alethzero/CMakeLists.txt
+++ b/alethzero/CMakeLists.txt
@@ -58,5 +58,5 @@ if (NOT ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC"))
 endif()
 
 # eth_install_executable is defined in cmake/EthExecutableHelper.cmake
-eth_install_executable(${EXECUTABLE})
+eth_install_executable(${EXECUTABLE} DLLS ${MHD_DLL_RELEASE})
 

--- a/cmake/EthExecutableHelper.cmake
+++ b/cmake/EthExecutableHelper.cmake
@@ -56,7 +56,7 @@ macro(eth_install_executable EXECUTABLE)
 	set (extra_macro_args ${ARGN})
 	set (options)
 	set (one_value_args QMLDIR)
-	set (multi_value_args)
+	set (multi_value_args DLLS)
 	cmake_parse_arguments (ETH_INSTALL_EXECUTABLE "${options}" "${one_value_args}" "${multi_value_args}" "${extra_macro_args}")
 	
 	if (ETH_INSTALL_EXECUTABLE_QMLDIR)
@@ -99,6 +99,15 @@ macro(eth_install_executable EXECUTABLE)
 			COMMAND cmd /C "(echo [Paths] & echo.Prefix=.)" > "qt.conf"
 			WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR} VERBATIM
 		)
+
+		#copy additional dlls
+		foreach(dll ${ETH_INSTALL_EXECUTABLE_DLLS})
+			add_custom_command(TARGET ${EXECUTABLE} POST_BUILD
+			COMMAND ${CMAKE_COMMAND}
+			ARGS -E copy ${dll} "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}"
+		)
+		endforeach(dll)
+
 		install( TARGETS ${EXECUTABLE} RUNTIME 
 			DESTINATION bin
 			COMPONENT ${EXECUTABLE}

--- a/cmake/EthExecutableHelper.cmake
+++ b/cmake/EthExecutableHelper.cmake
@@ -90,15 +90,20 @@ macro(eth_install_executable EXECUTABLE)
 			" COMPONENT RUNTIME )
 
 	elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-		add_custom_command(TARGET ${EXECUTABLE} POST_BUILD
-			COMMAND cmd /C "set PATH=${Qt5Core_DIR}/../../../bin;%PATH% && ${WINDEPLOYQT_APP} ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/${EXECUTABLE}.exe ${eth_qml_dir}"
-			WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
-		)
-		#workaround for https://bugreports.qt.io/browse/QTBUG-42083
-		add_custom_command(TARGET ${EXECUTABLE} POST_BUILD
-			COMMAND cmd /C "(echo [Paths] & echo.Prefix=.)" > "qt.conf"
-			WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR} VERBATIM
-		)
+
+		get_target_property(TARGET_LIBS ${EXECUTABLE} INTERFACE_LINK_LIBRARIES)
+		string(REGEX MATCH "Qt5::Core" HAVE_QT ${TARGET_LIBS})
+		if ("${HAVE_QT}" STREQUAL "Qt5::Core")
+			add_custom_command(TARGET ${EXECUTABLE} POST_BUILD
+				COMMAND cmd /C "set PATH=${Qt5Core_DIR}/../../../bin;%PATH% && ${WINDEPLOYQT_APP} ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/${EXECUTABLE}.exe ${eth_qml_dir}"
+				WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+			)
+			#workaround for https://bugreports.qt.io/browse/QTBUG-42083
+			add_custom_command(TARGET ${EXECUTABLE} POST_BUILD
+				COMMAND cmd /C "(echo [Paths] & echo.Prefix=.)" > "qt.conf"
+				WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR} VERBATIM
+			)
+		endif()
 
 		#copy additional dlls
 		foreach(dll ${ETH_INSTALL_EXECUTABLE_DLLS})

--- a/cmake/FindMHD.cmake
+++ b/cmake/FindMHD.cmake
@@ -29,13 +29,19 @@ set(MHD_LIBRARIES ${MHD_LIBRARY})
 # boost is using the same "hack" as us with "optimized" and "debug"
 # official MHD project actually uses _d suffix
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+
+	#TODO: place dlls into CMAKE_CFG_INTDIR subfolders
+	string(REPLACE ".lib" ".dll" MHD_DLL_RELEASE ${MHD_LIBRARY})
+	string(REPLACE "/lib/" "/bin/" MHD_DLL_RELEASE ${MHD_DLL_RELEASE})
+
 	find_library(
 		MHD_LIBRARY_DEBUG
 		NAMES microhttpd_d microhttpd-10_d libmicrohttpd_d libmicrohttpd-dll_d
 		DOC "mhd debug library"
 	)
-
-	set(MHD_LIBRARIES optimized ${MHD_LIBRARIES} debug ${MHD_LIBRARY_DEBUG})
+	# always use release for now
+	#string(REPLACE ".lib" ".dll" MHD_DLL_DEBUG ${MHD_LIBRARY_DEBUG})
+	#set(MHD_LIBRARIES optimized ${MHD_LIBRARIES} debug ${MHD_LIBRARY_DEBUG})
 
 endif()
 

--- a/eth/CMakeLists.txt
+++ b/eth/CMakeLists.txt
@@ -28,5 +28,9 @@ endif()
 target_link_libraries(${EXECUTABLE} webthree)
 target_link_libraries(${EXECUTABLE} secp256k1)
 
+if (WIN32)
+	add_custom_command(TARGET ${EXECUTABLE} POST_BUILD COMMAND ${CMAKE_COMMAND} ARGS -E copy ${MHD_DLL_RELEASE} "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}")
+endif()
+
 install( TARGETS ${EXECUTABLE} DESTINATION bin )
 

--- a/third/CMakeLists.txt
+++ b/third/CMakeLists.txt
@@ -51,5 +51,5 @@ target_link_libraries(${EXECUTABLE} web3jsonrpc)
 target_link_libraries(${EXECUTABLE} jsqrc) 
 
 # eth_install_executable is defined in cmake/EthExecutableHelper.cmake
-eth_install_executable(${EXECUTABLE})
+eth_install_executable(${EXECUTABLE} DLLS ${MHD_DLL_RELEASE})
 


### PR DESCRIPTION
 #1101
We should either build it as static lib like the rest of the non-qt libs, or at least designate a common 
location for dlls in extdeps