### PR TITLE
p2p: fixes

### DIFF
--- a/libdevcrypto/CryptoPP.cpp
+++ b/libdevcrypto/CryptoPP.cpp
@@ -319,8 +319,7 @@ void Secp256k1::agree(Secret const& _s, Public const& _r, h256& o_s)
 	assert(d.AgreedValueLength() == sizeof(o_s));
 	byte remote[65] = {0x04};
 	memcpy(&remote[1], _r.data(), 64);
-	bool result = d.Agree(o_s.data(), _s.data(), remote);
-	assert(result);
+	d.Agree(o_s.data(), _s.data(), remote);
 }
 
 void Secp256k1::exportPublicKey(CryptoPP::DL_PublicKey_EC<CryptoPP::ECP> const& _k, Public& o_p)

--- a/libethereum/Client.h
+++ b/libethereum/Client.h
@@ -46,7 +46,6 @@
 
 namespace dev
 {
-
 namespace eth
 {
 

--- a/test/peer.cpp
+++ b/test/peer.cpp
@@ -63,6 +63,7 @@ BOOST_AUTO_TEST_CASE(save_nodes)
 	for (auto i:{0,1,2,3,4,5})
 	{
 		Host* h = new Host("Test", NetworkPreferences(30300 + i, "127.0.0.1", true, true));
+		h->setIdealPeerCount(10);
 		// starting host is required so listenport is available
 		h->start();
 		while (!h->isStarted())


### PR DESCRIPTION
fix for -warning in cryptopp.cpp. 
add mutex to host iteration of peers for connect. 
only try to connect to as many peers as is necessary. update unit test.