### PR TITLE
Limit DNS resolution to ipv4.

### DIFF
--- a/libp2p/Network.cpp
+++ b/libp2p/Network.cpp
@@ -226,7 +226,7 @@ bi::tcp::endpoint Network::resolveHost(string const& _addr)
 		boost::system::error_code ec;
 		// resolve returns an iterator (host can resolve to multiple addresses)
 		bi::tcp::resolver r(s_resolverIoService);
-		auto it = r.resolve({split[0], toString(port)}, ec);
+		auto it = r.resolve({bi::tcp::v4(), split[0], toString(port)}, ec);
 		if (ec)
 			clog(NetWarn) << "Error resolving host address..." << LogTag::Url << _addr << ":" << LogTag::Error << ec.message();
 		else


### PR DESCRIPTION
On some systems w/ipv6 enabled the resolver returns ipv6 address even though the system doesn't have a routable ipv6 address.