### PR TITLE
Fixed segmentation fault, also added more user confirmation

### DIFF
--- a/alethzero/MainWin.cpp
+++ b/alethzero/MainWin.cpp
@@ -1984,6 +1984,7 @@ void Main::on_newAccount_triggered()
 		m_keyManager.import(p.secret(), s.toStdString());
 	keysChanged();
 }
+
 void Main::on_killAccount_triggered()
 {
 	if (ui->ourAccounts->currentRow() >= 0)
@@ -1993,7 +1994,6 @@ void Main::on_killAccount_triggered()
 
 		auto k = m_keyManager.accountDetails()[h];
 	
-		//ethereum()->balanceAt(h) != 0 &&
 		QString s = QInputDialog::getText(this, QString::fromStdString("Kill Account " + k.first + "?!"),
 			QString::fromStdString("Account " + k.first + " (" + render(h) + ") has " + formatBalance(ethereum()->balanceAt(h)) + " in it.\r\nIt, and any contract that this account can access, will be lost forever if you continue. Do NOT continue unless you know what you are doing.\n"
 			"Are you sure you want to continue? \r\n If so, type 'YES' to confirm."),

--- a/alethzero/MainWin.cpp
+++ b/alethzero/MainWin.cpp
@@ -1984,22 +1984,26 @@ void Main::on_newAccount_triggered()
 		m_keyManager.import(p.secret(), s.toStdString());
 	keysChanged();
 }
-
 void Main::on_killAccount_triggered()
 {
 	if (ui->ourAccounts->currentRow() >= 0)
 	{
-		auto hba = ui->accounts->currentItem()->data(Qt::UserRole).toByteArray();
+		auto hba = ui->ourAccounts->currentItem()->data(Qt::UserRole).toByteArray();
 		Address h((byte const*)hba.data(), Address::ConstructFromPointer);
+
 		auto k = m_keyManager.accountDetails()[h];
-		if (
-			ethereum()->balanceAt(h) != 0 &&
-			QMessageBox::critical(this, QString::fromStdString("Kill Account " + k.first + "?!"),
-				QString::fromStdString("Account " + k.first + " (" + render(h) + ") has " + formatBalance(ethereum()->balanceAt(h)) + " in it. It, and any contract that this account can access, will be lost forever if you continue. Do NOT continue unless you know what you are doing.\n"
-				"Are you sure you want to continue?"),
-				QMessageBox::Yes, QMessageBox::No) == QMessageBox::No)
+	
+		//ethereum()->balanceAt(h) != 0 &&
+		QString s = QInputDialog::getText(this, QString::fromStdString("Kill Account " + k.first + "?!"),
+			QString::fromStdString("Account " + k.first + " (" + render(h) + ") has " + formatBalance(ethereum()->balanceAt(h)) + " in it.\r\nIt, and any contract that this account can access, will be lost forever if you continue. Do NOT continue unless you know what you are doing.\n"
+			"Are you sure you want to continue? \r\n If so, type 'YES' to confirm."),
+			QLineEdit::Normal, "NO");
+
+		if ( s != "YES")
 			return;
+
 		m_keyManager.kill(h);
+
 		if (m_keyManager.accounts().empty())
 			m_keyManager.import(Secret::random(), "Default account");
 		m_beneficiary = *m_keyManager.accounts().begin();


### PR DESCRIPTION
…before killing the selected account when a user selects "Kill Account" in alethzero. The user now has to explicitly write 'YES' in a box (regardless of whether the account holds funds or not - it may still own contracts). 

The segfault happened because `ui->accounts->currentItem` was used instead of `ui->ourAccounts->currentItem`