### PR TITLE
exception in destructor

### DIFF
--- a/libdevcore/TransientDirectory.cpp
+++ b/libdevcore/TransientDirectory.cpp
@@ -52,7 +52,7 @@ TransientDirectory::~TransientDirectory()
 		}
 		catch (...)
 		{
-			std::this_thread::sleep_for(chrono::milliseconds(10));
+			this_thread::sleep_for(chrono::milliseconds(10));
 		}
 	}
 }

--- a/libdevcore/TransientDirectory.cpp
+++ b/libdevcore/TransientDirectory.cpp
@@ -19,6 +19,7 @@
  * @date 2015
  */
 
+#include <thread>
 #include <boost/filesystem.hpp>
 #include "Exceptions.h"
 #include "TransientDirectory.h"
@@ -42,5 +43,16 @@ TransientDirectory::TransientDirectory(std::string const& _path):
 
 TransientDirectory::~TransientDirectory()
 {
-	boost::filesystem::remove_all(m_path);
+	for (int i = 0; i < 3; ++i)
+	{
+		try
+		{
+			boost::filesystem::remove_all(m_path);
+			break;
+		}
+		catch (...)
+		{
+			std::this_thread::sleep_for(chrono::milliseconds(10));
+		}
+	}
 }

--- a/libdevcore/TransientDirectory.cpp
+++ b/libdevcore/TransientDirectory.cpp
@@ -24,6 +24,7 @@
 #include "Exceptions.h"
 #include "TransientDirectory.h"
 #include "CommonIO.h"
+#include "Log.h"
 using namespace std;
 using namespace dev;
 
@@ -43,16 +44,19 @@ TransientDirectory::TransientDirectory(std::string const& _path):
 
 TransientDirectory::~TransientDirectory()
 {
-	for (int i = 0; i < 3; ++i)
-	{
-		try
-		{
-			boost::filesystem::remove_all(m_path);
-			break;
-		}
-		catch (...)
-		{
-			this_thread::sleep_for(chrono::milliseconds(10));
-		}
-	}
+	boost::system::error_code ec;		
+	boost::filesystem::remove_all(m_path, ec);
+	if (0 == ec)
+		return;
+
+	// In some cases, antivirus runnig on Windows will scan all the newly created directories.
+	// As a consequence, directory is locked and can not be deleted immediately.
+	// Retry after 10 milliseconds usually is successful.
+	// This will help our tests run smoothly in such environment.
+	this_thread::sleep_for(chrono::milliseconds(10));
+
+	ec.clear();
+	boost::filesystem::remove_all(m_path, ec);
+	if (ec != 0)
+		cwarn << "Failed to delete directory '" << m_path << "': " << ec.message();
 }


### PR DESCRIPTION
Tests crash in my Windows environment because of exception in TransientDirectory destructor. Apparently, sleeping for approximately 10 ms solves the problem, but exceptions in destructor should be avoided.