### PR TITLE
split #1351, cmake eth_add_test macro

### DIFF
--- a/cmake/EthDependencies.cmake
+++ b/cmake/EthDependencies.cmake
@@ -30,6 +30,9 @@ if (APPLE)
 	set (CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} "/usr/local/opt/qt5")
 endif()
 
+find_program(CTEST_COMMAND ctest)
+message(STATUS "ctest path: ${CTEST_COMMAND}")
+
 # Dependencies must have a version number, to ensure reproducible build. The version provided here is the one that is in the extdep repository. If you use system libraries, version numbers may be different.
 
 find_package (CryptoPP 5.6.2 EXACT REQUIRED)

--- a/cmake/EthUtils.cmake
+++ b/cmake/EthUtils.cmake
@@ -22,3 +22,43 @@ macro(replace_if_different SOURCE DST)
 	endif()
 endmacro()
 
+macro(eth_add_test NAME) 
+
+	# parse arguments here
+	set(commands)
+	set(current_command "")
+	foreach (arg ${ARGN})
+		if (arg STREQUAL "ARGS")
+			if (current_command)
+				list(APPEND commands ${current_command})
+			endif()
+			set(current_command "")
+		else ()
+			set(current_command "${current_command} ${arg}")
+		endif()
+	endforeach(arg)
+	list(APPEND commands ${current_command})
+
+	message(STATUS "test: ${NAME} | ${commands}")
+
+	# create tests
+	set(index 0)
+	list(LENGTH commands count)
+	while (index LESS count)
+		list(GET commands ${index} test_arguments)
+
+		set(run_test "--run_test=${NAME}")
+		add_test(NAME "${NAME}.${index}" COMMAND testeth ${run_test} ${test_arguments})
+		
+		math(EXPR index "${index} + 1")
+	endwhile(index LESS count)
+
+	# add target to run them
+	add_custom_target("test.${NAME}"
+		DEPENDS testeth
+		WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+		COMMAND ${CMAKE_COMMAND} -DETH_TEST_NAME="${NAME}" -DCTEST_COMMAND="${CTEST_COMMAND}" -P "${ETH_SCRIPTS_DIR}/runtest.cmake"
+	)
+
+endmacro()
+

--- a/cmake/scripts/runtest.cmake
+++ b/cmake/scripts/runtest.cmake
@@ -1,0 +1,15 @@
+# Should be used to run ctest
+# 
+# example usage:
+# cmake -DETH_TEST_NAME=TestInterfaceStub -DCTEST_COMMAND=/path/to/ctest -P scripts/runtest.cmake
+
+if (NOT CTEST_COMMAND)
+	message(FATAL_ERROR "ctest could not be found!")
+endif()
+
+# verbosity is off, cause BOOST_MESSAGE is not thread safe and output is a trash
+# see https://codecrafter.wordpress.com/2012/11/01/c-unit-test-framework-adapter-part-3/
+#
+# output might not be usefull cause of thread safety issue 
+execute_process(COMMAND ${CTEST_COMMAND} --force-new-ctest-process -C Debug --output-on-failure -j 4 -R "${ETH_TEST_NAME}[.].*")
+


### PR DESCRIPTION
macro `eth_add_test` provides a way to run tests in parallel using [ctest](http://www.cmake.org/Wiki/CMake/Testing_With_CTest). It also creates a target for this test set.

example usage:

```bash
eth_add_test(ClientBase
	ARGS --eth_testfile=BlockTests/bcJS_API_Test --eth_threads=1
	ARGS --eth_testfile=BlockTests/bcJS_API_Test --eth_threads=3
	ARGS --eth_testfile=BlockTests/bcJS_API_Test --eth_threads=10
	ARGS --eth_testfile=BlockTests/bcValidBlockTest --eth_threads=1
	ARGS --eth_testfile=BlockTests/bcValidBlockTest --eth_threads=3
	ARGS --eth_testfile=BlockTests/bcValidBlockTest --eth_threads=10
)
```

Where `ClientBase` is the name of boost::test test_suite.

it can be run from command line:

```bash
make -j 4 test.ClientBase
```

The output of the tests is in the following format:

```
Test project /Users/marekkotewicz/ethereum/cpp-ethereum/build2/test
    Start 1: ClientBase.0
    Start 3: ClientBase.2
    Start 2: ClientBase.1
    Start 5: ClientBase.4
1/6 Test #5: ClientBase.4 .....................   Passed    0.60 sec
    Start 6: ClientBase.5
2/6 Test #3: ClientBase.2 .....................   Passed    0.81 sec
3/6 Test #2: ClientBase.1 .....................   Passed    0.82 sec
    Start 4: ClientBase.3
4/6 Test #1: ClientBase.0 .....................   Passed    0.92 sec
5/6 Test #6: ClientBase.5 .....................   Passed    0.31 sec
6/6 Test #4: ClientBase.3 .....................   Passed    0.24 sec

100% tests passed, 0 tests failed out of 6
```