### PR TITLE
adding --network-id option to eth cli

### DIFF
--- a/eth/main.cpp
+++ b/eth/main.cpp
@@ -146,6 +146,7 @@ void help()
 		<< "    --listen <port>  Listen on the given port for incoming connections (default: 30303)." << endl
 		<< "    -r,--remote <host>(:<port>)  Connect to remote host (default: none)." << endl
 		<< "    --port <port>  Connect to remote port (default: 30303)." << endl
+		<< "    --network-id <n> Only connect to other hosts with this network id (default:0)." << endl
 		<< "    --upnp <on/off>  Use UPnP for NAT (default: on)." << endl
 #if ETH_JSONRPC || !ETH_TRUE
 		<< "Work farming mode:" << endl
@@ -515,6 +516,7 @@ int main(int argc, char** argv)
 	unsigned short remotePort = 30303;
 	unsigned peers = 5;
 	bool bootstrap = false;
+	unsigned networkId = 0;
 
 	/// Mining params
 	unsigned mining = 0;
@@ -668,6 +670,15 @@ int main(int argc, char** argv)
 				return -1;
 			}
 		}
+		else if (arg == "--network-id" && i + 1 < argc)
+			try {
+				networkId = stol(argv[++i]);
+			}
+			catch (...)
+			{
+				cerr << "Bad " << arg << " option: " << argv[i] << endl;
+				return -1;
+			}
 		else if (arg == "--benchmark-warmup" && i + 1 < argc)
 			try {
 				benchmarkWarmup = stol(argv[++i]);
@@ -1034,6 +1045,7 @@ int main(int argc, char** argv)
 		c->setForceMining(forceMining);
 		c->setTurboMining(minerType == MinerType::GPU);
 		c->setAddress(coinbase);
+		c->setNetworkId(networkId);
 	}
 
 	cout << "Transaction Signer: " << sigKey.address() << endl;


### PR DESCRIPTION
This CLI option allows setting up a private testnet using remote nodes that have public IPs (i.e. when using a public cloud provider). It also allows you to set up a private testnet with both eth and geth nodes (this is a port of the --networkid CLI option in geth). 
Without this option, nothing stops your private testnet nodes from connecting to other networks (i.e. poc-9).

Usage:
Start eth with the ``--network-id`` option and enter a random number greater than 0. Use the same network id for all the nodes that you are starting in your testnet. Nodes started with this option will only connect to other nodes that have the same network id. You will be able to maintain your own private chain, even if your nodes have public IP addresses.