### PR TITLE
Ignore interfaces which aren't UP.

### DIFF
--- a/libp2p/Network.cpp
+++ b/libp2p/Network.cpp
@@ -84,7 +84,7 @@ std::set<bi::address> Network::getInterfaceAddresses()
 
 	for (auto ifa = ifaddr; ifa != NULL; ifa = ifa->ifa_next)
 	{
-		if (!ifa->ifa_addr || string(ifa->ifa_name) == "lo0")
+		if (!ifa->ifa_addr || string(ifa->ifa_name) == "lo0" || !(ifa->ifa_flags & IFF_UP))
 			continue;
 
 		if (ifa->ifa_addr->sa_family == AF_INET)


### PR DESCRIPTION
This causes a crash on osx when tethering is used and wifi is disabled.