### PR TITLE
Tx and block RLP must be a list

### DIFF
--- a/libethcore/BlockInfo.cpp
+++ b/libethcore/BlockInfo.cpp
@@ -134,7 +134,7 @@ void BlockInfo::populate(bytesConstRef _block, bool _checkNonce)
 	RLP header = root[0];
 
 	if (!header.isList())
-		BOOST_THROW_EXCEPTION(InvalidBlockFormat(0,header.data()) << errinfo_comment("block header needs to be a list"));
+		BOOST_THROW_EXCEPTION(InvalidBlockFormat(0, header.data()) << errinfo_comment("block header needs to be a list"));
 	populateFromHeader(header, _checkNonce);
 
 	if (!root[1].isList())

--- a/libethereum/BlockChain.cpp
+++ b/libethereum/BlockChain.cpp
@@ -209,6 +209,11 @@ h256s BlockChain::import(bytes const& _block, OverlayDB const& _db)
 	try
 #endif
 	{
+		RLP blockRLP(_block);
+
+		if (!blockRLP.isList())
+			BOOST_THROW_EXCEPTION(InvalidBlockFormat(0,blockRLP.data()) << errinfo_comment("block header needs to be a list"));
+
 		bi.populate(&_block);
 		bi.verifyInternals(&_block);
 	}

--- a/libethereum/BlockChain.cpp
+++ b/libethereum/BlockChain.cpp
@@ -212,7 +212,7 @@ h256s BlockChain::import(bytes const& _block, OverlayDB const& _db)
 		RLP blockRLP(_block);
 
 		if (!blockRLP.isList())
-			BOOST_THROW_EXCEPTION(InvalidBlockFormat(0,blockRLP.data()) << errinfo_comment("block header needs to be a list"));
+			BOOST_THROW_EXCEPTION(InvalidBlockFormat(0, blockRLP.data()) << errinfo_comment("block header needs to be a list"));
 
 		bi.populate(&_block);
 		bi.verifyInternals(&_block);

--- a/libethereum/Transaction.cpp
+++ b/libethereum/Transaction.cpp
@@ -36,6 +36,9 @@ Transaction::Transaction(bytesConstRef _rlpData, CheckSignature _checkSig)
 	RLP rlp(_rlpData);
 	try
 	{
+		if (!rlp.isList())
+			BOOST_THROW_EXCEPTION(BadRLP() << errinfo_comment("transaction RLP must be a list"));
+
 		m_nonce = rlp[field = 0].toInt<u256>();
 		m_gasPrice = rlp[field = 1].toInt<u256>();
 		m_gas = rlp[field = 2].toInt<u256>();


### PR DESCRIPTION
@winsvega  found that txs were accepted as byte arrays and lists (see test https://github.com/ethereum/tests/blob/develop/TransactionTests/ttWrongRLPTransaction.json#L34).
But according to my interpretation of the YP, it needs to be a RLP list, otherwise it is invalid.
The same is true for block RLPs.