### PR TITLE
don't return anything when ecrecover fails

### DIFF
--- a/libethereum/Precompiled.cpp
+++ b/libethereum/Precompiled.cpp
@@ -55,9 +55,13 @@ void ecrecoverCode(bytesConstRef _in, bytesRef _out)
 		{
 			try
 			{
-				ret = sha3(recover(sig, in.hash));
+				Public rec = recover(sig, in.hash);
+				if (rec)
+					ret = dev::sha3(rec);
+				else
+					return;
 			}
-			catch (...) {}
+			catch (...) { return; }
 		}
 	}
 


### PR DESCRIPTION
YP: “Importantly in the case of an invalid signature (ECDSARECOVER(h, v, r, s) = ∅), then we have no output.”
We didn't do that, we just hashed the empty byte sequence, but go and python did. We have tests for that : https://github.com/ethereum/cpp-ethereum/pull/2111
