### PR TITLE
Unify blocks that share code.

### DIFF
--- a/libevmasm/Assembly.cpp
+++ b/libevmasm/Assembly.cpp
@@ -24,6 +24,7 @@
 #include <libdevcore/Log.h>
 #include <libevmasm/CommonSubexpressionEliminator.h>
 #include <libevmasm/ControlFlowGraph.h>
+#include <libevmasm/BlockDeduplicator.h>
 #include <json/json.h>
 using namespace std;
 using namespace dev;
@@ -348,8 +349,17 @@ Assembly& Assembly::optimise(bool _enable)
 						copy(orig, iter, back_inserter(optimisedItems));
 				}
 			}
+
 			if (optimisedItems.size() < m_items.size())
+			{
 				m_items = move(optimisedItems);
+				count++;
+			}
+
+			// This only modifies PushTags, we have to run again to actually remove code.
+			BlockDeduplicator dedup(m_items);
+			if (dedup.deduplicate())
+				count++;
 		}
 	}
 

--- a/libevmasm/AssemblyItem.h
+++ b/libevmasm/AssemblyItem.h
@@ -68,6 +68,8 @@ public:
 	/// @returns true iff the type and data of the items are equal.
 	bool operator==(AssemblyItem const& _other) const { return m_type == _other.m_type && m_data == _other.m_data; }
 	bool operator!=(AssemblyItem const& _other) const { return !operator==(_other); }
+	/// Less-than operator compatible with operator==.
+	bool operator<(AssemblyItem const& _other) const { return std::tie(m_type, m_data) < std::tie(_other.m_type, _other.m_data); }
 
 	/// @returns an upper bound for the number of bytes required by this item, assuming that
 	/// the value of a jump tag takes @a _addressLength bytes.

--- a/libevmasm/BlockDeduplicator.cpp
+++ b/libevmasm/BlockDeduplicator.cpp
@@ -26,8 +26,6 @@
 #include <libevmasm/AssemblyItem.h>
 #include <libevmasm/SemanticInformation.h>
 
-#include <libdevcore/CommonIO.h>
-
 using namespace std;
 using namespace dev;
 using namespace dev::eth;

--- a/libevmasm/BlockDeduplicator.cpp
+++ b/libevmasm/BlockDeduplicator.cpp
@@ -1,0 +1,93 @@
+/*
+	This file is part of cpp-ethereum.
+
+	cpp-ethereum is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	cpp-ethereum is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/**
+ * @file BlockDeduplicator.cpp
+ * @author Christian <c@ethdev.com>
+ * @date 2015
+ * Unifies basic blocks that share content.
+ */
+
+#include <libevmasm/BlockDeduplicator.h>
+#include <functional>
+#include <libevmasm/AssemblyItem.h>
+#include <libevmasm/SemanticInformation.h>
+
+#include <libdevcore/CommonIO.h>
+
+using namespace std;
+using namespace dev;
+using namespace dev::eth;
+
+
+bool BlockDeduplicator::deduplicate()
+{
+	// Compares indices based on the suffix that starts there, ignoring tags and stopping at
+	// opcodes that stop the control flow.
+	function<bool(size_t, size_t)> comparator = [&](size_t _i, size_t _j)
+	{
+		if (_i == _j)
+			return false;
+
+		BlockIterator first(m_items.begin() + _i, m_items.end());
+		BlockIterator second(m_items.begin() + _j, m_items.end());
+		BlockIterator end(m_items.end(), m_items.end());
+
+		if (first != end && (*first).type() == Tag)
+			++first;
+		if (second != end && (*second).type() == Tag)
+			++second;
+
+		return std::lexicographical_compare(first, end, second, end);
+	};
+
+	set<size_t, function<bool(size_t, size_t)>> blocksSeen(comparator);
+	map<u256, u256> tagReplacement;
+	for (size_t i = 0; i < m_items.size(); ++i)
+	{
+		if (m_items.at(i).type() != Tag)
+			continue;
+		auto it = blocksSeen.find(i);
+		if (it == blocksSeen.end())
+			blocksSeen.insert(i);
+		else
+			tagReplacement[m_items.at(i).data()] = m_items.at(*it).data();
+	}
+
+	bool ret = false;
+	for (AssemblyItem& item: m_items)
+		if (item.type() == PushTag && tagReplacement.count(item.data()))
+		{
+			ret = true;
+			item.setData(tagReplacement.at(item.data()));
+		}
+	return ret;
+}
+
+BlockDeduplicator::BlockIterator& BlockDeduplicator::BlockIterator::operator++()
+{
+	if (it == end)
+		return *this;
+	if (SemanticInformation::altersControlFlow(*it) && *it != AssemblyItem(eth::Instruction::JUMPI))
+		it = end;
+	else
+	{
+		++it;
+		while (it != end && it->type() == Tag)
+			++it;
+	}
+	return *this;
+}

--- a/libevmasm/BlockDeduplicator.h
+++ b/libevmasm/BlockDeduplicator.h
@@ -1,0 +1,69 @@
+/*
+	This file is part of cpp-ethereum.
+
+	cpp-ethereum is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	cpp-ethereum is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/**
+ * @file BlockDeduplicator.h
+ * @author Christian <c@ethdev.com>
+ * @date 2015
+ * Unifies basic blocks that share content.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <vector>
+#include <functional>
+
+namespace dev
+{
+namespace eth
+{
+
+class AssemblyItem;
+using AssemblyItems = std::vector<AssemblyItem>;
+
+/**
+ * Optimizer class to be used to unify blocks that share content.
+ * Modifies the passed vector in place.
+ */
+class BlockDeduplicator
+{
+public:
+	BlockDeduplicator(AssemblyItems& _items): m_items(_items) {}
+	/// @returns true if something was changed
+	bool deduplicate();
+
+private:
+	/// Iterator that skips tags skips to the end if (all branches of) the control
+	/// flow does not continue to the next instruction.
+	struct BlockIterator: std::iterator<std::forward_iterator_tag, AssemblyItem const>
+	{
+	public:
+		BlockIterator(AssemblyItems::const_iterator _it, AssemblyItems::const_iterator _end):
+			it(_it), end(_end) { }
+		BlockIterator& operator++();
+		bool operator==(BlockIterator const& _other) const { return it == _other.it; }
+		bool operator!=(BlockIterator const& _other) const { return it != _other.it; }
+		AssemblyItem const& operator*() const { return *it; }
+		AssemblyItems::const_iterator it;
+		AssemblyItems::const_iterator end;
+	};
+
+	AssemblyItems& m_items;
+};
+
+}
+}


### PR DESCRIPTION
This reduces the wallet to approx. 3500 bytes and 1681 runtime opcodes.