### PR TITLE
Increase win32 executable stack size to 32MB

### DIFF
--- a/cmake/EthCompilerSettings.cmake
+++ b/cmake/EthCompilerSettings.cmake
@@ -44,7 +44,7 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 	# warning LNK4075: ignoring '/EDITANDCONTINUE' due to '/SAFESEH' specification 
 	# warning LNK4099: pdb was not found with lib
 	# stack size 16MB
-	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /ignore:4099,4075 /STACK:16777216")
+	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /ignore:4099,4075 /STACK:33554432")
 
 	# windows likes static
 	if (NOT ETH_STATIC)


### PR DESCRIPTION
@gluk256 Please confirm that windows stack tests pass with a clean build and this commit in. So make sure that the `testeth` executable is no longer affected by our `editbin` changes. 