### PR TITLE
Support for building with clang and GNU gold linker on linux

### DIFF
--- a/cmake/EthCompilerSettings.cmake
+++ b/cmake/EthCompilerSettings.cmake
@@ -25,6 +25,10 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
 	set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g -DETH_DEBUG")
 	set(ETH_SHARED 1)
 
+	if ("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libstdc++ -fcolor-diagnostics -Qunused-arguments -DBOOST_ASIO_HAS_CLANG_LIBCXX")
+	endif()
+
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 
 	# enable parallel compilation
@@ -45,5 +49,16 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 
 else ()
 	message(WARNING "Your compiler is not tested, if you run into any issues, we'd welcome any patches.")
+endif ()
+
+if (("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU") OR ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang"))
+	option(USE_LD_GOLD "Use GNU gold linker" ON)
+	if (USE_LD_GOLD)
+		execute_process(COMMAND ${CMAKE_C_COMPILER} -fuse-ld=gold -Wl,--version ERROR_QUIET OUTPUT_VARIABLE LD_VERSION)
+		if ("${LD_VERSION}" MATCHES "GNU gold")
+			set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fuse-ld=gold")
+			set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fuse-ld=gold")
+		endif ()
+	endif ()
 endif ()
 

--- a/libdevcore/Common.h
+++ b/libdevcore/Common.h
@@ -87,7 +87,7 @@ using strings = std::vector<std::string>;
 
 // Fixed-length string types.
 using string32 = std::array<char, 32>;
-static const string32 ZeroString32 = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+static const string32 ZeroString32 = {{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }};
 
 // Null/Invalid values for convenience.
 static const u256 Invalid256 = ~(u256)0;

--- a/test/SolidityEndToEndTest.cpp
+++ b/test/SolidityEndToEndTest.cpp
@@ -421,7 +421,7 @@ BOOST_AUTO_TEST_CASE(short_circuiting)
 
 	auto short_circuiting_cpp = [](u256 n) -> u256
 	{
-		n == 0 || (n = 8) > 0;
+		(void)(n == 0 || (n = 8) > 0);
 		return n;
 	};
 


### PR DESCRIPTION
30% faster build time with clang+gold, less memory usage
also fixed clang warnings