### PR TITLE
RLP length with first zeros

### DIFF
--- a/libdevcore/RLP.cpp
+++ b/libdevcore/RLP.cpp
@@ -149,7 +149,7 @@ unsigned RLP::length() const
 		return n - c_rlpDataImmLenStart;
 	else if (n < c_rlpListStart)
 	{
-		if ((int)m_data.size() <= n - c_rlpDataIndLenZero)
+		if ((int)m_data.size() <= n - c_rlpDataIndLenZero || m_data[1] == 0)
 			BOOST_THROW_EXCEPTION(BadRLP());
 		for (int i = 0; i < n - c_rlpDataIndLenZero; ++i)
 			ret = (ret << 8) | m_data[i + 1];
@@ -158,7 +158,7 @@ unsigned RLP::length() const
 		return n - c_rlpListStart;
 	else
 	{
-		if ((int)m_data.size() <= n - c_rlpListIndLenZero)
+		if ((int)m_data.size() <= n - c_rlpListIndLenZero || m_data[1] == 0)
 			BOOST_THROW_EXCEPTION(BadRLP());
 		for (int i = 0; i < n - c_rlpListIndLenZero; ++i)
 			ret = (ret << 8) | m_data[i + 1];

--- a/libdevcore/RLP.cpp
+++ b/libdevcore/RLP.cpp
@@ -149,8 +149,11 @@ unsigned RLP::length() const
 		return n - c_rlpDataImmLenStart;
 	else if (n < c_rlpListStart)
 	{
-		if ((int)m_data.size() <= n - c_rlpDataIndLenZero || m_data[1] == 0)
+		if ((int)m_data.size() <= n - c_rlpDataIndLenZero)
 			BOOST_THROW_EXCEPTION(BadRLP());
+		if ((int)m_data.size() > 1)
+			if (m_data[1] == 0)
+				BOOST_THROW_EXCEPTION(BadRLP());
 		for (int i = 0; i < n - c_rlpDataIndLenZero; ++i)
 			ret = (ret << 8) | m_data[i + 1];
 	}
@@ -158,8 +161,11 @@ unsigned RLP::length() const
 		return n - c_rlpListStart;
 	else
 	{
-		if ((int)m_data.size() <= n - c_rlpListIndLenZero || m_data[1] == 0)
+		if ((int)m_data.size() <= n - c_rlpListIndLenZero)
 			BOOST_THROW_EXCEPTION(BadRLP());
+		if ((int)m_data.size() > 1)
+			if (m_data[1] == 0)
+				BOOST_THROW_EXCEPTION(BadRLP());
 		for (int i = 0; i < n - c_rlpListIndLenZero; ++i)
 			ret = (ret << 8) | m_data[i + 1];
 	}

--- a/libdevcore/RLP.h
+++ b/libdevcore/RLP.h
@@ -303,7 +303,7 @@ private:
 	/// Single-byte data payload.
 	bool isSingleByte() const { return !isNull() && m_data[0] < c_rlpDataImmLenStart; }
 
-	/// @returns the bytes used to encode the length of the data. Valid for all types.
+	/// @returns the amount of bytes used to encode the length of the data. Valid for all types.
 	unsigned lengthSize() const { if (isData() && m_data[0] > c_rlpDataIndLenZero) return m_data[0] - c_rlpDataIndLenZero; if (isList() && m_data[0] > c_rlpListIndLenZero) return m_data[0] - c_rlpListIndLenZero; return 0; }
 
 	/// @returns the size in bytes of the payload, as given by the RLP as opposed to as inferred from m_data.


### PR DESCRIPTION
>If a string is more than 55 bytes long, the RLP encoding consists of a single byte with value 0xb7 plus the length of the length of the string in binary form, followed by the length of the string, followed by the string.

leading zeros in  length of the string are not covered. 

https://github.com/ethereum/yellowpaper/issues/116