### PR TITLE
Windows doesn't like %F %T datetime format

### DIFF
--- a/libdevcore/CommonIO.h
+++ b/libdevcore/CommonIO.h
@@ -77,7 +77,7 @@ template <class T, class U> inline std::ostream& operator<<(std::ostream& _out, 
 template <class T, class U> inline std::ostream& operator<<(std::ostream& _out, std::multimap<T, U> const& _e);
 template <class _S, class _T> _S& operator<<(_S& _out, std::shared_ptr<_T> const& _p);
 
-template <class T> inline std::string toString(std::chrono::time_point<T> const& _e, std::string _format = "%F %T")
+template <class T> inline std::string toString(std::chrono::time_point<T> const& _e, std::string _format = "%Y-%m-%d %H:%M:%S") 
 {
 	unsigned long milliSecondsSinceEpoch = std::chrono::duration_cast<std::chrono::milliseconds>(_e.time_since_epoch()).count();
 	auto const durationSinceEpoch = std::chrono::milliseconds(milliSecondsSinceEpoch);


### PR DESCRIPTION
%F and %T aren't supported by Windows so I changed this into something that does the same and works on Windows. 

btw the output that is produced doesn't really make sense:
```
*** [ 17:38:40 | eth ] Since 1970-02-11 20:12:43.702Z (15): 15ticks
```
but at least it doesn't crash