### PR TITLE
VM refactor: more OS stack usage reductions

### DIFF
--- a/libevm/VM.cpp
+++ b/libevm/VM.cpp
@@ -594,7 +594,7 @@ bytesConstRef VM::execImpl(u256& io_gas, ExtVMFace& _ext, OnOpFunc const& _onOp)
 			break;
 		case Instruction::CREATE:
 		{
-			auto& endowment = m_stack.back();
+			auto endowment = m_stack.back();
 			m_stack.pop_back();
 			unsigned initOff = (unsigned)m_stack.back();
 			m_stack.pop_back();

--- a/libevm/VM.h
+++ b/libevm/VM.h
@@ -54,7 +54,7 @@ class VM: public VMFace
 public:
 	virtual bytesConstRef execImpl(u256& io_gas, ExtVMFace& _ext, OnOpFunc const& _onOp) override final;
 
-	u256 curPC() const { return m_curPC; }
+	uint64_t curPC() const { return m_curPC; }
 
 	bytes const& memory() const { return m_temp; }
 	u256s const& stack() const { return m_stack; }
@@ -64,7 +64,7 @@ private:
 	void require(u256 _n, u256 _d) { if (m_stack.size() < _n) { if (m_onFail) m_onFail(); BOOST_THROW_EXCEPTION(StackUnderflow() << RequirementError((bigint)_n, (bigint)m_stack.size())); } if (m_stack.size() - _n + _d > c_stackLimit) { if (m_onFail) m_onFail(); BOOST_THROW_EXCEPTION(OutOfStack() << RequirementError((bigint)(_d - _n), (bigint)m_stack.size())); } }
 	void requireMem(unsigned _n) { if (m_temp.size() < _n) { m_temp.resize(_n); } }
 
-	u256 m_curPC = 0;
+	uint64_t m_curPC = 0;
 	uint64_t m_steps = 0;
 	bytes m_temp;
 	u256s m_stack;

--- a/libevm/VM.h
+++ b/libevm/VM.h
@@ -60,10 +60,12 @@ public:
 	u256s const& stack() const { return m_stack; }
 
 private:
+	void checkRequirements(u256& io_gas, ExtVMFace& _ext, OnOpFunc const& _onOp, Instruction _inst);
 	void require(u256 _n, u256 _d) { if (m_stack.size() < _n) { if (m_onFail) m_onFail(); BOOST_THROW_EXCEPTION(StackUnderflow() << RequirementError((bigint)_n, (bigint)m_stack.size())); } if (m_stack.size() - _n + _d > c_stackLimit) { if (m_onFail) m_onFail(); BOOST_THROW_EXCEPTION(OutOfStack() << RequirementError((bigint)(_d - _n), (bigint)m_stack.size())); } }
 	void requireMem(unsigned _n) { if (m_temp.size() < _n) { m_temp.resize(_n); } }
 
 	u256 m_curPC = 0;
+	uint64_t m_steps = 0;
 	bytes m_temp;
 	u256s m_stack;
 	std::vector<uint64_t> m_jumpDests;


### PR DESCRIPTION
- VM instruction pointer is now uint64_t.
- CALL params are placed on stack instead of heap. That reduces OS stack usage by ~30%.

