### PR TITLE
Fallback takes constant amount of gas, and send no gas with send.

### DIFF
--- a/libsolidity/ExpressionCompiler.cpp
+++ b/libsolidity/ExpressionCompiler.cpp
@@ -1058,10 +1058,15 @@ void ExpressionCompiler::appendExternalFunctionCall(
 	unsigned gasStackPos = m_context.currentToBaseStackOffset(gasValueSize);
 	unsigned valueStackPos = m_context.currentToBaseStackOffset(1);
 
+	bool returnSuccessCondition =
+		_functionType.getLocation() == FunctionType::Location::Bare ||
+		_functionType.getLocation() == FunctionType::Location::BareCallCode;
 	//@todo only return the first return value for now
 	Type const* firstType = _functionType.getReturnParameterTypes().empty() ? nullptr :
 							_functionType.getReturnParameterTypes().front().get();
 	unsigned retSize = firstType ? firstType->getCalldataEncodedSize() : 0;
+	if (returnSuccessCondition)
+		retSize = 0; // return value actually is success condition
 	m_context << u256(retSize) << u256(0);
 
 	if (_functionType.isBareCall())
@@ -1112,19 +1117,27 @@ void ExpressionCompiler::appendExternalFunctionCall(
 	else
 		m_context << eth::Instruction::CALL;
 
-	//Propagate error condition (if CALL pushes 0 on stack).
-	m_context << eth::Instruction::ISZERO;
-	m_context.appendConditionalJumpTo(m_context.errorTag());
+	unsigned remainsSize = 1 + // contract address
+			_functionType.valueSet() +
+			_functionType.gasSet() +
+			!_functionType.isBareCall();
 
-	if (_functionType.valueSet())
-		m_context << eth::Instruction::POP;
-	if (_functionType.gasSet())
-		m_context << eth::Instruction::POP;
-	if (!_functionType.isBareCall())
-		m_context << eth::Instruction::POP;
-	m_context << eth::Instruction::POP; // pop contract address
+	if (returnSuccessCondition)
+		m_context << eth::swapInstruction(remainsSize);
+	else
+	{
+		//Propagate error condition (if CALL pushes 0 on stack).
+		m_context << eth::Instruction::ISZERO;
+		m_context.appendConditionalJumpTo(m_context.errorTag());
+	}
 
-	if (_functionType.getLocation() == FunctionType::Location::RIPEMD160)
+	CompilerUtils(m_context).popStackSlots(remainsSize);
+
+	if (returnSuccessCondition)
+	{
+		// already there
+	}
+	else if (_functionType.getLocation() == FunctionType::Location::RIPEMD160)
 	{
 		// fix: built-in contract returns right-aligned data
 		CompilerUtils(m_context).loadFromMemory(0, IntegerType(160), false, true);

--- a/libsolidity/ExpressionCompiler.cpp
+++ b/libsolidity/ExpressionCompiler.cpp
@@ -1117,10 +1117,11 @@ void ExpressionCompiler::appendExternalFunctionCall(
 	else
 		m_context << eth::Instruction::CALL;
 
-	unsigned remainsSize = 1 + // contract address
-			_functionType.valueSet() +
-			_functionType.gasSet() +
-			!_functionType.isBareCall();
+	unsigned remainsSize =
+		1 + // contract address
+		_functionType.valueSet() +
+		_functionType.gasSet() +
+		!_functionType.isBareCall();
 
 	if (returnSuccessCondition)
 		m_context << eth::swapInstruction(remainsSize);

--- a/libsolidity/ExpressionCompiler.cpp
+++ b/libsolidity/ExpressionCompiler.cpp
@@ -521,6 +521,7 @@ bool ExpressionCompiler::visit(FunctionCall const& _functionCall)
 			break;
 		case Location::Send:
 			_functionCall.getExpression().accept(*this);
+			m_context << u256(0); // do not send gas (there still is the stipend)
 			arguments.front()->accept(*this);
 			appendTypeConversion(*arguments.front()->getType(),
 								 *function.getParameterTypes().front(), true);
@@ -532,7 +533,7 @@ bool ExpressionCompiler::visit(FunctionCall const& _functionCall)
 					strings(),
 					Location::Bare,
 					false,
-					false,
+					true,
 					true
 				),
 				{}

--- a/libsolidity/Types.cpp
+++ b/libsolidity/Types.cpp
@@ -317,9 +317,9 @@ TypePointer IntegerType::binaryOperatorResult(Token::Value _operator, TypePointe
 
 const MemberList IntegerType::AddressMemberList({
 	{"balance", make_shared<IntegerType >(256)},
-	{"call", make_shared<FunctionType>(strings(), strings(), FunctionType::Location::Bare, true)},
-	{"callcode", make_shared<FunctionType>(strings(), strings(), FunctionType::Location::BareCallCode, true)},
-	{"send", make_shared<FunctionType>(strings{"uint"}, strings{}, FunctionType::Location::Send)}
+	{"call", make_shared<FunctionType>(strings(), strings{"bool"}, FunctionType::Location::Bare, true)},
+	{"callcode", make_shared<FunctionType>(strings(), strings{"bool"}, FunctionType::Location::BareCallCode, true)},
+	{"send", make_shared<FunctionType>(strings{"uint"}, strings{"bool"}, FunctionType::Location::Send)}
 });
 
 IntegerConstantType::IntegerConstantType(Literal const& _literal)

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -4187,6 +4187,28 @@ BOOST_AUTO_TEST_CASE(positive_integers_to_signed)
 	BOOST_CHECK(callContractFunction("q()") == encodeArgs(250));
 }
 
+BOOST_AUTO_TEST_CASE(failing_send)
+{
+	char const* sourceCode = R"(
+		contract Helper {
+			uint[] data;
+			function () {
+				data[9]; // trigger exception
+			}
+		}
+		contract Main {
+			function callHelper(address _a) returns (bool r, uint bal) {
+				r = !_a.send(5);
+				bal = this.balance;
+			}
+		}
+	)";
+	compileAndRun(sourceCode, 0, "Helper");
+	u160 const c_helperAddress = m_contractAddress;
+	compileAndRun(sourceCode, 20, "Main");
+	BOOST_REQUIRE(callContractFunction("callHelper(address)", c_helperAddress) == encodeArgs(true, 20));
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 }


### PR DESCRIPTION
Several interleaving changes:
 - send now returns bool (true if sending worked) and never throws
 - send provides zero gas
 - function selector in receiver is cheap on failure (works with gas stipend alone)