### PR TITLE
Interface contracts

### DIFF
--- a/libsolidity/AST.cpp
+++ b/libsolidity/AST.cpp
@@ -60,6 +60,7 @@ void ContractDefinition::checkTypeRequirements()
 
 	FunctionDefinition const* fallbackFunction = nullptr;
 	for (ASTPointer<FunctionDefinition> const& function: getDefinedFunctions())
+	{
 		if (function->getName().empty())
 		{
 			if (fallbackFunction)
@@ -71,6 +72,9 @@ void ContractDefinition::checkTypeRequirements()
 					BOOST_THROW_EXCEPTION(fallbackFunction->getParameterList().createTypeError("Fallback function cannot take parameters."));
 			}
 		}
+		if (!function->isFullyImplemented())
+			setFullyImplemented(false);
+	}
 	for (ASTPointer<ModifierDefinition> const& modifier: getFunctionModifiers())
 		modifier->checkTypeRequirements();
 

--- a/libsolidity/AST.cpp
+++ b/libsolidity/AST.cpp
@@ -311,8 +311,8 @@ void FunctionDefinition::checkTypeRequirements()
 		modifier->checkTypeRequirements(isConstructor() ?
 			dynamic_cast<ContractDefinition const&>(*getScope()).getBaseContracts() :
 			vector<ASTPointer<InheritanceSpecifier>>());
-
-	m_body->checkTypeRequirements();
+	if (m_body)
+		m_body->checkTypeRequirements();
 }
 
 string FunctionDefinition::getCanonicalSignature() const

--- a/libsolidity/AST.cpp
+++ b/libsolidity/AST.cpp
@@ -136,34 +136,20 @@ void ContractDefinition::checkAbstractFunctions()
 
 	// Search from base to derived
 	for (ContractDefinition const* contract: boost::adaptors::reverse(getLinearizedBaseContracts()))
-	{
 		for (ASTPointer<FunctionDefinition> const& function: contract->getDefinedFunctions())
 		{
 			string const& name = function->getName();
 			if (!function->isFullyImplemented() && functions.count(name) && functions[name])
 				BOOST_THROW_EXCEPTION(function->createTypeError("Redeclaring an already implemented function as abstract"));
-			// if (functions.count(name) && !functions[name] && function->isFullyImplemented())
-			// 	functions.insert(make_pair(name, true);
-
-			// if (functions.count(name) && !functions[name] && function->isFullyImplemented)
-			// 	functions.insert(make_pair(name, true));
-			
-			// functions.insert(make_pair(name, function->isFullyImplemented()));
 			functions[name] = function->isFullyImplemented();
-			
-			// if (function->isFullyImplemented())
-			// 	full_functions.insert(make_pair(name, function.get()));
-			// else
-			// 	abs_functions.insert(make_pair(name, function.get()));
 		}
-	}
+
 	for (auto const& it: functions)
 		if (!it.second)
 		{
 			setFullyImplemented(false);
 			break;
 		}
-
 }
 
 void ContractDefinition::checkIllegalOverrides() const
@@ -682,7 +668,7 @@ void NewExpression::checkTypeRequirements()
 	if (!m_contract)
 		BOOST_THROW_EXCEPTION(createTypeError("Identifier is not a contract."));
 	if (!m_contract->isFullyImplemented())
-		BOOST_THROW_EXCEPTION(m_contract->createTypeError("Trying to create an object of an abstract contract."));
+		BOOST_THROW_EXCEPTION(m_contract->createTypeError("Trying to create an instance of an abstract contract."));
 	shared_ptr<ContractType const> contractType = make_shared<ContractType>(*m_contract);
 	TypePointers const& parameterTypes = contractType->getConstructorType()->getParameterTypes();
 	m_type = make_shared<FunctionType>(parameterTypes, TypePointers{contractType},

--- a/libsolidity/AST.h
+++ b/libsolidity/AST.h
@@ -196,6 +196,21 @@ protected:
 	ASTPointer<ASTString> m_documentation;
 };
 
+/**
+ * Abstract class that is added to AST nodes that can be marked as not being fully implemented
+ */
+class ImplementationOptional
+{
+public:
+	explicit ImplementationOptional(bool _implemented): m_implemented(_implemented) {}
+
+	/// @return whether this node is fully implemented or not
+	bool isFullyImplemented() const { return m_implemented; }
+
+protected:
+	bool m_implemented;
+};
+
 /// @}
 
 /**
@@ -203,20 +218,25 @@ protected:
  * document order. It first visits all struct declarations, then all variable declarations and
  * finally all function declarations.
  */
-class ContractDefinition: public Declaration, public Documented
+class ContractDefinition: public Declaration, public Documented, public ImplementationOptional
 {
 public:
-	ContractDefinition(SourceLocation const& _location,
-					   ASTPointer<ASTString> const& _name,
-					   ASTPointer<ASTString> const& _documentation,
-					   std::vector<ASTPointer<InheritanceSpecifier>> const& _baseContracts,
-					   std::vector<ASTPointer<StructDefinition>> const& _definedStructs,
-					   std::vector<ASTPointer<EnumDefinition>> const& _definedEnums,
-					   std::vector<ASTPointer<VariableDeclaration>> const& _stateVariables,
-					   std::vector<ASTPointer<FunctionDefinition>> const& _definedFunctions,
-					   std::vector<ASTPointer<ModifierDefinition>> const& _functionModifiers,
-					   std::vector<ASTPointer<EventDefinition>> const& _events):
-		Declaration(_location, _name), Documented(_documentation),
+	ContractDefinition(
+		SourceLocation const& _location,
+		ASTPointer<ASTString> const& _name,
+		ASTPointer<ASTString> const& _documentation,
+		std::vector<ASTPointer<InheritanceSpecifier>> const& _baseContracts,
+		std::vector<ASTPointer<StructDefinition>> const& _definedStructs,
+		std::vector<ASTPointer<EnumDefinition>> const& _definedEnums,
+		std::vector<ASTPointer<VariableDeclaration>> const& _stateVariables,
+		std::vector<ASTPointer<FunctionDefinition>> const& _definedFunctions,
+		std::vector<ASTPointer<ModifierDefinition>> const& _functionModifiers,
+		std::vector<ASTPointer<EventDefinition>> const& _events,
+		bool _isFullyImplemented
+	):
+		Declaration(_location, _name),
+		Documented(_documentation),
+		ImplementationOptional(_isFullyImplemented),
 		m_baseContracts(_baseContracts),
 		m_definedStructs(_definedStructs),
 		m_definedEnums(_definedEnums),
@@ -224,7 +244,7 @@ public:
 		m_definedFunctions(_definedFunctions),
 		m_functionModifiers(_functionModifiers),
 		m_events(_events)
-	{}
+		{}
 
 	virtual void accept(ASTVisitor& _visitor) override;
 	virtual void accept(ASTConstVisitor& _visitor) const override;
@@ -378,25 +398,30 @@ private:
 	std::vector<ASTPointer<VariableDeclaration>> m_parameters;
 };
 
-class FunctionDefinition: public Declaration, public VariableScope, public Documented
+class FunctionDefinition: public Declaration, public VariableScope, public Documented, public ImplementationOptional
 {
 public:
-	FunctionDefinition(SourceLocation const& _location, ASTPointer<ASTString> const& _name,
-					Declaration::Visibility _visibility, bool _isConstructor,
-					ASTPointer<ASTString> const& _documentation,
-					ASTPointer<ParameterList> const& _parameters,
-					bool _isDeclaredConst,
-					std::vector<ASTPointer<ModifierInvocation>> const& _modifiers,
-					ASTPointer<ParameterList> const& _returnParameters,
-					ASTPointer<Block> const& _body):
-	Declaration(_location, _name, _visibility), Documented(_documentation),
-	m_isConstructor(_isConstructor),
-	m_parameters(_parameters),
-	m_isDeclaredConst(_isDeclaredConst),
-	m_functionModifiers(_modifiers),
-	m_returnParameters(_returnParameters),
-	m_body(_body)
-	{}
+	FunctionDefinition(
+		SourceLocation const& _location,
+		ASTPointer<ASTString> const& _name,
+		Declaration::Visibility _visibility, bool _isConstructor,
+		ASTPointer<ASTString> const& _documentation,
+		ASTPointer<ParameterList> const& _parameters,
+		bool _isDeclaredConst,
+		std::vector<ASTPointer<ModifierInvocation>> const& _modifiers,
+		ASTPointer<ParameterList> const& _returnParameters,
+		ASTPointer<Block> const& _body
+	):
+		Declaration(_location, _name, _visibility),
+		Documented(_documentation),
+		ImplementationOptional(_body != nullptr),
+		m_isConstructor(_isConstructor),
+		m_parameters(_parameters),
+		m_isDeclaredConst(_isDeclaredConst),
+		m_functionModifiers(_modifiers),
+		m_returnParameters(_returnParameters),
+		m_body(_body)
+		{}
 
 	virtual void accept(ASTVisitor& _visitor) override;
 	virtual void accept(ASTConstVisitor& _visitor) const override;

--- a/libsolidity/AST.h
+++ b/libsolidity/AST.h
@@ -283,6 +283,7 @@ public:
 
 private:
 	void checkIllegalOverrides() const;
+	void checkAbstractFunctions();
 
 	std::vector<std::pair<FixedHash<4>, FunctionTypePointer>> const& getInterfaceFunctionList() const;
 

--- a/libsolidity/AST.h
+++ b/libsolidity/AST.h
@@ -206,6 +206,7 @@ public:
 
 	/// @return whether this node is fully implemented or not
 	bool isFullyImplemented() const { return m_implemented; }
+	void setFullyImplemented(bool _implemented) {  m_implemented = _implemented; }
 
 protected:
 	bool m_implemented;
@@ -231,12 +232,11 @@ public:
 		std::vector<ASTPointer<VariableDeclaration>> const& _stateVariables,
 		std::vector<ASTPointer<FunctionDefinition>> const& _definedFunctions,
 		std::vector<ASTPointer<ModifierDefinition>> const& _functionModifiers,
-		std::vector<ASTPointer<EventDefinition>> const& _events,
-		bool _isFullyImplemented
+		std::vector<ASTPointer<EventDefinition>> const& _events
 	):
 		Declaration(_location, _name),
 		Documented(_documentation),
-		ImplementationOptional(_isFullyImplemented),
+		ImplementationOptional(true),
 		m_baseContracts(_baseContracts),
 		m_definedStructs(_definedStructs),
 		m_definedEnums(_definedEnums),
@@ -244,7 +244,7 @@ public:
 		m_definedFunctions(_definedFunctions),
 		m_functionModifiers(_functionModifiers),
 		m_events(_events)
-		{}
+	{}
 
 	virtual void accept(ASTVisitor& _visitor) override;
 	virtual void accept(ASTConstVisitor& _visitor) const override;
@@ -421,7 +421,7 @@ public:
 		m_functionModifiers(_modifiers),
 		m_returnParameters(_returnParameters),
 		m_body(_body)
-		{}
+	{}
 
 	virtual void accept(ASTVisitor& _visitor) override;
 	virtual void accept(ASTConstVisitor& _visitor) const override;

--- a/libsolidity/AST_accept.h
+++ b/libsolidity/AST_accept.h
@@ -175,7 +175,8 @@ void FunctionDefinition::accept(ASTVisitor& _visitor)
 		if (m_returnParameters)
 			m_returnParameters->accept(_visitor);
 		listAccept(m_functionModifiers, _visitor);
-		m_body->accept(_visitor);
+		if (m_body)
+			m_body->accept(_visitor);
 	}
 	_visitor.endVisit(*this);
 }
@@ -188,7 +189,8 @@ void FunctionDefinition::accept(ASTConstVisitor& _visitor) const
 		if (m_returnParameters)
 			m_returnParameters->accept(_visitor);
 		listAccept(m_functionModifiers, _visitor);
-		m_body->accept(_visitor);
+		if (m_body)
+			m_body->accept(_visitor);
 	}
 	_visitor.endVisit(*this);
 }

--- a/libsolidity/CompilerStack.cpp
+++ b/libsolidity/CompilerStack.cpp
@@ -138,6 +138,8 @@ void CompilerStack::compile(bool _optimize)
 		for (ASTPointer<ASTNode> const& node: source->ast->getNodes())
 			if (ContractDefinition* contract = dynamic_cast<ContractDefinition*>(node.get()))
 			{
+				if (!contract->isFullyImplemented())
+					continue;
 				shared_ptr<Compiler> compiler = make_shared<Compiler>(_optimize);
 				compiler->compileContract(*contract, contractBytecode);
 				Contract& compiledContract = m_contracts[contract->getName()];

--- a/libsolidity/Parser.cpp
+++ b/libsolidity/Parser.cpp
@@ -116,6 +116,7 @@ ASTPointer<ContractDefinition> Parser::parseContractDefinition()
 {
 	ASTNodeFactory nodeFactory(*this);
 	ASTPointer<ASTString> docString;
+	bool contractFullyImplemented = true;
 	if (m_scanner->getCurrentCommentLiteral() != "")
 		docString = make_shared<ASTString>(m_scanner->getCurrentCommentLiteral());
 	expectToken(Token::Contract);
@@ -141,7 +142,12 @@ ASTPointer<ContractDefinition> Parser::parseContractDefinition()
 		if (currentToken == Token::RBrace)
 			break;
 		else if (currentToken == Token::Function)
-			functions.push_back(parseFunctionDefinition(name.get()));
+		{
+			ASTPointer<FunctionDefinition> func = parseFunctionDefinition(name.get());
+			functions.push_back(func);
+			if (!func->isFullyImplemented())
+				contractFullyImplemented = false;
+		}
 		else if (currentToken == Token::Struct)
 			structs.push_back(parseStructDefinition());
 		else if (currentToken == Token::Enum)
@@ -164,8 +170,18 @@ ASTPointer<ContractDefinition> Parser::parseContractDefinition()
 	}
 	nodeFactory.markEndPosition();
 	expectToken(Token::RBrace);
-	return nodeFactory.createNode<ContractDefinition>(name, docString, baseContracts, structs, enums,
-													  stateVariables, functions, modifiers, events);
+	return nodeFactory.createNode<ContractDefinition>(
+		name,
+		docString,
+		baseContracts,
+		structs,
+		enums,
+		stateVariables,
+		functions,
+		modifiers,
+		events,
+		contractFullyImplemented
+	);
 }
 
 ASTPointer<InheritanceSpecifier> Parser::parseInheritanceSpecifier()
@@ -247,8 +263,15 @@ ASTPointer<FunctionDefinition> Parser::parseFunctionDefinition(ASTString const* 
 	}
 	else
 		returnParameters = createEmptyParameterList();
-	ASTPointer<Block> block = parseBlock();
-	nodeFactory.setEndPositionFromNode(block);
+	ASTPointer<Block> block = ASTPointer<Block>();
+	nodeFactory.markEndPosition();
+	if (m_scanner->getCurrentToken() != Token::Semicolon)
+	{
+		block = parseBlock();
+		nodeFactory.setEndPositionFromNode(block);
+	}
+	else
+		m_scanner->next(); // just consume the ';'
 	bool const c_isConstructor = (_contractName && *name == *_contractName);
 	return nodeFactory.createNode<FunctionDefinition>(name, visibility, c_isConstructor, docstring,
 													  parameters, isDeclaredConst, modifiers,

--- a/libsolidity/Parser.cpp
+++ b/libsolidity/Parser.cpp
@@ -116,7 +116,6 @@ ASTPointer<ContractDefinition> Parser::parseContractDefinition()
 {
 	ASTNodeFactory nodeFactory(*this);
 	ASTPointer<ASTString> docString;
-	bool contractFullyImplemented = true;
 	if (m_scanner->getCurrentCommentLiteral() != "")
 		docString = make_shared<ASTString>(m_scanner->getCurrentCommentLiteral());
 	expectToken(Token::Contract);
@@ -145,8 +144,6 @@ ASTPointer<ContractDefinition> Parser::parseContractDefinition()
 		{
 			ASTPointer<FunctionDefinition> func = parseFunctionDefinition(name.get());
 			functions.push_back(func);
-			if (!func->isFullyImplemented())
-				contractFullyImplemented = false;
 		}
 		else if (currentToken == Token::Struct)
 			structs.push_back(parseStructDefinition());
@@ -179,8 +176,7 @@ ASTPointer<ContractDefinition> Parser::parseContractDefinition()
 		stateVariables,
 		functions,
 		modifiers,
-		events,
-		contractFullyImplemented
+		events
 	);
 }
 

--- a/libsolidity/Parser.cpp
+++ b/libsolidity/Parser.cpp
@@ -141,10 +141,7 @@ ASTPointer<ContractDefinition> Parser::parseContractDefinition()
 		if (currentToken == Token::RBrace)
 			break;
 		else if (currentToken == Token::Function)
-		{
-			ASTPointer<FunctionDefinition> func = parseFunctionDefinition(name.get());
-			functions.push_back(func);
-		}
+			functions.push_back(parseFunctionDefinition(name.get()));
 		else if (currentToken == Token::Struct)
 			structs.push_back(parseStructDefinition());
 		else if (currentToken == Token::Enum)

--- a/test/SolidityNameAndTypeResolution.cpp
+++ b/test/SolidityNameAndTypeResolution.cpp
@@ -353,12 +353,54 @@ BOOST_AUTO_TEST_CASE(function_no_implementation)
 		"  function functionName(bytes32 input) returns (bytes32 out);\n"
 		"}\n";
 	ETH_TEST_REQUIRE_NO_THROW(sourceUnit = parseTextAndResolveNames(text), "Parsing and name Resolving failed");
-	ContractDefinition* contract;
-	for (ASTPointer<ASTNode> const& node: sourceUnit->getNodes())
-		contract = dynamic_cast<ContractDefinition*>(node.get());
+	std::vector<ASTPointer<ASTNode>> nodes = sourceUnit->getNodes();
+	ContractDefinition* contract = dynamic_cast<ContractDefinition*>(nodes[0].get());
 	BOOST_CHECK(contract);
 	BOOST_CHECK(!contract->isFullyImplemented());
 	BOOST_CHECK(!contract->getDefinedFunctions()[0]->isFullyImplemented());
+}
+
+BOOST_AUTO_TEST_CASE(abstract_contract)
+{
+	ASTPointer<SourceUnit> sourceUnit;
+	char const* text = R"(
+		contract base { function foo(); }
+		contract derived is base { function foo() {} }
+		)";
+	ETH_TEST_REQUIRE_NO_THROW(sourceUnit = parseTextAndResolveNames(text), "Parsing and name Resolving failed");
+	std::vector<ASTPointer<ASTNode>> nodes = sourceUnit->getNodes();
+	ContractDefinition* base = dynamic_cast<ContractDefinition*>(nodes[0].get());
+	ContractDefinition* derived = dynamic_cast<ContractDefinition*>(nodes[1].get());
+	BOOST_CHECK(base);
+	BOOST_CHECK(!base->isFullyImplemented());
+	BOOST_CHECK(!base->getDefinedFunctions()[0]->isFullyImplemented());
+	BOOST_CHECK(derived);
+	BOOST_CHECK(derived->isFullyImplemented());
+	BOOST_CHECK(derived->getDefinedFunctions()[0]->isFullyImplemented());
+}
+
+BOOST_AUTO_TEST_CASE(create_abstract_contract)
+{
+	ASTPointer<SourceUnit> sourceUnit;
+	char const* text = R"(
+		contract base { function foo(); }
+		contract derived { 
+			base b;
+            function foo() { b = new base();}
+        }
+		)";
+	BOOST_CHECK_THROW(parseTextAndResolveNames(text), TypeError);
+}
+
+BOOST_AUTO_TEST_CASE(redeclare_implemented_abstract_function_as_abstract)
+{
+	ASTPointer<SourceUnit> sourceUnit;
+	char const* text = R"(
+		contract base { function foo(); }
+		contract derived is base { function foo() {} }
+		contract wrong is derived { function foo(); }
+		)";
+	BOOST_CHECK_THROW(parseTextAndResolveNames(text), TypeError);
 }
 
 BOOST_AUTO_TEST_CASE(function_canonical_signature)

--- a/test/SolidityNameAndTypeResolution.cpp
+++ b/test/SolidityNameAndTypeResolution.cpp
@@ -384,10 +384,10 @@ BOOST_AUTO_TEST_CASE(create_abstract_contract)
 	ASTPointer<SourceUnit> sourceUnit;
 	char const* text = R"(
 		contract base { function foo(); }
-		contract derived { 
+		contract derived {
 			base b;
-            function foo() { b = new base();}
-        }
+			function foo() { b = new base();}
+			}
 		)";
 	BOOST_CHECK_THROW(parseTextAndResolveNames(text), TypeError);
 }

--- a/test/SolidityNameAndTypeResolution.cpp
+++ b/test/SolidityNameAndTypeResolution.cpp
@@ -346,6 +346,21 @@ BOOST_AUTO_TEST_CASE(comparison_bitop_precedence)
 	ETH_TEST_CHECK_NO_THROW(parseTextAndResolveNames(text), "Parsing and Name Resolving Failed");
 }
 
+BOOST_AUTO_TEST_CASE(function_no_implementation)
+{
+	ASTPointer<SourceUnit> sourceUnit;
+	char const* text = "contract test {\n"
+		"  function functionName(bytes32 input) returns (bytes32 out);\n"
+		"}\n";
+	ETH_TEST_REQUIRE_NO_THROW(sourceUnit = parseTextAndResolveNames(text), "Parsing and name Resolving failed");
+	ContractDefinition* contract;
+	for (ASTPointer<ASTNode> const& node: sourceUnit->getNodes())
+		contract = dynamic_cast<ContractDefinition*>(node.get());
+	BOOST_CHECK(contract);
+	BOOST_CHECK(!contract->isFullyImplemented());
+	BOOST_CHECK(!contract->getDefinedFunctions()[0]->isFullyImplemented());
+}
+
 BOOST_AUTO_TEST_CASE(function_canonical_signature)
 {
 	ASTPointer<SourceUnit> sourceUnit;

--- a/test/SolidityParser.cpp
+++ b/test/SolidityParser.cpp
@@ -108,6 +108,14 @@ BOOST_AUTO_TEST_CASE(single_function_param)
 	ETH_TEST_CHECK_NO_THROW(parseText(text), "Parsing failed.");
 }
 
+BOOST_AUTO_TEST_CASE(function_no_body)
+{
+	char const* text = "contract test {\n"
+					   "  function functionName(bytes32 input) returns (bytes32 out);\n"
+					   "}\n";
+	ETH_TEST_CHECK_NO_THROW(parseText(text), "Parsing failed.");
+}
+
 BOOST_AUTO_TEST_CASE(missing_parameter_name_in_named_args)
 {
 	char const* text = "contract test {\n"


### PR DESCRIPTION
- Adding the possibility of omitting a function body by simply ending a
  function definition with a semicolon

- Such a function is marked as not fully implemented and any contract
  that contains such a function is considered a not fully implemented contract