### PR TITLE
Abstract contract contructors

### DIFF
--- a/libsolidity/AST.cpp
+++ b/libsolidity/AST.cpp
@@ -166,7 +166,7 @@ void ContractDefinition::checkAbstractConstructors()
 		if (constructor)
 		{
 			if (!constructor->getParameters().empty())
-				argumentsProvided.insert(constructor);
+				argumentsNeeded.insert(constructor);
 			for (auto const& modifier: constructor->getModifiers())
 			{
 				auto baseContract = dynamic_cast<ContractDefinition const*>(
@@ -174,8 +174,8 @@ void ContractDefinition::checkAbstractConstructors()
 				if (baseContract)
 				{
 					FunctionDefinition const* baseConstructor = baseContract->getConstructor();
-					if (argumentsProvided.count(baseConstructor) == 1)
-						argumentsNeeded.insert(baseConstructor);
+					if (argumentsNeeded.count(baseConstructor) == 1)
+						argumentsProvided.insert(baseConstructor);
 				}
 			}
 		}
@@ -186,10 +186,13 @@ void ContractDefinition::checkAbstractConstructors()
 				base->getName()->getReferencedDeclaration());
 			solAssert(baseContract, "");
 			FunctionDefinition const* baseConstructor = baseContract->getConstructor();
-			if (argumentsProvided.count(baseConstructor) == 1)
-				argumentsNeeded.insert(baseConstructor);
+			if (argumentsNeeded.count(baseConstructor) == 1)
+				argumentsProvided.insert(baseConstructor);
 		}
 	}
+	// add this contract's constructor to the provided too
+	if (getConstructor() && !getConstructor()->getParameters().empty())
+		argumentsProvided.insert(getConstructor());
 	if (argumentsProvided != argumentsNeeded)
 		setFullyImplemented(false);
 }

--- a/libsolidity/AST.cpp
+++ b/libsolidity/AST.cpp
@@ -728,7 +728,7 @@ void NewExpression::checkTypeRequirements()
 	if (!m_contract)
 		BOOST_THROW_EXCEPTION(createTypeError("Identifier is not a contract."));
 	if (!m_contract->isFullyImplemented())
-		BOOST_THROW_EXCEPTION(m_contract->createTypeError("Trying to create an instance of an abstract contract."));
+		BOOST_THROW_EXCEPTION(createTypeError("Trying to create an instance of an abstract contract."));
 	shared_ptr<ContractType const> contractType = make_shared<ContractType>(*m_contract);
 	TypePointers const& parameterTypes = contractType->getConstructorType()->getParameterTypes();
 	m_type = make_shared<FunctionType>(parameterTypes, TypePointers{contractType},

--- a/libsolidity/AST.cpp
+++ b/libsolidity/AST.cpp
@@ -323,7 +323,7 @@ void InheritanceSpecifier::checkTypeRequirements()
 	ContractDefinition const* base = dynamic_cast<ContractDefinition const*>(m_baseName->getReferencedDeclaration());
 	solAssert(base, "Base contract not available.");
 	TypePointers parameterTypes = ContractType(*base).getConstructorType()->getParameterTypes();
-	if (m_arguments.size() != 0 && parameterTypes.size() != m_arguments.size())
+	if (!m_arguments.empty() && parameterTypes.size() != m_arguments.size())
 		BOOST_THROW_EXCEPTION(createTypeError("Wrong argument count for constructor call."));
 	for (size_t i = 0; i < m_arguments.size(); ++i)
 		if (!m_arguments[i]->getType()->isImplicitlyConvertibleTo(*parameterTypes[i]))

--- a/libsolidity/AST.h
+++ b/libsolidity/AST.h
@@ -566,7 +566,7 @@ public:
 	std::vector<ASTPointer<Expression>> const& getArguments() const { return m_arguments; }
 
 	/// @param _bases is the list of base contracts for base constructor calls. For modifiers an empty vector should be passed.
-	void checkTypeRequirements(std::vector<ASTPointer<InheritanceSpecifier>> const& _bases);
+	void checkTypeRequirements(std::vector<ContractDefinition const*> const& _bases);
 
 private:
 	ASTPointer<Identifier> m_modifierName;

--- a/libsolidity/AST.h
+++ b/libsolidity/AST.h
@@ -284,6 +284,7 @@ public:
 private:
 	void checkIllegalOverrides() const;
 	void checkAbstractFunctions();
+	void checkAbstractConstructors();
 
 	std::vector<std::pair<FixedHash<4>, FunctionTypePointer>> const& getInterfaceFunctionList() const;
 
@@ -376,7 +377,7 @@ class EnumValue: public Declaration
 
 	virtual void accept(ASTVisitor& _visitor) override;
 	virtual void accept(ASTConstVisitor& _visitor) const override;
-	TypePointer getType(ContractDefinition const* = nullptr) const;
+	TypePointer getType(ContractDefinition const* = nullptr) const override;
 };
 
 /**

--- a/libsolidity/AST.h
+++ b/libsolidity/AST.h
@@ -377,7 +377,7 @@ class EnumValue: public Declaration
 
 	virtual void accept(ASTVisitor& _visitor) override;
 	virtual void accept(ASTConstVisitor& _visitor) const override;
-	TypePointer getType(ContractDefinition const* = nullptr) const override;
+	virtual TypePointer getType(ContractDefinition const* = nullptr) const override;
 };
 
 /**

--- a/libsolidity/Compiler.cpp
+++ b/libsolidity/Compiler.cpp
@@ -136,6 +136,7 @@ void Compiler::appendBaseConstructor(FunctionDefinition const& _constructor)
 	FunctionType constructorType(_constructor);
 	if (!constructorType.getParameterTypes().empty())
 	{
+		solAssert(m_baseArguments.count(&_constructor), "");
 		std::vector<ASTPointer<Expression>> const* arguments = m_baseArguments[&_constructor];
 		solAssert(arguments, "");
 		for (unsigned i = 0; i < arguments->size(); ++i)

--- a/libsolidity/CompilerStack.cpp
+++ b/libsolidity/CompilerStack.cpp
@@ -157,14 +157,16 @@ bytes const& CompilerStack::compile(string const& _sourceCode, bool _optimize)
 	return getBytecode();
 }
 
-eth::AssemblyItems const& CompilerStack::getAssemblyItems(string const& _contractName) const
+eth::AssemblyItems const* CompilerStack::getAssemblyItems(string const& _contractName) const
 {
-	return getContract(_contractName).compiler->getAssemblyItems();
+	Contract const& contract = getContract(_contractName);
+	return contract.compiler ? &getContract(_contractName).compiler->getAssemblyItems() : nullptr;
 }
 
-eth::AssemblyItems const& CompilerStack::getRuntimeAssemblyItems(string const& _contractName) const
+eth::AssemblyItems const* CompilerStack::getRuntimeAssemblyItems(string const& _contractName) const
 {
-	return getContract(_contractName).compiler->getRuntimeAssemblyItems();
+	Contract const& contract = getContract(_contractName);
+	return contract.compiler ? &getContract(_contractName).compiler->getRuntimeAssemblyItems() : nullptr;
 }
 
 bytes const& CompilerStack::getBytecode(string const& _contractName) const
@@ -184,7 +186,11 @@ dev::h256 CompilerStack::getContractCodeHash(string const& _contractName) const
 
 void CompilerStack::streamAssembly(ostream& _outStream, string const& _contractName, StringMap _sourceCodes) const
 {
-	getContract(_contractName).compiler->streamAssembly(_outStream, _sourceCodes);
+	Contract const& contract = getContract(_contractName);
+	if (contract.compiler)
+		getContract(_contractName).compiler->streamAssembly(_outStream, _sourceCodes);
+	else
+		_outStream << "Contract not fully implemented" << endl;
 }
 
 string const& CompilerStack::getInterface(string const& _contractName) const

--- a/libsolidity/CompilerStack.h
+++ b/libsolidity/CompilerStack.h
@@ -94,9 +94,9 @@ public:
 	/// @returns the runtime bytecode for the contract, i.e. the code that is returned by the constructor.
 	bytes const& getRuntimeBytecode(std::string const& _contractName = "") const;
 	/// @returns normal contract assembly items
-	eth::AssemblyItems const& getAssemblyItems(std::string const& _contractName = "") const;
+	eth::AssemblyItems const* getAssemblyItems(std::string const& _contractName = "") const;
 	/// @returns runtime contract assembly items
-	eth::AssemblyItems const& getRuntimeAssemblyItems(std::string const& _contractName = "") const;
+	eth::AssemblyItems const* getRuntimeAssemblyItems(std::string const& _contractName = "") const;
 	/// @returns hash of the runtime bytecode for the contract, i.e. the code that is returned by the constructor.
 	dev::h256 getContractCodeHash(std::string const& _contractName = "") const;
 

--- a/mix/CodeModel.cpp
+++ b/mix/CodeModel.cpp
@@ -136,7 +136,7 @@ CompiledContract::CompiledContract(const dev::solidity::CompilerStack& _compiler
 	m_storage = collectStorage(contractDefinition);
 	contractDefinition.accept(visitor);
 	m_assemblyItems = *_compiler.getRuntimeAssemblyItems(name);
-	m_constructorAssemblyItems = _compiler.getAssemblyItems(name);
+	m_constructorAssemblyItems = *_compiler.getAssemblyItems(name);
 }
 
 QString CompiledContract::codeHex() const

--- a/mix/CodeModel.cpp
+++ b/mix/CodeModel.cpp
@@ -135,7 +135,7 @@ CompiledContract::CompiledContract(const dev::solidity::CompilerStack& _compiler
 	CollectDeclarationsVisitor visitor(&m_functions, &m_locals);
 	m_storage = collectStorage(contractDefinition);
 	contractDefinition.accept(visitor);
-	m_assemblyItems = _compiler.getRuntimeAssemblyItems(name);
+	m_assemblyItems = *_compiler.getRuntimeAssemblyItems(name);
 	m_constructorAssemblyItems = _compiler.getAssemblyItems(name);
 }
 

--- a/test/SolidityNameAndTypeResolution.cpp
+++ b/test/SolidityNameAndTypeResolution.cpp
@@ -407,6 +407,20 @@ BOOST_AUTO_TEST_CASE(create_abstract_contract)
 	BOOST_CHECK_THROW(parseTextAndResolveNames(text), TypeError);
 }
 
+BOOST_AUTO_TEST_CASE(abstract_contract_constructor_args_optional)
+{
+	ASTPointer<SourceUnit> sourceUnit;
+	char const* text = R"(
+		contract BaseBase { function BaseBase(uint j); }
+		contract base is BaseBase { function foo(); }
+		contract derived is base {
+			function derived(uint i) BaseBase(i){}
+			function foo() {}
+		}
+		)";
+	ETH_TEST_REQUIRE_NO_THROW(parseTextAndResolveNames(text), "Parsing and name resolving failed");
+}
+
 BOOST_AUTO_TEST_CASE(redeclare_implemented_abstract_function_as_abstract)
 {
 	ASTPointer<SourceUnit> sourceUnit;
@@ -665,7 +679,7 @@ BOOST_AUTO_TEST_CASE(missing_base_constructor_arguments)
 		contract A { function A(uint a) { } }
 		contract B is A { }
 	)";
-	BOOST_CHECK_THROW(parseTextAndResolveNames(text), TypeError);
+	ETH_TEST_CHECK_NO_THROW(parseTextAndResolveNames(text), "Parsing and Name Resolving Failed");
 }
 
 BOOST_AUTO_TEST_CASE(base_constructor_arguments_override)
@@ -674,7 +688,7 @@ BOOST_AUTO_TEST_CASE(base_constructor_arguments_override)
 		contract A { function A(uint a) { } }
 		contract B is A { }
 	)";
-	BOOST_CHECK_THROW(parseTextAndResolveNames(text), TypeError);
+	ETH_TEST_CHECK_NO_THROW(parseTextAndResolveNames(text), "Parsing and Name Resolving Failed");
 }
 
 BOOST_AUTO_TEST_CASE(implicit_derived_to_base_conversion)

--- a/test/SolidityNameAndTypeResolution.cpp
+++ b/test/SolidityNameAndTypeResolution.cpp
@@ -421,6 +421,25 @@ BOOST_AUTO_TEST_CASE(abstract_contract_constructor_args_optional)
 	ETH_TEST_REQUIRE_NO_THROW(parseTextAndResolveNames(text), "Parsing and name resolving failed");
 }
 
+BOOST_AUTO_TEST_CASE(abstract_contract_constructor_args_not_provided)
+{
+	ASTPointer<SourceUnit> sourceUnit;
+	char const* text = R"(
+		contract BaseBase { function BaseBase(uint j); }
+		contract base is BaseBase { function foo(); }
+		contract derived is base {
+			function derived(uint i) {}
+			function foo() {}
+		}
+		)";
+	ETH_TEST_REQUIRE_NO_THROW(sourceUnit = parseTextAndResolveNames(text), "Parsing and name resolving failed");
+	std::vector<ASTPointer<ASTNode>> nodes = sourceUnit->getNodes();
+	BOOST_CHECK_EQUAL(nodes.size(), 3);
+	ContractDefinition* derived = dynamic_cast<ContractDefinition*>(nodes[2].get());
+	BOOST_CHECK(derived);
+	BOOST_CHECK(!derived->isFullyImplemented());
+}
+
 BOOST_AUTO_TEST_CASE(redeclare_implemented_abstract_function_as_abstract)
 {
 	ASTPointer<SourceUnit> sourceUnit;


### PR DESCRIPTION
Implementing last bullet point of the [Abstract contracts story](https://www.pivotaltracker.com/story/show/88344782) converning constructors of base contracts and proper checks for providing all arguments. 

If not all arguments to base constructors are provided the contract is marked as abstract.