### PR TITLE
Use seedhash everywhere in EthashAux

### DIFF
--- a/alethzero/MainWin.cpp
+++ b/alethzero/MainWin.cpp
@@ -945,7 +945,11 @@ void Main::on_preview_triggered()
 
 void Main::on_prepNextDAG_triggered()
 {
-	EthashAux::computeFull(ethereum()->blockChain().number() + ETHASH_EPOCH_LENGTH);
+	EthashAux::computeFull(
+		EthashAux::seedHash(
+			ethereum()->blockChain().number() + ETHASH_EPOCH_LENGTH
+		)
+	);
 }
 
 void Main::refreshMining()

--- a/eth/main.cpp
+++ b/eth/main.cpp
@@ -857,7 +857,7 @@ int main(int argc, char** argv)
 				auto boundary = bi.boundary();
 				m = boost::to_lower_copy(string(argv[++i]));
 				bi.nonce = h64(m);
-				auto r = EthashAux::eval((uint64_t)bi.number, powHash, bi.nonce);
+				auto r = EthashAux::eval(bi.seedHash(), powHash, bi.nonce);
 				bool valid = r.value < boundary;
 				cout << (valid ? "VALID :-)" : "INVALID :-(") << endl;
 				cout << r.value << (valid ? " < " : " >= ") << boundary << endl;
@@ -866,7 +866,7 @@ int main(int argc, char** argv)
 				cout << "  with seed as " << seedHash << endl;
 				if (valid)
 					cout << "(mixHash = " << r.mixHash << ")" << endl;
-				cout << "SHA3( light(seed) ) = " << sha3(EthashAux::light((uint64_t)bi.number)->data()) << endl;
+				cout << "SHA3( light(seed) ) = " << sha3(EthashAux::light(bi)->data()) << endl;
 				exit(0);
 			}
 			catch (...)

--- a/eth/main.cpp
+++ b/eth/main.cpp
@@ -866,7 +866,7 @@ int main(int argc, char** argv)
 				cout << "  with seed as " << seedHash << endl;
 				if (valid)
 					cout << "(mixHash = " << r.mixHash << ")" << endl;
-				cout << "SHA3( light(seed) ) = " << sha3(EthashAux::light(bi)->data()) << endl;
+				cout << "SHA3( light(seed) ) = " << sha3(EthashAux::light(bi.seedHash())->data()) << endl;
 				exit(0);
 			}
 			catch (...)

--- a/ethminer/main.cpp
+++ b/ethminer/main.cpp
@@ -441,7 +441,7 @@ int main(int argc, char** argv)
 				cout << "  with seed as " << seedHash << endl;
 				if (valid)
 					cout << "(mixHash = " << r.mixHash << ")" << endl;
-				cout << "SHA3( light(seed) ) = " << sha3(EthashAux::light(bi)->data()) << endl;
+				cout << "SHA3( light(seed) ) = " << sha3(EthashAux::light(bi.seedHash())->data()) << endl;
 				exit(0);
 			}
 			catch (...)

--- a/ethminer/main.cpp
+++ b/ethminer/main.cpp
@@ -269,8 +269,8 @@ void doFarm(MinerType _m, string const& _remote, unsigned _recheckPeriod)
 			cnote << "  Header-hash:" << current.headerHash.hex();
 			cnote << "  Seedhash:" << current.seedHash.hex();
 			cnote << "  Target: " << h256(current.boundary).hex();
-			cnote << "  Ethash: " << h256(EthashAux::eval(EthashAux::number(current.seedHash), current.headerHash, solution.nonce).value).hex();
-			if (EthashAux::eval(EthashAux::number(current.seedHash), current.headerHash, solution.nonce).value < current.boundary)
+			cnote << "  Ethash: " << h256(EthashAux::eval(current.seedHash, current.headerHash, solution.nonce).value).hex();
+			if (EthashAux::eval(current.seedHash, current.headerHash, solution.nonce).value < current.boundary)
 			{
 				bool ok = rpc.eth_submitWork("0x" + toString(solution.nonce), "0x" + toString(current.headerHash), "0x" + toString(solution.mixHash));
 				if (ok)
@@ -432,7 +432,7 @@ int main(int argc, char** argv)
 				auto boundary = bi.boundary();
 				m = boost::to_lower_copy(string(argv[++i]));
 				bi.nonce = h64(m);
-				auto r = EthashAux::eval((uint64_t)bi.number, powHash, bi.nonce);
+				auto r = EthashAux::eval(bi.seedHash(), powHash, bi.nonce);
 				bool valid = r.value < boundary;
 				cout << (valid ? "VALID :-)" : "INVALID :-(") << endl;
 				cout << r.value << (valid ? " < " : " >= ") << boundary << endl;
@@ -441,7 +441,7 @@ int main(int argc, char** argv)
 				cout << "  with seed as " << seedHash << endl;
 				if (valid)
 					cout << "(mixHash = " << r.mixHash << ")" << endl;
-				cout << "SHA3( light(seed) ) = " << sha3(EthashAux::light((uint64_t)bi.number)->data()) << endl;
+				cout << "SHA3( light(seed) ) = " << sha3(EthashAux::light(bi)->data()) << endl;
 				exit(0);
 			}
 			catch (...)

--- a/libethcore/Ethash.cpp
+++ b/libethcore/Ethash.cpp
@@ -77,7 +77,7 @@ Ethash::WorkPackage Ethash::package(BlockInfo const& _bi)
 
 void Ethash::prep(BlockInfo const& _header, std::function<int(unsigned)> const& _f)
 {
-	EthashAux::full((unsigned)_header.number, _f);
+	EthashAux::full(_header.seedHash(), _f);
 }
 
 bool Ethash::preVerify(BlockInfo const& _header)
@@ -134,7 +134,7 @@ void Ethash::CPUMiner::workLoop()
 
 	WorkPackage w = work();
 
-	auto dag = EthashAux::full(EthashAux::number(w.seedHash));
+	auto dag = EthashAux::full(w.seedHash);
 	h256 boundary = w.boundary;
 	unsigned hashCount = 1;
 	for (; !shouldStop(); tryNonce++, hashCount++)
@@ -283,7 +283,7 @@ Ethash::GPUMiner::~GPUMiner()
 bool Ethash::GPUMiner::report(uint64_t _nonce)
 {
 	Nonce n = (Nonce)(u64)_nonce;
-	Result r = EthashAux::eval(EthashAux::number(work().seedHash), work().headerHash, n);
+	Result r = EthashAux::eval(work().seedHash, work().headerHash, n);
 	if (r.value < work().boundary)
 		return submitProof(Solution{n, r.mixHash});
 	return false;
@@ -310,14 +310,14 @@ void Ethash::GPUMiner::workLoop()
 
 			unsigned device = instances() > 1 ? index() : s_deviceId;
 
-			while (EthashAux::computeFull(EthashAux::number(w.seedHash)) != 100 && !shouldStop())
+			while (EthashAux::computeFull(w.seedHash) != 100 && !shouldStop())
 			{
-				cnote << "Awaiting DAG" << EthashAux::computeFull(EthashAux::number(w.seedHash));
+				cnote << "Awaiting DAG" << EthashAux::computeFull(w.seedHash);
 				this_thread::sleep_for(chrono::milliseconds(500));
 			}
 			if (shouldStop())
 				return;
-			EthashAux::FullType dag = EthashAux::full(EthashAux::number(w.seedHash));
+			EthashAux::FullType dag = EthashAux::full(w.seedHash);
 			bytesConstRef dagData = dag->data();
 			m_miner->init(dagData.data(), dagData.size(), 32, s_platformId, device);
 		}

--- a/libethcore/Ethash.h
+++ b/libethcore/Ethash.h
@@ -66,7 +66,7 @@ public:
 
 		h256 boundary;
 		h256 headerHash;	///< When h256() means "pause until notified a new work package is available".
-		h256 seedHash; /// LTODO: IS this needed now that we use the block number instead?
+		h256 seedHash;
 	};
 
 	static const WorkPackage NullWorkPackage;
@@ -78,7 +78,7 @@ public:
 	static bool preVerify(BlockInfo const& _header);
 	static WorkPackage package(BlockInfo const& _header);
 	static void assignResult(Solution const& _r, BlockInfo& _header) { _header.nonce = _r.nonce; _header.mixHash = _r.mixHash; }
-	
+
 
 	class CPUMiner: public Miner, Worker
 	{
@@ -119,7 +119,7 @@ public:
 		static void setDefaultPlatform(unsigned _id) { s_platformId = _id; }
 		static void setDefaultDevice(unsigned _id) { s_deviceId = _id; }
 		static void setNumInstances(unsigned _instances) { s_numInstances = std::min<unsigned>(_instances, getNumDevices()); }
-		
+
 	protected:
 		void kickOff() override;
 		void pause() override;

--- a/libethcore/EthashAux.cpp
+++ b/libethcore/EthashAux.cpp
@@ -105,11 +105,6 @@ void EthashAux::killCache(h256 const& _s)
 	m_lights.erase(_s);
 }
 
-EthashAux::LightType EthashAux::light(BlockInfo const& _header)
-{
-	return light(_header.seedHash());
-}
-
 EthashAux::LightType EthashAux::light(h256 const& _seedHash)
 {
 	RecursiveGuard l(get()->x_lights);

--- a/libethcore/EthashAux.h
+++ b/libethcore/EthashAux.h
@@ -65,7 +65,6 @@ public:
 	static uint64_t number(h256 const& _seedHash);
 	static uint64_t cacheSize(BlockInfo const& _header);
 
-	static LightType light(BlockInfo const& _header);
 	static LightType light(h256 const& _seedHash);
 
 	static const uint64_t NotGenerating = (uint64_t)-1;

--- a/libethcore/EthashAux.h
+++ b/libethcore/EthashAux.h
@@ -40,7 +40,7 @@ public:
 
 	struct LightAllocation
 	{
-		LightAllocation(uint64_t _blockNumber);
+		LightAllocation(h256 const& _seedHash);
 		~LightAllocation();
 		bytesConstRef data() const;
 		Ethash::Result compute(h256 const& _headerHash, Nonce const& _nonce) const;
@@ -66,19 +66,19 @@ public:
 	static uint64_t cacheSize(BlockInfo const& _header);
 
 	static LightType light(BlockInfo const& _header);
-	static LightType light(uint64_t _blockNumber);
+	static LightType light(h256 const& _seedHash);
 
 	static const uint64_t NotGenerating = (uint64_t)-1;
-	/// Kicks off generation of DAG for @a _blocknumber and @returns false or @returns true if ready.
-	static unsigned computeFull(uint64_t _blockNumber);
+	/// Kicks off generation of DAG for @a _seedHash and @returns false or @returns true if ready.
+	static unsigned computeFull(h256 const& _seedHash);
 	/// Information on the generation progress.
 	static std::pair<uint64_t, unsigned> fullGeneratingProgress() { return std::make_pair(get()->m_generatingFullNumber, get()->m_fullProgress); }
 	/// Kicks off generation of DAG for @a _blocknumber and blocks until ready; @returns result.
-	static FullType full(uint64_t _blockNumber, std::function<int(unsigned)> const& _f = std::function<int(unsigned)>());
+	static FullType full(h256 const& _seedHash, std::function<int(unsigned)> const& _f = std::function<int(unsigned)>());
 
 	static Ethash::Result eval(BlockInfo const& _header) { return eval(_header, _header.nonce); }
 	static Ethash::Result eval(BlockInfo const& _header, Nonce const& _nonce);
-	static Ethash::Result eval(uint64_t _blockNumber, h256 const& _headerHash, Nonce const& _nonce);
+	static Ethash::Result eval(h256 const& _seedHash, h256 const& _headerHash, Nonce const& _nonce);
 
 private:
 	EthashAux() {}

--- a/test/libethcore/dagger.cpp
+++ b/test/libethcore/dagger.cpp
@@ -63,14 +63,14 @@ BOOST_AUTO_TEST_CASE(basic_test)
 
 		unsigned cacheSize(o["cache_size"].get_int());
 		h256 cacheHash(o["cache_hash"].get_str());
-		BOOST_REQUIRE_EQUAL(EthashAux::get()->light(header)->size, cacheSize);
-		BOOST_REQUIRE_EQUAL(sha3(EthashAux::get()->light(header)->data()), cacheHash);
+		BOOST_REQUIRE_EQUAL(EthashAux::get()->light(header.seedHash())->size, cacheSize);
+		BOOST_REQUIRE_EQUAL(sha3(EthashAux::get()->light(header.seedHash())->data()), cacheHash);
 
 #if TEST_FULL
 		unsigned fullSize(o["full_size"].get_int());
 		h256 fullHash(o["full_hash"].get_str());
-		BOOST_REQUIRE_EQUAL(EthashAux::get()->full(header)->size(), fullSize);
-		BOOST_REQUIRE_EQUAL(sha3(EthashAux::get()->full(header)->data()), fullHash);
+		BOOST_REQUIRE_EQUAL(EthashAux::get()->full(header.seedHash())->size(), fullSize);
+		BOOST_REQUIRE_EQUAL(sha3(EthashAux::get()->full(header.seedHash())->data()), fullHash);
 #endif
 
 		h256 result(o["result"].get_str());


### PR DESCRIPTION
We now use seedhash everywhere and generate a block number only where
it's needed. Namely ethash_light_new()