### PR TITLE
Retain more gas for the case that the called contract is not yet created

### DIFF
--- a/libsolidity/ExpressionCompiler.cpp
+++ b/libsolidity/ExpressionCompiler.cpp
@@ -1029,7 +1029,7 @@ void ExpressionCompiler::appendExternalFunctionCall(FunctionType const& _functio
 	else
 		// send all gas except the amount needed to execute "SUB" and "CALL"
 		// @todo this retains too much gas for now, needs to be fine-tuned.
-		m_context << u256(50 + (_functionType.valueSet() ? 9000 : 0)) << eth::Instruction::GAS << eth::Instruction::SUB;
+		m_context << u256(50 + (_functionType.valueSet() ? 9000 : 0) + 25000) << eth::Instruction::GAS << eth::Instruction::SUB;
 	m_context << eth::Instruction::CALL;
 	auto tag = m_context.appendConditionalJump();
 	m_context << eth::Instruction::STOP << tag;	// STOP if CALL leaves 0.

--- a/test/SolidityEndToEndTest.cpp
+++ b/test/SolidityEndToEndTest.cpp
@@ -1414,8 +1414,6 @@ BOOST_AUTO_TEST_CASE(sha3)
 	testSolidityAgainstCpp("a(bytes32)", f, u256(-1));
 }
 
-#ifdef PRECOMPILED_CONTRACTS_GAS_FIXED_IN_SOLIDITY
-
 BOOST_AUTO_TEST_CASE(sha256)
 {
 	char const* sourceCode = "contract test {\n"
@@ -3631,5 +3629,3 @@ BOOST_AUTO_TEST_SUITE_END()
 }
 }
 } // end namespaces
-
-#endif


### PR DESCRIPTION
This fixes some problems with tests that call sha256, ecrecover, ...

Note that this actually sends less gas to the called contract since the costs are subtracted from the calling frame's gas right before the call is made.