### PR TITLE
Make currect some of the testing framework

### DIFF
--- a/libethereum/State.h
+++ b/libethereum/State.h
@@ -347,7 +347,6 @@ private:
 	/// Debugging only. Good for checking the Trie is in shape.
 	void paranoia(std::string const& _when, bool _enforceRefs = false) const;
 
-
 	OverlayDB m_db;								///< Our overlay for the state tree.
 	SecureTrieDB<Address, OverlayDB> m_state;	///< Our state tree, as an OverlayDB DB.
 	Transactions m_transactions;				///< The current list of transactions that we've included in the state.

--- a/test/solidityExecutionFramework.h
+++ b/test/solidityExecutionFramework.h
@@ -171,7 +171,7 @@ protected:
 	Address m_contractAddress;
 	eth::State m_state;
 	u256 const m_gasPrice = 100 * eth::szabo;
-	u256 const m_gas = 100000000;
+	u256 const m_gas = 3141592;
 	bytes m_output;
 	eth::LogEntries m_logs;
 };


### PR DESCRIPTION
Doesn't actually fix it (broken in libsol anyway, it seems), but does make more correct certain parts (though seems to break a lot of tests :-/)

- Ensure enough gas is in the sender account and that the sender is actually that acocunt, not just some randomly generated one
- Ensure the gas given to the call is <= block limit