### PR TITLE
Fix mutex when evicting node from node table.

### DIFF
--- a/libp2p/NodeTable.cpp
+++ b/libp2p/NodeTable.cpp
@@ -576,8 +576,8 @@ void NodeTable::doCheckEvictions(boost::system::error_code const& _ec)
 		bool evictionsRemain = false;
 		list<shared_ptr<NodeEntry>> drop;
 		{
-			Guard ln(x_nodes);
 			Guard le(x_evictions);
+			Guard ln(x_nodes);
 			for (auto& e: m_evictions)
 				if (chrono::steady_clock::now() - e.first.second > c_reqTimeout)
 					if (m_nodes.count(e.second))

--- a/libp2p/NodeTable.h
+++ b/libp2p/NodeTable.h
@@ -254,7 +254,7 @@ private:
 	mutable Mutex x_state;									///< LOCK x_state first if both x_nodes and x_state locks are required.
 	std::array<NodeBucket, s_bins> m_state;					///< State of p2p node network.
 
-	Mutex x_evictions;										///< LOCK x_nodes first if both x_nodes and x_evictions locks are required.
+	Mutex x_evictions;										///< LOCK x_evictions first if both x_nodes and x_evictions locks are required.
 	std::deque<EvictionTimeout> m_evictions;					///< Eviction timeouts.
 	
 	Mutex x_pubkDiscoverPings;								///< LOCK x_nodes first if both x_nodes and x_pubkDiscoverPings locks are required.


### PR DESCRIPTION
The code where a deadlock may occur is just after Line 443 where nodeEntry() requires a lock on x_nodes.

```
	Guard le(x_evictions);
	bool evictionEntry = false;
	for (auto it = m_evictions.begin(); it != m_evictions.end(); it++)
		if (it->first.first == nodeid && it->first.second > std::chrono::steady_clock::now())
		{
			evictionEntry = true;
			if (auto n = nodeEntry(it->second))
				dropNode(n);
```