### PR TITLE
fixed no jsonrpc build for cmake 2.8.12

### DIFF
--- a/libtestutils/CMakeLists.txt
+++ b/libtestutils/CMakeLists.txt
@@ -32,7 +32,10 @@ endif()
 target_link_libraries(${EXECUTABLE} ${Boost_FILESYSTEM_LIBRARIES})
 target_link_libraries(${EXECUTABLE} ${JSONCPP_LIBRARIES})
 target_link_libraries(${EXECUTABLE} ethereum)
-target_link_libraries(${EXECUTABLE} web3jsonrpc)
+
+if (JSONRPC)
+	target_link_libraries(${EXECUTABLE} web3jsonrpc)
+endif()
 
 install( TARGETS ${EXECUTABLE} RUNTIME DESTINATION bin ARCHIVE DESTINATION lib LIBRARY DESTINATION lib )
 install( FILES ${HEADERS} DESTINATION include/${EXECUTABLE} )


### PR DESCRIPTION
fixed issue occuring on cmake 2.8.12

```
Linking CXX shared library libtestutils.so
/usr/bin/ld.gold: error: cannot find -lweb3jsonrpc
collect2: error: ld returned 1 exit status
make[2]: *** [libtestutils/libtestutils.so] Error 1
make[1]: *** [libtestutils/CMakeFiles/testutils.dir/all] Error 2
make: *** [all] Error 2
```
