### PR TITLE
Fix segfault when using upnp and increase handshake timeout

### DIFF
--- a/libp2p/RLPxHandshake.h
+++ b/libp2p/RLPxHandshake.h
@@ -95,7 +95,7 @@ protected:
 	void transition(boost::system::error_code _ech = boost::system::error_code());
 
 	/// Timeout for remote to respond to transition events. Enforced by m_idleTimer and refreshed by transition().
-	boost::posix_time::milliseconds const c_timeout = boost::posix_time::milliseconds(1000);
+	boost::posix_time::milliseconds const c_timeout = boost::posix_time::milliseconds(1800);
 
 	State m_nextState = New;			///< Current or expected state of transition.
 	bool m_cancel = false;			///< Will be set to true if connection was canceled.

--- a/libp2p/UDP.h
+++ b/libp2p/UDP.h
@@ -163,7 +163,14 @@ void UDPSocket<Handler, MaxDatagramSize>::connect()
 		return;
 
 	m_socket.open(bi::udp::v4());
-	m_socket.bind(m_endpoint);
+	try
+	{
+		m_socket.bind(m_endpoint);
+	}
+	catch (...)
+	{
+		m_socket.bind(bi::udp::endpoint(bi::udp::v4(), m_endpoint.port()));
+	}
 
 	// clear write queue so reconnect doesn't send stale messages
 	Guard l(x_sendQ);


### PR DESCRIPTION
#1398 #1404

Handshake timeout increased to account for tcp overhead (some public nodes not connecting to each other).