### PR TITLE
Remove deprecated std::auto_ptr

### DIFF
--- a/libtestutils/BlockChainLoader.h
+++ b/libtestutils/BlockChainLoader.h
@@ -44,7 +44,7 @@ public:
 
 private:
 	TransientDirectory m_dir;
-	std::auto_ptr<eth::BlockChain> m_bc;
+	std::unique_ptr<eth::BlockChain> m_bc;
 	eth::State m_state;
 };
 

--- a/mix/MixClient.h
+++ b/mix/MixClient.h
@@ -94,7 +94,7 @@ private:
 	eth::State m_state;
 	eth::State m_startState;
 	OverlayDB m_stateDB;
-	std::auto_ptr<MixBlockChain> m_bc;
+	std::unique_ptr<MixBlockChain> m_bc;
 	mutable boost::shared_mutex x_state;
 	mutable boost::shared_mutex x_executions;
 	ExecutionResults m_executions;


### PR DESCRIPTION
- With gcc 5.1.0 we now get warnings for usage of std::auto_ptr. It is
  deprecated by the C++0x standard and afterwards so it's prudent to
  replace them with unique pointers.