### PR TITLE
remove c_sstoreClearGas

### DIFF
--- a/libethcore/Params.cpp
+++ b/libethcore/Params.cpp
@@ -46,7 +46,6 @@ u256 const c_sha3WordGas = 6;
 u256 const c_sloadGas = 50;
 u256 const c_sstoreSetGas = 20000;
 u256 const c_sstoreResetGas = 5000;
-u256 const c_sstoreClearGas = 5000;
 u256 const c_sstoreRefundGas = 15000;
 u256 const c_jumpdestGas = 1;
 u256 const c_logGas = 375;

--- a/libethcore/Params.h
+++ b/libethcore/Params.h
@@ -48,8 +48,7 @@ extern u256 const c_sha3WordGas;			///< Once per word of the SHA3 operation's da
 extern u256 const c_copyGas;				///< Multiplied by the number of 32-byte words that are copied (round up) for any *COPY operation and added.
 extern u256 const c_sloadGas;				///< Once per SLOAD operation.
 extern u256 const c_sstoreSetGas;			///< Once per SSTORE operation if the zeroness changes from zero.
-extern u256 const c_sstoreResetGas;			///< Once per SSTORE operation if the zeroness doesn't change.
-extern u256 const c_sstoreClearGas;			///< Once per SSTORE operation if the zeroness changes to zero.
+extern u256 const c_sstoreResetGas;			///< Once per SSTORE operation if the zeroness does not change from zero. NOTE: when c_sstoreSetGas does not apply.
 extern u256 const c_sstoreRefundGas;		///< Refunded gas, once per SSTORE operation if the zeroness changes to zero.
 extern u256 const c_jumpdestGas;			///< Once per JUMPDEST operation.
 extern u256 const c_logGas;					///< Per LOG* operation.

--- a/libevm/VM.cpp
+++ b/libevm/VM.cpp
@@ -108,7 +108,7 @@ bytesConstRef VM::go(ExtVMFace& _ext, OnOpFunc const& _onOp, uint64_t _steps)
 				runGas = c_sstoreSetGas;
 			else if (_ext.store(m_stack.back()) && !m_stack[m_stack.size() - 2])
 			{
-				runGas = c_sstoreClearGas;
+				runGas = c_sstoreResetGas;
 				_ext.sub.refunds += c_sstoreRefundGas;
 			}
 			else


### PR DESCRIPTION
Since it has the same price as sstoreResetGas, one can simplify the sstore logic:
Always pay 20000 for zeroness change from zero, and 5000 otherwise.
(plus the refund when changing the zeroness to zero again)