### PR TITLE
Let Solidity pack its storage

### DIFF
--- a/libsolidity/ArrayUtils.h
+++ b/libsolidity/ArrayUtils.h
@@ -41,19 +41,19 @@ public:
 
 	/// Copies an array to an array in storage. The arrays can be of different types only if
 	/// their storage representation is the same.
-	/// Stack pre: [source_reference] target_reference
-	/// Stack post: target_reference
+	/// Stack pre: source_reference [source_byte_offset/source_length] target_reference target_byte_offset
+	/// Stack post: target_reference target_byte_offset
 	void copyArrayToStorage(ArrayType const& _targetType, ArrayType const& _sourceType) const;
 	/// Clears the given dynamic or static array.
-	/// Stack pre: reference
+	/// Stack pre: storage_ref storage_byte_offset
 	/// Stack post:
 	void clearArray(ArrayType const& _type) const;
 	/// Clears the length and data elements of the array referenced on the stack.
-	/// Stack pre: reference
+	/// Stack pre: reference (excludes byte offset)
 	/// Stack post:
 	void clearDynamicArray(ArrayType const& _type) const;
 	/// Changes the size of a dynamic array and clears the tail if it is shortened.
-	/// Stack pre: reference new_length
+	/// Stack pre: reference (excludes byte offset) new_length
 	/// Stack post:
 	void resizeDynamicArray(ArrayType const& _type) const;
 	/// Appends a loop that clears a sequence of storage slots of the given type (excluding end).
@@ -67,7 +67,7 @@ public:
 	void convertLengthToSize(ArrayType const& _arrayType, bool _pad = false) const;
 	/// Retrieves the length (number of elements) of the array ref on the stack. This also
 	/// works for statically-sized arrays.
-	/// Stack pre: reference
+	/// Stack pre: reference (excludes byte offset for dynamic storage arrays)
 	/// Stack post: reference length
 	void retrieveLength(ArrayType const& _arrayType) const;
 

--- a/libsolidity/CompilerContext.h
+++ b/libsolidity/CompilerContext.h
@@ -24,6 +24,7 @@
 
 #include <ostream>
 #include <stack>
+#include <utility>
 #include <libevmcore/Instruction.h>
 #include <libevmcore/Assembly.h>
 #include <libsolidity/ASTForward.h>
@@ -42,7 +43,7 @@ class CompilerContext
 {
 public:
 	void addMagicGlobal(MagicVariableDeclaration const& _declaration);
-	void addStateVariable(VariableDeclaration const& _declaration);
+	void addStateVariable(VariableDeclaration const& _declaration, u256 const& _storageOffset, unsigned _byteOffset);
 	void addVariable(VariableDeclaration const& _declaration, unsigned _offsetToCurrent = 0);
 	void removeVariable(VariableDeclaration const& _declaration);
 	void addAndInitializeVariable(VariableDeclaration const& _declaration);
@@ -82,7 +83,7 @@ public:
 	/// Converts an offset relative to the current stack height to a value that can be used later
 	/// with baseToCurrentStackOffset to point to the same stack element.
 	unsigned currentToBaseStackOffset(unsigned _offset) const;
-	u256 getStorageLocationOfVariable(Declaration const& _declaration) const;
+	std::pair<u256, unsigned> getStorageLocationOfVariable(Declaration const& _declaration) const;
 
 	/// Appends a JUMPI instruction to a new tag and @returns the tag
 	eth::AssemblyItem appendConditionalJump() { return m_asm.appendJumpI().tag(); }
@@ -144,10 +145,8 @@ private:
 	std::set<Declaration const*> m_magicGlobals;
 	/// Other already compiled contracts to be used in contract creation calls.
 	std::map<ContractDefinition const*, bytes const*> m_compiledContracts;
-	/// Size of the state variables, offset of next variable to be added.
-	u256 m_stateVariablesSize = 0;
 	/// Storage offsets of state variables
-	std::map<Declaration const*, u256> m_stateVariables;
+	std::map<Declaration const*, std::pair<u256, unsigned>> m_stateVariables;
 	/// Offsets of local variables on the stack (relative to stack base).
 	std::map<Declaration const*, unsigned> m_localVariables;
 	/// Labels pointing to the entry points of functions.

--- a/libsolidity/CompilerUtils.cpp
+++ b/libsolidity/CompilerUtils.cpp
@@ -93,6 +93,7 @@ void CompilerUtils::storeInMemoryDynamic(Type const& _type, bool _padToWordBound
 		else
 		{
 			solAssert(type.getLocation() == ArrayType::Location::Storage, "Memory arrays not yet implemented.");
+			m_context << eth::Instruction::POP; //@todo
 			m_context << eth::Instruction::DUP1 << eth::Instruction::SLOAD;
 			// stack here: memory_offset storage_offset length_bytes
 			// jump to end if length is zero

--- a/libsolidity/CompilerUtils.cpp
+++ b/libsolidity/CompilerUtils.cpp
@@ -199,7 +199,6 @@ unsigned CompilerUtils::loadFromMemoryHelper(Type const& _type, bool _fromCallda
 	return numBytes;
 }
 
-
 unsigned CompilerUtils::prepareMemoryStore(Type const& _type, bool _padToWordBoundaries) const
 {
 	unsigned numBytes = _type.getCalldataEncodedSize(_padToWordBoundaries);

--- a/libsolidity/ExpressionCompiler.cpp
+++ b/libsolidity/ExpressionCompiler.cpp
@@ -81,6 +81,7 @@ void ExpressionCompiler::appendStateVariableAccessor(VariableDeclaration const& 
 		returnType = dynamic_cast<MappingType const&>(*returnType).getValueType();
 	}
 
+	m_context << u256(0); // @todo
 	unsigned retSizeOnStack = 0;
 	solAssert(accessorType.getReturnParameterTypes().size() >= 1, "");
 	if (StructType const* structType = dynamic_cast<StructType const*>(returnType.get()))
@@ -90,15 +91,18 @@ void ExpressionCompiler::appendStateVariableAccessor(VariableDeclaration const& 
 		// struct
 		for (size_t i = 0; i < names.size(); ++i)
 		{
-			m_context << eth::Instruction::DUP1
-					  << structType->getStorageOffsetOfMember(names[i])
-					  << eth::Instruction::ADD;
+			if (types[i]->getCategory() == Type::Category::Mapping)
+				continue;
+			m_context
+				<< eth::Instruction::DUP2 << structType->getStorageOffsetOfMember(names[i])
+				<< eth::Instruction::ADD;
+			m_context << u256(0); //@todo
 			StorageItem(m_context, *types[i]).retrieveValue(SourceLocation(), true);
 			solAssert(types[i]->getSizeOnStack() == 1, "Returning struct elements with stack size != 1 not yet implemented.");
-			m_context << eth::Instruction::SWAP1;
+			m_context << eth::Instruction::SWAP2 << eth::Instruction::SWAP1;
 			retSizeOnStack += types[i]->getSizeOnStack();
 		}
-		m_context << eth::Instruction::POP;
+		m_context << eth::Instruction::POP << eth::Instruction::POP;
 	}
 	else
 	{
@@ -280,23 +284,24 @@ bool ExpressionCompiler::visit(UnaryOperation const& _unaryOperation)
 	case Token::Dec: // -- (pre- or postfix)
 		solAssert(!!m_currentLValue, "LValue not retrieved.");
 		m_currentLValue->retrieveValue(_unaryOperation.getLocation());
-		solAssert(m_currentLValue->sizeOnStack() <= 1, "Not implemented.");
 		if (!_unaryOperation.isPrefixOperation())
 		{
-			if (m_currentLValue->sizeOnStack() == 1)
-				m_context << eth::Instruction::SWAP1 << eth::Instruction::DUP2;
-			else
-				m_context << eth::Instruction::DUP1;
+			// store value for later
+			solAssert(_unaryOperation.getType()->getSizeOnStack() == 1, "Stack size != 1 not implemented.");
+			m_context << eth::Instruction::DUP1;
+			if (m_currentLValue->sizeOnStack() > 0)
+				for (unsigned i = 1 + m_currentLValue->sizeOnStack(); i > 0; --i)
+					m_context << eth::swapInstruction(i);
 		}
 		m_context << u256(1);
 		if (_unaryOperation.getOperator() == Token::Inc)
 			m_context << eth::Instruction::ADD;
 		else
-			m_context << eth::Instruction::SWAP1 << eth::Instruction::SUB; // @todo avoid the swap
-		// Stack for prefix: [ref] (*ref)+-1
-		// Stack for postfix: *ref [ref] (*ref)+-1
-		if (m_currentLValue->sizeOnStack() == 1)
-			m_context << eth::Instruction::SWAP1;
+			m_context << eth::Instruction::SWAP1 << eth::Instruction::SUB;
+		// Stack for prefix: [ref...] (*ref)+-1
+		// Stack for postfix: *ref [ref...] (*ref)+-1
+		for (unsigned i = m_currentLValue->sizeOnStack(); i > 0; --i)
+			m_context << eth::swapInstruction(i);
 		m_currentLValue->storeValue(
 			*_unaryOperation.getType(), _unaryOperation.getLocation(),
 			!_unaryOperation.isPrefixOperation());
@@ -661,7 +666,10 @@ void ExpressionCompiler::endVisit(MemberAccess const& _memberAccess)
 	case Type::Category::Struct:
 	{
 		StructType const& type = dynamic_cast<StructType const&>(*_memberAccess.getExpression().getType());
+		m_context << eth::Instruction::POP; //@todo
 		m_context << type.getStorageOffsetOfMember(member) << eth::Instruction::ADD;
+		//@todo
+		m_context << u256(0);
 		setLValueToStorageItem(_memberAccess);
 		break;
 	}
@@ -729,20 +737,22 @@ bool ExpressionCompiler::visit(IndexAccess const& _indexAccess)
 	Type const& baseType = *_indexAccess.getBaseExpression().getType();
 	if (baseType.getCategory() == Type::Category::Mapping)
 	{
+		// storage byte offset is ignored for mappings, it should be zero.
+		m_context << eth::Instruction::POP;
+		// stack: storage_base_ref
 		Type const& keyType = *dynamic_cast<MappingType const&>(baseType).getKeyType();
-		m_context << u256(0);
+		m_context << u256(0); // memory position
 		solAssert(_indexAccess.getIndexExpression(), "Index expression expected.");
 		appendExpressionCopyToMemory(keyType, *_indexAccess.getIndexExpression());
-		solAssert(baseType.getSizeOnStack() == 1,
-				  "Unexpected: Not exactly one stack slot taken by subscriptable expression.");
 		m_context << eth::Instruction::SWAP1;
 		appendTypeMoveToMemory(IntegerType(256));
 		m_context << u256(0) << eth::Instruction::SHA3;
+		m_context << u256(0);
 		setLValueToStorageItem( _indexAccess);
 	}
 	else if (baseType.getCategory() == Type::Category::Array)
 	{
-		// stack layout: <base_ref> [<length>] <index>
+		// stack layout: <base_ref> [storage_byte_offset] [<length>] <index>
 		ArrayType const& arrayType = dynamic_cast<ArrayType const&>(baseType);
 		solAssert(_indexAccess.getIndexExpression(), "Index expression expected.");
 		ArrayType::Location location = arrayType.getLocation();
@@ -758,9 +768,11 @@ bool ExpressionCompiler::visit(IndexAccess const& _indexAccess)
 		else if (location == ArrayType::Location::CallData)
 			// length is stored on the stack
 			m_context << eth::Instruction::SWAP1;
+		else if (location == ArrayType::Location::Storage)
+			m_context << eth::Instruction::DUP3 << load;
 		else
 			m_context << eth::Instruction::DUP2 << load;
-		// stack: <base_ref> <index> <length>
+		// stack: <base_ref> [storage_byte_offset] <index> <length>
 		// check out-of-bounds access
 		m_context << eth::Instruction::DUP2 << eth::Instruction::LT;
 		eth::AssemblyItem legalAccess = m_context.appendConditionalJump();
@@ -768,7 +780,7 @@ bool ExpressionCompiler::visit(IndexAccess const& _indexAccess)
 		m_context << eth::Instruction::STOP;
 
 		m_context << legalAccess;
-		// stack: <base_ref> <index>
+		// stack: <base_ref> [storage_byte_offset] <index>
 		if (arrayType.isByteArray())
 			// byte array is packed differently, especially in storage
 			switch (location)
@@ -776,14 +788,15 @@ bool ExpressionCompiler::visit(IndexAccess const& _indexAccess)
 			case ArrayType::Location::Storage:
 				// byte array index storage lvalue on stack (goal):
 				// <ref> <byte_number> = <base_ref + index / 32> <index % 32>
-				m_context << u256(32) << eth::Instruction::SWAP2;
+				m_context << u256(32) << eth::Instruction::SWAP3;
 				CompilerUtils(m_context).computeHashStatic();
-				// stack: 32 index data_ref
+				// stack: 32 storage_byte_offset index data_ref
 				m_context
-					<< eth::Instruction::DUP3 << eth::Instruction::DUP3
+					<< eth::Instruction::DUP4 << eth::Instruction::DUP3
 					<< eth::Instruction::DIV << eth::Instruction::ADD
-				// stack: 32 index (data_ref + index / 32)
-					<< eth::Instruction::SWAP2 << eth::Instruction::SWAP1 << eth::Instruction::MOD;
+				// stack: 32 storage_byte_offset index (data_ref + index / 32)
+					<< eth::Instruction::SWAP3 << eth::Instruction::SWAP2
+					<< eth::Instruction::POP << eth::Instruction::MOD;
 				setLValue<StorageByteArrayElement>(_indexAccess);
 				break;
 			case ArrayType::Location::CallData:
@@ -797,6 +810,10 @@ bool ExpressionCompiler::visit(IndexAccess const& _indexAccess)
 			}
 		else
 		{
+			// stack: <base_ref> [storage_byte_offset] <index>
+			if (location == ArrayType::Location::Storage)
+				//@todo use byte offset, remove it for now
+				m_context << eth::Instruction::SWAP1 << eth::Instruction::POP;
 			u256 elementSize =
 				location == ArrayType::Location::Storage ?
 					arrayType.getBaseType()->getStorageSize() :
@@ -822,6 +839,7 @@ bool ExpressionCompiler::visit(IndexAccess const& _indexAccess)
 					CompilerUtils(m_context).loadFromMemoryDynamic(*arrayType.getBaseType(), true, true, false);
 				break;
 			case ArrayType::Location::Storage:
+				m_context << u256(0); // @todo
 				setLValueToStorageItem(_indexAccess);
 				break;
 			case ArrayType::Location::Memory:
@@ -1141,7 +1159,7 @@ void ExpressionCompiler::setLValueFromDeclaration(Declaration const& _declaratio
 	if (m_context.isLocalVariable(&_declaration))
 		setLValue<StackVariable>(_expression, _declaration);
 	else if (m_context.isStateVariable(&_declaration))
-			setLValue<StorageItem>(_expression, _declaration);
+		setLValue<StorageItem>(_expression, _declaration);
 	else
 		BOOST_THROW_EXCEPTION(InternalCompilerError()
 			<< errinfo_sourceLocation(_expression.getLocation())

--- a/libsolidity/ExpressionCompiler.h
+++ b/libsolidity/ExpressionCompiler.h
@@ -140,7 +140,6 @@ void ExpressionCompiler::setLValue(Expression const& _expression, _Arguments con
 		m_currentLValue = move(lvalue);
 	else
 		lvalue->retrieveValue(_expression.getLocation(), true);
-
 }
 
 }

--- a/libsolidity/LValue.h
+++ b/libsolidity/LValue.h
@@ -98,7 +98,9 @@ private:
 };
 
 /**
- * Reference to some item in storage. The (starting) position of the item is stored on the stack.
+ * Reference to some item in storage. On the stack this is <storage key> <offset_inside_value>,
+ * where 0 <= offset_inside_value < 32 and an offset of i means that the value is multiplied
+ * by 2**i before storing it.
  */
 class StorageItem: public LValue
 {
@@ -107,6 +109,7 @@ public:
 	StorageItem(CompilerContext& _compilerContext, Declaration const& _declaration);
 	/// Constructs the LValue and assumes that the storage reference is already on the stack.
 	StorageItem(CompilerContext& _compilerContext, Type const& _type);
+	virtual unsigned sizeOnStack() const { return 2; }
 	virtual void retrieveValue(SourceLocation const& _location, bool _remove = false) const override;
 	virtual void storeValue(
 		Type const& _sourceType,
@@ -117,11 +120,6 @@ public:
 		SourceLocation const& _location = SourceLocation(),
 		bool _removeReference = true
 	) const override;
-
-private:
-	/// Number of stack elements occupied by the value (not the reference).
-	/// Only used for value types.
-	unsigned m_size;
 };
 
 /**

--- a/libsolidity/Types.cpp
+++ b/libsolidity/Types.cpp
@@ -79,6 +79,12 @@ pair<u256, unsigned> const* StorageOffsets::getOffset(size_t _index) const
 		return nullptr;
 }
 
+MemberList& MemberList::operator=(MemberList&& _other)
+{
+	m_memberTypes = std::move(_other.m_memberTypes);
+	m_storageOffsets = std::move(_other.m_storageOffsets);
+}
+
 std::pair<u256, unsigned> const* MemberList::getMemberStorageOffset(string const& _name) const
 {
 	if (!m_storageOffsets)

--- a/libsolidity/Types.cpp
+++ b/libsolidity/Types.cpp
@@ -644,6 +644,9 @@ unsigned ArrayType::getSizeOnStack() const
 	if (m_location == Location::CallData)
 		// offset [length] (stack top)
 		return 1 + (isDynamicallySized() ? 1 : 0);
+	else if (m_location == Location::Storage)
+		// storage_key storage_offset
+		return 2;
 	else
 		// offset
 		return 1;

--- a/libsolidity/Types.cpp
+++ b/libsolidity/Types.cpp
@@ -83,6 +83,7 @@ MemberList& MemberList::operator=(MemberList&& _other)
 {
 	m_memberTypes = std::move(_other.m_memberTypes);
 	m_storageOffsets = std::move(_other.m_storageOffsets);
+	return *this;
 }
 
 std::pair<u256, unsigned> const* MemberList::getMemberStorageOffset(string const& _name) const
@@ -223,7 +224,7 @@ TypePointer Type::commonType(TypePointer const& _a, TypePointer const& _b)
 		return TypePointer();
 }
 
-const MemberList Type::EmptyMemberList = MemberList();
+const MemberList Type::EmptyMemberList;
 
 IntegerType::IntegerType(int _bits, IntegerType::Modifier _modifier):
 	m_bits(_bits), m_modifier(_modifier)
@@ -309,10 +310,11 @@ TypePointer IntegerType::binaryOperatorResult(Token::Value _operator, TypePointe
 	return commonType;
 }
 
-const MemberList IntegerType::AddressMemberList =
-	MemberList({{"balance", make_shared<IntegerType >(256)},
-				{"call", make_shared<FunctionType>(strings(), strings(), FunctionType::Location::Bare, true)},
-				{"send", make_shared<FunctionType>(strings{"uint"}, strings{}, FunctionType::Location::Send)}});
+const MemberList IntegerType::AddressMemberList({
+	{"balance", make_shared<IntegerType >(256)},
+	{"call", make_shared<FunctionType>(strings(), strings(), FunctionType::Location::Bare, true)},
+	{"send", make_shared<FunctionType>(strings{"uint"}, strings{}, FunctionType::Location::Send)}
+});
 
 IntegerConstantType::IntegerConstantType(Literal const& _literal)
 {
@@ -749,7 +751,7 @@ shared_ptr<ArrayType> ArrayType::copyForLocation(ArrayType::Location _location) 
 	return copy;
 }
 
-const MemberList ArrayType::s_arrayTypeMemberList = MemberList({{"length", make_shared<IntegerType>(256)}});
+const MemberList ArrayType::s_arrayTypeMemberList({{"length", make_shared<IntegerType>(256)}});
 
 bool ContractType::operator==(Type const& _other) const
 {

--- a/libsolidity/Types.cpp
+++ b/libsolidity/Types.cpp
@@ -1246,23 +1246,29 @@ MagicType::MagicType(MagicType::Kind _kind):
 	switch (m_kind)
 	{
 	case Kind::Block:
-		m_members = MemberList({{"coinbase", make_shared<IntegerType>(0, IntegerType::Modifier::Address)},
-								{"timestamp", make_shared<IntegerType>(256)},
-								{"blockhash", make_shared<FunctionType>(strings{"uint"}, strings{"bytes32"}, FunctionType::Location::BlockHash)},
-								{"difficulty", make_shared<IntegerType>(256)},
-								{"number", make_shared<IntegerType>(256)},
-								{"gaslimit", make_shared<IntegerType>(256)}});
+		m_members = move(MemberList({
+			{"coinbase", make_shared<IntegerType>(0, IntegerType::Modifier::Address)},
+			{"timestamp", make_shared<IntegerType>(256)},
+			{"blockhash", make_shared<FunctionType>(strings{"uint"}, strings{"bytes32"}, FunctionType::Location::BlockHash)},
+			{"difficulty", make_shared<IntegerType>(256)},
+			{"number", make_shared<IntegerType>(256)},
+			{"gaslimit", make_shared<IntegerType>(256)}
+		}));
 		break;
 	case Kind::Message:
-		m_members = MemberList({{"sender", make_shared<IntegerType>(0, IntegerType::Modifier::Address)},
-								{"gas", make_shared<IntegerType>(256)},
-								{"value", make_shared<IntegerType>(256)},
-								{"data", make_shared<ArrayType>(ArrayType::Location::CallData)},
-								{"sig", make_shared<FixedBytesType>(4)}});
+		m_members = move(MemberList({
+			{"sender", make_shared<IntegerType>(0, IntegerType::Modifier::Address)},
+			{"gas", make_shared<IntegerType>(256)},
+			{"value", make_shared<IntegerType>(256)},
+			{"data", make_shared<ArrayType>(ArrayType::Location::CallData)},
+			{"sig", make_shared<FixedBytesType>(4)}
+		}));
 		break;
 	case Kind::Transaction:
-		m_members = MemberList({{"origin", make_shared<IntegerType>(0, IntegerType::Modifier::Address)},
-								{"gasprice", make_shared<IntegerType>(256)}});
+		m_members = move(MemberList({
+			{"origin", make_shared<IntegerType>(0, IntegerType::Modifier::Address)},
+			{"gasprice", make_shared<IntegerType>(256)}
+		}));
 		break;
 	default:
 		BOOST_THROW_EXCEPTION(InternalCompilerError() << errinfo_comment("Unknown kind of magic."));

--- a/libsolidity/Types.h
+++ b/libsolidity/Types.h
@@ -43,6 +43,26 @@ using TypePointer = std::shared_ptr<Type const>;
 using FunctionTypePointer = std::shared_ptr<FunctionType const>;
 using TypePointers = std::vector<TypePointer>;
 
+
+/**
+ * Helper class to compute storage offsets of members of structs and contracts.
+ */
+class StorageOffsets
+{
+public:
+	/// Resets the StorageOffsets objects and determines the position in storage for each
+	/// of the elements of @a _types.
+	void computeOffsets(TypePointers const& _types);
+	/// @returns the offset of the given member, might be null if the member is not part of storage.
+	std::pair<u256, unsigned> const* getOffset(size_t _index) const;
+	/// @returns the total number of slots occupied by all members.
+	u256 const& getStorageSize() const { return m_storageSize; }
+
+private:
+	u256 m_storageSize;
+	std::map<size_t, std::pair<u256, unsigned>> m_offsets;
+};
+
 /**
  * List of members of a type.
  */
@@ -71,8 +91,7 @@ public:
 
 private:
 	MemberMap m_memberTypes;
-	mutable u256 m_storageSize = 0;
-	mutable std::unique_ptr<std::map<std::string, std::pair<u256, unsigned>>> m_storageOffsets;
+	mutable std::unique_ptr<StorageOffsets> m_storageOffsets;
 };
 
 /**
@@ -411,7 +430,7 @@ public:
 
 	virtual MemberList const& getMembers() const override;
 
-	u256 getStorageOffsetOfMember(std::string const& _name) const;
+	std::pair<u256, unsigned> const& getStorageOffsetsOfMember(std::string const& _name) const;
 
 private:
 	StructDefinition const& m_struct;

--- a/libsolidity/Types.h
+++ b/libsolidity/Types.h
@@ -73,6 +73,7 @@ public:
 
 	MemberList() {}
 	explicit MemberList(MemberMap const& _members): m_memberTypes(_members) {}
+	MemberList& operator=(MemberList&& _other);
 	TypePointer getMemberType(std::string const& _name) const
 	{
 		for (auto const& it: m_memberTypes)

--- a/libsolidity/Types.h
+++ b/libsolidity/Types.h
@@ -284,6 +284,9 @@ public:
 /**
  * The type of an array. The flavours are byte array (bytes), statically- (<type>[<length>])
  * and dynamically-sized array (<type>[]).
+ * In storage, all arrays are packed tightly (as long as more than one elementary type fits in
+ * one slot). Dynamically sized arrays (including byte arrays) start with their size as a uint and
+ * thus start on their own slot.
  */
 class ArrayType: public Type
 {
@@ -384,7 +387,7 @@ public:
 	virtual bool operator==(Type const& _other) const override;
 	virtual u256 getStorageSize() const override;
 	virtual bool canLiveOutsideStorage() const override;
-	virtual unsigned getSizeOnStack() const override { return 1; /*@todo*/ }
+	virtual unsigned getSizeOnStack() const override { return 2; }
 	virtual std::string toString() const override;
 
 	virtual MemberList const& getMembers() const override;
@@ -527,6 +530,7 @@ private:
 
 /**
  * The type of a mapping, there is one distinct type per key/value type pair.
+ * Mappings always occupy their own storage slot, but do not actually use it.
  */
 class MappingType: public Type
 {
@@ -537,6 +541,7 @@ public:
 
 	virtual bool operator==(Type const& _other) const override;
 	virtual std::string toString() const override;
+	virtual unsigned getSizeOnStack() const override { return 2; }
 	virtual bool canLiveOutsideStorage() const override { return false; }
 
 	TypePointer const& getKeyType() const { return m_keyType; }

--- a/test/SolidityEndToEndTest.cpp
+++ b/test/SolidityEndToEndTest.cpp
@@ -534,6 +534,27 @@ BOOST_AUTO_TEST_CASE(empty_string_on_stack)
 	BOOST_CHECK(callContractFunction("run(bytes0,uint8)", string(), byte(0x02)) == encodeArgs(0x2, string(""), string("abc\0")));
 }
 
+BOOST_AUTO_TEST_CASE(inc_dec_operators)
+{
+	char const* sourceCode = R"(
+		contract test {
+			uint8 x;
+			uint v;
+			function f() returns (uint r) {
+				uint a = 6;
+				r = a;
+				r += (a++) * 0x10;
+				r += (++a) * 0x100;
+				v = 3;
+				r += (v++) * 0x1000;
+				r += (++v) * 0x10000;
+			}
+		}
+	)";
+	compileAndRun(sourceCode);
+	BOOST_CHECK(callContractFunction("f()") == encodeArgs(0x53866));
+}
+
 BOOST_AUTO_TEST_CASE(state_smoke_test)
 {
 	char const* sourceCode = "contract test {\n"
@@ -2502,7 +2523,7 @@ BOOST_AUTO_TEST_CASE(struct_copy)
 		contract c {
 			struct Nested { uint x; uint y; }
 			struct Struct { uint a; mapping(uint => Struct) b; Nested nested; uint c; }
-			mapping(uint => Struct) public data;
+			mapping(uint => Struct) data;
 			function set(uint k) returns (bool) {
 				data[k].a = 1;
 				data[k].nested.x = 3;

--- a/test/SolidityOptimizer.cpp
+++ b/test/SolidityOptimizer.cpp
@@ -120,7 +120,7 @@ BOOST_AUTO_TEST_CASE(unused_expressions)
 				data;
 			}
 		})";
-	compileBothVersions(29, sourceCode);
+	compileBothVersions(36, sourceCode);
 	compareVersions("f()");
 }
 

--- a/test/SolidityOptimizer.cpp
+++ b/test/SolidityOptimizer.cpp
@@ -120,7 +120,7 @@ BOOST_AUTO_TEST_CASE(unused_expressions)
 				data;
 			}
 		})";
-	compileBothVersions(33, sourceCode);
+	compileBothVersions(29, sourceCode);
 	compareVersions("f()");
 }
 

--- a/test/SolidityTypes.cpp
+++ b/test/SolidityTypes.cpp
@@ -1,0 +1,82 @@
+/*
+	This file is part of cpp-ethereum.
+
+	cpp-ethereum is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	cpp-ethereum is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/**
+ * @author Christian <c@ethdev.com>
+ * @date 2015
+ * Unit tests for the type system of Solidity.
+ */
+
+#include <libsolidity/Types.h>
+#include <boost/test/unit_test.hpp>
+
+using namespace std;
+
+namespace dev
+{
+namespace solidity
+{
+namespace test
+{
+
+BOOST_AUTO_TEST_SUITE(SolidityTypes)
+
+BOOST_AUTO_TEST_CASE(storage_layout_simple)
+{
+	MemberList members(MemberList::MemberMap({
+		{string("first"), Type::fromElementaryTypeName("uint128")},
+		{string("second"), Type::fromElementaryTypeName("uint120")},
+		{string("wraps"), Type::fromElementaryTypeName("uint16")}
+	}));
+	BOOST_REQUIRE_EQUAL(u256(2), members.getStorageSize());
+	BOOST_REQUIRE(members.getMemberStorageOffset("first") != nullptr);
+	BOOST_REQUIRE(members.getMemberStorageOffset("second") != nullptr);
+	BOOST_REQUIRE(members.getMemberStorageOffset("wraps") != nullptr);
+	BOOST_CHECK(*members.getMemberStorageOffset("first") == make_pair(u256(0), unsigned(0)));
+	BOOST_CHECK(*members.getMemberStorageOffset("second") == make_pair(u256(0), unsigned(16)));
+	BOOST_CHECK(*members.getMemberStorageOffset("wraps") == make_pair(u256(1), unsigned(0)));
+}
+
+BOOST_AUTO_TEST_CASE(storage_layout_mapping)
+{
+	MemberList members(MemberList::MemberMap({
+		{string("first"), Type::fromElementaryTypeName("uint128")},
+		{string("second"), make_shared<MappingType>(
+			Type::fromElementaryTypeName("uint8"),
+			Type::fromElementaryTypeName("uint8")
+		)},
+		{string("third"), Type::fromElementaryTypeName("uint16")},
+		{string("final"), make_shared<MappingType>(
+			Type::fromElementaryTypeName("uint8"),
+			Type::fromElementaryTypeName("uint8")
+		)},
+	}));
+	BOOST_REQUIRE_EQUAL(u256(4), members.getStorageSize());
+	BOOST_REQUIRE(members.getMemberStorageOffset("first") != nullptr);
+	BOOST_REQUIRE(members.getMemberStorageOffset("second") != nullptr);
+	BOOST_REQUIRE(members.getMemberStorageOffset("third") != nullptr);
+	BOOST_REQUIRE(members.getMemberStorageOffset("final") != nullptr);
+	BOOST_CHECK(*members.getMemberStorageOffset("first") == make_pair(u256(0), unsigned(0)));
+	BOOST_CHECK(*members.getMemberStorageOffset("second") == make_pair(u256(1), unsigned(0)));
+	BOOST_CHECK(*members.getMemberStorageOffset("third") == make_pair(u256(2), unsigned(0)));
+	BOOST_CHECK(*members.getMemberStorageOffset("final") == make_pair(u256(3), unsigned(0)));
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}
+}
+}


### PR DESCRIPTION
Everything is packed as tightly as possible and it starts in a new storage slot, if it does not fit.
Structs always start a new storage slot.
Mapping (heads) always start a new storage slot.
Array data always starts a new storage slot.

The reason behind this is that we do not want run-time computation of whether a type has to be moved to the next slot or not because it does not fit, or put otherwise: The code to access a struct item does not depend on the alignment of the struct itself.

Still to be implemented: Pack array elements.