### PR TITLE
Adding msg.sig Solidity Magic type

### DIFF
--- a/libsolidity/ExpressionCompiler.cpp
+++ b/libsolidity/ExpressionCompiler.cpp
@@ -646,6 +646,8 @@ void ExpressionCompiler::endVisit(MemberAccess const& _memberAccess)
 			m_context << eth::Instruction::GASPRICE;
 		else if (member == "data")
 			m_context << u256(0) << eth::Instruction::CALLDATASIZE;
+		else if (member == "sig")
+			m_context << u256(0) << eth::Instruction::CALLDATALOAD << (u256(0xffffffff) << (256 - 32))<< eth::Instruction::AND;
 		else
 			BOOST_THROW_EXCEPTION(InternalCompilerError() << errinfo_comment("Unknown magic member."));
 		break;

--- a/libsolidity/ExpressionCompiler.cpp
+++ b/libsolidity/ExpressionCompiler.cpp
@@ -647,7 +647,8 @@ void ExpressionCompiler::endVisit(MemberAccess const& _memberAccess)
 		else if (member == "data")
 			m_context << u256(0) << eth::Instruction::CALLDATASIZE;
 		else if (member == "sig")
-			m_context << u256(0) << eth::Instruction::CALLDATALOAD << (u256(0xffffffff) << (256 - 32))<< eth::Instruction::AND;
+			m_context << u256(0) << eth::Instruction::CALLDATALOAD
+				<< (u256(0xffffffff) << (256 - 32)) << eth::Instruction::AND;
 		else
 			BOOST_THROW_EXCEPTION(InternalCompilerError() << errinfo_comment("Unknown magic member."));
 		break;

--- a/libsolidity/Types.cpp
+++ b/libsolidity/Types.cpp
@@ -1160,7 +1160,8 @@ MagicType::MagicType(MagicType::Kind _kind):
 		m_members = MemberList({{"sender", make_shared<IntegerType>(0, IntegerType::Modifier::Address)},
 								{"gas", make_shared<IntegerType>(256)},
 								{"value", make_shared<IntegerType>(256)},
-								{"data", make_shared<ArrayType>(ArrayType::Location::CallData)}});
+								{"data", make_shared<ArrayType>(ArrayType::Location::CallData)},
+								{"sig", make_shared<FixedBytesType>(4)}});
 		break;
 	case Kind::Transaction:
 		m_members = MemberList({{"origin", make_shared<IntegerType>(0, IntegerType::Modifier::Address)},

--- a/test/SolidityEndToEndTest.cpp
+++ b/test/SolidityEndToEndTest.cpp
@@ -1044,6 +1044,22 @@ BOOST_AUTO_TEST_CASE(msg_sig)
 	BOOST_CHECK(callContractFunctionWithValue("foo(uint256)", 13) == encodeArgs(asString(FixedHash<4>(dev::sha3("foo(uint256)")).asBytes())));
 }
 
+BOOST_AUTO_TEST_CASE(msg_sig_after_internal_call_is_same)
+{
+	char const* sourceCode = R"(
+		contract test {
+			function boo() returns (bytes4 value) {
+				return msg.sig;
+			}
+			function foo(uint256 a) returns (bytes4 value) {
+				return boo();
+			}
+		}
+	)";
+	compileAndRun(sourceCode);
+	BOOST_CHECK(callContractFunctionWithValue("foo(uint256)", 13) == encodeArgs(asString(FixedHash<4>(dev::sha3("foo(uint256)")).asBytes())));
+}
+
 BOOST_AUTO_TEST_CASE(now)
 {
 	char const* sourceCode = "contract test {\n"

--- a/test/SolidityEndToEndTest.cpp
+++ b/test/SolidityEndToEndTest.cpp
@@ -1031,6 +1031,19 @@ BOOST_AUTO_TEST_CASE(blockchain)
 	BOOST_CHECK(callContractFunctionWithValue("someInfo()", 28) == encodeArgs(28, 0, 1));
 }
 
+BOOST_AUTO_TEST_CASE(msg_sig)
+{
+	char const* sourceCode = R"(
+		contract test {
+			function foo(uint256 a) returns (bytes4 value) {
+				return msg.sig;
+			}
+		}
+	)";
+	compileAndRun(sourceCode);
+	BOOST_CHECK(callContractFunctionWithValue("foo(uint256)", 13) == encodeArgs(asString(FixedHash<4>(dev::sha3("foo(uint256)")).asBytes())));
+}
+
 BOOST_AUTO_TEST_CASE(now)
 {
 	char const* sourceCode = "contract test {\n"


### PR DESCRIPTION
msg.sig will return a bytes4 with the function signature located in CALLDATALOAD