### PR TITLE
VM refactor: instruction requirements checking.

### DIFF
--- a/libevm/VM.h
+++ b/libevm/VM.h
@@ -60,10 +60,12 @@ public:
 	u256s const& stack() const { return m_stack; }
 
 private:
+	void checkRequirements(u256& io_gas, ExtVMFace& _ext, OnOpFunc const& _onOp, Instruction _inst);
 	void require(u256 _n, u256 _d) { if (m_stack.size() < _n) { if (m_onFail) m_onFail(); BOOST_THROW_EXCEPTION(StackUnderflow() << RequirementError((bigint)_n, (bigint)m_stack.size())); } if (m_stack.size() - _n + _d > c_stackLimit) { if (m_onFail) m_onFail(); BOOST_THROW_EXCEPTION(OutOfStack() << RequirementError((bigint)(_d - _n), (bigint)m_stack.size())); } }
 	void requireMem(unsigned _n) { if (m_temp.size() < _n) { m_temp.resize(_n); } }
 
 	u256 m_curPC = 0;
+	uint64_t m_steps = 0;
 	bytes m_temp;
 	u256s m_stack;
 	std::vector<uint64_t> m_jumpDests;


### PR DESCRIPTION
Move an instruction requirements checking in VM to a separated helper function.
Instruction execution is now split into two parts what reduces OS stack memory usage.