### PR TITLE
implement overloaded funciton

### DIFF
--- a/libsolidity/AST.cpp
+++ b/libsolidity/AST.cpp
@@ -356,7 +356,12 @@ void VariableDeclaration::checkTypeRequirements()
 	else
 	{
 		// no type declared and no previous assignment, infer the type
-		m_value->checkTypeRequirements();
+		Identifier* identifier = dynamic_cast<Identifier*>(m_value.get());
+		if (identifier)
+			identifier->checkTypeRequirementsFromVariableDeclaration();
+		else
+			m_value->checkTypeRequirements();
+
 		TypePointer type = m_value->getType();
 		if (type->getCategory() == Type::Category::IntegerConstant)
 		{
@@ -484,39 +489,7 @@ void Return::checkTypeRequirements()
 
 void VariableDeclarationStatement::checkTypeRequirements()
 {
-<<<<<<< HEAD
 	m_variable->checkTypeRequirements();
-=======
-	// Variables can be declared without type (with "var"), in which case the first assignment
-	// sets the type.
-	// Note that assignments before the first declaration are legal because of the special scoping
-	// rules inherited from JavaScript.
-	if (m_variable->getValue())
-	{
-		if (m_variable->getType())
-			m_variable->getValue()->expectType(*m_variable->getType());
-		else
-		{
-			// no type declared and no previous assignment, infer the type
-			Identifier* identifier = dynamic_cast<Identifier*>(m_variable->getValue().get());
-			if (identifier)
-				identifier->checkTypeRequirementsFromVariableDeclaration();
-			else
-				m_variable->getValue()->checkTypeRequirements();
-			TypePointer type = m_variable->getValue()->getType();
-			if (type->getCategory() == Type::Category::IntegerConstant)
-			{
-				auto intType = dynamic_pointer_cast<IntegerConstantType const>(type)->getIntegerType();
-				if (!intType)
-					BOOST_THROW_EXCEPTION(m_variable->getValue()->createTypeError("Invalid integer constant " + type->toString()));
-				type = intType;
-			}
-			else if (type->getCategory() == Type::Category::Void)
-				BOOST_THROW_EXCEPTION(m_variable->createTypeError("var cannot be void type"));
-			m_variable->setType(type);
-		}
-	}
->>>>>>> implement overload resolution
 }
 
 void Assignment::checkTypeRequirements()

--- a/libsolidity/AST.cpp
+++ b/libsolidity/AST.cpp
@@ -82,7 +82,8 @@ void ContractDefinition::checkTypeRequirements()
 	{
 		string signature = function->getCanonicalSignature();
 		if (functions.count(signature))
-			BOOST_THROW_EXCEPTION(DeclarationError() << errinfo_comment("Duplicate functions are not allowed."));
+			BOOST_THROW_EXCEPTION(DeclarationError() << errinfo_sourceLocation(function->getLocation())
+														<< errinfo_comment("Duplicate functions are not allowed."));
 		functions.insert(signature);
 	}
 

--- a/libsolidity/AST.cpp
+++ b/libsolidity/AST.cpp
@@ -493,14 +493,10 @@ void VariableDeclarationStatement::checkTypeRequirements()
 	if (m_variable->getValue())
 	{
 		if (m_variable->getType())
-		{
-			std::cout << "getType() ok" << std::endl;
 			m_variable->getValue()->expectType(*m_variable->getType());
-		}
 		else
 		{
 			// no type declared and no previous assignment, infer the type
-			std::cout << "here's where called...." << std::endl;
 			Identifier* identifier = dynamic_cast<Identifier*>(m_variable->getValue().get());
 			if (identifier)
 				identifier->checkTypeRequirementsFromVariableDeclaration();
@@ -804,14 +800,9 @@ void Identifier::checkTypeRequirementsFromVariableDeclaration()
 
 void Identifier::checkTypeRequirements()
 {
-	// var x = f; TODO!
 	solAssert(m_referencedDeclaration, "Identifier not resolved.");
 
 	m_isLValue = m_referencedDeclaration->isLValue();
-	if (m_isLValue)
-		std::cout << "Identifier: " << string(getName()) << " -> true" << std::endl;
-	else
-		std::cout << "Identifier: " << string(getName()) << " -> true" << std::endl;
 	m_type = m_referencedDeclaration->getType(m_currentContract);
 	if (!m_type)
 		BOOST_THROW_EXCEPTION(createTypeError("Declaration referenced before type could be determined."));
@@ -846,7 +837,6 @@ void Identifier::overloadResolution(FunctionCall const& _functionCall)
 							})))
 				possibles.push_back(declaration);			
 		}
-		std::cout << "possibles: " << possibles.size() << std::endl;
 		if (possibles.empty())
 			BOOST_THROW_EXCEPTION(createTypeError("Can't resolve identifier"));
 		else if (std::none_of(possibles.cbegin() + 1, possibles.cend(),
@@ -859,11 +849,9 @@ void Identifier::overloadResolution(FunctionCall const& _functionCall)
 			BOOST_THROW_EXCEPTION(createTypeError("Can't resolve identifier"));
 	}
 	else
-	{
 		// named arguments
 		// TODO: don't support right now
-		// BOOST_THROW_EXCEPTION(createTypeError("Named arguments with overloaded functions are not supported yet."));
-	}
+		BOOST_THROW_EXCEPTION(createTypeError("Named arguments with overloaded functions are not supported yet."));
 }
 
 void ElementaryTypeNameExpression::checkTypeRequirements()

--- a/libsolidity/AST.h
+++ b/libsolidity/AST.h
@@ -1157,7 +1157,7 @@ public:
 	void checkTypeRequirementsWithFunctionCall(FunctionCall const& _functionCall);
 	void checkTypeRequirementsFromVariableDeclaration();
 
-	void overloadResolution(FunctionCall const& _functionCall);
+	Declaration const* overloadResolution(FunctionCall const& _functionCall);
 private:
 
 	ASTPointer<ASTString> m_name;

--- a/libsolidity/AST.h
+++ b/libsolidity/AST.h
@@ -1134,8 +1134,8 @@ public:
 class Identifier: public PrimaryExpression
 {
 public:
-	Identifier(SourceLocation const& _location, ASTPointer<ASTString> const& _name, bool _isCallable):
-		PrimaryExpression(_location), m_name(_name), m_isCallable(_isCallable) {}
+	Identifier(SourceLocation const& _location, ASTPointer<ASTString> const& _name):
+		PrimaryExpression(_location), m_name(_name) {}
 	virtual void accept(ASTVisitor& _visitor) override;
 	virtual void accept(ASTConstVisitor& _visitor) const override;
 	virtual void checkTypeRequirements() override;
@@ -1151,9 +1151,15 @@ public:
 	Declaration const* getReferencedDeclaration() const { return m_referencedDeclaration; }
 	ContractDefinition const* getCurrentContract() const { return m_currentContract; }
 
-	bool isCallable() const { return m_isCallable; }
+	void setOverloadedDeclarations(std::set<Declaration const*> const& _declarations) { m_overloadedDeclarations = _declarations; }
+	std::set<Declaration const*> getOverloadedDeclarations() const { return m_overloadedDeclarations; }
 
+	void checkTypeRequirementsWithFunctionCall(FunctionCall const& _functionCall);
+	void checkTypeRequirementsFromVariableDeclaration();
+
+	void overloadResolution(FunctionCall const& _functionCall);
 private:
+
 	ASTPointer<ASTString> m_name;
 
 	/// Declaration the name refers to.
@@ -1161,7 +1167,8 @@ private:
 	/// Stores a reference to the current contract. This is needed because types of base contracts
 	/// change depending on the context.
 	ContractDefinition const* m_currentContract = nullptr;
-	bool m_isCallable = false;
+	/// A set of overloaded declarations, right now only FunctionDefinition has overloaded declarations.
+	std::set<Declaration const*> m_overloadedDeclarations;
 };
 
 /**

--- a/libsolidity/AST.h
+++ b/libsolidity/AST.h
@@ -1134,8 +1134,8 @@ public:
 class Identifier: public PrimaryExpression
 {
 public:
-	Identifier(SourceLocation const& _location, ASTPointer<ASTString> const& _name):
-		PrimaryExpression(_location), m_name(_name) {}
+	Identifier(SourceLocation const& _location, ASTPointer<ASTString> const& _name, bool _isCallable):
+		PrimaryExpression(_location), m_name(_name), m_isCallable(_isCallable) {}
 	virtual void accept(ASTVisitor& _visitor) override;
 	virtual void accept(ASTConstVisitor& _visitor) const override;
 	virtual void checkTypeRequirements() override;
@@ -1151,6 +1151,8 @@ public:
 	Declaration const* getReferencedDeclaration() const { return m_referencedDeclaration; }
 	ContractDefinition const* getCurrentContract() const { return m_currentContract; }
 
+	bool isCallable() const { return m_isCallable; }
+
 private:
 	ASTPointer<ASTString> m_name;
 
@@ -1159,6 +1161,7 @@ private:
 	/// Stores a reference to the current contract. This is needed because types of base contracts
 	/// change depending on the context.
 	ContractDefinition const* m_currentContract = nullptr;
+	bool m_isCallable = false;
 };
 
 /**

--- a/libsolidity/CompilerContext.cpp
+++ b/libsolidity/CompilerContext.cpp
@@ -106,8 +106,12 @@ eth::AssemblyItem CompilerContext::getVirtualFunctionEntryLabel(FunctionDefiniti
 	solAssert(!m_inheritanceHierarchy.empty(), "No inheritance hierarchy set.");
 	for (ContractDefinition const* contract: m_inheritanceHierarchy)
 		for (ASTPointer<FunctionDefinition> const& function: contract->getDefinedFunctions())
-			if (!function->isConstructor() && function->getName() == _function.getName())
+		{
+			if (!function->isConstructor() &&
+				dynamic_cast<FunctionType const&>(*function->getType()).getCanonicalSignature() ==
+				dynamic_cast<FunctionType const&>(*_function.getType()).getCanonicalSignature())
 				return getFunctionEntryLabel(*function);
+		}
 	solAssert(false, "Virtual function " + _function.getName() + " not found.");
 	return m_asm.newTag(); // not reached
 }
@@ -117,7 +121,7 @@ eth::AssemblyItem CompilerContext::getSuperFunctionEntryLabel(string const& _nam
 	auto it = getSuperContract(_base);
 	for (; it != m_inheritanceHierarchy.end(); ++it)
 		for (ASTPointer<FunctionDefinition> const& function: (*it)->getDefinedFunctions())
-			if (!function->isConstructor() && function->getName() == _name)
+			if (!function->isConstructor() && function->getName() == _name)     // TODO: add a test case for this!
 				return getFunctionEntryLabel(*function);
 	solAssert(false, "Super function " + _name + " not found.");
 	return m_asm.newTag(); // not reached

--- a/libsolidity/CompilerContext.cpp
+++ b/libsolidity/CompilerContext.cpp
@@ -108,8 +108,8 @@ eth::AssemblyItem CompilerContext::getVirtualFunctionEntryLabel(FunctionDefiniti
 		for (ASTPointer<FunctionDefinition> const& function: contract->getDefinedFunctions())
 		{
 			if (!function->isConstructor() &&
-				dynamic_cast<FunctionType const&>(*function->getType()).getCanonicalSignature() ==
-				dynamic_cast<FunctionType const&>(*_function.getType()).getCanonicalSignature())
+				dynamic_cast<FunctionType const&>(*function->getType(contract)).getCanonicalSignature() ==
+				dynamic_cast<FunctionType const&>(*_function.getType(contract)).getCanonicalSignature())
 				return getFunctionEntryLabel(*function);
 		}
 	solAssert(false, "Virtual function " + _function.getName() + " not found.");

--- a/libsolidity/DeclarationContainer.h
+++ b/libsolidity/DeclarationContainer.h
@@ -48,14 +48,14 @@ public:
 	/// @param _update if true, replaces a potential declaration that is already present
 	/// @returns false if the name was already declared.
 	bool registerDeclaration(Declaration const& _declaration, bool _invisible = false, bool _update = false);
-	Declaration const* resolveName(ASTString const& _name, bool _recursive = false) const;
+	std::set<Declaration const*> resolveName(ASTString const& _name, bool _recursive = false) const;
 	Declaration const* getEnclosingDeclaration() const { return m_enclosingDeclaration; }
-	std::map<ASTString, Declaration const*> const& getDeclarations() const { return m_declarations; }
+	std::map<ASTString, std::set<Declaration const*>> const& getDeclarations() const { return m_declarations; }
 
 private:
 	Declaration const* m_enclosingDeclaration;
 	DeclarationContainer const* m_enclosingContainer;
-	std::map<ASTString, Declaration const*> m_declarations;
+	std::map<ASTString, std::set<Declaration const*>> m_declarations;
 	std::set<ASTString> m_invisibleDeclarations;
 };
 

--- a/libsolidity/ExpressionCompiler.cpp
+++ b/libsolidity/ExpressionCompiler.cpp
@@ -822,7 +822,11 @@ bool ExpressionCompiler::visit(IndexAccess const& _indexAccess)
 void ExpressionCompiler::endVisit(Identifier const& _identifier)
 {
 	Declaration const* declaration = _identifier.getReferencedDeclaration();
-	if (MagicVariableDeclaration const* magicVar = dynamic_cast<MagicVariableDeclaration const*>(declaration))
+	if (declaration == nullptr)
+	{
+		// no-op
+	}
+	else if (MagicVariableDeclaration const* magicVar = dynamic_cast<MagicVariableDeclaration const*>(declaration))
 	{
 		if (magicVar->getType()->getCategory() == Type::Category::Contract)
 			// "this" or "super"

--- a/libsolidity/ExpressionCompiler.cpp
+++ b/libsolidity/ExpressionCompiler.cpp
@@ -822,11 +822,7 @@ bool ExpressionCompiler::visit(IndexAccess const& _indexAccess)
 void ExpressionCompiler::endVisit(Identifier const& _identifier)
 {
 	Declaration const* declaration = _identifier.getReferencedDeclaration();
-	if (declaration == nullptr)
-	{
-		// no-op
-	}
-	else if (MagicVariableDeclaration const* magicVar = dynamic_cast<MagicVariableDeclaration const*>(declaration))
+	if (MagicVariableDeclaration const* magicVar = dynamic_cast<MagicVariableDeclaration const*>(declaration))
 	{
 		if (magicVar->getType()->getCategory() == Type::Category::Contract)
 			// "this" or "super"
@@ -848,6 +844,13 @@ void ExpressionCompiler::endVisit(Identifier const& _identifier)
 	else if (dynamic_cast<EnumDefinition const*>(declaration))
 	{
 		// no-op
+	}
+	else if (declaration == nullptr && _identifier.getOverloadedDeclarations().size() > 1)
+	{
+		// var x = f;
+		declaration = *_identifier.getOverloadedDeclarations().begin();
+		FunctionDefinition const* functionDef = dynamic_cast<FunctionDefinition const*>(declaration);
+		m_context << m_context.getVirtualFunctionEntryLabel(*functionDef).pushTag();
 	}
 	else
 	{

--- a/libsolidity/NameAndTypeResolver.h
+++ b/libsolidity/NameAndTypeResolver.h
@@ -56,11 +56,11 @@ public:
 	/// Resolves the given @a _name inside the scope @a _scope. If @a _scope is omitted,
 	/// the global scope is used (i.e. the one containing only the contract).
 	/// @returns a pointer to the declaration on success or nullptr on failure.
-	Declaration const* resolveName(ASTString const& _name, Declaration const* _scope = nullptr) const;
+	std::set<Declaration const*> resolveName(ASTString const& _name, Declaration const* _scope = nullptr) const;
 
 	/// Resolves a name in the "current" scope. Should only be called during the initial
 	/// resolving phase.
-	Declaration const* getNameFromCurrentScope(ASTString const& _name, bool _recursive = true);
+	std::set<Declaration const*> getNameFromCurrentScope(ASTString const& _name, bool _recursive = true);
 
 private:
 	void reset();

--- a/libsolidity/Parser.cpp
+++ b/libsolidity/Parser.cpp
@@ -837,9 +837,14 @@ ASTPointer<Expression> Parser::parsePrimaryExpression()
 		expression = nodeFactory.createNode<Literal>(token, getLiteralAndAdvance());
 		break;
 	case Token::Identifier:
+	{
 		nodeFactory.markEndPosition();
-		expression = nodeFactory.createNode<Identifier>(getLiteralAndAdvance());
+		// if the next token is '(', this identifier looks like function call,
+		// it could be a contract, event etc.
+		bool isCallable = m_scanner->peekNextToken() == Token::LParen;
+		expression = nodeFactory.createNode<Identifier>(getLiteralAndAdvance(), isCallable);
 		break;
+	}
 	case Token::LParen:
 	{
 		m_scanner->next();

--- a/libsolidity/Parser.cpp
+++ b/libsolidity/Parser.cpp
@@ -837,14 +837,9 @@ ASTPointer<Expression> Parser::parsePrimaryExpression()
 		expression = nodeFactory.createNode<Literal>(token, getLiteralAndAdvance());
 		break;
 	case Token::Identifier:
-	{
 		nodeFactory.markEndPosition();
-		// if the next token is '(', this identifier looks like function call,
-		// it could be a contract, event etc.
-		bool isCallable = m_scanner->peekNextToken() == Token::LParen;
-		expression = nodeFactory.createNode<Identifier>(getLiteralAndAdvance(), isCallable);
+		expression = nodeFactory.createNode<Identifier>(getLiteralAndAdvance());
 		break;
-	}
 	case Token::LParen:
 	{
 		m_scanner->next();

--- a/libsolidity/Types.h
+++ b/libsolidity/Types.h
@@ -527,13 +527,14 @@ private:
 class OverloadedFunctionType: public Type
 {
 public:
-	explicit OverloadedFunctionType(std::set<Declaration const*> const& _overloadedDeclarations, Identifier* _identifier):
-		m_overloadedDeclarations(_overloadedDeclarations), m_identifier(_identifier) {}
+	explicit OverloadedFunctionType(Identifier* _identifier): m_identifier(_identifier) {}
+
 	virtual Category getCategory() const override { return Category::OverloadedFunctions; }
 	virtual std::string toString() const override { return "OverloadedFunctions"; }
 
-// private:
-	std::set<Declaration const*> m_overloadedDeclarations;
+	Identifier* getIdentifier() const { return m_identifier; }
+
+private:
 	Identifier * m_identifier;
 };
 

--- a/libsolidity/Types.h
+++ b/libsolidity/Types.h
@@ -77,7 +77,7 @@ public:
 	enum class Category
 	{
 		Integer, IntegerConstant, Bool, Real, Array,
-		String, Contract, Struct, Function, Enum,
+		String, Contract, Struct, Function, OverloadedFunctions, Enum,
 		Mapping, Void, TypeType, Modifier, Magic
 	};
 
@@ -522,6 +522,19 @@ private:
 	bool m_isConstant = false;
 	mutable std::unique_ptr<MemberList> m_members;
 	Declaration const* m_declaration = nullptr;
+};
+
+class OverloadedFunctionType: public Type
+{
+public:
+	explicit OverloadedFunctionType(std::set<Declaration const*> const& _overloadedDeclarations, Identifier* _identifier):
+		m_overloadedDeclarations(_overloadedDeclarations), m_identifier(_identifier) {}
+	virtual Category getCategory() const override { return Category::OverloadedFunctions; }
+	virtual std::string toString() const override { return "OverloadedFunctions"; }
+
+// private:
+	std::set<Declaration const*> m_overloadedDeclarations;
+	Identifier * m_identifier;
 };
 
 /**

--- a/test/SolidityEndToEndTest.cpp
+++ b/test/SolidityEndToEndTest.cpp
@@ -3218,10 +3218,13 @@ BOOST_AUTO_TEST_CASE(derived_overload_base_function_direct)
 {
 	char const* sourceCode = R"(
 		contract B { function f() returns(uint) { return 10; } }
-		contract C is B { function f(uint i) returns(uint) { return 2 * i; } }
+		contract C is B {
+			function f(uint i) returns(uint) { return 2 * i; }
+			function g() returns(uint) { return f(1); }
+		}
 	)";
-	compileAndRun(sourceCode, "C");
-	BOOST_CHECK(callContractFunction("f(uint)", 1) == encodeArgs(2));
+	compileAndRun(sourceCode, 0, "C");
+	BOOST_CHECK(callContractFunction("g()") == encodeArgs(2));
 }
 
 BOOST_AUTO_TEST_CASE(derived_overload_base_function_indirect)
@@ -3229,11 +3232,14 @@ BOOST_AUTO_TEST_CASE(derived_overload_base_function_indirect)
 	char const* sourceCode = R"(
 		contract A { function f(uint a) returns(uint) { return 2 * a; } }
 		contract B { function f() returns(uint) { return 10; } }
-		contract C is A, B { }
+		contract C is A, B {
+			function g() returns(uint) { return f(); }
+			function h() returns(uint) { return f(1); }
+		}
 	)";
-	compileAndRun(sourceCode, "C");
-	BOOST_CHECK(callContractFunction("f(uint)", 1) == encodeArgs(2));
-	BOOST_CHECK(callContractFunction("f()") == encodeArgs(10));
+	compileAndRun(sourceCode, 0, "C");
+	BOOST_CHECK(callContractFunction("g()") == encodeArgs(10));
+	BOOST_CHECK(callContractFunction("h()") == encodeArgs(2));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/SolidityEndToEndTest.cpp
+++ b/test/SolidityEndToEndTest.cpp
@@ -3210,6 +3210,27 @@ BOOST_AUTO_TEST_CASE(overloaded_function_call_with_if_else)
 			}
 		}
 	)";
+	compileAndRun(sourceCode);
+	BOOST_CHECK(callContractFunction("g(bool)", true) == encodeArgs(3));
+	BOOST_CHECK(callContractFunction("g(bool)", false) == encodeArgs(10));
+}
+
+BOOST_AUTO_TEST_CASE(overloaded_function_with_var)
+{
+	char const* sourceCode = R"(
+		contract test {
+			function f(uint k) returns(uint d) { return k; }
+			function f(uint a, uint b) returns(uint d) { return a + b; }
+			function g(bool flag) returns(uint d) {
+				var x = f;
+				if (flag)
+					return x(3);
+				else
+					return x(3, 7);
+			}
+		}
+	)";
+	compileAndRun(sourceCode);
 	BOOST_CHECK(callContractFunction("g(bool)", true) == encodeArgs(3));
 	BOOST_CHECK(callContractFunction("g(bool)", false) == encodeArgs(10));
 }

--- a/test/SolidityEndToEndTest.cpp
+++ b/test/SolidityEndToEndTest.cpp
@@ -3214,6 +3214,30 @@ BOOST_AUTO_TEST_CASE(overloaded_function_call_with_if_else)
 	BOOST_CHECK(callContractFunction("g(bool)", false) == encodeArgs(10));
 }
 
+BOOST_AUTO_TEST_CASE(derived_overload_base_function_direct)
+{
+	char const* sourceCode = R"(
+		contract B { function f() returns(uint) { return 10; } }
+		contract C is B { function f(uint i) returns(uint) { return 2 * i; } }
+	)";
+	compileAndRun(sourceCode, "C");
+	BOOST_CHECK(callContractFunction("f(uint)", 1) == encodeArgs(2));
+}
+
+BOOST_AUTO_TEST_CASE(derived_overload_base_function_indirect)
+{
+	char const* sourceCode = R"(
+		contract A { function f(uint a) returns(uint) { return 2 * a; } }
+		contract B { function f() returns(uint) { return 10; } }
+		contract C is A, B { }
+	)";
+	compileAndRun(sourceCode, "C");
+	BOOST_CHECK(callContractFunction("f(uint)", 1) == encodeArgs(2));
+	BOOST_CHECK(callContractFunction("f()") == encodeArgs(10));
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
 }
 }
 } // end namespaces

--- a/test/SolidityEndToEndTest.cpp
+++ b/test/SolidityEndToEndTest.cpp
@@ -3170,8 +3170,49 @@ BOOST_AUTO_TEST_CASE(pass_dynamic_arguments_to_the_base_base_with_gap)
 	BOOST_CHECK(callContractFunction("m_i()") == encodeArgs(4));
 }
 
+BOOST_AUTO_TEST_CASE(overloaded_function_call_resolve_to_first)
+{
+	char const* sourceCode = R"(
+		contract test {
+			function f(uint k) returns(uint d) { return k; }
+			function f(uint a, uint b) returns(uint d) { return a + b; }
+			function g() returns(uint d) { return f(3); }
+		}
+	)";
+	compileAndRun(sourceCode);
+	BOOST_CHECK(callContractFunction("g()") == encodeArgs(3));
+}
 
-BOOST_AUTO_TEST_SUITE_END()
+BOOST_AUTO_TEST_CASE(overloaded_function_call_resolve_to_second)
+{
+	char const* sourceCode = R"(
+		contract test {
+			function f(uint a, uint b) returns(uint d) { return a + b; }
+			function f(uint k) returns(uint d) { return k; }
+			function g() returns(uint d) { return f(3, 7); }
+		}
+	)";
+	compileAndRun(sourceCode);
+	BOOST_CHECK(callContractFunction("g()") == encodeArgs(10));
+}
+
+BOOST_AUTO_TEST_CASE(overloaded_function_call_with_if_else)
+{
+	char const* sourceCode = R"(
+		contract test {
+			function f(uint a, uint b) returns(uint d) { return a + b; }
+			function f(uint k) returns(uint d) { return k; }
+			function g(bool flag) returns(uint d) {
+				if (flag)
+					return f(3);
+				else
+					return f(3, 7);
+			}
+		}
+	)";
+	BOOST_CHECK(callContractFunction("g(bool)", true) == encodeArgs(3));
+	BOOST_CHECK(callContractFunction("g(bool)", false) == encodeArgs(10));
+}
 
 }
 }

--- a/test/SolidityExpressionCompiler.cpp
+++ b/test/SolidityExpressionCompiler.cpp
@@ -79,7 +79,9 @@ Declaration const& resolveDeclaration(
 	// bracers are required, cause msvc couldnt handle this macro in for statement
 	for (string const& namePart: _namespacedName)
 	{
-		BOOST_REQUIRE(declaration = _resolver.resolveName(namePart, declaration));
+		auto declarations = _resolver.resolveName(namePart, declaration);
+		BOOST_REQUIRE(!declarations.empty());
+		BOOST_REQUIRE(declaration = *declarations.begin());
 	}
 	BOOST_REQUIRE(declaration);
 	return *declaration;

--- a/test/SolidityNameAndTypeResolution.cpp
+++ b/test/SolidityNameAndTypeResolution.cpp
@@ -1287,6 +1287,31 @@ BOOST_AUTO_TEST_CASE(storage_variable_initialization_with_incorrect_type_string)
 	BOOST_CHECK_THROW(parseTextAndResolveNames(text), TypeError);
 }
 
+BOOST_AUTO_TEST_CASE(overloaded_function_cannot_resolve)
+{
+	char const* sourceCode = R"(
+		contract test {
+			function f() returns(uint) { return 1; }
+			function f(uint a) returns(uint) { return a; }
+			function g() returns(uint) { return f(3, 5); }
+		}
+	)";
+	BOOST_CHECK_THROW(parseTextAndResolveNames(sourceCode), TypeError);
+}
+
+BOOST_AUTO_TEST_CASE(ambiguous_overloaded_function)
+{
+	// literal 1 can be both converted to uint8 and uint8, so it's ambiguous.
+	char const* sourceCode = R"(
+		contract test {
+			function f(uint8 a) returns(uint) { return a; }
+			function f(uint a) returns(uint) { return 2*a; }
+			function g() returns(uint) { return f(1); }
+		}
+	)";
+	BOOST_CHECK_THROW(parseTextAndResolveNames(sourceCode), TypeError);
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 }

--- a/test/SolidityNameAndTypeResolution.cpp
+++ b/test/SolidityNameAndTypeResolution.cpp
@@ -424,23 +424,23 @@ BOOST_AUTO_TEST_CASE(cyclic_inheritance)
 	BOOST_CHECK_THROW(parseTextAndResolveNames(text), TypeError);
 }
 
-BOOST_AUTO_TEST_CASE(illegal_override_direct)
+BOOST_AUTO_TEST_CASE(legal_override_direct)
 {
 	char const* text = R"(
 		contract B { function f() {} }
 		contract C is B { function f(uint i) {} }
 	)";
-	BOOST_CHECK_THROW(parseTextAndResolveNames(text), TypeError);
+	BOOST_CHECK_NO_THROW(parseTextAndResolveNames(text));
 }
 
-BOOST_AUTO_TEST_CASE(illegal_override_indirect)
+BOOST_AUTO_TEST_CASE(legal_override_indirect)
 {
 	char const* text = R"(
 		contract A { function f(uint a) {} }
 		contract B { function f() {} }
 		contract C is A, B { }
 	)";
-	BOOST_CHECK_THROW(parseTextAndResolveNames(text), TypeError);
+	BOOST_CHECK_NO_THROW(parseTextAndResolveNames(text));
 }
 
 BOOST_AUTO_TEST_CASE(illegal_override_visibility)

--- a/test/SolidityParser.cpp
+++ b/test/SolidityParser.cpp
@@ -126,6 +126,31 @@ BOOST_AUTO_TEST_CASE(missing_argument_in_named_args)
 	BOOST_CHECK_THROW(parseText(text), ParserError);
 }
 
+BOOST_AUTO_TEST_CASE(two_exact_functions)
+{
+	char const* text = R"(
+		contract test {
+			function fun(uint a) returns(uint r) { return a; }
+			function fun(uint a) returns(uint r) { return a; }
+		}
+	)";
+	// with support of overloaded functions, during parsing,
+	// we can't determine whether they match exactly, however
+	// it will throw DeclarationError in following stage.
+	BOOST_CHECK_NO_THROW(parseText(text));
+}
+
+BOOST_AUTO_TEST_CASE(overloaded_functions)
+{
+	char const* text = R"(
+		contract test {
+			function fun(uint a) returns(uint r) { return a; }
+			function fun(uint a, uint b) returns(uint r) { return a + b; }
+		}
+	)";
+	BOOST_CHECK_NO_THROW(parseText(text));
+}
+
 BOOST_AUTO_TEST_CASE(function_natspec_documentation)
 {
 	ASTPointer<ContractDefinition> contract;


### PR DESCRIPTION
@chriseth This is my almost done patch, I'd like to have some comments from you instead of heading down on the wrong path :) It can pass all solidity test cases except "inheritance_diamond_basic", working on that.

Here are my design choices, at first place, I created another ASTNode called FunctionIdentifier, but being more familiar with the code base, I want to combine FunctionIdentifier with simply Identifier. I want your advice on this.

Another point is whether I should treat this illegal or legal? Base contract has a function called fun(), but the derived one has a different signature, in the original implementation, we don't allow this, how about now?