### PR TITLE
Uninitialized member in EthereumPeer

### DIFF
--- a/libethereum/EthereumPeer.h
+++ b/libethereum/EthereumPeer.h
@@ -131,7 +131,7 @@ private:
 	DownloadSub m_sub;
 
 	/// Have we received a GetTransactions packet that we haven't yet answered?
-	bool m_requireTransactions;
+	bool m_requireTransactions = false;
 
 	Mutex x_knownBlocks;
 	h256Set m_knownBlocks;					///< Blocks that the peer already knows about (that don't need to be sent to them).


### PR DESCRIPTION
Was referenced uninitialized in EthereumHost::maintainTransactions