### PR TITLE
Improved error checking for ethash_full_new()

### DIFF
--- a/libethash/io.h
+++ b/libethash/io.h
@@ -55,6 +55,23 @@ enum ethash_io_rc {
 #endif
 
 /**
+ * Logs a critical error in important parts of ethash. Should mostly help
+ * figure out what kind of problem (I/O, memory e.t.c.) causes a NULL
+ * ethash_full_t
+ */
+#ifdef ETHASH_PRINT_CRITICAL_OUTPUT
+#define ETHASH_CRITICAL(...)							\
+	do													\
+	{													\
+		printf("ETHASH CRITICAL ERROR: "__VA_ARGS__);	\
+		printf("\n");									\
+		fflush(stdout);									\
+	} while (0)
+#else
+#define ETHASH_CRITICAL(...)          
+#endif
+
+/**
  * Prepares io for ethash
  *
  * Create the DAG directory and the DAG file if they don't exist.

--- a/libethcore/EthashAux.cpp
+++ b/libethcore/EthashAux.cpp
@@ -137,7 +137,10 @@ EthashAux::FullAllocation::FullAllocation(ethash_light_t _light, ethash_callback
 	full = ethash_full_new(_light, _cb);
 //	cdebug << "Called OK.";
 	if (!full)
-		BOOST_THROW_EXCEPTION(ExternalFunctionFailure("ethash_full_new()"));
+	{
+		clog(DAGChannel) << "DAG Generation Failure. Reason: "  << strerror(errno);
+		BOOST_THROW_EXCEPTION(ExternalFunctionFailure("ethash_full_new"));
+	}
 }
 
 EthashAux::FullAllocation::~FullAllocation()


### PR DESCRIPTION
Pulling latest commits from ethash and using them in order to attempt to provide more information to the user as to why `ethash_full_new()` failed.