### PR TITLE
call m_miner->finish after mining

### DIFF
--- a/libethcore/Ethash.cpp
+++ b/libethcore/Ethash.cpp
@@ -276,6 +276,7 @@ Ethash::GPUMiner::GPUMiner(ConstructionInfo const& _ci):
 Ethash::GPUMiner::~GPUMiner()
 {
 	pause();
+	m_miner->finish();
 	delete m_miner;
 	delete m_hook;
 }


### PR DESCRIPTION
this function is never called. I assume it is needed to free the memory, but I am not an OpenCL expert. 