### PR TITLE
phonehome sent wrong innermean (innerMean * (trials -2)) 

### DIFF
--- a/eth/main.cpp
+++ b/eth/main.cpp
@@ -317,8 +317,9 @@ void doBenchmark(MinerType _m, bool _phoneHome, unsigned _warmupDuration = 15, u
 			innerMean += rate;
 	}
 	f.stop();
+	innerMean /= (_trials - 2);
 	cout << "min/mean/max: " << results.begin()->second.rate() << "/" << (mean / _trials) << "/" << results.rbegin()->second.rate() << " H/s" << endl;
-	cout << "inner mean: " << (innerMean / (_trials - 2)) << " H/s" << endl;
+	cout << "inner mean: " << innerMean << " H/s" << endl;
 
 	(void)_phoneHome;
 #if ETH_JSONRPC || !ETH_TRUE

--- a/ethminer/main.cpp
+++ b/ethminer/main.cpp
@@ -188,8 +188,9 @@ void doBenchmark(MinerType _m, bool _phoneHome, unsigned _warmupDuration = 15, u
 			innerMean += rate;
 	}
 	f.stop();
+	innerMean /= (_trials - 2);
 	cout << "min/mean/max: " << results.begin()->second.rate() << "/" << (mean / _trials) << "/" << results.rbegin()->second.rate() << " H/s" << endl;
-	cout << "inner mean: " << (innerMean / (_trials - 2)) << " H/s" << endl;
+	cout << "inner mean: " << innerMean << " H/s" << endl;
 
 	(void)_phoneHome;
 #if ETH_JSONRPC || !ETH_TRUE


### PR DESCRIPTION
display (cout)  of innerMean was correct, but the rpc call (with default 5 trials) sent 3 times the hasrate.