### PR TITLE
add input limit tests

### DIFF
--- a/test/vm.cpp
+++ b/test/vm.cpp
@@ -533,33 +533,43 @@ BOOST_AUTO_TEST_CASE(vmPerformanceTest)
 	}
 }
 
-//BOOST_AUTO_TEST_CASE(vmInputLimitsTest1)
-//{
-//	for (int i = 1; i < boost::unit_test::framework::master_test_suite().argc; ++i)
-//	{
-//		string arg = boost::unit_test::framework::master_test_suite().argv[i];
-//		if (arg == "--inputlimits" || arg == "--all")
-//		{
-//			auto start = chrono::steady_clock::now();
+BOOST_AUTO_TEST_CASE(vmInputLimitsTest1)
+{
+	for (int i = 1; i < boost::unit_test::framework::master_test_suite().argc; ++i)
+	{
+		string arg = boost::unit_test::framework::master_test_suite().argv[i];
+		if (arg == "--inputlimits" || arg == "--all")
+		{
+			auto start = chrono::steady_clock::now();
 
-//			dev::test::executeTests("vmInputLimitsTest1", "/VMTests", dev::test::doVMTests);
+			dev::test::executeTests("vmInputLimits1", "/VMTests", dev::test::doVMTests);
 
-//			auto end = chrono::steady_clock::now();
-//			auto duration(chrono::duration_cast<chrono::milliseconds>(end - start));
-//			cnote << "test duration: " << duration.count() << " milliseconds.\n";
-//		}
-//	}
-//}
+			auto end = chrono::steady_clock::now();
+			auto duration(chrono::duration_cast<chrono::milliseconds>(end - start));
+			cnote << "test duration: " << duration.count() << " milliseconds.\n";
+		}
+	}
+}
 
-//BOOST_AUTO_TEST_CASE(vmInputLimitsTest2)
-//{
-//	for (int i = 1; i < boost::unit_test::framework::master_test_suite().argc; ++i)
-//	{
-//		string arg = boost::unit_test::framework::master_test_suite().argv[i];
-//		if (arg == "--inputlimits" || arg == "--all")
-//			dev::test::executeTests("vmInputLimitsTest2", "/VMTests", dev::test::doVMTests);
-//	}
-//}
+BOOST_AUTO_TEST_CASE(vmInputLimitsTest2)
+{
+	for (int i = 1; i < boost::unit_test::framework::master_test_suite().argc; ++i)
+	{
+		string arg = boost::unit_test::framework::master_test_suite().argv[i];
+		if (arg == "--inputlimits" || arg == "--all")
+			dev::test::executeTests("vmInputLimits2", "/VMTests", dev::test::doVMTests);
+	}
+}
+
+BOOST_AUTO_TEST_CASE(vmInputLimitsLightTest)
+{
+	for (int i = 1; i < boost::unit_test::framework::master_test_suite().argc; ++i)
+	{
+		string arg = boost::unit_test::framework::master_test_suite().argv[i];
+		if (arg == "--inputlimits" || arg == "--all")
+			dev::test::executeTests("vmInputLimitsLight", "/VMTests", dev::test::doVMTests);
+	}
+}
 
 BOOST_AUTO_TEST_CASE(vmRandom)
 {


### PR DESCRIPTION
all opcodes are tested with all permutations of {0, 1, 2^160-1, 2^160, 2^256-2, 2^256-1} (PoC9 updated tests are in test repo)
