### PR TITLE
Test macros for printing Exception information

### DIFF
--- a/libdevcore/Exceptions.h
+++ b/libdevcore/Exceptions.h
@@ -33,8 +33,8 @@ namespace dev
 // base class for all exceptions
 struct Exception: virtual std::exception, virtual boost::exception
 {
-	Exception(std::string _message = {}) : m_message(std::move(_message)) {}
-	const char* what() const noexcept override { return m_message.c_str(); }
+	Exception(std::string _message = {}): m_message(std::move(_message)) {}
+	const char* what() const noexcept override { return m_message.empty() ? std::exception::what() : m_message.c_str(); }
 
 private:
 	std::string m_message;

--- a/test/SolidityABIJSON.cpp
+++ b/test/SolidityABIJSON.cpp
@@ -20,7 +20,7 @@
  * Unit tests for the solidity compiler JSON Interface output.
  */
 
-#include <boost/test/unit_test.hpp>
+#include "TestHelper.h"
 #include <libsolidity/CompilerStack.h>
 #include <json/json.h>
 #include <libdevcore/Exceptions.h>
@@ -39,15 +39,7 @@ public:
 
 	void checkInterface(std::string const& _code, std::string const& _expectedInterfaceString)
 	{
-		try
-		{
-			m_compilerStack.parse(_code);
-		}
-		catch(boost::exception const& _e)
-		{
-			auto msg = std::string("Parsing contract failed with: ") + boost::diagnostic_information(_e);
-			BOOST_FAIL(msg);
-		}
+		ETH_TEST_REQUIRE_NO_THROW(m_compilerStack.parse(_code), "Parsing contract failed");
 		std::string generatedInterfaceString = m_compilerStack.getMetadata("", DocumentationType::ABIInterface);
 		Json::Value generatedInterface;
 		m_reader.parse(generatedInterfaceString, generatedInterface);

--- a/test/SolidityExpressionCompiler.cpp
+++ b/test/SolidityExpressionCompiler.cpp
@@ -44,6 +44,23 @@ namespace test
 namespace
 {
 
+// LTODO: Move to some more generic location. We really need it
+/// Make sure that no Exception is thrown during testing. If one is thrown show its info.
+/// @param _expression    The expression for which to make sure no exceptions are thrown
+/// @param _message       A message to act as a prefix to the expression's error information
+#define ETH_TEST_REQUIRE_NO_THROW(_expression, _message)				\
+	do {																\
+		try															\
+		{																\
+			_expression;												\
+		}																\
+		catch (boost::exception const& _e)								\
+		{																\
+			auto msg = std::string(_message) + boost::diagnostic_information(_e); \
+			BOOST_FAIL(msg);											\
+		}																\
+	}while (0)
+
 /// Helper class that extracts the first expression in an AST.
 class FirstExpressionExtractor: private ASTVisitor
 {
@@ -72,8 +89,8 @@ private:
 	Expression* m_expression;
 };
 
-Declaration const& resolveDeclaration(vector<string> const& _namespacedName,
-											  NameAndTypeResolver const& _resolver)
+Declaration const& resolveDeclaration(
+	vector<string> const& _namespacedName, NameAndTypeResolver const& _resolver)
 {
 	Declaration const* declaration = nullptr;
 	// bracers are required, cause msvc couldnt handle this macro in for statement
@@ -112,13 +129,13 @@ bytes compileFirstExpression(const string& _sourceCode, vector<vector<string>> _
 	for (ASTPointer<ASTNode> const& node: sourceUnit->getNodes())
 		if (ContractDefinition* contract = dynamic_cast<ContractDefinition*>(node.get()))
 		{
-			BOOST_REQUIRE_NO_THROW(resolver.resolveNamesAndTypes(*contract));
+			ETH_TEST_REQUIRE_NO_THROW(resolver.resolveNamesAndTypes(*contract), "Resolving names failed");
 			inheritanceHierarchy = vector<ContractDefinition const*>(1, contract);
 		}
 	for (ASTPointer<ASTNode> const& node: sourceUnit->getNodes())
 		if (ContractDefinition* contract = dynamic_cast<ContractDefinition*>(node.get()))
 		{
-			BOOST_REQUIRE_NO_THROW(resolver.checkTypeRequirements(*contract));
+			ETH_TEST_REQUIRE_NO_THROW(resolver.checkTypeRequirements(*contract), "Checking type Requirements failed");
 		}
 	for (ASTPointer<ASTNode> const& node: sourceUnit->getNodes())
 		if (ContractDefinition* contract = dynamic_cast<ContractDefinition*>(node.get()))

--- a/test/SolidityExpressionCompiler.cpp
+++ b/test/SolidityExpressionCompiler.cpp
@@ -30,7 +30,7 @@
 #include <libsolidity/CompilerContext.h>
 #include <libsolidity/ExpressionCompiler.h>
 #include <libsolidity/AST.h>
-#include <boost/test/unit_test.hpp>
+#include "TestHelper.h"
 
 using namespace std;
 
@@ -43,23 +43,6 @@ namespace test
 
 namespace
 {
-
-// LTODO: Move to some more generic location. We really need it
-/// Make sure that no Exception is thrown during testing. If one is thrown show its info.
-/// @param _expression    The expression for which to make sure no exceptions are thrown
-/// @param _message       A message to act as a prefix to the expression's error information
-#define ETH_TEST_REQUIRE_NO_THROW(_expression, _message)				\
-	do {																\
-		try															\
-		{																\
-			_expression;												\
-		}																\
-		catch (boost::exception const& _e)								\
-		{																\
-			auto msg = std::string(_message) + boost::diagnostic_information(_e); \
-			BOOST_FAIL(msg);											\
-		}																\
-	}while (0)
 
 /// Helper class that extracts the first expression in an AST.
 class FirstExpressionExtractor: private ASTVisitor

--- a/test/SolidityInterface.cpp
+++ b/test/SolidityInterface.cpp
@@ -20,7 +20,7 @@
  * Unit tests for generating source interfaces for Solidity contracts.
  */
 
-#include <boost/test/unit_test.hpp>
+#include "TestHelper.h"
 #include <libsolidity/CompilerStack.h>
 #include <libsolidity/AST.h>
 
@@ -42,9 +42,9 @@ public:
 	ContractDefinition const& checkInterface(string const& _code, string const& _contractName = "")
 	{
 		m_code = _code;
-		BOOST_REQUIRE_NO_THROW(m_compilerStack.parse(_code));
+		ETH_TEST_REQUIRE_NO_THROW(m_compilerStack.parse(_code), "Parsing failed");
 		m_interface = m_compilerStack.getMetadata("", DocumentationType::ABISolidityInterface);
-		BOOST_REQUIRE_NO_THROW(m_reCompiler.parse(m_interface));
+		ETH_TEST_REQUIRE_NO_THROW(m_reCompiler.parse(m_interface), "Interface parsing failed");
 		return m_reCompiler.getContractDefinition(_contractName);
 	}
 

--- a/test/SolidityNameAndTypeResolution.cpp
+++ b/test/SolidityNameAndTypeResolution.cpp
@@ -28,7 +28,7 @@
 #include <libsolidity/Parser.h>
 #include <libsolidity/NameAndTypeResolver.h>
 #include <libsolidity/Exceptions.h>
-#include <boost/test/unit_test.hpp>
+#include "TestHelper.h"
 
 using namespace std;
 
@@ -55,30 +55,6 @@ ASTPointer<SourceUnit> parseTextAndResolveNames(std::string const& _source)
 		if (ContractDefinition* contract = dynamic_cast<ContractDefinition*>(node.get()))
 			resolver.checkTypeRequirements(*contract);
 
-	return sourceUnit;
-}
-
-ASTPointer<SourceUnit> parseTextAndResolveNamesWithChecks(std::string const& _source)
-{
-	Parser parser;
-	ASTPointer<SourceUnit> sourceUnit;
-	try
-	{
-		sourceUnit = parser.parse(std::make_shared<Scanner>(CharStream(_source)));
-		NameAndTypeResolver resolver({});
-		resolver.registerDeclarations(*sourceUnit);
-		for (ASTPointer<ASTNode> const& node: sourceUnit->getNodes())
-			if (ContractDefinition* contract = dynamic_cast<ContractDefinition*>(node.get()))
-				resolver.resolveNamesAndTypes(*contract);
-		for (ASTPointer<ASTNode> const& node: sourceUnit->getNodes())
-			if (ContractDefinition* contract = dynamic_cast<ContractDefinition*>(node.get()))
-				resolver.checkTypeRequirements(*contract);
-	}
-	catch(boost::exception const& _e)
-	{
-		auto msg = std::string("Parsing text and resolving names failed with: \n") + boost::diagnostic_information(_e);
-		BOOST_FAIL(msg);
-	}
 	return sourceUnit;
 }
 
@@ -109,7 +85,7 @@ BOOST_AUTO_TEST_CASE(smoke_test)
 					   "  uint256 stateVariable1;\n"
 					   "  function fun(uint256 arg1) { var x; uint256 y; }"
 					   "}\n";
-	BOOST_CHECK_NO_THROW(parseTextAndResolveNamesWithChecks(text));
+	ETH_TEST_CHECK_NO_THROW(parseTextAndResolveNames(text), "Parsing and Name Resolving Failed");
 }
 
 BOOST_AUTO_TEST_CASE(double_stateVariable_declaration)
@@ -144,7 +120,7 @@ BOOST_AUTO_TEST_CASE(name_shadowing)
 					   "  uint256 variable;\n"
 					   "  function f() { uint32 variable ; }"
 					   "}\n";
-	BOOST_CHECK_NO_THROW(parseTextAndResolveNames(text));
+	ETH_TEST_CHECK_NO_THROW(parseTextAndResolveNames(text), "Parsing and Name Resolving Failed");
 }
 
 BOOST_AUTO_TEST_CASE(name_references)
@@ -153,7 +129,7 @@ BOOST_AUTO_TEST_CASE(name_references)
 					   "  uint256 variable;\n"
 					   "  function f(uint256 arg) returns (uint out) { f(variable); test; out; }"
 					   "}\n";
-	BOOST_CHECK_NO_THROW(parseTextAndResolveNames(text));
+	ETH_TEST_CHECK_NO_THROW(parseTextAndResolveNames(text), "Parsing and Name Resolving Failed");
 }
 
 BOOST_AUTO_TEST_CASE(undeclared_name)
@@ -171,7 +147,7 @@ BOOST_AUTO_TEST_CASE(reference_to_later_declaration)
 					   "  function g() { f(); }"
 					   "  function f() {  }"
 					   "}\n";
-	BOOST_CHECK_NO_THROW(parseTextAndResolveNames(text));
+	ETH_TEST_CHECK_NO_THROW(parseTextAndResolveNames(text), "Parsing and Name Resolving Failed");
 }
 
 BOOST_AUTO_TEST_CASE(struct_definition_directly_recursive)
@@ -209,7 +185,7 @@ BOOST_AUTO_TEST_CASE(struct_definition_recursion_via_mapping)
 					   "    mapping(uint => MyStructName1) x;\n"
 					   "  }\n"
 					   "}\n";
-	BOOST_CHECK_NO_THROW(parseTextAndResolveNames(text));
+	ETH_TEST_CHECK_NO_THROW(parseTextAndResolveNames(text), "Parsing and Name Resolving Failed");
 }
 
 BOOST_AUTO_TEST_CASE(type_inference_smoke_test)
@@ -217,7 +193,7 @@ BOOST_AUTO_TEST_CASE(type_inference_smoke_test)
 	char const* text = "contract test {\n"
 					   "  function f(uint256 arg1, uint32 arg2) returns (bool ret) { var x = arg1 + arg2 == 8; ret = x; }"
 					   "}\n";
-	BOOST_CHECK_NO_THROW(parseTextAndResolveNames(text));
+	ETH_TEST_CHECK_NO_THROW(parseTextAndResolveNames(text), "Parsing and Name Resolving Failed");
 }
 
 BOOST_AUTO_TEST_CASE(type_checking_return)
@@ -225,7 +201,7 @@ BOOST_AUTO_TEST_CASE(type_checking_return)
 	char const* text = "contract test {\n"
 					   "  function f() returns (bool r) { return 1 >= 2; }"
 					   "}\n";
-	BOOST_CHECK_NO_THROW(parseTextAndResolveNames(text));
+	ETH_TEST_CHECK_NO_THROW(parseTextAndResolveNames(text), "Parsing and Name Resolving Failed");
 }
 
 BOOST_AUTO_TEST_CASE(type_checking_return_wrong_number)
@@ -250,7 +226,7 @@ BOOST_AUTO_TEST_CASE(type_checking_function_call)
 					   "  function f() returns (bool r) { return g(12, true) == 3; }\n"
 					   "  function g(uint256 a, bool b) returns (uint256 r) { }\n"
 					   "}\n";
-	BOOST_CHECK_NO_THROW(parseTextAndResolveNames(text));
+	ETH_TEST_CHECK_NO_THROW(parseTextAndResolveNames(text), "Parsing and Name Resolving Failed");
 }
 
 BOOST_AUTO_TEST_CASE(type_conversion_for_comparison)
@@ -258,7 +234,7 @@ BOOST_AUTO_TEST_CASE(type_conversion_for_comparison)
 	char const* text = "contract test {\n"
 					   "  function f() { uint32(2) == int64(2); }"
 					   "}\n";
-	BOOST_CHECK_NO_THROW(parseTextAndResolveNames(text));
+	ETH_TEST_CHECK_NO_THROW(parseTextAndResolveNames(text), "Parsing and Name Resolving Failed");
 }
 
 BOOST_AUTO_TEST_CASE(type_conversion_for_comparison_invalid)
@@ -274,7 +250,7 @@ BOOST_AUTO_TEST_CASE(type_inference_explicit_conversion)
 	char const* text = "contract test {\n"
 					   "  function f() returns (int256 r) { var x = int256(uint32(2)); return x; }"
 					   "}\n";
-	BOOST_CHECK_NO_THROW(parseTextAndResolveNames(text));
+	ETH_TEST_CHECK_NO_THROW(parseTextAndResolveNames(text), "Parsing and Name Resolving Failed");
 }
 
 BOOST_AUTO_TEST_CASE(large_string_literal)
@@ -292,7 +268,7 @@ BOOST_AUTO_TEST_CASE(balance)
 					   "    uint256 x = address(0).balance;\n"
 					   "  }\n"
 					   "}\n";
-	BOOST_CHECK_NO_THROW(parseTextAndResolveNames(text));
+	ETH_TEST_CHECK_NO_THROW(parseTextAndResolveNames(text), "Parsing and Name Resolving Failed");
 }
 
 BOOST_AUTO_TEST_CASE(balance_invalid)
@@ -332,7 +308,7 @@ BOOST_AUTO_TEST_CASE(assignment_to_struct)
 					   "    data = a;\n"
 					   "  }\n"
 					   "}\n";
-	BOOST_CHECK_NO_THROW(parseTextAndResolveNames(text));
+	ETH_TEST_CHECK_NO_THROW(parseTextAndResolveNames(text), "Parsing and Name Resolving Failed");
 }
 
 BOOST_AUTO_TEST_CASE(returns_in_constructor)
@@ -356,7 +332,7 @@ BOOST_AUTO_TEST_CASE(forward_function_reference)
 					   "    if (First(2).fun() == true) return 1;\n"
 					   "  }\n"
 					   "}\n";
-	BOOST_CHECK_NO_THROW(parseTextAndResolveNames(text));
+	ETH_TEST_CHECK_NO_THROW(parseTextAndResolveNames(text), "Parsing and Name Resolving Failed");
 }
 
 BOOST_AUTO_TEST_CASE(comparison_bitop_precedence)
@@ -366,7 +342,7 @@ BOOST_AUTO_TEST_CASE(comparison_bitop_precedence)
 					   "    return 1 & 2 == 8 & 9 && 1 ^ 2 < 4 | 6;\n"
 					   "  }\n"
 					   "}\n";
-	BOOST_CHECK_NO_THROW(parseTextAndResolveNames(text));
+	ETH_TEST_CHECK_NO_THROW(parseTextAndResolveNames(text), "Parsing and Name Resolving Failed");
 }
 
 BOOST_AUTO_TEST_CASE(function_canonical_signature)
@@ -423,7 +399,7 @@ BOOST_AUTO_TEST_CASE(inheritance_basic)
 			function f() { baseMember = 7; }
 		}
 	)";
-	BOOST_CHECK_NO_THROW(parseTextAndResolveNames(text));
+	ETH_TEST_CHECK_NO_THROW(parseTextAndResolveNames(text), "Parsing and Name Resolving Failed");
 }
 
 BOOST_AUTO_TEST_CASE(inheritance_diamond_basic)
@@ -436,7 +412,7 @@ BOOST_AUTO_TEST_CASE(inheritance_diamond_basic)
 			function g() { f(); rootFunction(); }
 		}
 	)";
-	BOOST_CHECK_NO_THROW(parseTextAndResolveNamesWithChecks(text));
+	ETH_TEST_CHECK_NO_THROW(parseTextAndResolveNames(text), "Parsing and Name Resolving Failed");
 }
 
 BOOST_AUTO_TEST_CASE(cyclic_inheritance)
@@ -492,7 +468,7 @@ BOOST_AUTO_TEST_CASE(complex_inheritance)
 		contract B { function f() {} function g() returns (uint8 r) {} }
 		contract C is A, B { }
 	)";
-	BOOST_CHECK_NO_THROW(parseTextAndResolveNames(text));
+	ETH_TEST_CHECK_NO_THROW(parseTextAndResolveNames(text), "Parsing and Name Resolving Failed");
 }
 
 BOOST_AUTO_TEST_CASE(constructor_visibility)
@@ -502,7 +478,7 @@ BOOST_AUTO_TEST_CASE(constructor_visibility)
 		contract A { function A() { } }
 		contract B is A { function f() { A x = A(0); } }
 	)";
-	BOOST_CHECK_NO_THROW(parseTextAndResolveNames(text));
+	ETH_TEST_CHECK_NO_THROW(parseTextAndResolveNames(text), "Parsing and Name Resolving Failed");
 }
 
 BOOST_AUTO_TEST_CASE(overriding_constructor)
@@ -512,7 +488,7 @@ BOOST_AUTO_TEST_CASE(overriding_constructor)
 		contract A { function A() { } }
 		contract B is A { function A() returns (uint8 r) {} }
 	)";
-	BOOST_CHECK_NO_THROW(parseTextAndResolveNames(text));
+	ETH_TEST_CHECK_NO_THROW(parseTextAndResolveNames(text), "Parsing and Name Resolving Failed");
 }
 
 BOOST_AUTO_TEST_CASE(missing_base_constructor_arguments)
@@ -541,7 +517,7 @@ BOOST_AUTO_TEST_CASE(implicit_derived_to_base_conversion)
 			function f() { A a = B(1); }
 		}
 	)";
-	BOOST_CHECK_NO_THROW(parseTextAndResolveNames(text));
+	ETH_TEST_CHECK_NO_THROW(parseTextAndResolveNames(text), "Parsing and Name Resolving Failed");
 }
 
 BOOST_AUTO_TEST_CASE(implicit_base_to_derived_conversion)
@@ -564,7 +540,7 @@ BOOST_AUTO_TEST_CASE(function_modifier_invocation)
 			modifier mod2(string7 a) { while (a == "1234567") _ }
 		}
 	)";
-	BOOST_CHECK_NO_THROW(parseTextAndResolveNames(text));
+	ETH_TEST_CHECK_NO_THROW(parseTextAndResolveNames(text), "Parsing and Name Resolving Failed");
 }
 
 BOOST_AUTO_TEST_CASE(invalid_function_modifier_type)
@@ -587,7 +563,7 @@ BOOST_AUTO_TEST_CASE(function_modifier_invocation_parameters)
 			modifier mod2(string7 a) { while (a == "1234567") _ }
 		}
 	)";
-	BOOST_CHECK_NO_THROW(parseTextAndResolveNames(text));
+	ETH_TEST_CHECK_NO_THROW(parseTextAndResolveNames(text), "Parsing and Name Resolving Failed");
 }
 
 BOOST_AUTO_TEST_CASE(function_modifier_invocation_local_variables)
@@ -598,7 +574,7 @@ BOOST_AUTO_TEST_CASE(function_modifier_invocation_local_variables)
 			modifier mod(uint a) { if (a > 0) _ }
 		}
 	)";
-	BOOST_CHECK_NO_THROW(parseTextAndResolveNames(text));
+	ETH_TEST_CHECK_NO_THROW(parseTextAndResolveNames(text), "Parsing and Name Resolving Failed");
 }
 
 BOOST_AUTO_TEST_CASE(legal_modifier_override)
@@ -607,7 +583,7 @@ BOOST_AUTO_TEST_CASE(legal_modifier_override)
 		contract A { modifier mod(uint a) {} }
 		contract B is A { modifier mod(uint a) {} }
 	)";
-	BOOST_CHECK_NO_THROW(parseTextAndResolveNames(text));
+	ETH_TEST_CHECK_NO_THROW(parseTextAndResolveNames(text), "Parsing and Name Resolving Failed");
 }
 
 BOOST_AUTO_TEST_CASE(illegal_modifier_override)
@@ -661,7 +637,7 @@ BOOST_AUTO_TEST_CASE(state_variable_accessors)
 
 	ASTPointer<SourceUnit> source;
 	ContractDefinition const* contract;
-	BOOST_CHECK_NO_THROW(source = parseTextAndResolveNamesWithChecks(text));
+	ETH_TEST_CHECK_NO_THROW(source = parseTextAndResolveNames(text), "Parsing and Resolving names failed");
 	BOOST_REQUIRE((contract = retrieveContract(source, 0)) != nullptr);
 	FunctionTypePointer function = retrieveFunctionBySignature(contract, "foo()");
 	BOOST_REQUIRE(function && function->hasDeclaration());
@@ -711,7 +687,7 @@ BOOST_AUTO_TEST_CASE(private_state_variable)
 
 	ASTPointer<SourceUnit> source;
 	ContractDefinition const* contract;
-	BOOST_CHECK_NO_THROW(source = parseTextAndResolveNamesWithChecks(text));
+	ETH_TEST_CHECK_NO_THROW(source = parseTextAndResolveNames(text), "Parsing and Resolving names failed");
 	BOOST_CHECK((contract = retrieveContract(source, 0)) != nullptr);
 	FunctionTypePointer function;
 	function = retrieveFunctionBySignature(contract, "foo()");
@@ -729,7 +705,7 @@ BOOST_AUTO_TEST_CASE(base_class_state_variable_accessor)
 					   "contract Child is Parent{\n"
 					   "    function foo() returns (uint256) { return Parent.m_aMember; }\n"
 					   "}\n";
-	BOOST_CHECK_NO_THROW(parseTextAndResolveNamesWithChecks(text));
+	ETH_TEST_CHECK_NO_THROW(parseTextAndResolveNames(text), "Parsing and Name Resolving Failed");
 }
 
 BOOST_AUTO_TEST_CASE(base_class_state_variable_internal_member)
@@ -740,7 +716,7 @@ BOOST_AUTO_TEST_CASE(base_class_state_variable_internal_member)
 					   "contract Child is Parent{\n"
 					   "    function foo() returns (uint256) { return Parent.m_aMember; }\n"
 					   "}\n";
-	BOOST_CHECK_NO_THROW(parseTextAndResolveNamesWithChecks(text));
+	ETH_TEST_CHECK_NO_THROW(parseTextAndResolveNames(text), "Parsing and Name Resolving Failed");
 }
 
 BOOST_AUTO_TEST_CASE(state_variable_member_of_wrong_class1)
@@ -780,7 +756,7 @@ BOOST_AUTO_TEST_CASE(fallback_function)
 			function() { x = 2; }
 		}
 	)";
-	BOOST_CHECK_NO_THROW(parseTextAndResolveNames(text));
+	ETH_TEST_CHECK_NO_THROW(parseTextAndResolveNames(text), "Parsing and Name Resolving Failed");
 }
 
 BOOST_AUTO_TEST_CASE(fallback_function_with_arguments)
@@ -817,7 +793,7 @@ BOOST_AUTO_TEST_CASE(fallback_function_inheritance)
 			function() { x = 2; }
 		}
 	)";
-	BOOST_CHECK_NO_THROW(parseTextAndResolveNames(text));
+	ETH_TEST_CHECK_NO_THROW(parseTextAndResolveNames(text), "Parsing and Name Resolving Failed");
 }
 
 BOOST_AUTO_TEST_CASE(event)
@@ -827,7 +803,7 @@ BOOST_AUTO_TEST_CASE(event)
 			event e(uint indexed a, string3 indexed s, bool indexed b);
 			function f() { e(2, "abc", true); }
 		})";
-	BOOST_CHECK_NO_THROW(parseTextAndResolveNames(text));
+	ETH_TEST_CHECK_NO_THROW(parseTextAndResolveNames(text), "Parsing and Name Resolving Failed");
 }
 
 BOOST_AUTO_TEST_CASE(event_too_many_indexed)
@@ -847,7 +823,7 @@ BOOST_AUTO_TEST_CASE(event_call)
 			event e(uint a, string3 indexed s, bool indexed b);
 			function f() { e(2, "abc", true); }
 		})";
-	BOOST_CHECK_NO_THROW(parseTextAndResolveNames(text));
+	ETH_TEST_CHECK_NO_THROW(parseTextAndResolveNames(text), "Parsing and Name Resolving Failed");
 }
 
 BOOST_AUTO_TEST_CASE(event_inheritance)
@@ -859,7 +835,7 @@ BOOST_AUTO_TEST_CASE(event_inheritance)
 		contract c is base {
 			function f() { e(2, "abc", true); }
 		})";
-	BOOST_CHECK_NO_THROW(parseTextAndResolveNames(text));
+	ETH_TEST_CHECK_NO_THROW(parseTextAndResolveNames(text), "Parsing and Name Resolving Failed");
 }
 
 BOOST_AUTO_TEST_CASE(multiple_events_argument_clash)
@@ -869,7 +845,7 @@ BOOST_AUTO_TEST_CASE(multiple_events_argument_clash)
 			event e1(uint a, uint e1, uint e2);
 			event e2(uint a, uint e1, uint e2);
 		})";
-	BOOST_CHECK_NO_THROW(parseTextAndResolveNames(text));
+	ETH_TEST_CHECK_NO_THROW(parseTextAndResolveNames(text), "Parsing and Name Resolving Failed");
 }
 
 BOOST_AUTO_TEST_CASE(access_to_default_function_visibility)
@@ -881,7 +857,7 @@ BOOST_AUTO_TEST_CASE(access_to_default_function_visibility)
 		contract d {
 			function g() { c(0).f(); }
 		})";
-	BOOST_CHECK_NO_THROW(parseTextAndResolveNames(text));
+	ETH_TEST_CHECK_NO_THROW(parseTextAndResolveNames(text), "Parsing and Name Resolving Failed");
 }
 
 BOOST_AUTO_TEST_CASE(access_to_internal_function)
@@ -917,7 +893,7 @@ BOOST_AUTO_TEST_CASE(access_to_internal_state_variable)
 		contract d {
 			function g() { c(0).a(); }
 		})";
-	BOOST_CHECK_NO_THROW(parseTextAndResolveNames(text));
+	ETH_TEST_CHECK_NO_THROW(parseTextAndResolveNames(text), "Parsing and Name Resolving Failed");
 }
 
 BOOST_AUTO_TEST_CASE(error_count_in_named_args)
@@ -963,7 +939,7 @@ BOOST_AUTO_TEST_CASE(empty_name_input_parameter)
 			function f(uint){
 		}
 	})";
-	BOOST_CHECK_NO_THROW(parseTextAndResolveNames(text));
+	ETH_TEST_CHECK_NO_THROW(parseTextAndResolveNames(text), "Parsing and Name Resolving Failed");
 }
 
 BOOST_AUTO_TEST_CASE(empty_name_return_parameter)
@@ -973,7 +949,7 @@ BOOST_AUTO_TEST_CASE(empty_name_return_parameter)
 			function f() returns(bool){
 		}
 		})";
-	BOOST_CHECK_NO_THROW(parseTextAndResolveNames(text));
+	ETH_TEST_CHECK_NO_THROW(parseTextAndResolveNames(text), "Parsing and Name Resolving Failed");
 }
 
 BOOST_AUTO_TEST_CASE(empty_name_input_parameter_with_named_one)
@@ -984,7 +960,7 @@ BOOST_AUTO_TEST_CASE(empty_name_input_parameter_with_named_one)
 				return k;
 		}
 	})";
-	BOOST_CHECK_NO_THROW(parseTextAndResolveNames(text));
+	ETH_TEST_CHECK_NO_THROW(parseTextAndResolveNames(text), "Parsing and Name Resolving Failed");
 }
 
 BOOST_AUTO_TEST_CASE(empty_name_return_parameter_with_named_one)
@@ -1014,7 +990,8 @@ BOOST_AUTO_TEST_CASE(overflow_caused_by_ether_units)
 			}
 			uint256 a;
 		})";
-	BOOST_CHECK_NO_THROW(parseTextAndResolveNames(sourceCodeFine));
+	ETH_TEST_CHECK_NO_THROW(parseTextAndResolveNames(sourceCodeFine),
+		"Parsing and Resolving names failed");
 	char const* sourceCode = R"(
 		contract c {
 			function c ()
@@ -1056,7 +1033,7 @@ BOOST_AUTO_TEST_CASE(enum_member_access)
 				ActionChoices choices;
 			}
 	)";
-	BOOST_CHECK_NO_THROW(parseTextAndResolveNamesWithChecks(text));
+	ETH_TEST_CHECK_NO_THROW(parseTextAndResolveNames(text), "Parsing and Name Resolving Failed");
 }
 
 BOOST_AUTO_TEST_CASE(enum_invalid_member_access)
@@ -1088,7 +1065,7 @@ BOOST_AUTO_TEST_CASE(enum_explicit_conversion_is_okay)
 				uint64 b;
 			}
 	)";
-	BOOST_CHECK_NO_THROW(parseTextAndResolveNamesWithChecks(text));
+	ETH_TEST_CHECK_NO_THROW(parseTextAndResolveNames(text), "Parsing and Name Resolving Failed");
 }
 
 BOOST_AUTO_TEST_CASE(int_to_enum_explicit_conversion_is_okay)
@@ -1105,7 +1082,7 @@ BOOST_AUTO_TEST_CASE(int_to_enum_explicit_conversion_is_okay)
 				ActionChoices b;
 			}
 	)";
-	BOOST_CHECK_NO_THROW(parseTextAndResolveNamesWithChecks(text));
+	ETH_TEST_CHECK_NO_THROW(parseTextAndResolveNames(text), "Parsing and Name Resolving Failed");
 }
 
 BOOST_AUTO_TEST_CASE(enum_implicit_conversion_is_not_okay)
@@ -1225,7 +1202,7 @@ BOOST_AUTO_TEST_CASE(test_for_bug_override_function_with_bytearray_type)
 			function f(bytes _a) external returns (uint256 r) {r = 42;}
 		}
 		)";
-	BOOST_CHECK_NO_THROW(parseTextAndResolveNamesWithChecks(sourceCode));
+	ETH_TEST_CHECK_NO_THROW(parseTextAndResolveNames(sourceCode), "Parsing and Name Resolving failed");
 }
 
 BOOST_AUTO_TEST_CASE(array_with_nonconstant_length)
@@ -1267,7 +1244,7 @@ BOOST_AUTO_TEST_CASE(array_copy_with_different_types_conversion_possible)
 			uint8[] b;
 			function f() { a = b; }
 		})";
-	BOOST_CHECK_NO_THROW(parseTextAndResolveNames(text));
+	ETH_TEST_CHECK_NO_THROW(parseTextAndResolveNames(text), "Parsing and Name Resolving Failed");
 }
 
 BOOST_AUTO_TEST_CASE(array_copy_with_different_types_static_dynamic)
@@ -1278,7 +1255,7 @@ BOOST_AUTO_TEST_CASE(array_copy_with_different_types_static_dynamic)
 			uint8[80] b;
 			function f() { a = b; }
 		})";
-	BOOST_CHECK_NO_THROW(parseTextAndResolveNames(text));
+	ETH_TEST_CHECK_NO_THROW(parseTextAndResolveNames(text), "Parsing and Name Resolving Failed");
 }
 
 BOOST_AUTO_TEST_CASE(array_copy_with_different_types_dynamic_static)

--- a/test/SolidityNatspecJSON.cpp
+++ b/test/SolidityNatspecJSON.cpp
@@ -20,7 +20,7 @@
  * Unit tests for the solidity compiler JSON Interface output.
  */
 
-#include <boost/test/unit_test.hpp>
+#include "TestHelper.h"
 #include <json/json.h>
 #include <libsolidity/CompilerStack.h>
 #include <libsolidity/Exceptions.h>
@@ -43,15 +43,7 @@ public:
 					  bool _userDocumentation)
 	{
 		std::string generatedDocumentationString;
-		try
-		{
-			m_compilerStack.parse(_code);
-		}
-		catch(boost::exception const& _e)
-		{
-			auto msg = std::string("Parsing contract failed with: ") + boost::diagnostic_information(_e);
-			BOOST_FAIL(msg);
-		}
+		ETH_TEST_REQUIRE_NO_THROW(m_compilerStack.parse(_code), "Parsing failed");
 
 		if (_userDocumentation)
 			generatedDocumentationString = m_compilerStack.getMetadata("", DocumentationType::NatspecUser);

--- a/test/SolidityParser.cpp
+++ b/test/SolidityParser.cpp
@@ -26,7 +26,7 @@
 #include <libsolidity/Scanner.h>
 #include <libsolidity/Parser.h>
 #include <libsolidity/Exceptions.h>
-#include <boost/test/unit_test.hpp>
+#include "TestHelper.h"
 
 using namespace std;
 
@@ -50,22 +50,6 @@ ASTPointer<ContractDefinition> parseText(std::string const& _source)
 	return ASTPointer<ContractDefinition>();
 }
 
-ASTPointer<ContractDefinition> parseTextExplainError(std::string const& _source)
-{
-	try
-	{
-		return parseText(_source);
-	}
-	catch (Exception const& exception)
-	{
-		// LTODO: Print the error in a kind of a better way?
-		// In absence of CompilerStack we can't use SourceReferenceFormatter
-		cout << "Exception while parsing: " << diagnostic_information(exception);
-		// rethrow to signal test failure
-		throw exception;
-	}
-}
-
 static void checkFunctionNatspec(ASTPointer<FunctionDefinition> _function,
 								 std::string const& _expectedDoc)
 {
@@ -84,7 +68,7 @@ BOOST_AUTO_TEST_CASE(smoke_test)
 	char const* text = "contract test {\n"
 					   "  uint256 stateVariable1;\n"
 					   "}\n";
-	BOOST_CHECK_NO_THROW(parseText(text));
+	ETH_TEST_CHECK_NO_THROW(parseText(text), "Parsing failed.");
 }
 
 BOOST_AUTO_TEST_CASE(missing_variable_name_in_declaration)
@@ -103,7 +87,7 @@ BOOST_AUTO_TEST_CASE(empty_function)
 					   "    returns (int id)\n"
 					   "  { }\n"
 					   "}\n";
-	BOOST_CHECK_NO_THROW(parseText(text));
+	ETH_TEST_CHECK_NO_THROW(parseText(text), "Parsing failed.");
 }
 
 BOOST_AUTO_TEST_CASE(no_function_params)
@@ -112,7 +96,7 @@ BOOST_AUTO_TEST_CASE(no_function_params)
 					   "  uint256 stateVar;\n"
 					   "  function functionName() {}\n"
 					   "}\n";
-	BOOST_CHECK_NO_THROW(parseText(text));
+	ETH_TEST_CHECK_NO_THROW(parseText(text), "Parsing failed.");
 }
 
 BOOST_AUTO_TEST_CASE(single_function_param)
@@ -121,7 +105,7 @@ BOOST_AUTO_TEST_CASE(single_function_param)
 					   "  uint256 stateVar;\n"
 					   "  function functionName(hash hashin) returns (hash hashout) {}\n"
 					   "}\n";
-	BOOST_CHECK_NO_THROW(parseText(text));
+	ETH_TEST_CHECK_NO_THROW(parseText(text), "Parsing failed.");
 }
 
 BOOST_AUTO_TEST_CASE(missing_parameter_name_in_named_args)
@@ -151,9 +135,9 @@ BOOST_AUTO_TEST_CASE(function_natspec_documentation)
 					   "  /// This is a test function\n"
 					   "  function functionName(hash hashin) returns (hash hashout) {}\n"
 					   "}\n";
-	BOOST_REQUIRE_NO_THROW(contract = parseText(text));
+	ETH_TEST_REQUIRE_NO_THROW(contract = parseText(text), "Parsing failed");
 	auto functions = contract->getDefinedFunctions();
-	BOOST_REQUIRE_NO_THROW(function = functions.at(0));
+	ETH_TEST_REQUIRE_NO_THROW(function = functions.at(0), "Failed to retrieve function");
 	checkFunctionNatspec(function, "This is a test function");
 }
 
@@ -166,9 +150,9 @@ BOOST_AUTO_TEST_CASE(function_normal_comments)
 					   "  // We won't see this comment\n"
 					   "  function functionName(hash hashin) returns (hash hashout) {}\n"
 					   "}\n";
-	BOOST_REQUIRE_NO_THROW(contract = parseText(text));
+	ETH_TEST_REQUIRE_NO_THROW(contract = parseText(text), "Parsing failed");
 	auto functions = contract->getDefinedFunctions();
-	BOOST_REQUIRE_NO_THROW(function = functions.at(0));
+	ETH_TEST_REQUIRE_NO_THROW(function = functions.at(0), "Failed to retrieve function");
 	BOOST_CHECK_MESSAGE(function->getDocumentation() == nullptr,
 						"Should not have gotten a Natspecc comment for this function");
 }
@@ -188,20 +172,20 @@ BOOST_AUTO_TEST_CASE(multiple_functions_natspec_documentation)
 					   "  /// This is test function 4\n"
 					   "  function functionName4(hash hashin) returns (hash hashout) {}\n"
 					   "}\n";
-	BOOST_REQUIRE_NO_THROW(contract = parseText(text));
+	ETH_TEST_REQUIRE_NO_THROW(contract = parseText(text), "Parsing failed");
 	auto functions = contract->getDefinedFunctions();
 
-	BOOST_REQUIRE_NO_THROW(function = functions.at(0));
+	ETH_TEST_REQUIRE_NO_THROW(function = functions.at(0), "Failed to retrieve function");
 	checkFunctionNatspec(function, "This is test function 1");
 
-	BOOST_REQUIRE_NO_THROW(function = functions.at(1));
+	ETH_TEST_REQUIRE_NO_THROW(function = functions.at(1), "Failed to retrieve function");
 	checkFunctionNatspec(function, "This is test function 2");
 
-	BOOST_REQUIRE_NO_THROW(function = functions.at(2));
+	ETH_TEST_REQUIRE_NO_THROW(function = functions.at(2), "Failed to retrieve function");
 	BOOST_CHECK_MESSAGE(function->getDocumentation() == nullptr,
 						"Should not have gotten natspec comment for functionName3()");
 
-	BOOST_REQUIRE_NO_THROW(function = functions.at(3));
+	ETH_TEST_REQUIRE_NO_THROW(function = functions.at(3), "Failed to retrieve function");
 	checkFunctionNatspec(function, "This is test function 4");
 }
 
@@ -215,10 +199,10 @@ BOOST_AUTO_TEST_CASE(multiline_function_documentation)
 					   "  /// and it has 2 lines\n"
 					   "  function functionName1(hash hashin) returns (hash hashout) {}\n"
 					   "}\n";
-	BOOST_REQUIRE_NO_THROW(contract = parseText(text));
+	ETH_TEST_REQUIRE_NO_THROW(contract = parseText(text), "Parsing failed");
 	auto functions = contract->getDefinedFunctions();
 
-	BOOST_REQUIRE_NO_THROW(function = functions.at(0));
+	ETH_TEST_REQUIRE_NO_THROW(function = functions.at(0), "Failed to retrieve function");
 	checkFunctionNatspec(function, "This is a test function\n"
 						 " and it has 2 lines");
 }
@@ -240,13 +224,13 @@ BOOST_AUTO_TEST_CASE(natspec_comment_in_function_body)
 					   "  /// and it has 2 lines\n"
 					   "  function fun(hash hashin) returns (hash hashout) {}\n"
 					   "}\n";
-	BOOST_REQUIRE_NO_THROW(contract = parseText(text));
+	ETH_TEST_REQUIRE_NO_THROW(contract = parseText(text), "Parsing failed");
 	auto functions = contract->getDefinedFunctions();
 
-	BOOST_REQUIRE_NO_THROW(function = functions.at(0));
+	ETH_TEST_REQUIRE_NO_THROW(function = functions.at(0), "Failed to retrieve function");
 	checkFunctionNatspec(function, "fun1 description");
 
-	BOOST_REQUIRE_NO_THROW(function = functions.at(1));
+	ETH_TEST_REQUIRE_NO_THROW(function = functions.at(1), "Failed to retrieve function");
 	checkFunctionNatspec(function, "This is a test function\n"
 						 " and it has 2 lines");
 }
@@ -266,10 +250,10 @@ BOOST_AUTO_TEST_CASE(natspec_docstring_between_keyword_and_signature)
 					   "    string name = \"Solidity\";"
 					   "  }\n"
 					   "}\n";
-	BOOST_REQUIRE_NO_THROW(contract = parseText(text));
+	ETH_TEST_REQUIRE_NO_THROW(contract = parseText(text), "Parsing failed");
 	auto functions = contract->getDefinedFunctions();
 
-	BOOST_REQUIRE_NO_THROW(function = functions.at(0));
+	ETH_TEST_REQUIRE_NO_THROW(function = functions.at(0), "Failed to retrieve function");
 	BOOST_CHECK_MESSAGE(!function->getDocumentation(),
 						"Shouldn't get natspec docstring for this function");
 }
@@ -289,10 +273,10 @@ BOOST_AUTO_TEST_CASE(natspec_docstring_after_signature)
 					   "    string name = \"Solidity\";"
 					   "  }\n"
 					   "}\n";
-	BOOST_REQUIRE_NO_THROW(contract = parseText(text));
+	ETH_TEST_REQUIRE_NO_THROW(contract = parseText(text), "Parsing failed");
 	auto functions = contract->getDefinedFunctions();
 
-	BOOST_REQUIRE_NO_THROW(function = functions.at(0));
+	ETH_TEST_REQUIRE_NO_THROW(function = functions.at(0), "Failed to retrieve function");
 	BOOST_CHECK_MESSAGE(!function->getDocumentation(),
 						"Shouldn't get natspec docstring for this function");
 }
@@ -306,7 +290,7 @@ BOOST_AUTO_TEST_CASE(struct_definition)
 					   "    uint256 count;\n"
 					   "  }\n"
 					   "}\n";
-	BOOST_CHECK_NO_THROW(parseText(text));
+	ETH_TEST_CHECK_NO_THROW(parseText(text), "Parsing failed");
 }
 
 BOOST_AUTO_TEST_CASE(mapping)
@@ -314,7 +298,7 @@ BOOST_AUTO_TEST_CASE(mapping)
 	char const* text = "contract test {\n"
 					   "  mapping(address => string) names;\n"
 					   "}\n";
-	BOOST_CHECK_NO_THROW(parseText(text));
+	ETH_TEST_CHECK_NO_THROW(parseText(text), "Parsing failed");
 }
 
 BOOST_AUTO_TEST_CASE(mapping_in_struct)
@@ -326,7 +310,7 @@ BOOST_AUTO_TEST_CASE(mapping_in_struct)
 					   "    mapping(hash => test_struct) self_reference;\n"
 					   "  }\n"
 					   "}\n";
-	BOOST_CHECK_NO_THROW(parseText(text));
+	ETH_TEST_CHECK_NO_THROW(parseText(text), "Parsing failed");
 }
 
 BOOST_AUTO_TEST_CASE(mapping_to_mapping_in_struct)
@@ -337,7 +321,7 @@ BOOST_AUTO_TEST_CASE(mapping_to_mapping_in_struct)
 					   "    mapping (uint64 => mapping (hash => uint)) complex_mapping;\n"
 					   "  }\n"
 					   "}\n";
-	BOOST_CHECK_NO_THROW(parseText(text));
+	ETH_TEST_CHECK_NO_THROW(parseText(text), "Parsing failed");
 }
 
 BOOST_AUTO_TEST_CASE(variable_definition)
@@ -350,7 +334,7 @@ BOOST_AUTO_TEST_CASE(variable_definition)
 					   "    customtype varname;\n"
 					   "  }\n"
 					   "}\n";
-	BOOST_CHECK_NO_THROW(parseText(text));
+	ETH_TEST_CHECK_NO_THROW(parseText(text), "Parsing failed");
 }
 
 BOOST_AUTO_TEST_CASE(variable_definition_with_initialization)
@@ -364,7 +348,7 @@ BOOST_AUTO_TEST_CASE(variable_definition_with_initialization)
 					   "    customtype varname;\n"
 					   "  }\n"
 					   "}\n";
-	BOOST_CHECK_NO_THROW(parseText(text));
+	ETH_TEST_CHECK_NO_THROW(parseText(text), "Parsing failed");
 }
 
 BOOST_AUTO_TEST_CASE(variable_definition_in_function_parameter)
@@ -408,7 +392,7 @@ BOOST_AUTO_TEST_CASE(operator_expression)
 					   "    uint256 x = (1 + 4) || false && (1 - 12) + -9;\n"
 					   "  }\n"
 					   "}\n";
-	BOOST_CHECK_NO_THROW(parseText(text));
+	ETH_TEST_CHECK_NO_THROW(parseText(text), "Parsing failed");
 }
 
 BOOST_AUTO_TEST_CASE(complex_expression)
@@ -418,7 +402,7 @@ BOOST_AUTO_TEST_CASE(complex_expression)
 					   "    uint256 x = (1 + 4).member(++67)[a/=9] || true;\n"
 					   "  }\n"
 					   "}\n";
-	BOOST_CHECK_NO_THROW(parseText(text));
+	ETH_TEST_CHECK_NO_THROW(parseText(text), "Parsing failed");
 }
 
 BOOST_AUTO_TEST_CASE(exp_expression)
@@ -429,7 +413,7 @@ BOOST_AUTO_TEST_CASE(exp_expression)
 				uint256 x = 3 ** a;
 			}
 		})";
-	BOOST_CHECK_NO_THROW(parseText(text));
+	ETH_TEST_CHECK_NO_THROW(parseText(text), "Parsing failed");
 }
 
 BOOST_AUTO_TEST_CASE(while_loop)
@@ -439,7 +423,7 @@ BOOST_AUTO_TEST_CASE(while_loop)
 					   "    while (true) { uint256 x = 1; break; continue; } x = 9;\n"
 					   "  }\n"
 					   "}\n";
-	BOOST_CHECK_NO_THROW(parseText(text));
+	ETH_TEST_CHECK_NO_THROW(parseText(text), "Parsing failed");
 }
 
 BOOST_AUTO_TEST_CASE(for_loop_vardef_initexpr)
@@ -450,7 +434,7 @@ BOOST_AUTO_TEST_CASE(for_loop_vardef_initexpr)
 					   "    { uint256 x = i; break; continue; }\n"
 					   "  }\n"
 					   "}\n";
-	BOOST_CHECK_NO_THROW(parseTextExplainError(text));
+	ETH_TEST_CHECK_NO_THROW(parseText(text), "Parsing failed");
 }
 
 BOOST_AUTO_TEST_CASE(for_loop_simple_initexpr)
@@ -462,7 +446,7 @@ BOOST_AUTO_TEST_CASE(for_loop_simple_initexpr)
 					   "    { uint256 x = i; break; continue; }\n"
 					   "  }\n"
 					   "}\n";
-	BOOST_CHECK_NO_THROW(parseTextExplainError(text));
+	ETH_TEST_CHECK_NO_THROW(parseText(text), "Parsing failed");
 }
 
 BOOST_AUTO_TEST_CASE(for_loop_simple_noexpr)
@@ -474,7 +458,7 @@ BOOST_AUTO_TEST_CASE(for_loop_simple_noexpr)
 					   "    { uint256 x = i; break; continue; }\n"
 					   "  }\n"
 					   "}\n";
-	BOOST_CHECK_NO_THROW(parseTextExplainError(text));
+	ETH_TEST_CHECK_NO_THROW(parseText(text), "Parsing failed");
 }
 
 BOOST_AUTO_TEST_CASE(for_loop_single_stmt_body)
@@ -486,7 +470,7 @@ BOOST_AUTO_TEST_CASE(for_loop_single_stmt_body)
 					   "        continue;\n"
 					   "  }\n"
 					   "}\n";
-	BOOST_CHECK_NO_THROW(parseTextExplainError(text));
+	ETH_TEST_CHECK_NO_THROW(parseText(text), "Parsing failed");
 }
 
 BOOST_AUTO_TEST_CASE(if_statement)
@@ -496,7 +480,7 @@ BOOST_AUTO_TEST_CASE(if_statement)
 					   "    if (a >= 8) return 2; else { var b = 7; }\n"
 					   "  }\n"
 					   "}\n";
-	BOOST_CHECK_NO_THROW(parseText(text));
+	ETH_TEST_CHECK_NO_THROW(parseText(text), "Parsing failed");
 }
 
 BOOST_AUTO_TEST_CASE(else_if_statement)
@@ -506,7 +490,7 @@ BOOST_AUTO_TEST_CASE(else_if_statement)
 					   "    if (a < 0) b = 0x67; else if (a == 0) b = 0x12; else b = 0x78;\n"
 					   "  }\n"
 					   "}\n";
-	BOOST_CHECK_NO_THROW(parseText(text));
+	ETH_TEST_CHECK_NO_THROW(parseText(text), "Parsing failed");
 }
 
 BOOST_AUTO_TEST_CASE(statement_starting_with_type_conversion)
@@ -518,7 +502,7 @@ BOOST_AUTO_TEST_CASE(statement_starting_with_type_conversion)
 					   "    uint64[](3);\n"
 					   "  }\n"
 					   "}\n";
-	BOOST_CHECK_NO_THROW(parseText(text));
+	ETH_TEST_CHECK_NO_THROW(parseText(text), "Parsing failed");
 }
 
 BOOST_AUTO_TEST_CASE(type_conversion_to_dynamic_array)
@@ -528,7 +512,7 @@ BOOST_AUTO_TEST_CASE(type_conversion_to_dynamic_array)
 					   "    var x = uint64[](3);\n"
 					   "  }\n"
 					   "}\n";
-	BOOST_CHECK_NO_THROW(parseText(text));
+	ETH_TEST_CHECK_NO_THROW(parseText(text), "Parsing failed");
 }
 
 BOOST_AUTO_TEST_CASE(import_directive)
@@ -539,7 +523,7 @@ BOOST_AUTO_TEST_CASE(import_directive)
 					   "    uint64(2);\n"
 					   "  }\n"
 					   "}\n";
-	BOOST_CHECK_NO_THROW(parseText(text));
+	ETH_TEST_CHECK_NO_THROW(parseText(text), "Parsing failed");
 }
 
 BOOST_AUTO_TEST_CASE(multiple_contracts)
@@ -554,7 +538,7 @@ BOOST_AUTO_TEST_CASE(multiple_contracts)
 					   "    uint64(2);\n"
 					   "  }\n"
 					   "}\n";
-	BOOST_CHECK_NO_THROW(parseText(text));
+	ETH_TEST_CHECK_NO_THROW(parseText(text), "Parsing failed");
 }
 
 BOOST_AUTO_TEST_CASE(multiple_contracts_and_imports)
@@ -572,7 +556,7 @@ BOOST_AUTO_TEST_CASE(multiple_contracts_and_imports)
 					   "  }\n"
 					   "}\n"
 					   "import \"ghi\";\n";
-	BOOST_CHECK_NO_THROW(parseText(text));
+	ETH_TEST_CHECK_NO_THROW(parseText(text), "Parsing failed");
 }
 
 BOOST_AUTO_TEST_CASE(contract_inheritance)
@@ -587,7 +571,7 @@ BOOST_AUTO_TEST_CASE(contract_inheritance)
 					   "    uint64(2);\n"
 					   "  }\n"
 					   "}\n";
-	BOOST_CHECK_NO_THROW(parseText(text));
+	ETH_TEST_CHECK_NO_THROW(parseText(text), "Parsing failed");
 }
 
 BOOST_AUTO_TEST_CASE(contract_multiple_inheritance)
@@ -602,7 +586,7 @@ BOOST_AUTO_TEST_CASE(contract_multiple_inheritance)
 					   "    uint64(2);\n"
 					   "  }\n"
 					   "}\n";
-	BOOST_CHECK_NO_THROW(parseText(text));
+	ETH_TEST_CHECK_NO_THROW(parseText(text), "Parsing failed");
 }
 
 BOOST_AUTO_TEST_CASE(contract_multiple_inheritance_with_arguments)
@@ -617,7 +601,7 @@ BOOST_AUTO_TEST_CASE(contract_multiple_inheritance_with_arguments)
 					   "    uint64(2);\n"
 					   "  }\n"
 					   "}\n";
-	BOOST_CHECK_NO_THROW(parseText(text));
+	ETH_TEST_CHECK_NO_THROW(parseText(text), "Parsing failed");
 }
 
 BOOST_AUTO_TEST_CASE(placeholder_in_function_context)
@@ -628,7 +612,7 @@ BOOST_AUTO_TEST_CASE(placeholder_in_function_context)
 					   "    return _ + 1;"
 					   "  }\n"
 					   "}\n";
-	BOOST_CHECK_NO_THROW(parseText(text));
+	ETH_TEST_CHECK_NO_THROW(parseText(text), "Parsing failed");
 }
 
 BOOST_AUTO_TEST_CASE(modifier)
@@ -636,7 +620,7 @@ BOOST_AUTO_TEST_CASE(modifier)
 	char const* text = "contract c {\n"
 					   "  modifier mod { if (msg.sender == 0) _ }\n"
 					   "}\n";
-	BOOST_CHECK_NO_THROW(parseText(text));
+	ETH_TEST_CHECK_NO_THROW(parseText(text), "Parsing failed");
 }
 
 BOOST_AUTO_TEST_CASE(modifier_arguments)
@@ -644,7 +628,7 @@ BOOST_AUTO_TEST_CASE(modifier_arguments)
 	char const* text = "contract c {\n"
 					   "  modifier mod(uint a) { if (msg.sender == a) _ }\n"
 					   "}\n";
-	BOOST_CHECK_NO_THROW(parseText(text));
+	ETH_TEST_CHECK_NO_THROW(parseText(text), "Parsing failed");
 }
 
 BOOST_AUTO_TEST_CASE(modifier_invocation)
@@ -654,7 +638,7 @@ BOOST_AUTO_TEST_CASE(modifier_invocation)
 					   "  modifier mod2 { if (msg.sender == 2) _ }\n"
 					   "  function f() mod1(7) mod2 { }\n"
 					   "}\n";
-	BOOST_CHECK_NO_THROW(parseText(text));
+	ETH_TEST_CHECK_NO_THROW(parseText(text), "Parsing failed");
 }
 
 BOOST_AUTO_TEST_CASE(fallback_function)
@@ -662,7 +646,7 @@ BOOST_AUTO_TEST_CASE(fallback_function)
 	char const* text = "contract c {\n"
 					   "  function() { }\n"
 					   "}\n";
-	BOOST_CHECK_NO_THROW(parseText(text));
+	ETH_TEST_CHECK_NO_THROW(parseText(text), "Parsing failed");
 }
 
 BOOST_AUTO_TEST_CASE(event)
@@ -671,7 +655,7 @@ BOOST_AUTO_TEST_CASE(event)
 		contract c {
 			event e();
 		})";
-	BOOST_CHECK_NO_THROW(parseText(text));
+	ETH_TEST_CHECK_NO_THROW(parseText(text), "Parsing failed");
 }
 
 BOOST_AUTO_TEST_CASE(event_arguments)
@@ -680,7 +664,7 @@ BOOST_AUTO_TEST_CASE(event_arguments)
 		contract c {
 			event e(uint a, string32 s);
 		})";
-	BOOST_CHECK_NO_THROW(parseText(text));
+	ETH_TEST_CHECK_NO_THROW(parseText(text), "Parsing failed");
 }
 
 BOOST_AUTO_TEST_CASE(event_arguments_indexed)
@@ -689,7 +673,7 @@ BOOST_AUTO_TEST_CASE(event_arguments_indexed)
 		contract c {
 			event e(uint a, string32 indexed s, bool indexed b);
 		})";
-	BOOST_CHECK_NO_THROW(parseText(text));
+	ETH_TEST_CHECK_NO_THROW(parseText(text), "Parsing failed");
 }
 
 BOOST_AUTO_TEST_CASE(visibility_specifiers)
@@ -705,7 +689,7 @@ BOOST_AUTO_TEST_CASE(visibility_specifiers)
 			function f_public() public {}
 			function f_internal() internal {}
 		})";
-	BOOST_CHECK_NO_THROW(parseText(text));
+	ETH_TEST_CHECK_NO_THROW(parseText(text), "Parsing failed");
 }
 
 BOOST_AUTO_TEST_CASE(multiple_visibility_specifiers)
@@ -733,7 +717,7 @@ BOOST_AUTO_TEST_CASE(literal_constants_with_ether_subdenominations)
 			uint256 c;
 			uint256 d;
 		})";
-	BOOST_CHECK_NO_THROW(parseTextExplainError(text));
+	ETH_TEST_CHECK_NO_THROW(parseText(text), "Parsing failed");
 }
 
 BOOST_AUTO_TEST_CASE(literal_constants_with_ether_subdenominations_in_expressions)
@@ -746,7 +730,7 @@ BOOST_AUTO_TEST_CASE(literal_constants_with_ether_subdenominations_in_expression
 			}
 			uint256 a;
 		})";
-	BOOST_CHECK_NO_THROW(parseTextExplainError(text));
+	ETH_TEST_CHECK_NO_THROW(parseText(text), "Parsing failed");
 }
 
 BOOST_AUTO_TEST_CASE(enum_valid_declaration)
@@ -760,7 +744,7 @@ BOOST_AUTO_TEST_CASE(enum_valid_declaration)
 			}
 			uint256 a;
 		})";
-	BOOST_CHECK_NO_THROW(parseTextExplainError(text));
+	ETH_TEST_CHECK_NO_THROW(parseText(text), "Parsing failed");
 }
 
 BOOST_AUTO_TEST_CASE(empty_enum_declaration)
@@ -769,7 +753,7 @@ BOOST_AUTO_TEST_CASE(empty_enum_declaration)
 		contract c {
 			enum foo { }
 		})";
-	BOOST_CHECK_NO_THROW(parseTextExplainError(text));
+	ETH_TEST_CHECK_NO_THROW(parseText(text), "Parsing failed");
 }
 
 BOOST_AUTO_TEST_CASE(malformed_enum_declaration)
@@ -787,7 +771,7 @@ BOOST_AUTO_TEST_CASE(external_function)
 		contract c {
 			function x() external {}
 		})";
-	BOOST_CHECK_NO_THROW(parseTextExplainError(text));
+	ETH_TEST_CHECK_NO_THROW(parseText(text), "Parsing failed");
 }
 
 BOOST_AUTO_TEST_CASE(external_variable)
@@ -808,7 +792,7 @@ BOOST_AUTO_TEST_CASE(arrays_in_storage)
 			struct x { uint[2**20] b; y[0] c; }
 			struct y { uint d; mapping(uint=>x)[] e; }
 		})";
-	BOOST_CHECK_NO_THROW(parseText(text));
+	ETH_TEST_CHECK_NO_THROW(parseText(text), "Parsing failed");
 }
 
 BOOST_AUTO_TEST_CASE(arrays_in_events)
@@ -817,7 +801,7 @@ BOOST_AUTO_TEST_CASE(arrays_in_events)
 		contract c {
 			event e(uint[10] a, string7[8] indexed b, c[3] x);
 		})";
-	BOOST_CHECK_NO_THROW(parseText(text));
+	ETH_TEST_CHECK_NO_THROW(parseText(text), "Parsing failed");
 }
 
 BOOST_AUTO_TEST_CASE(arrays_in_expressions)
@@ -826,7 +810,7 @@ BOOST_AUTO_TEST_CASE(arrays_in_expressions)
 		contract c {
 			function f() { c[10] a = 7; uint8[10 * 2] x; }
 		})";
-	BOOST_CHECK_NO_THROW(parseText(text));
+	ETH_TEST_CHECK_NO_THROW(parseText(text), "Parsing failed");
 }
 
 BOOST_AUTO_TEST_CASE(multi_arrays)
@@ -835,7 +819,7 @@ BOOST_AUTO_TEST_CASE(multi_arrays)
 		contract c {
 			mapping(uint => mapping(uint => int8)[8][][9])[] x;
 		})";
-	BOOST_CHECK_NO_THROW(parseText(text));
+	ETH_TEST_CHECK_NO_THROW(parseText(text), "Parsing failed");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/TestHelper.h
+++ b/test/TestHelper.h
@@ -44,6 +44,41 @@ void connectClients(Client& c1, Client& c2);
 namespace test
 {
 
+/// Make sure that no Exception is thrown during testing. If one is thrown show its info and fail the test.
+/// Our version of BOOST_REQUIRE_NO_THROW()
+/// @param _expression    The expression for which to make sure no exceptions are thrown
+/// @param _message       A message to act as a prefix to the expression's error information
+#define ETH_TEST_REQUIRE_NO_THROW(_expression, _message)				\
+	do {																\
+		try															\
+		{																\
+			_expression;												\
+		}																\
+		catch (boost::exception const& _e)								\
+		{																\
+			auto msg = std::string(_message) + boost::diagnostic_information(_e); \
+			BOOST_FAIL(msg);											\
+		}																\
+	}while (0)
+
+/// Check if an Exception is thrown during testing. If one is thrown show its info and continue the test
+/// Our version of BOOST_CHECK_NO_THROW()
+/// @param _expression    The expression for which to make sure no exceptions are thrown
+/// @param _message       A message to act as a prefix to the expression's error information
+#define ETH_TEST_CHECK_NO_THROW(_expression, _message)					\
+	do {																\
+		try															\
+		{																\
+			_expression;												\
+		}																\
+		catch (boost::exception const& _e)								\
+		{																\
+			auto msg = std::string(_message) + boost::diagnostic_information(_e); \
+			BOOST_MESSAGE(msg);										\
+		}																\
+	}while (0)
+
+
 class ImportTest
 {
 public:

--- a/test/TestHelper.h
+++ b/test/TestHelper.h
@@ -49,34 +49,36 @@ namespace test
 /// @param _expression    The expression for which to make sure no exceptions are thrown
 /// @param _message       A message to act as a prefix to the expression's error information
 #define ETH_TEST_REQUIRE_NO_THROW(_expression, _message)				\
-	do {																\
+	do																	\
+	{																	\
 		try															\
 		{																\
 			_expression;												\
 		}																\
 		catch (boost::exception const& _e)								\
 		{																\
-			auto msg = std::string(_message) + boost::diagnostic_information(_e); \
+			auto msg = std::string(_message"\n") + boost::diagnostic_information(_e); \
 			BOOST_FAIL(msg);											\
 		}																\
-	}while (0)
+	} while (0)
 
 /// Check if an Exception is thrown during testing. If one is thrown show its info and continue the test
 /// Our version of BOOST_CHECK_NO_THROW()
 /// @param _expression    The expression for which to make sure no exceptions are thrown
 /// @param _message       A message to act as a prefix to the expression's error information
 #define ETH_TEST_CHECK_NO_THROW(_expression, _message)					\
-	do {																\
+	do																	\
+	{																	\
 		try															\
 		{																\
 			_expression;												\
 		}																\
 		catch (boost::exception const& _e)								\
 		{																\
-			auto msg = std::string(_message) + boost::diagnostic_information(_e); \
+			auto msg = std::string(_message"\n") + boost::diagnostic_information(_e); \
 			BOOST_MESSAGE(msg);										\
 		}																\
-	}while (0)
+	} while (0)
 
 
 class ImportTest

--- a/test/solidityExecutionFramework.h
+++ b/test/solidityExecutionFramework.h
@@ -25,7 +25,7 @@
 
 #include <string>
 #include <tuple>
-#include <boost/test/unit_test.hpp>
+#include "TestHelper.h"
 #include <libethereum/State.h>
 #include <libethereum/Executive.h>
 #include <libsolidity/CompilerStack.h>
@@ -46,16 +46,8 @@ public:
 	bytes const& compileAndRun(std::string const& _sourceCode, u256 const& _value = 0, std::string const& _contractName = "")
 	{
 		dev::solidity::CompilerStack compiler(m_addStandardSources);
-		try
-		{
-			compiler.addSource("", _sourceCode);
-			compiler.compile(m_optimize);
-		}
-		catch(boost::exception const& _e)
-		{
-			auto msg = std::string("Compiling contract failed with: ") + boost::diagnostic_information(_e);
-			BOOST_FAIL(msg);
-		}
+		compiler.addSource("", _sourceCode);
+		ETH_TEST_REQUIRE_NO_THROW(compiler.compile(m_optimize), "Compiling contract failed");
 
 		bytes code = compiler.getBytecode(_contractName);
 		sendMessage(code, true, _value);


### PR DESCRIPTION
`BOOST_XXX()` macros don't show any information about the exceptions that are thrown. With this PR I am adding some additional macros, the `ETH_TEST_XXX()` family of macros that should act exactly as the BOOST macros but instead print information about the thrown exception.

This is really necessary when debugging code we are not familiar with and need to know why and where a test fails. Only use them in SolidityTests for now but feel free to use them in your own tests too.

