### PR TITLE
Known state: store tags on stack as unions.

### DIFF
--- a/libevmasm/CommonSubexpressionEliminator.cpp
+++ b/libevmasm/CommonSubexpressionEliminator.cpp
@@ -153,7 +153,9 @@ AssemblyItems CSECodeGenerator::generateCode(
 		assertThrow(!m_classPositions[targetItem.second].empty(), OptimizerException, "");
 		if (m_classPositions[targetItem.second].count(targetItem.first))
 			continue;
-		SourceLocation const& location = m_expressionClasses.representative(targetItem.second).item->getLocation();
+		SourceLocation location;
+		if (m_expressionClasses.representative(targetItem.second).item)
+			location = m_expressionClasses.representative(targetItem.second).item->getLocation();
 		int position = classElementPosition(targetItem.second);
 		if (position < targetItem.first)
 			// it is already at its target, we need another copy
@@ -197,7 +199,9 @@ void CSECodeGenerator::addDependencies(Id _c)
 		addDependencies(argument);
 		m_neededBy.insert(make_pair(argument, _c));
 	}
-	if (expr.item->type() == Operation && (
+	if (
+		expr.item &&
+		expr.item->type() == Operation && (
 		expr.item->instruction() == Instruction::SLOAD ||
 		expr.item->instruction() == Instruction::MLOAD ||
 		expr.item->instruction() == Instruction::SHA3
@@ -288,6 +292,7 @@ void CSECodeGenerator::generateClassElement(Id _c, bool _allowSequenced)
 		OptimizerException,
 		"Sequence constrained operation requested out of sequence."
 	);
+	assertThrow(expr.item, OptimizerException, "Non-generated expression without item.");
 	vector<Id> const& arguments = expr.arguments;
 	for (Id arg: boost::adaptors::reverse(arguments))
 		generateClassElement(arg);

--- a/libevmasm/CommonSubexpressionEliminator.cpp
+++ b/libevmasm/CommonSubexpressionEliminator.cpp
@@ -199,9 +199,7 @@ void CSECodeGenerator::addDependencies(Id _c)
 		addDependencies(argument);
 		m_neededBy.insert(make_pair(argument, _c));
 	}
-	if (
-		expr.item &&
-		expr.item->type() == Operation && (
+	if (expr.item && expr.item->type() == Operation && (
 		expr.item->instruction() == Instruction::SLOAD ||
 		expr.item->instruction() == Instruction::MLOAD ||
 		expr.item->instruction() == Instruction::SHA3

--- a/libevmasm/ControlFlowGraph.h
+++ b/libevmasm/ControlFlowGraph.h
@@ -108,10 +108,6 @@ private:
 	void setPrevLinks();
 	BasicBlocks rebuildCode();
 
-	/// @returns the corresponding BlockId if _id is a pushed jump tag,
-	/// and an invalid BlockId otherwise.
-	BlockId expressionClassToBlockId(ExpressionClasses::Id _id, ExpressionClasses& _exprClasses);
-
 	BlockId generateNewId();
 
 	unsigned m_lastUsedId = 0;

--- a/libevmasm/ExpressionClasses.cpp
+++ b/libevmasm/ExpressionClasses.cpp
@@ -82,6 +82,16 @@ ExpressionClasses::Id ExpressionClasses::find(
 	return exp.id;
 }
 
+ExpressionClasses::Id ExpressionClasses::newClass(SourceLocation const& _location)
+{
+	Expression exp;
+	exp.id = m_representatives.size();
+	exp.item = storeItem(AssemblyItem(UndefinedItem, (u256(1) << 255) + exp.id, _location));
+	m_representatives.push_back(exp);
+	m_expressions.insert(exp);
+	return exp.id;
+}
+
 bool ExpressionClasses::knownToBeDifferent(ExpressionClasses::Id _a, ExpressionClasses::Id _b)
 {
 	// Try to simplify "_a - _b" and return true iff the value is a non-zero constant.

--- a/libevmasm/ExpressionClasses.h
+++ b/libevmasm/ExpressionClasses.h
@@ -52,7 +52,8 @@ public:
 		Id id;
 		AssemblyItem const* item = nullptr;
 		Ids arguments;
-		unsigned sequenceNumber; ///< Storage modification sequence, only used for SLOAD/SSTORE instructions.
+		/// Storage modification sequence, only used for storage and memory operations.
+		unsigned sequenceNumber = 0;
 		/// Behaves as if this was a tuple of (item->type(), item->data(), arguments, sequenceNumber).
 		bool operator<(Expression const& _other) const;
 	};
@@ -72,6 +73,9 @@ public:
 	Expression const& representative(Id _id) const { return m_representatives.at(_id); }
 	/// @returns the number of classes.
 	Id size() const { return m_representatives.size(); }
+
+	/// @returns the id of a new class which is different to all other classes.
+	Id newClass(SourceLocation const& _location);
 
 	/// @returns true if the values of the given classes are known to be different (on every input).
 	/// @note that this function might still return false for some different inputs.

--- a/libevmasm/KnownState.cpp
+++ b/libevmasm/KnownState.cpp
@@ -230,7 +230,7 @@ ExpressionClasses::Id KnownState::stackElement(int _stackHeight, SourceLocation 
 		return m_stackElements.at(_stackHeight);
 	// Stack element not found (not assigned yet), create new unknown equivalence class.
 	return m_stackElements[_stackHeight] =
-			m_expressionClasses->find(AssemblyItem(UndefinedItem, _stackHeight, _location));
+		m_expressionClasses->find(AssemblyItem(UndefinedItem, _stackHeight, _location));
 }
 
 void KnownState::clearTagUnions()


### PR DESCRIPTION
This helps discovering the return jump address in certain cases and thus retaining state information across returns.