### PR TITLE
OpenCL in MacosX does not like static variables

### DIFF
--- a/libethash-cl/ethash_cl_miner.cpp
+++ b/libethash-cl/ethash_cl_miner.cpp
@@ -429,7 +429,8 @@ void ethash_cl_miner::search(uint8_t const* header, uint64_t target, search_hook
 		};
 		queue<pending_batch> pending;
 
-		static uint32_t const c_zero = 0;
+		// this can't be a static because in MacOSX OpenCL implementation a segfault occurs when a static is passed to OpenCL functions
+		uint32_t const c_zero = 0;
 
 		// update header constant buffer
 		m_queue.enqueueWriteBuffer(m_header, false, 0, 32, header);


### PR DESCRIPTION
Should fix #2172