### PR TITLE
OpenCL smarter GPU memorycheck

### DIFF
--- a/ethminer/MinerAux.h
+++ b/ethminer/MinerAux.h
@@ -132,6 +132,8 @@ public:
 			ProofOfWork::GPUMiner::listDevices();
 			exit(0);
 		}
+		else if (arg == "--allow-opencl-cpu")
+			ProofOfWork::GPUMiner::allowCPU();
 		else if (arg == "--phone-home" && i + 1 < argc)
 		{
 			string m = argv[++i];

--- a/libethash-cl/ethash_cl_miner.cpp
+++ b/libethash-cl/ethash_cl_miner.cpp
@@ -137,8 +137,9 @@ unsigned ethash_cl_miner::getNumDevices(unsigned _platformId)
 	return devices.size();
 }
 
-bool ethash_cl_miner::configureGPU()
+bool ethash_cl_miner::configureGPU(bool _allowCPU)
 {
+	s_allowCPU = _allowCPU;
 	return searchForAllDevices([](cl::Device const _device) -> bool
 		{
 			cl_ulong result;
@@ -163,11 +164,6 @@ bool ethash_cl_miner::configureGPU()
 }
 
 bool ethash_cl_miner::s_allowCPU = false;
-
-void ethash_cl_miner::allowCPU()
-{
-	s_allowCPU = true;
-}
 
 bool ethash_cl_miner::searchForAllDevices(function<bool(cl::Device const&)> _callback)
 {

--- a/libethash-cl/ethash_cl_miner.cpp
+++ b/libethash-cl/ethash_cl_miner.cpp
@@ -51,6 +51,8 @@ using namespace std;
 
 // TODO: If at any point we can use libdevcore in here then we should switch to using a LogChannel
 #define ETHCL_LOG(_contents) cout << "[OPENCL]:" << _contents << endl
+// Types of OpenCL devices we are interested in
+#define ETHCL_QUERIED_DEVICE_TYPES (CL_DEVICE_TYPE_GPU | CL_DEVICE_TYPE_ACCELERATOR)
 
 static void addDefinition(string& _source, char const* _id, unsigned _value)
 {
@@ -82,9 +84,8 @@ string ethash_cl_miner::platform_info(unsigned _platformId, unsigned _deviceId)
 	}
 
 	// get GPU device of the selected platform
-	vector<cl::Device> devices;
 	unsigned platform_num = min<unsigned>(_platformId, platforms.size() - 1);
-	platforms[platform_num].getDevices(CL_DEVICE_TYPE_ALL, &devices);
+	vector<cl::Device> devices = getDevices(platforms, _platformId);
 	if (devices.empty())
 	{
 		ETHCL_LOG("No OpenCL devices found.");
@@ -97,6 +98,17 @@ string ethash_cl_miner::platform_info(unsigned _platformId, unsigned _deviceId)
 	string device_version = device.getInfo<CL_DEVICE_VERSION>();
 
 	return "{ \"platform\": \"" + platforms[platform_num].getInfo<CL_PLATFORM_NAME>() + "\", \"device\": \"" + device.getInfo<CL_DEVICE_NAME>() + "\", \"version\": \"" + device_version + "\" }";
+}
+
+std::vector<cl::Device> ethash_cl_miner::getDevices(std::vector<cl::Platform> const& _platforms, unsigned _platformId)
+{
+	vector<cl::Device> devices;
+	unsigned platform_num = min<unsigned>(_platformId, _platforms.size() - 1);
+	_platforms[platform_num].getDevices(
+		s_allowCPU ? CL_DEVICE_TYPE_ALL : ETHCL_QUERIED_DEVICE_TYPES,
+		&devices
+	);
+	return devices;
 }
 
 unsigned ethash_cl_miner::getNumPlatforms()
@@ -116,9 +128,7 @@ unsigned ethash_cl_miner::getNumDevices(unsigned _platformId)
 		return 0;
 	}
 
-	vector<cl::Device> devices;
-	unsigned platform_num = min<unsigned>(_platformId, platforms.size() - 1);
-	platforms[platform_num].getDevices(CL_DEVICE_TYPE_ALL, &devices);
+	vector<cl::Device> devices = getDevices(platforms, _platformId);
 	if (devices.empty())
 	{
 		ETHCL_LOG("No OpenCL devices found.");
@@ -152,6 +162,13 @@ bool ethash_cl_miner::configureGPU()
 	);
 }
 
+bool ethash_cl_miner::s_allowCPU = false;
+
+void ethash_cl_miner::allowCPU()
+{
+	s_allowCPU = true;
+}
+
 bool ethash_cl_miner::searchForAllDevices(function<bool(cl::Device const&)> _callback)
 {
 	vector<cl::Platform> platforms;
@@ -175,8 +192,7 @@ bool ethash_cl_miner::searchForAllDevices(unsigned _platformId, function<bool(cl
 	if (_platformId >= platforms.size())
 		return false;
 
-	vector<cl::Device> devices;
-	platforms[_platformId].getDevices(CL_DEVICE_TYPE_ALL, &devices);
+	vector<cl::Device> devices = getDevices(platforms, _platformId);
 	for (cl::Device const& device: devices)
 		if (_callback(device))
 			return true;
@@ -204,8 +220,7 @@ void ethash_cl_miner::doForAllDevices(unsigned _platformId, function<void(cl::De
 	if (_platformId >= platforms.size())
 		return;
 
-	vector<cl::Device> devices;
-	platforms[_platformId].getDevices(CL_DEVICE_TYPE_ALL, &devices);
+	vector<cl::Device> devices = getDevices(platforms, _platformId);
 	for (cl::Device const& device: devices)
 		_callback(device);
 }
@@ -253,8 +268,7 @@ bool ethash_cl_miner::init(
 		ETHCL_LOG("Using platform: " << platforms[_platformId].getInfo<CL_PLATFORM_NAME>().c_str());
 
 		// get GPU device of the default platform
-		vector<cl::Device> devices;
-		platforms[_platformId].getDevices(CL_DEVICE_TYPE_ALL, &devices);
+		vector<cl::Device> devices = getDevices(platforms, _platformId);
 		if (devices.empty())
 		{
 			ETHCL_LOG("No OpenCL devices found.");

--- a/libethash-cl/ethash_cl_miner.h
+++ b/libethash-cl/ethash_cl_miner.h
@@ -41,6 +41,7 @@ public:
 	static std::string platform_info(unsigned _platformId = 0, unsigned _deviceId = 0);
 	static void listDevices();
 	static bool configureGPU();
+	static void allowCPU();
 
 	bool init(
 		uint8_t const* _dag,
@@ -56,6 +57,9 @@ public:
 	void search_chunk(uint8_t const* header, uint64_t target, search_hook& hook);
 
 private:
+
+	static std::vector<cl::Device> getDevices(std::vector<cl::Platform> const& _platforms, unsigned _platformId);
+	
 	enum { c_max_search_results = 63, c_num_buffers = 2, c_hash_batch_size = 1024, c_search_batch_size = 1024*256 };
 
 	cl::Context m_context;
@@ -70,4 +74,5 @@ private:
 	unsigned m_workgroup_size;
 	bool m_opencl_1_1;
 
+	static bool s_allowCPU;
 };

--- a/libethash-cl/ethash_cl_miner.h
+++ b/libethash-cl/ethash_cl_miner.h
@@ -40,8 +40,7 @@ public:
 	static unsigned getNumDevices(unsigned _platformId = 0);
 	static std::string platform_info(unsigned _platformId = 0, unsigned _deviceId = 0);
 	static void listDevices();
-	static bool configureGPU();
-	static void allowCPU();
+	static bool configureGPU(bool _allowCPU);
 
 	bool init(
 		uint8_t const* _dag,

--- a/libethash-cl/ethash_cl_miner.h
+++ b/libethash-cl/ethash_cl_miner.h
@@ -12,6 +12,7 @@
 #include "cl.hpp"
 #endif
 
+#include <boost/optional.hpp>
 #include <time.h>
 #include <functional>
 #include <libethash/ethash.h>
@@ -40,7 +41,7 @@ public:
 	static unsigned getNumDevices(unsigned _platformId = 0);
 	static std::string platform_info(unsigned _platformId = 0, unsigned _deviceId = 0);
 	static void listDevices();
-	static bool configureGPU(bool _allowCPU);
+	static bool configureGPU(bool _allowCPU, unsigned _extraGPUMemory, boost::optional<uint64_t> _currentBlock);
 
 	bool init(
 		uint8_t const* _dag,
@@ -73,5 +74,9 @@ private:
 	unsigned m_workgroup_size;
 	bool m_opencl_1_1;
 
+	/// Allow CPU to appear as an OpenCL device or not. Default is false
 	static bool s_allowCPU;
+	/// GPU memory required for other things, like window rendering e.t.c.
+	/// User can set it via the --cl-extragpu-mem argument.
+	static unsigned s_extraRequiredGPUMem;
 };

--- a/libethash-cl/ethash_cl_miner_kernel.cl
+++ b/libethash-cl/ethash_cl_miner_kernel.cl
@@ -275,8 +275,6 @@ uint inner_loop_chunks(uint4 init, uint thread_id, __local uint* share, __global
 	return fnv_reduce(mix);
 }
 
-
-
 uint inner_loop(uint4 init, uint thread_id, __local uint* share, __global hash128_t const* g_dag, uint isolate)
 {
 	uint4 mix = init;

--- a/libethash-cl/ethash_cl_miner_kernel.cl
+++ b/libethash-cl/ethash_cl_miner_kernel.cl
@@ -275,6 +275,8 @@ uint inner_loop_chunks(uint4 init, uint thread_id, __local uint* share, __global
 	return fnv_reduce(mix);
 }
 
+
+
 uint inner_loop(uint4 init, uint thread_id, __local uint* share, __global hash128_t const* g_dag, uint isolate)
 {
 	uint4 mix = init;

--- a/libethcore/Ethash.cpp
+++ b/libethcore/Ethash.cpp
@@ -381,11 +381,17 @@ void Ethash::GPUMiner::listDevices()
 	return ethash_cl_miner::listDevices();
 }
 
-bool Ethash::GPUMiner::configureGPU(unsigned _platformId, unsigned _deviceId, bool _allowCPU)
+bool Ethash::GPUMiner::configureGPU(
+	unsigned _platformId,
+	unsigned _deviceId,
+	bool _allowCPU,
+	unsigned _extraGPUMemory,
+	boost::optional<uint64_t> _currentBlock
+)
 {
 	s_platformId = _platformId;
 	s_deviceId = _deviceId;
-	return ethash_cl_miner::configureGPU(_allowCPU);
+	return ethash_cl_miner::configureGPU(_allowCPU, _extraGPUMemory, _currentBlock);
 }
 
 #endif

--- a/libethcore/Ethash.cpp
+++ b/libethcore/Ethash.cpp
@@ -366,11 +366,6 @@ void Ethash::GPUMiner::pause()
 	stopWorking();
 }
 
-void Ethash::GPUMiner::allowCPU()
-{
-	return ethash_cl_miner::allowCPU();
-}
-
 std::string Ethash::GPUMiner::platformInfo()
 {
 	return ethash_cl_miner::platform_info(s_platformId, s_deviceId);
@@ -386,9 +381,11 @@ void Ethash::GPUMiner::listDevices()
 	return ethash_cl_miner::listDevices();
 }
 
-bool Ethash::GPUMiner::configureGPU()
+bool Ethash::GPUMiner::configureGPU(unsigned _platformId, unsigned _deviceId, bool _allowCPU)
 {
-	return ethash_cl_miner::configureGPU();
+	s_platformId = _platformId;
+	s_deviceId = _deviceId;
+	return ethash_cl_miner::configureGPU(_allowCPU);
 }
 
 #endif

--- a/libethcore/Ethash.cpp
+++ b/libethcore/Ethash.cpp
@@ -366,6 +366,11 @@ void Ethash::GPUMiner::pause()
 	stopWorking();
 }
 
+void Ethash::GPUMiner::allowCPU()
+{
+	return ethash_cl_miner::allowCPU();
+}
+
 std::string Ethash::GPUMiner::platformInfo()
 {
 	return ethash_cl_miner::platform_info(s_platformId, s_deviceId);

--- a/libethcore/Ethash.h
+++ b/libethcore/Ethash.h
@@ -87,12 +87,8 @@ public:
 
 		static unsigned instances() { return s_numInstances > 0 ? s_numInstances : std::thread::hardware_concurrency(); }
 		static std::string platformInfo();
-		static void setDefaultPlatform(unsigned) {}
-		static void setDagChunks(unsigned) {}
-		static void setDefaultDevice(unsigned) {}
 		static void listDevices() {}
-		static bool configureGPU() { return false; }
-		static void allowCPU() {}
+		static bool configureGPU(unsigned, unsigned, bool) { return false; }
 		static void setNumInstances(unsigned _instances) { s_numInstances = std::min<unsigned>(_instances, std::thread::hardware_concurrency()); }
 	protected:
 		void kickOff() override
@@ -121,10 +117,7 @@ public:
 		static std::string platformInfo();
 		static unsigned getNumDevices();
 		static void listDevices();
-		static bool configureGPU();
-		static void allowCPU();
-		static void setDefaultPlatform(unsigned _id) { s_platformId = _id; }
-		static void setDefaultDevice(unsigned _id) { s_deviceId = _id; }
+		static bool configureGPU(unsigned _platformId, unsigned _deviceId, bool _allowCPU);
 		static void setNumInstances(unsigned _instances) { s_numInstances = std::min<unsigned>(_instances, getNumDevices()); }
 
 	protected:

--- a/libethcore/Ethash.h
+++ b/libethcore/Ethash.h
@@ -92,6 +92,7 @@ public:
 		static void setDefaultDevice(unsigned) {}
 		static void listDevices() {}
 		static bool configureGPU() { return false; }
+		static void allowCPU() {}
 		static void setNumInstances(unsigned _instances) { s_numInstances = std::min<unsigned>(_instances, std::thread::hardware_concurrency()); }
 	protected:
 		void kickOff() override
@@ -121,6 +122,7 @@ public:
 		static unsigned getNumDevices();
 		static void listDevices();
 		static bool configureGPU();
+		static void allowCPU();
 		static void setDefaultPlatform(unsigned _id) { s_platformId = _id; }
 		static void setDefaultDevice(unsigned _id) { s_deviceId = _id; }
 		static void setNumInstances(unsigned _instances) { s_numInstances = std::min<unsigned>(_instances, getNumDevices()); }

--- a/libethcore/Ethash.h
+++ b/libethcore/Ethash.h
@@ -88,7 +88,7 @@ public:
 		static unsigned instances() { return s_numInstances > 0 ? s_numInstances : std::thread::hardware_concurrency(); }
 		static std::string platformInfo();
 		static void listDevices() {}
-		static bool configureGPU(unsigned, unsigned, bool) { return false; }
+		static bool configureGPU(unsigned, unsigned, bool, unsigned, boost::optional<uint64_t>) { return false; }
 		static void setNumInstances(unsigned _instances) { s_numInstances = std::min<unsigned>(_instances, std::thread::hardware_concurrency()); }
 	protected:
 		void kickOff() override
@@ -117,7 +117,13 @@ public:
 		static std::string platformInfo();
 		static unsigned getNumDevices();
 		static void listDevices();
-		static bool configureGPU(unsigned _platformId, unsigned _deviceId, bool _allowCPU);
+		static bool configureGPU(
+			unsigned _platformId,
+			unsigned _deviceId,
+			bool _allowCPU,
+			unsigned _extraGPUMemory,
+			boost::optional<uint64_t> _currentBlock
+		);
 		static void setNumInstances(unsigned _instances) { s_numInstances = std::min<unsigned>(_instances, getNumDevices()); }
 
 	protected:

--- a/libethcore/EthashAux.cpp
+++ b/libethcore/EthashAux.cpp
@@ -54,6 +54,11 @@ uint64_t EthashAux::cacheSize(BlockInfo const& _header)
 	return ethash_get_cachesize((uint64_t)_header.number);
 }
 
+uint64_t EthashAux::dataSize(uint64_t _blockNumber)
+{
+	return ethash_get_datasize(_blockNumber);
+}
+
 h256 EthashAux::seedHash(unsigned _number)
 {
 	unsigned epoch = _number / ETHASH_EPOCH_LENGTH;

--- a/libethcore/EthashAux.h
+++ b/libethcore/EthashAux.h
@@ -66,6 +66,7 @@ public:
 	static h256 seedHash(unsigned _number);
 	static uint64_t number(h256 const& _seedHash);
 	static uint64_t cacheSize(BlockInfo const& _header);
+	static uint64_t dataSize(uint64_t _blockNumber);
 
 	static LightType light(h256 const& _seedHash);
 


### PR DESCRIPTION
Depends on https://github.com/ethereum/cpp-ethereum/pull/2154

- Added new option ```--cl-extragpu-mem``` with which you can let the OpenCL
  miner know how much GPU memory you believe your system would need for
  miscellaneous stuff like Windowing system rendering e.t.c. The default
  is 350 MB.

- Added new option ```--curent-block``` with which you can let the miner know
  the current block during the configuration phase and as such help him
  provide a much more accurate calculation of how much GPU memory is
  required for the current epoch.

- Added help(documentation) for some arguments that did not have one


I don't particularly like having to add a ```--curent-block``` option but since we can't use `libdevcore` to query the database from inside ethminer at least for now the current block has to be provided as an argument. 

It's not really important since it's simply used as a means of more accurate GPU memory requirement check but still ...