### PR TITLE
Resync after downloading unknown new block

### DIFF
--- a/libethereum/EthereumHost.h
+++ b/libethereum/EthereumHost.h
@@ -97,6 +97,7 @@ private:
 	void foreachPeerPtr(std::function<void(std::shared_ptr<EthereumPeer>)> const& _f) const;
 	void foreachPeer(std::function<void(EthereumPeer*)> const& _f) const;
 	bool isSyncing_UNSAFE() const;
+	void resetSyncTo(h256 const& _h);
 
 	/// Sync with the BlockChain. It might contain one of our mined blocks, we might have new candidates from the network.
 	void doWork();
@@ -151,6 +152,7 @@ private:
 	bool m_needSyncBlocks = true;				///< Indicates if we still need to download some blocks
 	h256 m_syncingLatestHash;					///< Latest block's hash, as of the current sync.
 	u256 m_syncingTotalDifficulty;				///< Latest block's total difficulty, as of the current sync.
+	bool m_syncingNewHashes = false;			///< True if currently downloading hashes received with NewHashes
 	h256s m_hashes;								///< List of hashes with unknown block numbers. Used for PV60 chain downloading and catching up to a particular unknown
 	unsigned m_estimatedHashes = 0;				///< Number of estimated hashes for the last peer over PV60. Used for status reporting only.
 	bool m_syncingV61 = false;					///< True if recent activity was over pv61+. Used for status reporting only.

--- a/libp2p/Host.cpp
+++ b/libp2p/Host.cpp
@@ -61,17 +61,22 @@ ReputationManager::ReputationManager()
 
 void ReputationManager::noteRude(Session const& _s, std::string const& _sub)
 {
-	m_nodes[make_pair(_s.id(), _s.info().clientVersion)].subs[_sub].isRude = true;
+	DEV_WRITE_GUARDED(x_nodes)
+		m_nodes[make_pair(_s.id(), _s.info().clientVersion)].subs[_sub].isRude = true;
 }
 
 bool ReputationManager::isRude(Session const& _s, std::string const& _sub) const
 {
-	auto nit = m_nodes.find(make_pair(_s.id(), _s.info().clientVersion));
-	if (nit == m_nodes.end())
-		return false;
-	auto sit = nit->second.subs.find(_sub);
-	bool ret = sit == nit->second.subs.end() ? false : sit->second.isRude;
-	return _sub.empty() ? ret : (ret || isRude(_s));
+	DEV_READ_GUARDED(x_nodes)
+	{
+		auto nit = m_nodes.find(make_pair(_s.id(), _s.info().clientVersion));
+		if (nit == m_nodes.end())
+			return false;
+		auto sit = nit->second.subs.find(_sub);
+		bool ret = sit == nit->second.subs.end() ? false : sit->second.isRude;
+		return _sub.empty() ? ret : (ret || isRude(_s));
+	}
+	return false;
 }
 
 Host::Host(std::string const& _clientVersion, NetworkPreferences const& _n, bytesConstRef _restoreNetwork):

--- a/libp2p/Host.h
+++ b/libp2p/Host.h
@@ -99,6 +99,7 @@ public:
 
 private:
 	std::unordered_map<std::pair<p2p::NodeId, std::string>, Reputation> m_nodes;	///< Nodes that were impolite while syncing. We avoid syncing from these if possible.
+	SharedMutex mutable x_nodes;
 };
 
 /**


### PR DESCRIPTION
* Resync after downloading unknown new block
* Sync new blocks/hashes with single peer only
* Disabled rude check for hashchain get
* Fixed a race condition in rep manager