### PR TITLE
fix for building OpenCL on some linux distributions

### DIFF
--- a/cmake/FindOpenCL.cmake
+++ b/cmake/FindOpenCL.cmake
@@ -118,7 +118,7 @@ if(WIN32)
   endif()
 else()
   find_library(OpenCL_LIBRARY
-    NAMES OpenCL)
+    NAMES OpenCL libOpenCL.so.1)
 endif()
 
 set(OpenCL_LIBRARIES ${OpenCL_LIBRARY})


### PR DESCRIPTION
On some linux distributions OpenCL doesn't install symlink `libOpenCL.so`. There is only `libOpenCL.so.1`, so we need to help cmake find it.

This should fix [issue from this buildbot log](https://build.ethdev.com/builders/Linux%20C%2B%2B%20develop%20deb%20amd64-utopic/builds/778/steps/cowbuilder/logs/stdio)

```
-- Could NOT find OpenCL (missing:  OpenCL_LIBRARY) (found version "1.2")
```