### PR TITLE
Improve getpass() usage

### DIFF
--- a/libdevcore/CommonIO.cpp
+++ b/libdevcore/CommonIO.cpp
@@ -24,6 +24,9 @@
 #include <cstdlib>
 #include <fstream>
 #include "Exceptions.h"
+#ifndef _WIN32
+#include <termios.h>
+#endif
 using namespace std;
 using namespace dev;
 
@@ -126,6 +129,29 @@ std::string dev::getPassword(std::string const& _prompt)
 	std::getline(cin, ret);
 	return ret;
 #else
-	return getpass(_prompt.c_str());
+	struct termios oflags;
+	struct termios nflags;
+	char password[128];
+
+	// disable echo in the terminal
+	tcgetattr(fileno(stdin), &oflags);
+	nflags = oflags;
+	nflags.c_lflag &= ~ECHO;
+	nflags.c_lflag |= ECHONL;
+
+	if (tcsetattr(fileno(stdin), TCSANOW, &nflags) != 0)
+		BOOST_THROW_EXCEPTION(ExternalFunctionFailure("tcsetattr"));
+
+	printf("%s", _prompt.c_str());
+	if (!fgets(password, sizeof(password), stdin))
+		BOOST_THROW_EXCEPTION(ExternalFunctionFailure("fgets"));
+	password[strlen(password) - 1] = 0;
+
+	// restore terminal
+	if (tcsetattr(fileno(stdin), TCSANOW, &oflags) != 0) {
+		BOOST_THROW_EXCEPTION(ExternalFunctionFailure("tcsetattr"));
+	}
+
+	return password;
 #endif
 }

--- a/libdevcore/CommonIO.cpp
+++ b/libdevcore/CommonIO.cpp
@@ -131,7 +131,7 @@ std::string dev::getPassword(std::string const& _prompt)
 #else
 	struct termios oflags;
 	struct termios nflags;
-	char password[128];
+	char password[256];
 
 	// disable echo in the terminal
 	tcgetattr(fileno(stdin), &oflags);
@@ -148,9 +148,9 @@ std::string dev::getPassword(std::string const& _prompt)
 	password[strlen(password) - 1] = 0;
 
 	// restore terminal
-	if (tcsetattr(fileno(stdin), TCSANOW, &oflags) != 0) {
+	if (tcsetattr(fileno(stdin), TCSANOW, &oflags) != 0)
 		BOOST_THROW_EXCEPTION(ExternalFunctionFailure("tcsetattr"));
-	}
+
 
 	return password;
 #endif

--- a/libdevcore/Exceptions.h
+++ b/libdevcore/Exceptions.h
@@ -54,6 +54,7 @@ struct FileError: virtual Exception {};
 struct Overflow: virtual Exception {};
 struct InterfaceNotSupported: virtual Exception { public: InterfaceNotSupported(std::string _f): Exception("Interface " + _f + " not supported.") {} };
 struct FailedInvariant: virtual Exception {};
+struct ExternalFunctionFailure: virtual Exception { public: ExternalFunctionFailure(std::string _f): Exception("Function " + _f + "() failed.") {} };
 
 // error information to be added to exceptions
 using errinfo_invalidSymbol = boost::error_info<struct tag_invalidSymbol, char>;


### PR DESCRIPTION
As can be seen from: http://unixhelp.ed.ac.uk/CGI/man-cgi?getpass+3
getpass() is a deprecated function and it's advised not to use
it.

What's more all signals are disabled so (SIGINT, SIGQUIT, SIGSTOP,
SIGTSTOP) will do nothing and as such if the user wants to quit the
program while typing the password in the password loop he is out of
luck.

With this commit we get a manual version of getpass(), inspired by this
SO answer: http://stackoverflow.com/a/1196696/110395