### PR TITLE
fix mining in tests

### DIFF
--- a/libethcore/Ethash.cpp
+++ b/libethcore/Ethash.cpp
@@ -142,7 +142,7 @@ void Ethash::CPUMiner::workLoop()
 	WorkPackage w = work();
 
 	EthashAux::FullType dag;
-	while (!shouldStop() && !(dag = EthashAux::full(w.seedHash)))
+	while (!shouldStop() && !(dag = EthashAux::full(w.seedHash, true)))
 		this_thread::sleep_for(chrono::milliseconds(500));
 
 	h256 boundary = w.boundary;

--- a/libethcore/Miner.h
+++ b/libethcore/Miner.h
@@ -44,7 +44,7 @@ struct MiningProgress
 //	MiningProgress& operator+=(MiningProgress const& _mp) { hashes += _mp.hashes; ms = std::max(ms, _mp.ms); return *this; }
 	uint64_t hashes = 0;		///< Total number of hashes computed.
 	uint64_t ms = 0;			///< Total number of milliseconds of mining thus far.
-	uint64_t rate() const { return hashes * 1000 / ms; }
+	uint64_t rate() const { return ms == 0 ? 0 : hashes * 1000 / ms; }
 };
 
 struct MineInfo: public MiningProgress {};


### PR DESCRIPTION
filling of BlockChainTests as well as mining in https://github.com/ethereum/cpp-ethereum/blob/develop/test/libethereum/stateOriginal.cpp#L72 did not work since https://github.com/ethereum/cpp-ethereum/commit/c4df26e82ed48138e5e8cf9323467f3113bc4506.
This is the fix.