### PR TITLE
EVMJIT: Change instruction scheduler

### DIFF
--- a/evmjit/libevmjit/ExecutionEngine.cpp
+++ b/evmjit/libevmjit/ExecutionEngine.cpp
@@ -88,10 +88,10 @@ void parseOptions()
 	//cl::ParseEnvironmentOptions("evmjit", "EVMJIT", "Ethereum EVM JIT Compiler");
 
 	// FIXME: LLVM workaround:
-	// Manually select instruction scheduler other than "source".
+	// Manually select instruction scheduler. Confirmed bad schedulers: source, list-burr, list-hybrid.
 	// "source" scheduler has a bug: http://llvm.org/bugs/show_bug.cgi?id=22304
 	auto envLine = std::getenv("EVMJIT");
-	auto commandLine = std::string{"evmjit "} + (envLine ? envLine : "") + " -pre-RA-sched=list-burr\0";
+	auto commandLine = std::string{"evmjit "} + (envLine ? envLine : "") + " -pre-RA-sched=list-ilp\0";
 	static const auto c_maxArgs = 20;
 	char const* argv[c_maxArgs] = {nullptr, };
 	auto arg = std::strtok(&*commandLine.begin(), " ");

--- a/test/state.cpp
+++ b/test/state.cpp
@@ -218,6 +218,8 @@ BOOST_AUTO_TEST_CASE(stCreateTest)
 
 BOOST_AUTO_TEST_CASE(stRandom)
 {
+	test::Options::get(); // parse command line options, e.g. to enable JIT
+
 	string testPath = dev::test::getTestPath();
 	testPath += "/StateTests/RandomTests";
 

--- a/test/vm.cpp
+++ b/test/vm.cpp
@@ -524,6 +524,8 @@ BOOST_AUTO_TEST_CASE(vmInputLimitsLightTest)
 
 BOOST_AUTO_TEST_CASE(vmRandom)
 {
+	test::Options::get(); // parse command line options, e.g. to enable JIT
+
 	string testPath = getTestPath();
 	testPath += "/VMTests/RandomTests";
 


### PR DESCRIPTION
Try different instruction scheduler in LLVM, other crashes sometimes.
Also parse command line options properly for random tests.