### PR TITLE
PoC: CALL execution stack offloading

### DIFF
--- a/cmake/EthDependencies.cmake
+++ b/cmake/EthDependencies.cmake
@@ -207,7 +207,7 @@ elseif (UNIX)
 
 endif()
 
-find_package(Boost 1.54.0 REQUIRED COMPONENTS thread date_time system regex chrono filesystem unit_test_framework program_options)
+find_package(Boost 1.54.0 REQUIRED COMPONENTS thread date_time system regex chrono filesystem unit_test_framework program_options context)
 
 message(" - boost header: ${Boost_INCLUDE_DIRS}")
 message(" - boost lib   : ${Boost_LIBRARIES}")

--- a/libethereum/CMakeLists.txt
+++ b/libethereum/CMakeLists.txt
@@ -29,6 +29,7 @@ target_link_libraries(${EXECUTABLE} devcrypto)
 target_link_libraries(${EXECUTABLE} ethcore)
 target_link_libraries(${EXECUTABLE} ${LEVELDB_LIBRARIES})
 target_link_libraries(${EXECUTABLE} ${Boost_REGEX_LIBRARIES})
+target_link_libraries(${EXECUTABLE} ${Boost_CONTEXT_LIBRARIES})
 target_link_libraries(${EXECUTABLE} secp256k1)
 
 if (CMAKE_COMPILER_IS_MINGW)

--- a/libevm/ExtVMFace.h
+++ b/libevm/ExtVMFace.h
@@ -22,7 +22,8 @@
 #pragma once
 
 #include <set>
-#include <functional>
+#include <functional> 
+#include <boost/context/fcontext.hpp>
 #include <libdevcore/Common.h>
 #include <libdevcore/CommonData.h>
 #include <libdevcore/RLP.h>
@@ -103,6 +104,7 @@ struct SubState
 
 class ExtVMFace;
 class VM;
+class Executive;
 
 using LastHashes = std::vector<h256>;
 
@@ -118,6 +120,10 @@ struct CallParameters
 	bytesConstRef data;
 	bytesRef out;
 	OnOpFunc onOp;
+	Executive* executive = nullptr;
+	ExtVMFace* extVM = nullptr;
+	boost::context::fcontext_t* callCtx;
+	boost::context::fcontext_t* retCtx;
 };
 
 /**


### PR DESCRIPTION
The strategy behind is simple: instead of using system stack for all calls and creates a new heap powered stack space is allocated for every call and create.

This uses Boost.Context from version 1.55. I know the API has changes in later version. Moreover, the implementation is heavy architecture dependent (different for x86, x64, Windows, Unix).

I'm not sure it is the best possible long term solution but let's test is for some time. Currently stacks has 16KB of size. That's what I need on linux/debug version.

Argument passing between contexts, calls, executives and others is a mess. It need to be refactored later on.