### PR TITLE
Gas estimation taking known state into account.

### DIFF
--- a/libevmasm/Assembly.cpp
+++ b/libevmasm/Assembly.cpp
@@ -431,6 +431,7 @@ bytes Assembly::assemble() const
 		case PushSubSize:
 		{
 			auto s = m_data[i.data()].size();
+			i.setPushedValue(u256(s));
 			byte b = max<unsigned>(1, dev::bytesRequired(s));
 			ret.push_back((byte)Instruction::PUSH1 - 1 + b);
 			ret.resize(ret.size() + b);

--- a/libevmasm/AssemblyItem.h
+++ b/libevmasm/AssemblyItem.h
@@ -84,11 +84,17 @@ public:
 	JumpType getJumpType() const { return m_jumpType; }
 	std::string getJumpTypeAsString() const;
 
+	void setPushedValue(u256 const& _value) const { m_pushedValue = std::make_shared<u256>(_value); }
+	u256 const* pushedValue() const { return m_pushedValue.get(); }
+
 private:
 	AssemblyItemType m_type;
 	u256 m_data;
 	SourceLocation m_location;
 	JumpType m_jumpType = JumpType::Ordinary;
+	/// Pushed value for operations with data to be determined during assembly stage,
+	/// e.g. PushSubSize, PushTag, PushSub, etc.
+	mutable std::shared_ptr<u256> m_pushedValue;
 };
 
 using AssemblyItems = std::vector<AssemblyItem>;

--- a/libevmasm/GasMeter.cpp
+++ b/libevmasm/GasMeter.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "GasMeter.h"
+#include <libevmasm/KnownState.h>
 #include <libevmcore/Params.h>
 
 using namespace std;
@@ -41,55 +42,162 @@ GasMeter::GasConsumption& GasMeter::GasConsumption::operator+=(GasConsumption co
 
 GasMeter::GasConsumption GasMeter::estimateMax(AssemblyItem const& _item)
 {
-	switch (_item.type()) {
+	GasConsumption gas;
+	switch (_item.type())
+	{
 	case Push:
 	case PushTag:
-		return runGas(Instruction::PUSH1);
+	case PushData:
+	case PushString:
+	case PushSub:
+	case PushSubSize:
+	case PushProgramSize:
+		gas = runGas(Instruction::PUSH1);
+		break;
 	case Tag:
-		return runGas(Instruction::JUMPDEST);
+		gas = runGas(Instruction::JUMPDEST);
+		break;
 	case Operation:
 	{
-		GasConsumption gas = runGas(_item.instruction());
+		ExpressionClasses& classes = m_state->expressionClasses();
+		gas = runGas(_item.instruction());
 		switch (_item.instruction())
 		{
 		case Instruction::SSTORE:
-			// @todo logic can be improved
-			gas += c_sstoreSetGas;
+		{
+			ExpressionClasses::Id slot = m_state->relativeStackElement(0);
+			ExpressionClasses::Id value = m_state->relativeStackElement(-1);
+			if (classes.knownZero(value) || (
+				m_state->storageContent().count(slot) &&
+				classes.knownNonZero(m_state->storageContent().at(slot))
+			))
+				gas += c_sstoreResetGas; //@todo take refunds into account
+			else
+				gas += c_sstoreSetGas;
 			break;
+		}
 		case Instruction::SLOAD:
 			gas += c_sloadGas;
 			break;
-		case Instruction::MSTORE:
-		case Instruction::MSTORE8:
-		case Instruction::MLOAD:
 		case Instruction::RETURN:
+			gas += memoryGas(0, -1);
+			break;
+		case Instruction::MLOAD:
+		case Instruction::MSTORE:
+			gas += memoryGas(classes.find(eth::Instruction::ADD, {
+				m_state->relativeStackElement(0),
+				classes.find(AssemblyItem(32))
+			}));
+			break;
+		case Instruction::MSTORE8:
+			gas += memoryGas(classes.find(eth::Instruction::ADD, {
+				m_state->relativeStackElement(0),
+				classes.find(AssemblyItem(1))
+			}));
+			break;
 		case Instruction::SHA3:
+			gas = c_sha3Gas;
+			gas += wordGas(c_sha3WordGas, m_state->relativeStackElement(-1));
+			gas += memoryGas(0, -1);
+			break;
 		case Instruction::CALLDATACOPY:
 		case Instruction::CODECOPY:
+			gas += memoryGas(0, -2);
+			gas += wordGas(c_copyGas, m_state->relativeStackElement(-2));
+			break;
 		case Instruction::EXTCODECOPY:
+			gas += memoryGas(-1, -3);
+			gas += wordGas(c_copyGas, m_state->relativeStackElement(-3));
+			break;
 		case Instruction::LOG0:
 		case Instruction::LOG1:
 		case Instruction::LOG2:
 		case Instruction::LOG3:
 		case Instruction::LOG4:
+		{
+			unsigned n = unsigned(_item.instruction()) - unsigned(Instruction::LOG0);
+			gas = c_logGas + c_logTopicGas * n;
+			gas += memoryGas(0, -1);
+			if (u256 const* value = classes.knownConstant(m_state->relativeStackElement(-1)))
+				gas += c_logDataGas * (*value);
+			else
+				gas = GasConsumption::infinite();
+			break;
+		}
 		case Instruction::CALL:
 		case Instruction::CALLCODE:
+			gas = c_callGas;
+			if (u256 const* value = classes.knownConstant(m_state->relativeStackElement(0)))
+				gas += (*value);
+			else
+				gas = GasConsumption::infinite();
+			if (_item.instruction() != Instruction::CALLCODE)
+				gas += c_callNewAccountGas; // We very rarely know whether the address exists.
+			if (!classes.knownZero(m_state->relativeStackElement(-2)))
+				gas += c_callValueTransferGas;
+			gas += memoryGas(-3, -4);
+			gas += memoryGas(-5, -6);
+			break;
 		case Instruction::CREATE:
+			gas = c_createGas;
+			gas += memoryGas(-1, -2);
+			break;
 		case Instruction::EXP:
-			// @todo logic can be improved
-			gas = GasConsumption::infinite();
+			gas = c_expGas;
+			if (u256 const* value = classes.knownConstant(m_state->relativeStackElement(-1)))
+				gas += c_expByteGas * (32 - (h256(*value).firstBitSet() / 8));
+			else
+				gas = GasConsumption::infinite();
 			break;
 		default:
 			break;
 		}
-		return gas;
 		break;
 	}
 	default:
+		gas = GasConsumption::infinite();
 		break;
 	}
 
-	return GasConsumption::infinite();
+	m_state->feedItem(_item);
+	return gas;
+}
+
+GasMeter::GasConsumption GasMeter::wordGas(u256 const& _multiplier, ExpressionClasses::Id _position)
+{
+	u256 const* value = m_state->expressionClasses().knownConstant(_position);
+	if (!value)
+		return GasConsumption::infinite();
+	return GasConsumption(_multiplier * ((*value + 31) / 32));
+}
+
+GasMeter::GasConsumption GasMeter::memoryGas(ExpressionClasses::Id _position)
+{
+	u256 const* value = m_state->expressionClasses().knownConstant(_position);
+	if (!value)
+		return GasConsumption::infinite();
+	if (*value < m_largestMemoryAccess)
+		return GasConsumption(u256(0));
+	u256 previous = m_largestMemoryAccess;
+	m_largestMemoryAccess = *value;
+	auto memGas = [](u256 const& pos) -> u256
+	{
+		u256 size = (pos + 31) / 32;
+		return c_memoryGas * size + size * size / c_quadCoeffDiv;
+	};
+	return memGas(*value) - memGas(previous);
+}
+
+GasMeter::GasConsumption GasMeter::memoryGas(int _stackPosOffset, int _stackPosSize)
+{
+	ExpressionClasses& classes = m_state->expressionClasses();
+	if (classes.knownZero(m_state->relativeStackElement(_stackPosSize)))
+		return GasConsumption(0);
+	else
+		return memoryGas(classes.find(eth::Instruction::ADD, {
+			m_state->relativeStackElement(_stackPosOffset),
+			m_state->relativeStackElement(_stackPosSize)
+		}));
 }
 
 GasMeter::GasConsumption GasMeter::runGas(Instruction _instruction)

--- a/libevmasm/KnownState.h
+++ b/libevmasm/KnownState.h
@@ -111,6 +111,8 @@ public:
 	/// Retrieves the current equivalence class fo the given stack element (or generates a new
 	/// one if it does not exist yet).
 	Id stackElement(int _stackHeight, SourceLocation const& _location);
+	/// @returns the stackElement relative to the current stack height.
+	Id relativeStackElement(int _stackOffset, SourceLocation const& _location = SourceLocation());
 
 	/// @returns its set of tags if the given expression class is a known tag union; returns a set
 	/// containing the tag if it is a PushTag expression and the empty set otherwise.
@@ -122,6 +124,8 @@ public:
 	int stackHeight() const { return m_stackHeight; }
 	std::map<int, Id> const& stackElements() const { return m_stackElements; }
 	ExpressionClasses& expressionClasses() const { return *m_expressionClasses; }
+
+	std::map<Id, Id> const& storageContent() const { return m_storageContent; }
 
 private:
 	/// Assigns a new equivalence class to the next sequence number of the given stack element.

--- a/libsolidity/ASTVisitor.h
+++ b/libsolidity/ASTVisitor.h
@@ -221,6 +221,26 @@ protected:
 };
 
 /**
+ * Utility class that accepts std::functions and calls them for visitNode and endVisitNode.
+ */
+class SimpleASTVisitor: public ASTConstVisitor
+{
+public:
+	SimpleASTVisitor(
+		std::function<bool(ASTNode const&)> _onVisit,
+		std::function<void(ASTNode const&)> _onEndVisit
+	): m_onVisit(_onVisit), m_onEndVisit(_onEndVisit) {}
+
+protected:
+	virtual bool visitNode(ASTNode const& _n) override { return m_onVisit ? m_onVisit(_n) : true; }
+	virtual void endVisitNode(ASTNode const& _n) override { m_onEndVisit(_n); }
+
+private:
+	std::function<bool(ASTNode const&)> m_onVisit;
+	std::function<void(ASTNode const&)> m_onEndVisit;
+};
+
+/**
  * Utility class that visits the AST in depth-first order and calls a function on each node and each edge.
  * Child nodes are only visited if the node callback of the parent returns true.
  * The node callback of a parent is called before any edge or node callback involving the children.

--- a/libsolidity/CompilerStack.cpp
+++ b/libsolidity/CompilerStack.cpp
@@ -55,10 +55,27 @@ const map<string, string> StandardSources = map<string, string>{
 };
 
 CompilerStack::CompilerStack(bool _addStandardSources):
-	m_addStandardSources(_addStandardSources), m_parseSuccessful(false)
+	m_parseSuccessful(false)
 {
-	if (m_addStandardSources)
+	if (_addStandardSources)
 		addSources(StandardSources, true); // add them as libraries
+}
+
+void CompilerStack::reset(bool _keepSources, bool _addStandardSources)
+{
+	m_parseSuccessful = false;
+	if (_keepSources)
+		for (auto sourcePair: m_sources)
+			sourcePair.second.reset();
+	else
+	{
+		m_sources.clear();
+		if (_addStandardSources)
+			addSources(StandardSources, true);
+	}
+	m_globalContext.reset();
+	m_sourceOrder.clear();
+	m_contracts.clear();
 }
 
 bool CompilerStack::addSource(string const& _name, string const& _content, bool _isLibrary)
@@ -267,23 +284,6 @@ tuple<int, int, int, int> CompilerStack::positionFromSourceLocation(SourceLocati
 	tie(endLine, endColumn) = getScanner(*_sourceLocation.sourceName).translatePositionToLineColumn(_sourceLocation.end);
 
 	return make_tuple(++startLine, ++startColumn, ++endLine, ++endColumn);
-}
-
-void CompilerStack::reset(bool _keepSources)
-{
-	m_parseSuccessful = false;
-	if (_keepSources)
-		for (auto sourcePair: m_sources)
-			sourcePair.second.reset();
-	else
-	{
-		m_sources.clear();
-		if (m_addStandardSources)
-			addSources(StandardSources, true);
-	}
-	m_globalContext.reset();
-	m_sourceOrder.clear();
-	m_contracts.clear();
 }
 
 void CompilerStack::resolveImports()

--- a/libsolidity/CompilerStack.h
+++ b/libsolidity/CompilerStack.h
@@ -72,6 +72,9 @@ public:
 	/// Creates a new compiler stack. Adds standard sources if @a _addStandardSources.
 	explicit CompilerStack(bool _addStandardSources = true);
 
+	/// Resets the compiler to a state where the sources are not parsed or even removed.
+	void reset(bool _keepSources = false, bool _addStandardSources = true);
+
 	/// Adds a source object (e.g. file) to the parser. After this, parse has to be called again.
 	/// @returns true if a source object by the name already existed and was replaced.
 	void addSources(StringMap const& _nameContents, bool _isLibrary = false) { for (auto const& i: _nameContents) addSource(i.first, i.second, _isLibrary); }
@@ -165,13 +168,11 @@ private:
 		Contract();
 	};
 
-	void reset(bool _keepSources = false);
 	void resolveImports();
 
 	Contract const& getContract(std::string const& _contractName = "") const;
 	Source const& getSource(std::string const& _sourceName = "") const;
 
-	bool m_addStandardSources; ///< If true, standard sources are added.
 	bool m_parseSuccessful;
 	std::map<std::string const, Source> m_sources;
 	std::shared_ptr<GlobalContext> m_globalContext;

--- a/libsolidity/StructuralGasEstimator.h
+++ b/libsolidity/StructuralGasEstimator.h
@@ -56,6 +56,10 @@ public:
 		ASTGasConsumptionSelfAccumulated const& _gasCosts,
 		std::vector<ASTNode const*> const& _roots
 	);
+
+private:
+	/// @returns the set of AST nodes which are the finest nodes at their location.
+	std::set<ASTNode const*> finestNodesAtLocation(std::vector<ASTNode const*> const& _roots);
 };
 
 }

--- a/test/libsolidity/solidityExecutionFramework.h
+++ b/test/libsolidity/solidityExecutionFramework.h
@@ -44,11 +44,11 @@ public:
 
 	bytes const& compileAndRun(std::string const& _sourceCode, u256 const& _value = 0, std::string const& _contractName = "")
 	{
-		dev::solidity::CompilerStack compiler(m_addStandardSources);
-		compiler.addSource("", _sourceCode);
-		ETH_TEST_REQUIRE_NO_THROW(compiler.compile(m_optimize), "Compiling contract failed");
+		m_compiler.reset(false, m_addStandardSources);
+		m_compiler.addSource("", _sourceCode);
+		ETH_TEST_REQUIRE_NO_THROW(m_compiler.compile(m_optimize), "Compiling contract failed");
 
-		bytes code = compiler.getBytecode(_contractName);
+		bytes code = m_compiler.getBytecode(_contractName);
 		sendMessage(code, true, _value);
 		BOOST_REQUIRE(!m_output.empty());
 		return m_output;
@@ -160,12 +160,14 @@ protected:
 		BOOST_REQUIRE(executive.go());
 		m_state.noteSending(m_sender);
 		executive.finalize();
+		m_gasUsed = executive.gasUsed();
 		m_output = executive.out().toVector();
 		m_logs = executive.logs();
 	}
 
 	bool m_optimize = false;
 	bool m_addStandardSources = false;
+	dev::solidity::CompilerStack m_compiler;
 	Address m_sender;
 	Address m_contractAddress;
 	eth::State m_state;
@@ -173,6 +175,7 @@ protected:
 	u256 const m_gas = 100000000;
 	bytes m_output;
 	eth::LogEntries m_logs;
+	u256 m_gasUsed;
 };
 
 }


### PR DESCRIPTION
Gas estimation takes into account as much as it can possibly know about the current state of the VM and thus makes it much more exact, e.g. computing the gas cost of instructions that use memory is possible.