### PR TITLE
split #1351, ethrpctest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,6 +178,7 @@ endif()
 
 if (JSONRPC)
 	add_subdirectory(libweb3jsonrpc)
+	add_subdirectory(ethrpctest)
 endif()
 
 add_subdirectory(secp256k1)

--- a/ethrpctest/CMakeLists.txt
+++ b/ethrpctest/CMakeLists.txt
@@ -1,0 +1,35 @@
+cmake_policy(SET CMP0015 NEW)
+set(CMAKE_AUTOMOC OFF)
+
+aux_source_directory(. SRC_LIST)
+
+include_directories(BEFORE ${JSONCPP_INCLUDE_DIRS})
+include_directories(BEFORE ..)
+include_directories(${Boost_INCLUDE_DIRS})
+include_directories(${JSON_RPC_CPP_INCLUDE_DIRS})
+
+set(EXECUTABLE ethrpctest)
+
+file(GLOB HEADERS "*.h")
+
+add_executable(${EXECUTABLE} ${SRC_LIST} ${HEADERS})
+
+add_dependencies(${EXECUTABLE} BuildInfo.h)
+
+target_link_libraries(${EXECUTABLE} ${Boost_REGEX_LIBRARIES})
+
+if (READLINE_FOUND)
+	target_link_libraries(${EXECUTABLE} ${READLINE_LIBRARIES})
+endif()
+
+target_link_libraries(${EXECUTABLE} ${Boost_FILESYSTEM_LIBRARIES})
+target_link_libraries(${EXECUTABLE} ${Boost_PROGRAM_OPTIONS_LIBRARIES})
+target_link_libraries(${EXECUTABLE} testutils)
+target_link_libraries(${EXECUTABLE} web3jsonrpc)
+
+if (DEFINED WIN32 AND NOT DEFINED CMAKE_COMPILER_IS_MINGW)
+	add_custom_command(TARGET ${EXECUTABLE} POST_BUILD COMMAND ${CMAKE_COMMAND} ARGS -E copy ${MHD_DLL_RELEASE} "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}")
+endif()
+
+install( TARGETS ${EXECUTABLE} DESTINATION bin )
+

--- a/ethrpctest/CommandLineInterface.cpp
+++ b/ethrpctest/CommandLineInterface.cpp
@@ -1,0 +1,129 @@
+/*
+	This file is part of cpp-ethereum.
+
+	cpp-ethereum is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	cpp-ethereum is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/** @file CommandLineInterface.cpp
+ * @author Marek Kotewicz <marek@ethdev.com>
+ * @date 2015
+ */
+
+#include <string>
+#include <iostream>
+#include <fstream>
+#include <csignal>
+#include <thread>
+#include <boost/filesystem.hpp>
+#include <jsonrpccpp/server/connectors/httpserver.h>
+#include <libtestutils/Common.h>
+#include <libtestutils/BlockChainLoader.h>
+#include <libtestutils/FixedClient.h>
+#include <libtestutils/FixedWebThreeServer.h>
+#include "CommandLineInterface.h"
+#include "BuildInfo.h"
+
+using namespace std;
+using namespace dev;
+using namespace dev::eth;
+using namespace dev::test;
+namespace po = boost::program_options;
+
+bool CommandLineInterface::parseArguments(int argc, char** argv)
+{
+	// Declare the supported options.
+	po::options_description desc("Allowed options");
+	desc.add_options()
+		("help", "Show help message and exit")
+		("json", po::value<vector<string>>()->required(), "input file")
+		("test", po::value<vector<string>>()->required(), "test case name");
+
+	// All positional options should be interpreted as input files
+	po::positional_options_description p;
+
+	// parse the compiler arguments
+	try
+	{
+		po::store(po::command_line_parser(argc, argv).options(desc).positional(p).allow_unregistered().run(), m_args);
+
+		if (m_args.count("help"))
+		{
+			cout << desc;
+			return false;
+		}
+
+		po::notify(m_args);
+	}
+	catch (po::error const& _exception)
+	{
+		cout << _exception.what() << endl;
+		return false;
+	}
+
+	return true;
+}
+
+bool CommandLineInterface::processInput()
+{
+	string infile = m_args["json"].as<vector<string>>()[0];
+
+	auto path = boost::filesystem::path(infile);
+	if (!boost::filesystem::exists(path))
+	{
+		cout << "Non existant input file \"" << infile << "\"" << endl;
+		return false;
+	}
+
+	string test = m_args["test"].as<vector<string>>()[0];
+	Json::Value j = dev::test::loadJsonFromFile(path.string());
+
+	if (j[test].empty())
+	{
+		cout << "Non existant test case \"" << infile << "\"" << endl;
+		return false;
+	}
+	
+	if (!j[test].isObject())
+	{
+		cout << "Incorrect JSON file \"" << infile << "\"" << endl;
+		return false;
+	}
+	
+	m_json = j[test];
+
+	return true;
+}
+
+bool g_exit = false;
+
+void sighandler(int)
+{
+	g_exit = true;
+}
+
+void CommandLineInterface::actOnInput()
+{
+	BlockChainLoader bcl(m_json);
+	FixedClient client(bcl.bc(), bcl.state());
+	unique_ptr<FixedWebThreeServer> jsonrpcServer;
+	auto server = new jsonrpc::HttpServer(8080, "", "", 2);
+	jsonrpcServer.reset(new FixedWebThreeServer(*server, {}, &client));
+	jsonrpcServer->StartListening();
+
+	signal(SIGABRT, &sighandler);
+	signal(SIGTERM, &sighandler);
+	signal(SIGINT, &sighandler);
+
+	while (!g_exit)
+		this_thread::sleep_for(chrono::milliseconds(1000));
+}

--- a/ethrpctest/CommandLineInterface.h
+++ b/ethrpctest/CommandLineInterface.h
@@ -1,0 +1,46 @@
+/*
+	This file is part of cpp-ethereum.
+
+	cpp-ethereum is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	cpp-ethereum is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/** CommandLineInterface.h
+ * @author Marek Kotewicz <marek@ethdev.com>
+ * @date 2015
+ */
+#pragma once
+
+#include <json/json.h>
+#include <boost/program_options.hpp>
+
+class CommandLineInterface
+{
+public:
+	CommandLineInterface() {}
+
+	/// Parse command line arguments and return false if we should not continue
+	bool parseArguments(int argc, char** argv);
+	/// Parse input file and check if test exists
+	bool processInput();
+	/// Start FixedJsonRpcServer
+	void actOnInput();
+
+private:
+
+	/// Compiler arguments variable map
+	boost::program_options::variables_map m_args;
+
+	/// loaded json test case
+	Json::Value m_json;
+};
+

--- a/ethrpctest/main.cpp
+++ b/ethrpctest/main.cpp
@@ -1,0 +1,34 @@
+/*
+	This file is part of cpp-ethereum.
+
+	cpp-ethereum is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	cpp-ethereum is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/** main.cpp
+ * @author Marek Kotewicz <c@ethdev.com>
+ * @date 2015
+ */
+
+#include "CommandLineInterface.h"
+
+int main(int argc, char** argv)
+{
+	CommandLineInterface cli;
+	if (!cli.parseArguments(argc, argv))
+		return 1;
+	if (!cli.processInput())
+		return 1;
+	cli.actOnInput();
+
+	return 0;
+}


### PR DESCRIPTION
executable that is needed to test jsonrpc api using [rpc-tests](https://github.com/ethereum/rpc-tests).

usage:

```bash
Allowed options:
  --help                Show help message and exit
  --json arg            input file
  --test arg            test case name
```

includes:
- #1407 ClientBase
- #1408 libtestutils
- #1406 NOMINMAX

please reviews these first