### PR TITLE
Direct more mundane failures to cerr as well.

### DIFF
--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -270,7 +270,7 @@ bool CommandLineInterface::parseArguments(int argc, char** argv)
 	}
 	catch (po::error const& _exception)
 	{
-		cout << _exception.what() << endl;
+		cerr << _exception.what() << endl;
 		return false;
 	}
 	if (m_args.count("combined-json"))
@@ -279,7 +279,7 @@ bool CommandLineInterface::parseArguments(int argc, char** argv)
 		for (string const& item: boost::split(requests, m_args["combined-json"].as<string>(), boost::is_any_of(",")))
 			if (!g_combinedJsonArgs.count(item))
 			{
-				cout << "Invalid option to --combined-json: " << item << endl;
+				cerr << "Invalid option to --combined-json: " << item << endl;
 				return false;
 			}
 	}
@@ -317,13 +317,13 @@ bool CommandLineInterface::processInput()
 			auto path = boost::filesystem::path(infile);
 			if (!boost::filesystem::exists(path))
 			{
-				cout << "Skipping non existant input file \"" << infile << "\"" << endl;
+				cerr << "Skipping non existant input file \"" << infile << "\"" << endl;
 				continue;
 			}
 
 			if (!boost::filesystem::is_regular_file(path))
 			{
-				cout << "\"" << infile << "\" is not a valid file. Skipping" << endl;
+				cerr << "\"" << infile << "\" is not a valid file. Skipping" << endl;
 				continue;
 			}
 


### PR DESCRIPTION
I was using the i/o redirection operators in bash to direct stdout from solc to files in a build directory, and discovered that if a filename is given incorrectly it just writes the "Skipping file" message to the built file. From my perspective, any message relating to the failure of the requested operation should be written to stderr. Only the results of the requested operation should be written to stdout.