### PR TITLE
Fix CALLCODE

### DIFF
--- a/libethereum/ExtVM.cpp
+++ b/libethereum/ExtVM.cpp
@@ -29,7 +29,7 @@ using namespace dev::eth;
 bool ExtVM::call(Address _receiveAddress, u256 _txValue, bytesConstRef _txData, u256& io_gas, bytesRef _out, OnOpFunc const& _onOp, Address _myAddressOverride, Address _codeAddressOverride)
 {
 	Executive e(m_s, lastHashes, depth + 1);
-	if (!e.call(_receiveAddress, _codeAddressOverride ? _codeAddressOverride : _receiveAddress, _myAddressOverride ? _myAddressOverride : myAddress, _txValue, gasPrice, _txData, io_gas, origin))
+	if (!e.call(_receiveAddress, _codeAddressOverride, _myAddressOverride ? _myAddressOverride : myAddress, _txValue, gasPrice, _txData, io_gas, origin))
 	{
 		e.go(_onOp);
 		e.accrueSubState(sub);

--- a/test/stSystemOperationsTestFiller.json
+++ b/test/stSystemOperationsTestFiller.json
@@ -835,6 +835,40 @@
         }
     },
 
+    "callcodeTo0": {
+        "env" : {
+            "previousHash" : "5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6",
+            "currentNumber" : "0",
+            "currentGasLimit" : "30000000",
+            "currentDifficulty" : "256",
+            "currentTimestamp" : "1",
+            "currentCoinbase" : "2adc25665018aa1fe0e6bc666dac8fc2697ff9ba"
+        },
+        "pre" : {
+            "095e7baea6a6c7c4c2dfeb977efac326af552d87" : {
+                "balance" : "1000000000000000000",
+                "nonce" : "0",
+                "code" : "{ [[ 0 ]] (CALLCODE 50000 0 1 0 0 0 0) }",
+                "storage": {}
+            },
+            "a94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "1000000000000000000",
+                "nonce" : "0",
+                "code" : "",
+                "storage": {}
+            }
+
+        },
+        "transaction" : {
+            "nonce" : "0",
+            "gasPrice" : "1",
+            "gasLimit" : "3000000",
+            "to" : "095e7baea6a6c7c4c2dfeb977efac326af552d87",
+            "value" : "100000",
+            "secretKey" : "45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "data" : ""
+        }
+    },
 
     "CallToNameRegistratorOutOfGas": {
         "env" : {


### PR DESCRIPTION
A `CALLCODE` to address `0` would lead to a `CALLCODE` to the code of the sender.
I guess this `_codeAddressOverride ? _codeAddressOverride : _receiveAddress` was only there to allow for lazyness in using `ExtVM::call`, by using the default `_codeAddressOverride` which is zero. But a `CALLCODE` to `0` would lead to a consensus break. 