### PR TITLE
fixed excessive RAM usage when GPU mining

### DIFF
--- a/libethash-cl/ethash_cl_miner.h
+++ b/libethash-cl/ethash_cl_miner.h
@@ -31,7 +31,7 @@ public:
 public:
 	ethash_cl_miner();
 
-	bool init(ethash_params const& params, std::function<void(void*)> _fillDAG, unsigned workgroup_size = 64, unsigned _platformId = 0, unsigned _deviceId = 0);
+	bool init(ethash_params const& params, const void * dag_ptr, unsigned workgroup_size = 64, unsigned _platformId = 0, unsigned _deviceId = 0);
 	static std::string platform_info(unsigned _platformId = 0, unsigned _deviceId = 0);
 	static unsigned get_num_devices(unsigned _platformId = 0);
 
@@ -39,7 +39,7 @@ public:
 	void finish();
 	void hash(uint8_t* ret, uint8_t const* header, uint64_t nonce, unsigned count);
 	void search(uint8_t const* header, uint64_t target, search_hook& hook);
-
+	void checkdag();
 private:
 	enum { c_max_search_results = 63, c_num_buffers = 2, c_hash_batch_size = 1024, c_search_batch_size = 1024*256 };
 
@@ -48,6 +48,7 @@ private:
 	cl::CommandQueue m_queue;
 	cl::Kernel m_hash_kernel;
 	cl::Kernel m_search_kernel;
+	cl::Kernel m_check_kernel;
 	cl::Buffer m_dag;
 	cl::Buffer m_header;
 	cl::Buffer m_hash_buf[c_num_buffers];

--- a/libethash-cl/ethash_cl_miner_kernel.cl
+++ b/libethash-cl/ethash_cl_miner_kernel.cl
@@ -223,7 +223,8 @@ typedef union
 
 typedef union
 {
-	uint uints[128 / sizeof(uint)];
+	uchar uchars[128 / sizeof(uchar)];
+	uint  uints[128 / sizeof(uint)];
 	uint4 uint4s[128 / sizeof(uint4)];
 } hash128_t;
 
@@ -456,5 +457,14 @@ __kernel void ethash_search(
 	{
 		uint slot = min(MAX_OUTPUTS, atomic_inc(&g_output[0]) + 1);
 		g_output[slot] = gid;
+	}
+}
+
+__kernel void ethash_checkdag(__global hash128_t const* g_dag)
+{
+	for (int i = 0; i < 16; i++) {
+		for (int j = 0; j < 16; j++) {
+			printf("%x ", g_dag[i].uchars[j]);
+		}
 	}
 }

--- a/libethcore/Ethash.cpp
+++ b/libethcore/Ethash.cpp
@@ -310,13 +310,18 @@ void Ethash::GPUMiner::workLoop()
 			m_miner = new ethash_cl_miner;
 
 			auto p = EthashAux::params(m_minerSeed);
-			auto cb = [&](void* d) { EthashAux::full(m_minerSeed, bytesRef((byte*)d, p.full_size)); };
+			//auto cb = [&](void* d) { EthashAux::full(m_minerSeed, bytesRef((byte*)d, p.full_size)); };
+
+			const void * dag_ptr;
+			EthashAux::full_ptr(m_minerSeed, &dag_ptr);
+
 			unsigned device = instances() > 1 ? index() : s_deviceId;
-			m_miner->init(p, cb, 32, s_platformId, device);
+			m_miner->init(p, dag_ptr, 32, s_platformId, device);
 		}
 
 		uint64_t upper64OfBoundary = (uint64_t)(u64)((u256)w.boundary >> 192);
 		m_miner->search(w.headerHash.data(), upper64OfBoundary, *m_hook);
+		//m_miner->checkdag();
 	}
 	catch (...)
 	{

--- a/libethcore/EthashAux.cpp
+++ b/libethcore/EthashAux.cpp
@@ -143,6 +143,14 @@ EthashAux::FullType EthashAux::full(BlockInfo const& _header, bytesRef _dest, bo
 	return full(_header.seedHash(), _dest, _createIfMissing);
 }
 
+EthashAux::FullType EthashAux::full_ptr(h256 const& _seedHash, const void ** ptr)
+{
+	RecursiveGuard l(get()->x_this);
+	FullType ret = get()->m_fulls[_seedHash].lock();
+	*ptr = (const void*)ret->data.begin();
+	return FullType();
+}
+
 EthashAux::FullType EthashAux::full(h256 const& _seedHash, bytesRef _dest, bool _createIfMissing)
 {
 	RecursiveGuard l(get()->x_this);

--- a/libethcore/EthashAux.h
+++ b/libethcore/EthashAux.h
@@ -62,7 +62,7 @@ public:
 	static LightType light(h256 const& _seedHash);
 	static FullType full(BlockInfo const& _header, bytesRef _dest = bytesRef(), bool _createIfMissing = true);
 	static FullType full(h256 const& _header, bytesRef _dest = bytesRef(), bool _createIfMissing = true);
-
+	static FullType full_ptr(h256 const& _seedHash, const void ** ptr);
 	static Ethash::Result eval(BlockInfo const& _header) { return eval(_header, _header.nonce); }
 	static Ethash::Result eval(BlockInfo const& _header, Nonce const& _nonce);
 	static Ethash::Result eval(h256 const& _seedHash, h256 const& _headerHash, Nonce const& _nonce);


### PR DESCRIPTION
By using the CL_MEM_USE_HOST_PTR flag on Buffer creation, only as much RAM as the dag is sized is required, instead of (1 + num GPUs) * dag_size, as it was before.

To verify the dag is really on the device, I wrote a simple kernel that outputs the first 256 bytes of the dag file. It seems to work fine.