### PR TITLE
don't write memory to vm trace if greater than 1000 bytes

### DIFF
--- a/libethereum/Executive.cpp
+++ b/libethereum/Executive.cpp
@@ -176,7 +176,7 @@ OnOpFunc Executive::simpleTrace()
 		o << endl << "    STACK" << endl;
 		for (auto i: vm.stack())
 			o << (h256)i << endl;
-		o << "    MEMORY" << endl << memDump(vm.memory());
+		o << "    MEMORY" << endl << (vm.memory().size() > 1000) ? " mem size greater than 1000 bytes " : memDump(vm.memory());
 		o << "    STORAGE" << endl;
 		for (auto const& i: ext.state().storage(ext.myAddress))
 			o << showbase << hex << i.first << ": " << i.second << endl;


### PR DESCRIPTION
StateTest/stMemoryTest.json will take forever in debug modus because of the vm trace. This fix avoids printing the memory to the trace if greater then 1000 bytes.