### PR TITLE
check nonce

### DIFF
--- a/libethereum/BlockChain.cpp
+++ b/libethereum/BlockChain.cpp
@@ -1072,7 +1072,7 @@ VerifiedBlockRef BlockChain::verifyBlock(bytes const& _block, function<void(Exce
 	try
 	{
 		Strictness strictness = Strictness::CheckEverything;
-		if (_ir & ~ImportRequirements::ValidNonce)
+		if (~_ir & ImportRequirements::ValidNonce)
 			strictness = Strictness::IgnoreNonce;
 
 		res.info.populate(_block, strictness);


### PR DESCRIPTION
The cpp equivalent of https://github.com/ethereum/go-ethereum/pull/1198
We actually did not check the nonce when `ImportRequirements::ValidNonce` was set. 