### PR TITLE
Sol fix accessing public variable of base class

### DIFF
--- a/libsolidity/AST.cpp
+++ b/libsolidity/AST.cpp
@@ -215,26 +215,23 @@ vector<ASTPointer<Declaration>> const& ContractDefinition::getInheritableMembers
 	{
 		set<string> memberSeen;
 		m_inheritableMembers.reset(new vector<ASTPointer<Declaration>>());
-		for (ContractDefinition const* contract: getLinearizedBaseContracts())
+		auto addInheritableMember = [&](ASTPointer<Declaration> const& _decl)
 		{
-			auto addInheritableMember = [&](ASTPointer<Declaration> const& _decl)
+			if (memberSeen.count(_decl->getName()) == 0 && _decl->isVisibleInDerivedContracts())
 			{
-				if (memberSeen.count(_decl->getName()) == 0 && _decl->isVisibleInDerivedContracts())
-				{
-					memberSeen.insert(_decl->getName());
-					m_inheritableMembers->push_back(_decl);
-				}
-			};
+				memberSeen.insert(_decl->getName());
+				m_inheritableMembers->push_back(_decl);
+			}
+		};
 
-			for (ASTPointer<FunctionDefinition> const& f: contract->getDefinedFunctions())
-				addInheritableMember(f);
+		for (ASTPointer<FunctionDefinition> const& f: getDefinedFunctions())
+			addInheritableMember(f);
 
-			for (ASTPointer<VariableDeclaration> const& v: contract->getStateVariables())
-				addInheritableMember(v);
+		for (ASTPointer<VariableDeclaration> const& v: getStateVariables())
+			addInheritableMember(v);
 
-			for (ASTPointer<StructDefinition> const& s: contract->getDefinedStructs())
-				addInheritableMember(s);
-		}
+		for (ASTPointer<StructDefinition> const& s: getDefinedStructs())
+			addInheritableMember(s);
 	}
 	return *m_inheritableMembers;
 }

--- a/libsolidity/AST.cpp
+++ b/libsolidity/AST.cpp
@@ -218,22 +218,21 @@ vector<ASTPointer<Declaration>> const& ContractDefinition::getInheritableMembers
 		for (ContractDefinition const* contract: getLinearizedBaseContracts())
 		{
 			for (ASTPointer<FunctionDefinition> const& f: contract->getDefinedFunctions())
-				if (f->isPublic() && !f->isConstructor() && !f->getName().empty()
-					&& memberSeen.count(f->getName()) == 0 && f->isVisibleInDerivedContracts())
+				if (memberSeen.count(f->getName()) == 0 && f->isVisibleInDerivedContracts())
 				{
 					memberSeen.insert(f->getName());
 					m_inheritableMembers->push_back(f);
 				}
 
 			for (ASTPointer<VariableDeclaration> const& v: contract->getStateVariables())
-				if (v->isPublic() && memberSeen.count(v->getName()) == 0)
+				if (memberSeen.count(v->getName()) == 0 && v->isVisibleInDerivedContracts())
 				{
 					memberSeen.insert(v->getName());
 					m_inheritableMembers->push_back(v);
 				}
 
 			for (ASTPointer<StructDefinition> const& s: contract->getDefinedStructs())
-				if (s->isPublic() && memberSeen.count(s->getName()) == 0)
+				if (memberSeen.count(s->getName()) == 0 && s->isVisibleInDerivedContracts())
 				{
 					memberSeen.insert(s->getName());
 					m_inheritableMembers->push_back(s);

--- a/libsolidity/AST.cpp
+++ b/libsolidity/AST.cpp
@@ -217,26 +217,23 @@ vector<ASTPointer<Declaration>> const& ContractDefinition::getInheritableMembers
 		m_inheritableMembers.reset(new vector<ASTPointer<Declaration>>());
 		for (ContractDefinition const* contract: getLinearizedBaseContracts())
 		{
-			for (ASTPointer<FunctionDefinition> const& f: contract->getDefinedFunctions())
-				if (memberSeen.count(f->getName()) == 0 && f->isVisibleInDerivedContracts())
+			auto addInheritableMember = [&](ASTPointer<Declaration> const& _decl)
+			{
+				if (memberSeen.count(_decl->getName()) == 0 && _decl->isVisibleInDerivedContracts())
 				{
-					memberSeen.insert(f->getName());
-					m_inheritableMembers->push_back(f);
+					memberSeen.insert(_decl->getName());
+					m_inheritableMembers->push_back(_decl);
 				}
+			};
+
+			for (ASTPointer<FunctionDefinition> const& f: contract->getDefinedFunctions())
+				addInheritableMember(f);
 
 			for (ASTPointer<VariableDeclaration> const& v: contract->getStateVariables())
-				if (memberSeen.count(v->getName()) == 0 && v->isVisibleInDerivedContracts())
-				{
-					memberSeen.insert(v->getName());
-					m_inheritableMembers->push_back(v);
-				}
+				addInheritableMember(v);
 
 			for (ASTPointer<StructDefinition> const& s: contract->getDefinedStructs())
-				if (memberSeen.count(s->getName()) == 0 && s->isVisibleInDerivedContracts())
-				{
-					memberSeen.insert(s->getName());
-					m_inheritableMembers->push_back(s);
-				}
+				addInheritableMember(s);
 		}
 	}
 	return *m_inheritableMembers;

--- a/libsolidity/AST.cpp
+++ b/libsolidity/AST.cpp
@@ -231,6 +231,13 @@ vector<ASTPointer<Declaration>> const& ContractDefinition::getInheritableMembers
 					memberSeen.insert(v->getName());
 					m_inheritableMembers->push_back(v);
 				}
+
+			for (ASTPointer<StructDefinition> const& s: contract->getDefinedStructs())
+				if (s->isPublic() && memberSeen.count(s->getName()) == 0)
+				{
+					memberSeen.insert(s->getName());
+					m_inheritableMembers->push_back(s);
+				}
 		}
 	}
 	return *m_inheritableMembers;

--- a/libsolidity/AST.cpp
+++ b/libsolidity/AST.cpp
@@ -209,13 +209,13 @@ vector<pair<FixedHash<4>, FunctionTypePointer>> const& ContractDefinition::getIn
 	return *m_interfaceFunctionList;
 }
 
-vector<ASTPointer<Declaration>> const& ContractDefinition::getInheritableMembers() const
+vector<Declaration const*> const& ContractDefinition::getInheritableMembers() const
 {
 	if (!m_inheritableMembers)
 	{
 		set<string> memberSeen;
-		m_inheritableMembers.reset(new vector<ASTPointer<Declaration>>());
-		auto addInheritableMember = [&](ASTPointer<Declaration> const& _decl)
+		m_inheritableMembers.reset(new vector<Declaration const*>());
+		auto addInheritableMember = [&](Declaration const* _decl)
 		{
 			if (memberSeen.count(_decl->getName()) == 0 && _decl->isVisibleInDerivedContracts())
 			{
@@ -225,13 +225,13 @@ vector<ASTPointer<Declaration>> const& ContractDefinition::getInheritableMembers
 		};
 
 		for (ASTPointer<FunctionDefinition> const& f: getDefinedFunctions())
-			addInheritableMember(f);
+			addInheritableMember(f.get());
 
 		for (ASTPointer<VariableDeclaration> const& v: getStateVariables())
-			addInheritableMember(v);
+			addInheritableMember(v.get());
 
 		for (ASTPointer<StructDefinition> const& s: getDefinedStructs())
-			addInheritableMember(s);
+			addInheritableMember(s.get());
 	}
 	return *m_inheritableMembers;
 }

--- a/libsolidity/AST.h
+++ b/libsolidity/AST.h
@@ -247,6 +247,9 @@ public:
 	/// as intended for use by the ABI.
 	std::map<FixedHash<4>, FunctionTypePointer> getInterfaceFunctions() const;
 
+	/// @returns a list of the inheritable members of this contract
+	std::vector<ASTPointer<Declaration>> const& getInheritableMembers() const;
+
 	/// List of all (direct and indirect) base contracts in order from derived to base, including
 	/// the contract itself. Available after name resolution
 	std::vector<ContractDefinition const*> const& getLinearizedBaseContracts() const { return m_linearizedBaseContracts; }
@@ -273,6 +276,7 @@ private:
 	std::vector<ContractDefinition const*> m_linearizedBaseContracts;
 	mutable std::unique_ptr<std::vector<std::pair<FixedHash<4>, FunctionTypePointer>>> m_interfaceFunctionList;
 	mutable std::unique_ptr<std::vector<ASTPointer<EventDefinition>>> m_interfaceEvents;
+	mutable std::unique_ptr<std::vector<ASTPointer<Declaration>>> m_inheritableMembers;
 };
 
 class InheritanceSpecifier: public ASTNode

--- a/libsolidity/AST.h
+++ b/libsolidity/AST.h
@@ -248,7 +248,7 @@ public:
 	std::map<FixedHash<4>, FunctionTypePointer> getInterfaceFunctions() const;
 
 	/// @returns a list of the inheritable members of this contract
-	std::vector<ASTPointer<Declaration>> const& getInheritableMembers() const;
+	std::vector<Declaration const*> const& getInheritableMembers() const;
 
 	/// List of all (direct and indirect) base contracts in order from derived to base, including
 	/// the contract itself. Available after name resolution
@@ -276,7 +276,7 @@ private:
 	std::vector<ContractDefinition const*> m_linearizedBaseContracts;
 	mutable std::unique_ptr<std::vector<std::pair<FixedHash<4>, FunctionTypePointer>>> m_interfaceFunctionList;
 	mutable std::unique_ptr<std::vector<ASTPointer<EventDefinition>>> m_interfaceEvents;
-	mutable std::unique_ptr<std::vector<ASTPointer<Declaration>>> m_inheritableMembers;
+	mutable std::unique_ptr<std::vector<Declaration const*>> m_inheritableMembers;
 };
 
 class InheritanceSpecifier: public ASTNode

--- a/libsolidity/AST.h
+++ b/libsolidity/AST.h
@@ -144,7 +144,7 @@ public:
 	Visibility getVisibility() const { return m_visibility == Visibility::Default ? getDefaultVisibility() : m_visibility; }
 	bool isPublic() const { return getVisibility() >= Visibility::Public; }
 	bool isVisibleInContract() const { return getVisibility() != Visibility::External; }
-	bool isVisibleInDerivedContracts() const { return isVisibleInContract() && getVisibility() >= Visibility::Internal; }
+	virtual bool isVisibleInDerivedContracts() const { return isVisibleInContract() && getVisibility() >= Visibility::Internal; }
 
 	/// @returns the scope this declaration resides in. Can be nullptr if it is the global scope.
 	/// Available only after name and type resolution step.
@@ -409,6 +409,11 @@ public:
 	ASTPointer<ParameterList> const& getReturnParameterList() const { return m_returnParameters; }
 	Block const& getBody() const { return *m_body; }
 
+	virtual bool isVisibleInDerivedContracts() const override
+	{
+		return !isConstructor() && !getName().empty() && isVisibleInContract() &&
+			getVisibility() >= Visibility::Internal;
+	}
 	virtual TypePointer getType(ContractDefinition const*) const override;
 
 	/// Checks that all parameters have allowed types and calls checkTypeRequirements on the body.

--- a/libsolidity/Types.cpp
+++ b/libsolidity/Types.cpp
@@ -628,8 +628,7 @@ MemberList const& ContractType::getMembers() const
 		{
 			for (ContractDefinition const* base: m_contract.getLinearizedBaseContracts())
 				for (ASTPointer<FunctionDefinition> const& function: base->getDefinedFunctions())
-					if (!function->isConstructor() && !function->getName().empty()&&
-							function->isVisibleInDerivedContracts())
+					if (function->isVisibleInDerivedContracts())
 						members.push_back(make_pair(function->getName(), make_shared<FunctionType>(*function, true)));
 		}
 		else

--- a/libsolidity/Types.cpp
+++ b/libsolidity/Types.cpp
@@ -1024,7 +1024,7 @@ MemberList const& TypeType::getMembers() const
 			if (find(currentBases.begin(), currentBases.end(), &contract) != currentBases.end())
 				// We are accessing the type of a base contract, so add all public and protected
 				// members. Note that this does not add inherited functions on purpose.
-				for (ASTPointer<Declaration> const& decl: contract.getInheritableMembers())
+				for (Declaration const* decl: contract.getInheritableMembers())
 					members.push_back(make_pair(decl->getName(), decl->getType()));
 		}
 		else if (m_actualType->getCategory() == Category::Enum)

--- a/libsolidity/Types.cpp
+++ b/libsolidity/Types.cpp
@@ -1025,9 +1025,8 @@ MemberList const& TypeType::getMembers() const
 			if (find(currentBases.begin(), currentBases.end(), &contract) != currentBases.end())
 				// We are accessing the type of a base contract, so add all public and protected
 				// functions. Note that this does not add inherited functions on purpose.
-				for (ASTPointer<FunctionDefinition> const& f: contract.getDefinedFunctions())
-					if (!f->isConstructor() && !f->getName().empty() && f->isVisibleInDerivedContracts())
-						members.push_back(make_pair(f->getName(), make_shared<FunctionType>(*f)));
+				for (ASTPointer<Declaration> const& decl: contract.getInheritableMembers())
+					members.push_back(make_pair(decl->getName(), decl->getType()));
 		}
 		else if (m_actualType->getCategory() == Category::Enum)
 		{

--- a/libsolidity/Types.cpp
+++ b/libsolidity/Types.cpp
@@ -1024,7 +1024,7 @@ MemberList const& TypeType::getMembers() const
 			vector<ContractDefinition const*> currentBases = m_currentContract->getLinearizedBaseContracts();
 			if (find(currentBases.begin(), currentBases.end(), &contract) != currentBases.end())
 				// We are accessing the type of a base contract, so add all public and protected
-				// functions. Note that this does not add inherited functions on purpose.
+				// members. Note that this does not add inherited functions on purpose.
 				for (ASTPointer<Declaration> const& decl: contract.getInheritableMembers())
 					members.push_back(make_pair(decl->getName(), decl->getType()));
 		}

--- a/test/SolidityNameAndTypeResolution.cpp
+++ b/test/SolidityNameAndTypeResolution.cpp
@@ -743,6 +743,35 @@ BOOST_AUTO_TEST_CASE(base_class_state_variable_internal_member)
 	BOOST_CHECK_NO_THROW(parseTextAndResolveNamesWithChecks(text));
 }
 
+BOOST_AUTO_TEST_CASE(state_variable_member_of_wrong_class1)
+{
+	char const* text = "contract Parent1 {\n"
+					   "    uint256 internal m_aMember1;\n"
+					   "}\n"
+					   "contract Parent2 is Parent1{\n"
+					   "    uint256 internal m_aMember2;\n"
+					   "}\n"
+					   "contract Child is Parent2{\n"
+					   "    function foo() returns (uint256) { return Parent2.m_aMember1; }\n"
+					   "}\n";
+	BOOST_CHECK_THROW(parseTextAndResolveNames(text), TypeError);
+}
+
+BOOST_AUTO_TEST_CASE(state_variable_member_of_wrong_class2)
+{
+	char const* text = "contract Parent1 {\n"
+					   "    uint256 internal m_aMember1;\n"
+					   "}\n"
+					   "contract Parent2 is Parent1{\n"
+					   "    uint256 internal m_aMember2;\n"
+					   "}\n"
+					   "contract Child is Parent2{\n"
+					   "    function foo() returns (uint256) { return Child.m_aMember2; }\n"
+					   "    uint256 public m_aMember3;\n"
+					   "}\n";
+	BOOST_CHECK_THROW(parseTextAndResolveNames(text), TypeError);
+}
+
 BOOST_AUTO_TEST_CASE(fallback_function)
 {
 	char const* text = R"(

--- a/test/SolidityNameAndTypeResolution.cpp
+++ b/test/SolidityNameAndTypeResolution.cpp
@@ -436,7 +436,7 @@ BOOST_AUTO_TEST_CASE(inheritance_diamond_basic)
 			function g() { f(); rootFunction(); }
 		}
 	)";
-	BOOST_CHECK_NO_THROW(parseTextAndResolveNames(text));
+	BOOST_CHECK_NO_THROW(parseTextAndResolveNamesWithChecks(text));
 }
 
 BOOST_AUTO_TEST_CASE(cyclic_inheritance)
@@ -725,6 +725,17 @@ BOOST_AUTO_TEST_CASE(base_class_state_variable_accessor)
 	// test for issue #1126 https://github.com/ethereum/cpp-ethereum/issues/1126
 	char const* text = "contract Parent {\n"
 					   "    uint256 public m_aMember;\n"
+					   "}\n"
+					   "contract Child is Parent{\n"
+					   "    function foo() returns (uint256) { return Parent.m_aMember; }\n"
+					   "}\n";
+	BOOST_CHECK_NO_THROW(parseTextAndResolveNamesWithChecks(text));
+}
+
+BOOST_AUTO_TEST_CASE(base_class_state_variable_internal_member)
+{
+	char const* text = "contract Parent {\n"
+					   "    uint256 internal m_aMember;\n"
 					   "}\n"
 					   "contract Child is Parent{\n"
 					   "    function foo() returns (uint256) { return Parent.m_aMember; }\n"

--- a/test/SolidityNameAndTypeResolution.cpp
+++ b/test/SolidityNameAndTypeResolution.cpp
@@ -720,6 +720,18 @@ BOOST_AUTO_TEST_CASE(private_state_variable)
 	BOOST_CHECK_MESSAGE(function == nullptr, "Accessor function of an internal variable should not exist");
 }
 
+BOOST_AUTO_TEST_CASE(base_class_state_variable_accessor)
+{
+	// test for issue #1126 https://github.com/ethereum/cpp-ethereum/issues/1126
+	char const* text = "contract Parent {\n"
+					   "    uint256 public m_aMember;\n"
+					   "}\n"
+					   "contract Child {\n"
+					   "    function foo() returns (uint256) { return Parent.m_aMember(); }\n"
+					   "}\n";
+	BOOST_CHECK_NO_THROW(parseTextAndResolveNamesWithChecks(text));
+}
+
 BOOST_AUTO_TEST_CASE(fallback_function)
 {
 	char const* text = R"(

--- a/test/SolidityNameAndTypeResolution.cpp
+++ b/test/SolidityNameAndTypeResolution.cpp
@@ -726,8 +726,8 @@ BOOST_AUTO_TEST_CASE(base_class_state_variable_accessor)
 	char const* text = "contract Parent {\n"
 					   "    uint256 public m_aMember;\n"
 					   "}\n"
-					   "contract Child {\n"
-					   "    function foo() returns (uint256) { return Parent.m_aMember(); }\n"
+					   "contract Child is Parent{\n"
+					   "    function foo() returns (uint256) { return Parent.m_aMember; }\n"
 					   "}\n";
 	BOOST_CHECK_NO_THROW(parseTextAndResolveNamesWithChecks(text));
 }


### PR DESCRIPTION
The following should now work
```
contract Parent {
    uint256 public m_aMember;
}
contract Child is Parent{
    function foo() returns (uint256) { return Parent.m_aMember; }
}
```