### PR TITLE
Fix calldataload

### DIFF
--- a/libevm/VM.cpp
+++ b/libevm/VM.cpp
@@ -344,9 +344,7 @@ bytesConstRef VM::go(ExtVMFace& _ext, OnOpFunc const& _onOp, uint64_t _steps)
 			if ((bigint)m_stack.back() + 31 < _ext.data.size())
 				m_stack.back() = (u256)*(h256 const*)(_ext.data.data() + (size_t)m_stack.back());
 			else if ((bigint)m_stack.back() >= _ext.data.size())
-			{
 				m_stack.back() = u256();
-			}
 			else
 			{
 				h256 r;

--- a/libevm/VM.cpp
+++ b/libevm/VM.cpp
@@ -341,8 +341,12 @@ bytesConstRef VM::go(ExtVMFace& _ext, OnOpFunc const& _onOp, uint64_t _steps)
 			break;
 		case Instruction::CALLDATALOAD:
 		{
-			if ((unsigned)m_stack.back() + (uint64_t)31 < _ext.data.size())
-				m_stack.back() = (u256)*(h256 const*)(_ext.data.data() + (unsigned)m_stack.back());
+			if ((bigint)m_stack.back() + 31 < _ext.data.size())
+				m_stack.back() = (u256)*(h256 const*)(_ext.data.data() + (size_t)m_stack.back());
+			else if ((bigint)m_stack.back() >= _ext.data.size())
+			{
+				m_stack.back() = u256();
+			}
 			else
 			{
 				h256 r;

--- a/test/vmEnvironmentalInfoTestFiller.json
+++ b/test/vmEnvironmentalInfoTestFiller.json
@@ -367,6 +367,34 @@
         }
     },
 
+    "calldataload_BigOffset": {
+        "env" : {
+            "previousHash" : "5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6",
+            "currentNumber" : "0",
+            "currentGasLimit" : "1000000",
+            "currentDifficulty" : "256",
+            "currentTimestamp" : "1",
+            "currentCoinbase" : "2adc25665018aa1fe0e6bc666dac8fc2697ff9ba"
+        },
+        "pre" : {
+            "0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6" : {
+                "balance" : "100000000000000000000000",
+                "nonce" : "0",
+                "code" : "{ [[ 0 ]] (CALLDATALOAD 0x4200000000000000000000000000000000000000000000000000000000000000)}",
+                "storage": {}
+            }
+        },
+        "exec" : {
+            "address" : "0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "origin" : "cd1722f3947def4cf144679da39c4c32bdc35681",
+            "caller" : "cd1722f3947def4cf144679da39c4c32bdc35681",
+            "value" : "1000000000000000000",
+            "data" : "0x4200000000000000000000000000000000000000000000000000000000000000",
+            "gasPrice" : "1000000000",
+            "gas" : "100000000000"
+        }
+    },
+
     "calldataload1": {
         "env" : {
             "previousHash" : "5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6",


### PR DESCRIPTION
The problem is that when the input value is larger than unsigned.max, it will be downcasted to a position where there could be some non zero data which will be pushed to the stack, although the correct behavior according to YP would be to push zeroes. The test given below, without the fix, would result in having 0x4200...00 in the storage instead of 0.