### PR TITLE
Add cmake command to turn CL Kernel code into a byte array

### DIFF
--- a/libethash-cl/CMakeLists.txt
+++ b/libethash-cl/CMakeLists.txt
@@ -1,22 +1,23 @@
 set(EXECUTABLE ethash-cl)
 
-include(bin2h.cmake)
-bin2h(SOURCE_FILE ethash_cl_miner_kernel.cl
-	VARIABLE_NAME ethash_cl_miner_kernel
-	HEADER_FILE ${CMAKE_CURRENT_BINARY_DIR}/ethash_cl_miner_kernel.h)
-
-#   Add a custom command so that the user can regenerate the header file containing the kernel
-#   code's bytearray by running "make clbin2h"
-	add_custom_target(clbin2h)
-	add_custom_command(TARGET clbin2h
-	PRE_BUILD
-	COMMAND ${CMAKE_COMMAND} -DBIN2H_SOURCE_FILE="${CMAKE_CURRENT_SOURCE_DIR}/ethash_cl_miner_kernel.cl"
+# A custom command and target to turn the OpenCL kernel into a byte array header
+# The normal build depends on it properly and if the kernel file is changed, then
+# a rebuild of libethash-cl should be triggered
+add_custom_command(
+	OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/ethash_cl_miner_kernel.h
+	COMMAND ${CMAKE_COMMAND} ARGS
+	-DBIN2H_SOURCE_FILE="${CMAKE_CURRENT_SOURCE_DIR}/ethash_cl_miner_kernel.cl"
 	-DBIN2H_VARIABLE_NAME=ethash_cl_miner_kernel
 	-DBIN2H_HEADER_FILE="${CMAKE_CURRENT_BINARY_DIR}/ethash_cl_miner_kernel.h"
-	-P "${CMAKE_CURRENT_SOURCE_DIR}/bin2h.cmake")
+	-P "${CMAKE_CURRENT_SOURCE_DIR}/bin2h.cmake"
+	COMMENT "Generating OpenCL Kernel Byte Array"
+	DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/ethash_cl_miner_kernel.cl
+)
+add_custom_target(clbin2h DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/ethash_cl_miner_kernel.h ${CMAKE_CURRENT_SOURCE_DIR}/ethash_cl_miner_kernel.cl)
 
 aux_source_directory(. SRC_LIST)
-file(GLOB HEADERS "*.h")
+file(GLOB OUR_HEADERS "*.h")
+set(HEADERS ${OUR_HEADERS} ${CMAKE_CURRENT_BINARY_DIR}/ethash_cl_miner_kernel.h)
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 include_directories(${OpenCL_INCLUDE_DIRS})

--- a/libethash-cl/CMakeLists.txt
+++ b/libethash-cl/CMakeLists.txt
@@ -5,6 +5,16 @@ bin2h(SOURCE_FILE ethash_cl_miner_kernel.cl
 	VARIABLE_NAME ethash_cl_miner_kernel
 	HEADER_FILE ${CMAKE_CURRENT_BINARY_DIR}/ethash_cl_miner_kernel.h)
 
+#   Add a custom command so that the user can regenerate the header file containing the kernel
+#   code's bytearray by running "make clbin2h"
+	add_custom_target(clbin2h)
+	add_custom_command(TARGET clbin2h
+	PRE_BUILD
+	COMMAND ${CMAKE_COMMAND} -DBIN2H_SOURCE_FILE="${CMAKE_CURRENT_SOURCE_DIR}/ethash_cl_miner_kernel.cl"
+	-DBIN2H_VARIABLE_NAME=ethash_cl_miner_kernel
+	-DBIN2H_HEADER_FILE="${CMAKE_CURRENT_BINARY_DIR}/ethash_cl_miner_kernel.h"
+	-P "${CMAKE_CURRENT_SOURCE_DIR}/bin2h.cmake")
+
 aux_source_directory(. SRC_LIST)
 file(GLOB HEADERS "*.h")
 

--- a/libethash-cl/bin2h.cmake
+++ b/libethash-cl/bin2h.cmake
@@ -6,31 +6,31 @@ include(CMakeParseArguments)
 #   VARIABLE    - The name of the CMake variable holding the string.
 #   AT_COLUMN   - The column position at which string will be wrapped.
 function(WRAP_STRING)
-    set(oneValueArgs VARIABLE AT_COLUMN)
-    cmake_parse_arguments(WRAP_STRING "${options}" "${oneValueArgs}" "" ${ARGN})
+	set(oneValueArgs VARIABLE AT_COLUMN)
+	cmake_parse_arguments(WRAP_STRING "${options}" "${oneValueArgs}" "" ${ARGN})
 
-    string(LENGTH ${${WRAP_STRING_VARIABLE}} stringLength)
-    math(EXPR offset "0")
+	string(LENGTH ${${WRAP_STRING_VARIABLE}} stringLength)
+	math(EXPR offset "0")
 
-    while(stringLength GREATER 0)
+	while(stringLength GREATER 0)
 
-        if(stringLength GREATER ${WRAP_STRING_AT_COLUMN})
-            math(EXPR length "${WRAP_STRING_AT_COLUMN}")
-        else()
-            math(EXPR length "${stringLength}")
-        endif()
+		if(stringLength GREATER ${WRAP_STRING_AT_COLUMN})
+			math(EXPR length "${WRAP_STRING_AT_COLUMN}")
+		else()
+			math(EXPR length "${stringLength}")
+		endif()
 
-        string(SUBSTRING ${${WRAP_STRING_VARIABLE}} ${offset} ${length} line)
-        set(lines "${lines}\n${line}")
+		string(SUBSTRING ${${WRAP_STRING_VARIABLE}} ${offset} ${length} line)
+		set(lines "${lines}\n${line}")
 
-        math(EXPR stringLength "${stringLength} - ${length}")
-        math(EXPR offset "${offset} + ${length}")
-    endwhile()
+		math(EXPR stringLength "${stringLength} - ${length}")
+		math(EXPR offset "${offset} + ${length}")
+	endwhile()
 
-    set(${WRAP_STRING_VARIABLE} "${lines}" PARENT_SCOPE)
+	set(${WRAP_STRING_VARIABLE} "${lines}" PARENT_SCOPE)
 endfunction()
 
-# Function to embed contents of a file as byte array in C/C++ header file(.h). The header file
+# Script to embed contents of a file as byte array in C/C++ header file(.h). The header file
 # will contain a byte array and integer variable holding the size of the array.
 # Parameters
 #   SOURCE_FILE     - The path of source file whose contents will be embedded in the header file.
@@ -42,45 +42,41 @@ endfunction()
 #                     useful if the source file is a text file and we want to use the file contents
 #                     as string. But the size variable holds size of the byte array without this
 #                     null byte.
-# Usage:
-#   bin2h(SOURCE_FILE "Logo.png" HEADER_FILE "Logo.h" VARIABLE_NAME "LOGO_PNG")
-function(BIN2H)
-    set(options APPEND NULL_TERMINATE)
-    set(oneValueArgs SOURCE_FILE VARIABLE_NAME HEADER_FILE)
-    cmake_parse_arguments(BIN2H "${options}" "${oneValueArgs}" "" ${ARGN})
+set(options APPEND NULL_TERMINATE)
+set(oneValueArgs SOURCE_FILE VARIABLE_NAME HEADER_FILE)
+# cmake_parse_arguments(BIN2H "${options}" "${oneValueArgs}" "" ${ARGN})
 
-    # reads source file contents as hex string
-    file(READ ${BIN2H_SOURCE_FILE} hexString HEX)
-    string(LENGTH ${hexString} hexStringLength)
+# reads source file contents as hex string
+file(READ ${BIN2H_SOURCE_FILE} hexString HEX)
+string(LENGTH ${hexString} hexStringLength)
 
-    # appends null byte if asked
-    if(BIN2H_NULL_TERMINATE)
-        set(hexString "${hexString}00")
-    endif()
+# appends null byte if asked
+if(BIN2H_NULL_TERMINATE)
+	set(hexString "${hexString}00")
+endif()
 
-    # wraps the hex string into multiple lines at column 32(i.e. 16 bytes per line)
-    wrap_string(VARIABLE hexString AT_COLUMN 32)
-    math(EXPR arraySize "${hexStringLength} / 2")
+# wraps the hex string into multiple lines at column 32(i.e. 16 bytes per line)
+wrap_string(VARIABLE hexString AT_COLUMN 32)
+math(EXPR arraySize "${hexStringLength} / 2")
 
-    # adds '0x' prefix and comma suffix before and after every byte respectively
-    string(REGEX REPLACE "([0-9a-f][0-9a-f])" "0x\\1, " arrayValues ${hexString})
-    # removes trailing comma
-    string(REGEX REPLACE ", $" "" arrayValues ${arrayValues})
+# adds '0x' prefix and comma suffix before and after every byte respectively
+string(REGEX REPLACE "([0-9a-f][0-9a-f])" "0x\\1, " arrayValues ${hexString})
+# removes trailing comma
+string(REGEX REPLACE ", $" "" arrayValues ${arrayValues})
 
-    # converts the variable name into proper C identifier
-    IF (${CMAKE_VERSION} GREATER 2.8.10) # fix for legacy cmake
-        string(MAKE_C_IDENTIFIER "${BIN2H_VARIABLE_NAME}" BIN2H_VARIABLE_NAME)
-    ENDIF()
-    string(TOUPPER "${BIN2H_VARIABLE_NAME}" BIN2H_VARIABLE_NAME)
+# converts the variable name into proper C identifier
+IF (${CMAKE_VERSION} GREATER 2.8.10) # fix for legacy cmake
+	string(MAKE_C_IDENTIFIER "${BIN2H_VARIABLE_NAME}" BIN2H_VARIABLE_NAME)
+ENDIF()
+string(TOUPPER "${BIN2H_VARIABLE_NAME}" BIN2H_VARIABLE_NAME)
 
-    # declares byte array and the length variables
-    set(arrayDefinition "const unsigned char ${BIN2H_VARIABLE_NAME}[] = { ${arrayValues} };")
-    set(arraySizeDefinition "const size_t ${BIN2H_VARIABLE_NAME}_SIZE = ${arraySize};")
+# declares byte array and the length variables
+set(arrayDefinition "const unsigned char ${BIN2H_VARIABLE_NAME}[] = { ${arrayValues} };")
+set(arraySizeDefinition "const size_t ${BIN2H_VARIABLE_NAME}_SIZE = ${arraySize};")
 
-    set(declarations "${arrayDefinition}\n\n${arraySizeDefinition}\n\n")
-    if(BIN2H_APPEND)
-        file(APPEND ${BIN2H_HEADER_FILE} "${declarations}")
-    else()
-        file(WRITE ${BIN2H_HEADER_FILE} "${declarations}")
-    endif()
-endfunction()
+set(declarations "${arrayDefinition}\n\n${arraySizeDefinition}\n\n")
+if(BIN2H_APPEND)
+	file(APPEND ${BIN2H_HEADER_FILE} "${declarations}")
+else()
+	file(WRITE ${BIN2H_HEADER_FILE} "${declarations}")
+endif()


### PR DESCRIPTION
The OpenCL kernel gets parsed and copied into a byte array accessible
by a specific header during the cmake configuration step.

We are now adding a special command "make clbin2h" which would generate
this header byte array on demand