### PR TITLE
Don't use unsigned for negative value.

### DIFF
--- a/libp2p/Host.cpp
+++ b/libp2p/Host.cpp
@@ -579,7 +579,7 @@ void Host::run(boost::system::error_code const&)
 	// is always live and to ensure reputation and fallback timers are properly
 	// updated. // disconnectLatePeers();
 
-	auto openSlots = m_idealPeerCount - peerCount();
+	int openSlots = m_idealPeerCount - peerCount();
 	if (openSlots > 0)
 	{
 		list<shared_ptr<Peer>> toConnect;


### PR DESCRIPTION
Prevents client from trying to connect to every peer when peercount > idealpeercount.