### PR TITLE
Transaction bug fix

### DIFF
--- a/libdevcore/RLP.h
+++ b/libdevcore/RLP.h
@@ -242,7 +242,9 @@ public:
 		AllowNonCanon = 1,
 		ThrowOnFail = 4,
 		FailIfTooBig = 8,
+		FailIfTooSmall = 16,
 		Strict = ThrowOnFail | FailIfTooBig,
+		VeryStrict = ThrowOnFail | FailIfTooBig | FailIfTooSmall,
 		LaisezFaire = AllowNonCanon
 	};
 
@@ -269,7 +271,7 @@ public:
 
 	template <class _N> _N toHash(int _flags = Strict) const
 	{
-		if (!isData() || (length() > _N::size && (_flags & FailIfTooBig)))
+		if (!isData() || (length() > _N::size && (_flags & FailIfTooBig)) || (length() < _N::size && (_flags & FailIfTooSmall)))
 			if (_flags & ThrowOnFail)
 				BOOST_THROW_EXCEPTION(BadCast());
 			else

--- a/libethereum/Transaction.cpp
+++ b/libethereum/Transaction.cpp
@@ -40,7 +40,7 @@ Transaction::Transaction(bytesConstRef _rlpData, CheckSignature _checkSig)
 		m_gasPrice = rlp[field = 1].toInt<u256>();
 		m_gas = rlp[field = 2].toInt<u256>();
 		m_type = rlp[field = 3].isEmpty() ? ContractCreation : MessageCall;
-		m_receiveAddress = rlp[field = 3].toHash<Address>(RLP::VeryStrict);
+		m_receiveAddress = rlp[field = 3].isEmpty() ? Address() : rlp[field = 3].toHash<Address>(RLP::VeryStrict);
 		m_value = rlp[field = 4].toInt<u256>();
 		m_data = rlp[field = 5].toBytes();
 		byte v = rlp[field = 6].toInt<byte>() - 27;

--- a/libethereum/Transaction.cpp
+++ b/libethereum/Transaction.cpp
@@ -40,7 +40,7 @@ Transaction::Transaction(bytesConstRef _rlpData, CheckSignature _checkSig)
 		m_gasPrice = rlp[field = 1].toInt<u256>();
 		m_gas = rlp[field = 2].toInt<u256>();
 		m_type = rlp[field = 3].isEmpty() ? ContractCreation : MessageCall;
-		m_receiveAddress = rlp[field = 3].toHash<Address>();
+		m_receiveAddress = rlp[field = 3].toHash<Address>(RLP::VeryStrict);
 		m_value = rlp[field = 4].toInt<u256>();
 		m_data = rlp[field = 5].toBytes();
 		byte v = rlp[field = 6].toInt<byte>() - 27;

--- a/test/TestHelper.cpp
+++ b/test/TestHelper.cpp
@@ -475,11 +475,11 @@ void executeTests(const string& _name, const string& _testPathAppendix, std::fun
 			}
 			catch (Exception const& _e)
 			{
-				BOOST_ERROR("Failed test with Exception: " << diagnostic_information(_e));
+				BOOST_ERROR("Failed filling test with Exception: " << diagnostic_information(_e));
 			}
 			catch (std::exception const& _e)
 			{
-				BOOST_ERROR("Failed test with Exception: " << _e.what());
+				BOOST_ERROR("Failed filling test with Exception: " << _e.what());
 			}
 			break;
 		}

--- a/test/transaction.cpp
+++ b/test/transaction.cpp
@@ -51,7 +51,7 @@ void doTransactionTests(json_spirit::mValue& _v, bool _fillin)
 			catch(...)
 			{
 				BOOST_CHECK_MESSAGE(o.count("transaction") == 0, "A transaction object should not be defined because the RLP is invalid!");
-				return;
+				continue;
 			}
 
 			BOOST_REQUIRE(o.count("transaction") > 0);
@@ -106,6 +106,11 @@ BOOST_AUTO_TEST_SUITE(TransactionTests)
 BOOST_AUTO_TEST_CASE(TransactionTest)
 {
 	dev::test::executeTests("ttTransactionTest", "/TransactionTests", dev::test::doTransactionTests);
+}
+
+BOOST_AUTO_TEST_CASE(ttWrongRLPTransaction)
+{
+	dev::test::executeTests("ttWrongRLPTransaction", "/TransactionTests", dev::test::doTransactionTests);
 }
 
 BOOST_AUTO_TEST_CASE(tt10mbDataField)


### PR DESCRIPTION
fixes https://github.com/ethereum/tests/issues/61.
The question is, is it allowed to have addresses with less than 20 bytes?
According to my interpretation of the YP it is not. YP: "to: The 160-bit address of the message call’s recipient".
But one could also argue that an address with less than 20 bytes (but still not empty) belongs to the set B_20 and could be considered valid. Then we need to ask should it be encoded in the RLP as 20 bytes, filling up the missing bytes with 0's, or is it allowed to have, e.g. 10 bytes, adresses RLP encoded? @gavofyork 