### PR TITLE
FreeBSD fix for ethash byte ordering

### DIFF
--- a/libethash/endian.h
+++ b/libethash/endian.h
@@ -32,6 +32,9 @@
 #include <libkern/OSByteOrder.h>
 #define ethash_swap_u32(input_) OSSwapInt32(input_)
 #define ethash_swap_u64(input_) OSSwapInt64(input_)
+#elif defined(__FreeBSD__) || defined(__DragonFly__) || defined(__NetBSD__)
+#define ethash_swap_u32(input_) bswap32(input_)
+#define ethash_swap_u64(input_) bswap64(input_)
 #else // posix
 #include <byteswap.h>
 #define ethash_swap_u32(input_) __bswap_32(input_)


### PR DESCRIPTION
byteswap.h does not exist on FreeBSD and related platforms (i.e. NetBSD, OpenBSD, and DragonFlyBSD) which breaks compilation of ethash.

Thankfully FreeBSD adds [byteorder related operations](https://www.freebsd.org/cgi/man.cgi?query=byteorder&sektion=9).