### PR TITLE
Mutex guard m_fulls on eval()

### DIFF
--- a/libethcore/EthashAux.cpp
+++ b/libethcore/EthashAux.cpp
@@ -240,8 +240,9 @@ Ethash::Result EthashAux::eval(BlockInfo const& _header, Nonce const& _nonce)
 
 Ethash::Result EthashAux::eval(h256 const& _seedHash, h256 const& _headerHash, Nonce const& _nonce)
 {
-	if (FullType dag = get()->m_fulls[_seedHash].lock())
-		return dag->compute(_headerHash, _nonce);
+	DEV_GUARDED(get()->x_fulls)
+		if (FullType dag = get()->m_fulls[_seedHash].lock())
+			return dag->compute(_headerHash, _nonce);
 	DEV_IF_THROWS(return EthashAux::get()->light(_seedHash)->compute(_headerHash, _nonce))
 	{
 		return Ethash::Result{ ~h256(), h256() };


### PR DESCRIPTION
This is an attempt to fix repetitive segfaults that I have been seeing while trying to download the blockchain. The segfault concerns double free or memory corruption and can happen randomly on any block during the importing of the blockchain.

It occurs on my machine quite a few times. This is how it looks:

```
Press Enter*** Error in `/home/lefteris/ew/cpp-ethereum/build/eth/eth': double free or corruption (fasttop): 0x00007fffd8000c90 ***


...
omitted memory map for sanity
...


(gdb) bt
#0  0x00007ffff2aa4528 in raise () from /usr/lib/libc.so.6
#1  0x00007ffff2aa593a in abort () from /usr/lib/libc.so.6
#2  0x00007ffff2ae2bb2 in __libc_message () from /usr/lib/libc.so.6
#3  0x00007ffff2ae80fe in malloc_printerr () from /usr/lib/libc.so.6
#4  0x00007ffff2ae88db in _int_free () from /usr/lib/libc.so.6
#5  0x0000000000510012 in __gnu_cxx::new_allocator<std::__detail::_Hash_node_base*>::deallocate (this=0x7fffecb021a7, __p=0x7fffd8000c90) at /usr/include/c++/5.1.0/ext/new_allocator.h:110
#6  0x0000000000508778 in std::allocator_traits<std::allocator<std::__detail::_Hash_node_base*> >::deallocate (__a=..., __p=0x7fffd8000c90, __n=11) at /usr/include/c++/5.1.0/bits/alloc_traits.h:386
#7  0x00007ffff665b2b6 in std::__detail::_Hashtable_alloc<std::allocator<std::__detail::_Hash_node<std::pair<dev::FixedHash<32u> const, std::weak_ptr<dev::eth::EthashAux::FullAllocation> >, true> > >::_M_deallocate_buckets (this=0x7fffd4001068, __bkts=0x7fffd8000c90, 
    __n=11) at /usr/include/c++/5.1.0/bits/hashtable_policy.h:2010
#8  0x00007ffff6659844 in std::_Hashtable<dev::FixedHash<32u>, std::pair<dev::FixedHash<32u> const, std::weak_ptr<dev::eth::EthashAux::FullAllocation> >, std::allocator<std::pair<dev::FixedHash<32u> const, std::weak_ptr<dev::eth::EthashAux::FullAllocation> > >, std::__detail::_Select1st, std::equal_to<dev::FixedHash<32u> >, std::hash<dev::FixedHash<32u> >, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<true, false, true> >::_M_deallocate_buckets (this=0x7fffd4001068, __bkts=0x7fffd8000c90, __n=11) at /usr/include/c++/5.1.0/bits/hashtable.h:356
#9  0x00007ffff6657670 in std::_Hashtable<dev::FixedHash<32u>, std::pair<dev::FixedHash<32u> const, std::weak_ptr<dev::eth::EthashAux::FullAllocation> >, std::allocator<std::pair<dev::FixedHash<32u> const, std::weak_ptr<dev::eth::EthashAux::FullAllocation> > >, std::__detail::_Select1st, std::equal_to<dev::FixedHash<32u> >, std::hash<dev::FixedHash<32u> >, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<true, false, true> >::_M_deallocate_buckets (this=0x7fffd4001068) at /usr/include/c++/5.1.0/bits/hashtable.h:361
#10 0x00007ffff665d887 in std::_Hashtable<dev::FixedHash<32u>, std::pair<dev::FixedHash<32u> const, std::weak_ptr<dev::eth::EthashAux::FullAllocation> >, std::allocator<std::pair<dev::FixedHash<32u> const, std::weak_ptr<dev::eth::EthashAux::FullAllocation> > >, std::__detail::_Select1st, std::equal_to<dev::FixedHash<32u> >, std::hash<dev::FixedHash<32u> >, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<true, false, true> >::_M_rehash_aux (
    this=0x7fffd4001068, __n=23) at /usr/include/c++/5.1.0/bits/hashtable.h:1999
#11 0x00007ffff665c4bd in std::_Hashtable<dev::FixedHash<32u>, std::pair<dev::FixedHash<32u> const, std::weak_ptr<dev::eth::EthashAux::FullAllocation> >, std::allocator<std::pair<dev::FixedHash<32u> const, std::weak_ptr<dev::eth::EthashAux::FullAllocation> > >, std::__detail::_Select1st, std::equal_to<dev::FixedHash<32u> >, std::hash<dev::FixedHash<32u> >, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<true, false, true> >::_M_rehash (
    this=0x7fffd4001068, __n=23, __state=@0x7fffecb02308: 11) at /usr/include/c++/5.1.0/bits/hashtable.h:1953
#12 0x00007ffff665aa5d in std::_Hashtable<dev::FixedHash<32u>, std::pair<dev::FixedHash<32u> const, std::weak_ptr<dev::eth::EthashAux::FullAllocation> >, std::allocator<std::pair<dev::FixedHash<32u> const, std::weak_ptr<dev::eth::EthashAux::FullAllocation> > >, std::__detail::_Select1st, std::equal_to<dev::FixedHash<32u> >, std::hash<dev::FixedHash<32u> >, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<true, false, true> >::_M_insert_unique_node (this=0x7fffd4001068, __bkt=0, __code=12557545471830497050, __node=0x7fffe40009c0) at /usr/include/c++/5.1.0/bits/hashtable.h:1600
#13 0x00007ffff66587bd in std::__detail::_Map_base<dev::FixedHash<32u>, std::pair<dev::FixedHash<32u> const, std::weak_ptr<dev::eth::EthashAux::FullAllocation> >, std::allocator<std::pair<dev::FixedHash<32u> const, std::weak_ptr<dev::eth::EthashAux::FullAllocation> > >, std::__detail::_Select1st, std::equal_to<dev::FixedHash<32u> >, std::hash<dev::FixedHash<32u> >, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<true, false, true>, true>::operator[] (this=0x7fffd4001068, __k=...) at /usr/include/c++/5.1.0/bits/hashtable_policy.h:600
#14 0x00007ffff66567c5 in std::unordered_map<dev::FixedHash<32u>, std::weak_ptr<dev::eth::EthashAux::FullAllocation>, std::hash<dev::FixedHash<32u> >, std::equal_to<dev::FixedHash<32u> >, std::allocator<std::pair<dev::FixedHash<32u> const, std::weak_ptr<dev::eth::EthashAux::FullAllocation> > > >::operator[] (this=0x7fffd4001068, __k=...) at /usr/include/c++/5.1.0/bits/unordered_map.h:630
#15 0x00007ffff6651d56 in dev::eth::EthashAux::eval (_seedHash=..., _headerHash=..., _nonce=...) at /home/lefteris/ew/cpp-ethereum/libethcore/EthashAux.cpp:243
#16 0x00007ffff6651d1b in dev::eth::EthashAux::eval (_header=..., _nonce=...) at /home/lefteris/ew/cpp-ethereum/libethcore/EthashAux.cpp:238
#17 0x00007ffff6610c0f in dev::eth::EthashAux::eval (_header=...) at /home/lefteris/ew/cpp-ethereum/libethcore/EthashAux.h:80
#18 0x00007ffff660d67a in dev::eth::Ethash::verify (_header=...) at /home/lefteris/ew/cpp-ethereum/libethcore/Ethash.cpp:114
#19 0x00007ffff6661915 in dev::eth::BlockInfo::populateFromHeader (this=0x7fffecb047d0, _header=..., _s=dev::eth::CheckEverything, _h=...) at /home/lefteris/ew/cpp-ethereum/libethcore/BlockInfo.cpp:153
#20 0x00007ffff66628e5 in dev::eth::BlockInfo::populate (this=0x7fffecb047d0, _block=..., _s=dev::eth::CheckEverything, _h=...) at /home/lefteris/ew/cpp-ethereum/libethcore/BlockInfo.cpp:184
#21 0x00007ffff700ca94 in dev::eth::BlockInfo::populate (this=0x7fffecb047d0, _block=std::vector of length 515, capacity 515 = {...}, _s=dev::eth::CheckEverything, _h=...) at /home/lefteris/ew/cpp-ethereum/libethereum/../libethcore/BlockInfo.h:126
#22 0x00007ffff7007b10 in dev::eth::BlockQueue::verifierBody (this=0xeb5e60) at /home/lefteris/ew/cpp-ethereum/libethereum/BlockQueue.cpp:81
#23 0x00007ffff700742b in dev::eth::BlockQueue::BlockQueue()::{lambda()#1}::operator()() const () at /home/lefteris/ew/cpp-ethereum/libethereum/BlockQueue.cpp:47
#24 0x00007ffff700c196 in std::_Bind_simple<dev::eth::BlockQueue::BlockQueue()::<lambda()>()>::_M_invoke<>(std::_Index_tuple<>) (this=0xedfb98) at /usr/include/c++/5.1.0/functional:1531
#25 0x00007ffff700c0ff in std::_Bind_simple<dev::eth::BlockQueue::BlockQueue()::<lambda()>()>::operator()(void) (this=0xedfb98) at /usr/include/c++/5.1.0/functional:1520
#26 0x00007ffff700c09e in std::thread::_Impl<std::_Bind_simple<dev::eth::BlockQueue::BlockQueue()::<lambda()>()> >::_M_run(void) (this=0xedfb80) at /usr/include/c++/5.1.0/thread:115
#27 0x00007ffff33e62f0 in std::(anonymous namespace)::execute_native_thread_routine (__p=<optimized out>) at /build/gcc-multilib/src/gcc-5-20150519/libstdc++-v3/src/c++11/thread.cc:84
#28 0x00007ffff36b6354 in start_thread () from /usr/lib/libpthread.so.0
#29 0x00007ffff2b58bfd in clone () from /usr/lib/libc.so.6
(gdb) 
```

I believe it's probably due to the `m_fulls` map access not being protected at line 243 and as such it's a race condition due to other threads trying to access it at the same time.