### PR TITLE
Trie performance optimizations

### DIFF
--- a/libdevcrypto/OverlayDB.cpp
+++ b/libdevcrypto/OverlayDB.cpp
@@ -94,7 +94,7 @@ void OverlayDB::commit()
 bytes OverlayDB::lookupAux(h256 const& _h) const
 {
 	bytes ret = MemoryDB::lookupAux(_h);
-	if (!ret.empty())
+	if (!ret.empty() || !m_db)
 		return move(ret);
 	std::string v;
 	bytes b = _h.asBytes();

--- a/libethcore/Common.cpp
+++ b/libethcore/Common.cpp
@@ -37,10 +37,11 @@ namespace eth
 
 const unsigned c_protocolVersion = 60;
 const unsigned c_minorProtocolVersion = 2;
-const unsigned c_databaseBaseVersion = 9;
 #if ETH_FATDB
+const unsigned c_databaseBaseVersion = 10;
 const unsigned c_databaseVersionModifier = 1;
 #else
+const unsigned c_databaseBaseVersion = 9;
 const unsigned c_databaseVersionModifier = 0;
 #endif
 

--- a/test/libdevcrypto/trie.cpp
+++ b/test/libdevcrypto/trie.cpp
@@ -601,7 +601,6 @@ template<typename Trie> void perfTestTrie(char const* _name)
 	}
 }
 
-
 BOOST_AUTO_TEST_CASE(triePerf)
 {
 	if (test::Options::get().performance)
@@ -611,7 +610,6 @@ BOOST_AUTO_TEST_CASE(triePerf)
 		perfTestTrie<SpecificTrieDB<FatGenericTrieDB<MemoryDB>, h256>>("FatGenericTrieDB");
 	}
 }
-
 
 BOOST_AUTO_TEST_SUITE_END()
 

--- a/test/libdevcrypto/trie.cpp
+++ b/test/libdevcrypto/trie.cpp
@@ -124,7 +124,9 @@ BOOST_AUTO_TEST_CASE(hex_encoded_securetrie_test)
 				BOOST_REQUIRE(t.check(true));
 				BOOST_REQUIRE(ht.check(true));
 				BOOST_REQUIRE(ft.check(true));
-				for (auto i = ft.begin(), j = t.begin(); i != ft.end() && j != t.end(); ++i, ++j)
+				auto i = ft.begin();
+				auto j = t.begin();
+				for (; i != ft.end() && j != t.end(); ++i, ++j)
 				{
 					BOOST_CHECK_EQUAL(i == ft.end(), j == t.end());
 					BOOST_REQUIRE((*i).first.toBytes() == (*j).first.toBytes());
@@ -189,7 +191,9 @@ BOOST_AUTO_TEST_CASE(trie_test_anyorder)
 				BOOST_REQUIRE(t.check(true));
 				BOOST_REQUIRE(ht.check(true));
 				BOOST_REQUIRE(ft.check(true));
-				for (auto i = ft.begin(), j = t.begin(); i != ft.end() && j != t.end(); ++i, ++j)
+				auto i = ft.begin();
+				auto j = t.begin();
+				for (; i != ft.end() && j != t.end(); ++i, ++j)
 				{
 					BOOST_CHECK_EQUAL(i == ft.end(), j == t.end());
 					BOOST_REQUIRE((*i).first.toBytes() == (*j).first.toBytes());
@@ -274,7 +278,9 @@ BOOST_AUTO_TEST_CASE(trie_tests_ordered)
 			BOOST_REQUIRE(t.check(true));
 			BOOST_REQUIRE(ht.check(true));
 			BOOST_REQUIRE(ft.check(true));
-			for (auto i = ft.begin(), j = t.begin(); i != ft.end() && j != t.end(); ++i, ++j)
+			auto i = ft.begin();
+			auto j = t.begin();
+			for (; i != ft.end() && j != t.end(); ++i, ++j)
 			{
 				BOOST_CHECK_EQUAL(i == ft.end(), j == t.end());
 				BOOST_REQUIRE((*i).first.toBytes() == (*j).first.toBytes());
@@ -557,6 +563,55 @@ BOOST_AUTO_TEST_CASE(trieStess)
 		}
 	}
 }
+
+template<typename Trie> void perfTestTrie(char const* _name)
+{
+	for (size_t p = 1000; p != 1000000; p*=10)
+	{
+		MemoryDB dm;
+		Trie d(&dm);
+		d.init();
+		cnote << "TriePerf " << _name << p;
+		std::vector<h256> keys(1000);
+		boost::timer t;
+		size_t ki = 0;
+		for (size_t i = 0; i < p; ++i)
+		{
+			auto k = h256::random();
+			auto v = toString(i);
+			d.insert(k, v);
+
+			if (i % (p / 1000) == 0)
+				keys[ki++] = k;
+		}
+		cnote << "Insert " << p << "values: " << t.elapsed();
+		t.restart();
+		for (auto k: keys)
+			d.at(k);
+		cnote << "Query 1000 values: " << t.elapsed();
+		t.restart();
+		size_t i = 0;
+		for (auto it = d.begin(); i < 1000 && it != d.end(); ++it, ++i)
+			*it;
+		cnote << "Iterate 1000 values: " << t.elapsed();
+		t.restart();
+		for (auto k: keys)
+			d.remove(k);
+		cnote << "Remove 1000 values:" << t.elapsed() << "\n";
+	}
+}
+
+
+BOOST_AUTO_TEST_CASE(triePerf)
+{
+	if (test::Options::get().performance)
+	{
+		perfTestTrie<SpecificTrieDB<GenericTrieDB<MemoryDB>, h256>>("GenericTrieDB");
+		perfTestTrie<SpecificTrieDB<HashedGenericTrieDB<MemoryDB>, h256>>("HashedGenericTrieDB");
+		perfTestTrie<SpecificTrieDB<FatGenericTrieDB<MemoryDB>, h256>>("FatGenericTrieDB");
+	}
+}
+
 
 BOOST_AUTO_TEST_SUITE_END()
 


### PR DESCRIPTION
* SHA3 was calculated twice for nodes in some cases.
* Replaced FATDB with secure Trie + simple hash to key mapping

Further optimizations won't gain much since 95% insertion time is SHA3 calculation. Might worth looking into faster SHA3 implementation.