### PR TITLE
bring back proper topics parsing

### DIFF
--- a/libweb3jsonrpc/WebThreeStubServerBase.cpp
+++ b/libweb3jsonrpc/WebThreeStubServerBase.cpp
@@ -201,7 +201,7 @@ static dev::eth::LogFilter toLogFilter(Json::Value const& _json)	// commented to
 					if (!t.isNull())
 						filter.topic(i, jsToFixed<32>(t.asString()));
 			}
-			else if (!_json["topics"][i].isNull())
+			else if (!_json["topics"][i].isNull()) // if it is anything else then string, it should and will fail
 				filter.topic(i, jsToFixed<32>(_json["topics"][i].asString()));
 		}
 	return filter;
@@ -233,7 +233,16 @@ static shh::Envelope toSealed(Json::Value const& _json, shh::Message const& _m, 
 	
 	if (!_json["topics"].empty())
 		for (auto i: _json["topics"])
-			bt.shift(jsToBytes(i.asString()));
+		{
+			if (i.isArray())
+			{
+				for (auto j: i)
+					if (!j.isNull())
+						bt.shift(jsToBytes(j.asString()));
+			}
+			else if (!i.isNull()) // if it is anything else then string, it should and will fail
+				bt.shift(jsToBytes(i.asString()));
+		}
 	
 	return _m.seal(_from, bt, ttl, workToProve);
 }

--- a/libweb3jsonrpc/WebThreeStubServerBase.cpp
+++ b/libweb3jsonrpc/WebThreeStubServerBase.cpp
@@ -194,7 +194,16 @@ static dev::eth::LogFilter toLogFilter(Json::Value const& _json)	// commented to
 	}
 	if (!_json["topics"].empty())
 		for (unsigned i = 0; i < _json["topics"].size(); i++)
-			filter.topic(i, jsToFixed<32>(_json["topics"][i].asString()));
+		{
+			if (_json["topics"][i].isArray())
+			{
+				for (auto t: _json["topics"][i])
+					if (!t.isNull())
+						filter.topic(i, jsToFixed<32>(t.asString()));
+			}
+			else if (!_json["topics"][i].isNull())
+				filter.topic(i, jsToFixed<32>(_json["topics"][i].asString()));
+		}
 	return filter;
 }
 


### PR DESCRIPTION
bring back proper topics parsing in WebThreeStubServerBase. I must have accidentally removed short after poc-8 was released.

[old eth topics parsing](https://github.com/ethereum/cpp-ethereum/blob/poc-8-tag/libweb3jsonrpc/WebThreeStubServerBase.cpp#L142-L154)

[old shh topics parsing](https://github.com/ethereum/cpp-ethereum/blob/poc-8-tag/libweb3jsonrpc/WebThreeStubServerBase.cpp#L180-L188)