### PR TITLE
cleaner output

### DIFF
--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -606,9 +606,10 @@ bool Client::remoteActive() const
 
 void Client::onPostStateChanged()
 {
-	cnote << "Post state changed: Restarting mining...";
+	cnote << "Post state changed";
 	if (isMining() || remoteActive())
 	{
+		cnote << "Restarting mining...";
 		DEV_WRITE_GUARDED(x_working)
 			m_working.commitToMine(m_bc);
 		DEV_READ_GUARDED(x_working)


### PR DESCRIPTION
even though I am not mining, I got this misleading output:
 > minestop
  ℹ  09:06:50|eth  Post state changed: Restarting mining...
  ℹ  09:06:50|eth  noteChanged: { pending , chain }
  ℹ  09:06:54|eth  Post state changed: Restarting mining...
  ℹ  09:06:54|eth  noteChanged: { pending , chain }
  ℹ  09:06:57|eth  Post state changed: Restarting mining...

