### PR TITLE
pysol work in progress

### DIFF
--- a/pysol/MANIFEST.in
+++ b/pysol/MANIFEST.in
@@ -1,13 +1,5 @@
 include pysol/*.cpp
 include *.py
-include libdevcore/*cpp
-include libdevcore/*h
-include libdevcrypto/*cpp
-include libdevcrypto/*h
-include libethcore/*cpp
-include libethcore/*h
-include libsolidity/*cpp
-include libsolidity/*h
-include libevmcore/*cpp
-include libevmcore/*h
+include build/libsolidity/libsolidity.so
+include build/libdevcrypto/libdevcrypto.so
 include pysol/README.md

--- a/pysol/setup.py
+++ b/pysol/setup.py
@@ -1,9 +1,7 @@
+from setuptools import setup, Extension
+from distutils.sysconfig import get_config_vars
 import os
 os.chdir('..')
-
-from setuptools import setup, Extension
-
-from distutils.sysconfig import get_config_vars
 
 (opt,) = get_config_vars('OPT')
 os.environ['OPT'] = " ".join(
@@ -27,9 +25,21 @@ setup(
     ext_modules=[
         Extension(
             'solidity',         # Python name of the module
-            sources= ['libdevcore/Common.cpp', 'libdevcore/CommonData.cpp', 'libdevcore/CommonIO.cpp', 'libdevcore/FixedHash.cpp', 'libdevcore/Guards.cpp', 'libdevcore/Log.cpp', 'libdevcore/RangeMask.cpp', 'libdevcore/RLP.cpp', 'libdevcore/Worker.cpp', 'libdevcrypto/AES.cpp', 'libdevcrypto/Common.cpp', 'libdevcrypto/CryptoPP.cpp', 'libdevcrypto/ECDHE.cpp', 'libdevcrypto/FileSystem.cpp', 'libdevcrypto/MemoryDB.cpp', 'libdevcrypto/OverlayDB.cpp', 'libdevcrypto/SHA3.cpp', 'libdevcrypto/TrieCommon.cpp', 'libdevcrypto/TrieDB.cpp', 'libethcore/CommonEth.cpp', 'libethcore/CommonJS.cpp', 'libethcore/Exceptions.cpp', 'libsolidity/AST.cpp', 'libsolidity/ASTJsonConverter.cpp', 'libsolidity/ASTPrinter.cpp', 'libsolidity/CompilerContext.cpp', 'libsolidity/Compiler.cpp', 'libsolidity/CompilerStack.cpp', 'libsolidity/CompilerUtils.cpp', 'libsolidity/DeclarationContainer.cpp', 'libsolidity/ExpressionCompiler.cpp', 'libsolidity/GlobalContext.cpp', 'libsolidity/InterfaceHandler.cpp', 'libsolidity/NameAndTypeResolver.cpp', 'libsolidity/Parser.cpp', 'libsolidity/Scanner.cpp', 'libsolidity/SourceReferenceFormatter.cpp', 'libsolidity/Token.cpp', 'libsolidity/Types.cpp', 'libevmcore/Assembly.cpp', 'libevmcore/Instruction.cpp', 'pysol/pysolidity.cpp'],
-            libraries=['boost_python', 'boost_filesystem', 'boost_chrono', 'boost_thread', 'cryptopp', 'leveldb', 'jsoncpp'],
-            include_dirs=['/usr/include/boost', '..', '../..', '.'],
+            sources=['pysol/pysolidity.cpp'],
+            library_dirs=['build/libsolidity/',
+                          'build/libdevcrypto/'],
+            libraries=['boost_python',
+                       'boost_filesystem',
+                       'boost_chrono',
+                       'boost_thread',
+                       'devcrypto',
+                       'leveldb',
+                       'jsoncpp',
+                       'solidity'],
+            include_dirs=['/usr/include/boost',
+                          '..',
+                          '../..',
+                          '.'],
             extra_compile_args=['--std=c++11', '-Wno-unknown-pragmas']
         )],
     py_modules=[


### PR DESCRIPTION
WARNING: Work in progress don't merge.

Just some attempts to address #1296. Will work on it more when I find more time.
Not really solved anything yet. It's a work in progress.

I am not familiar with the python `setup-tools` module enough but what I think is the proper solution for this is:

- Do not include the source files into the final package. Solidity itself is actually a library.
- Use the cpp-ethereum build files to build solidity
- The final package created by setup-tools should somehow link to the built libraries. This is the part I have not figured out yet. How can you package the libsolidity.so into a way that python will find it later? Is there any standard way in python? If I set the `LD_PATH` manually or if I copy it into the path this works.