### PR TITLE
OpenCL: Always try single chunk DAG upload

### DIFF
--- a/ethminer/MinerAux.h
+++ b/ethminer/MinerAux.h
@@ -134,8 +134,6 @@ public:
 			m_clAllowCPU = true;
 		else if (arg == "--cl-extragpu-mem" && i + 1 < argc)
 			m_extraGPUMemory = 1000000 * stol(argv[++i]);
-		else if (arg == "--force-single-chunk")
-			m_forceSingleChunk = true;
 		else if (arg == "--phone-home" && i + 1 < argc)
 		{
 			string m = argv[++i];
@@ -273,7 +271,6 @@ public:
 					m_openclDevice,
 					m_clAllowCPU,
 					m_extraGPUMemory,
-					m_forceSingleChunk,
 					m_currentBlock
 				))
 			{
@@ -318,10 +315,9 @@ public:
 			<< "    --opencl-device <n>  When mining using -G/--opencl use OpenCL device n (default: 0)." << endl
 			<< "    -t, --mining-threads <n> Limit number of CPU/GPU miners to n (default: use everything available on selected platform)" << endl
 			<< "    --allow-opencl-cpu Allows CPU to be considered as an OpenCL device if the OpenCL platform supports it." << endl
-			<< "    --list-devices List the detected OpenCL devices and exit." <<endl
-			<< "    --current-block Let the miner know the current block number at configuration time. Will help determine DAG size and required GPU memory." <<endl
-			<< "    --cl-extragpu-mem Set the memory (in MB) you believe your GPU requires for stuff other than mining. Windows rendering e.t.c.." <<endl
-			<< "    --force-single-chunk Force DAG uploading in a single chunk against OpenCL's judgement. Use at your own risk." <<endl
+			<< "    --list-devices List the detected OpenCL devices and exit." << endl
+			<< "    --current-block Let the miner know the current block number at configuration time. Will help determine DAG size and required GPU memory." << endl
+			<< "    --cl-extragpu-mem Set the memory (in MB) you believe your GPU requires for stuff other than mining. Windows rendering e.t.c.." << endl
 			;
 	}
 
@@ -510,7 +506,6 @@ private:
 	unsigned m_miningThreads = UINT_MAX;
 	bool m_shouldListDevices = false;
 	bool m_clAllowCPU = false;
-	bool m_forceSingleChunk = false;
 	boost::optional<uint64_t> m_currentBlock;
 	// default value is 350MB of GPU memory for other stuff (windows system rendering, e.t.c.)
 	unsigned m_extraGPUMemory = 350000000;

--- a/libethash-cl/ethash_cl_miner.cpp
+++ b/libethash-cl/ethash_cl_miner.cpp
@@ -321,7 +321,7 @@ bool ethash_cl_miner::init(
 			ETHCL_LOG("Printing program log");
 			ETHCL_LOG(program.getBuildInfo<CL_PROGRAM_BUILD_LOG>(device).c_str());
 		}
-		catch (cl::Error err)
+		catch (cl::Error const& err)
 		{
 			ETHCL_LOG(program.getBuildInfo<CL_PROGRAM_BUILD_LOG>(device).c_str());
 			return false;
@@ -334,7 +334,7 @@ bool ethash_cl_miner::init(
 			m_dagChunks.push_back(cl::Buffer(m_context, CL_MEM_READ_ONLY, _dagSize));
 			ETHCL_LOG("Created one big buffer for the DAG");
 		}
-		catch (cl::Error err)
+		catch (cl::Error const& err)
 		{
 			int errCode = err.err();
 			if (errCode != CL_INVALID_BUFFER_SIZE || errCode != CL_MEM_OBJECT_ALLOCATION_FAILURE)
@@ -345,6 +345,7 @@ bool ethash_cl_miner::init(
 				"Failed to allocate 1 big chunk. Max allocateable memory is "
 				<< result << ". Trying to allocate 4 chunks."
 			);
+			// The OpenCL kernel has a hard coded number of 4 chunks at the moment
 			m_dagChunksNum = 4;
 			for (unsigned i = 0; i < m_dagChunksNum; i++)
 			{
@@ -404,7 +405,7 @@ bool ethash_cl_miner::init(
 			m_search_buf[i] = cl::Buffer(m_context, CL_MEM_WRITE_ONLY, (c_max_search_results + 1) * sizeof(uint32_t));
 		}
 	}
-	catch (cl::Error err)
+	catch (cl::Error const& err)
 	{
 		ETHCL_LOG(err.what() << "(" << err.err() << ")");
 		return false;
@@ -498,7 +499,7 @@ void ethash_cl_miner::search(uint8_t const* header, uint64_t target, search_hook
 			pre_return_event.wait();
 #endif
 	}
-	catch (cl::Error err)
+	catch (cl::Error const& err)
 	{
 		ETHCL_LOG(err.what() << "(" << err.err() << ")");
 	}

--- a/libethash-cl/ethash_cl_miner.cpp
+++ b/libethash-cl/ethash_cl_miner.cpp
@@ -334,8 +334,11 @@ bool ethash_cl_miner::init(
 			m_dagChunks.push_back(cl::Buffer(m_context, CL_MEM_READ_ONLY, _dagSize));
 			ETHCL_LOG("Created one big buffer for the DAG");
 		}
-		catch (...)
+		catch (cl::Error err)
 		{
+			int errCode = err.err();
+			if (errCode != CL_INVALID_BUFFER_SIZE || errCode != CL_MEM_OBJECT_ALLOCATION_FAILURE)
+				ETHCL_LOG("Allocating single buffer failed with: " << err.what() << "(" << errCode << ")");
 			cl_ulong result;
 			device.getInfo(CL_DEVICE_MAX_MEM_ALLOC_SIZE, &result);
 			ETHCL_LOG(

--- a/libethash-cl/ethash_cl_miner.h
+++ b/libethash-cl/ethash_cl_miner.h
@@ -44,7 +44,6 @@ public:
 	static bool configureGPU(
 		bool _allowCPU,
 		unsigned _extraGPUMemory,
-		bool _forceSingleChunk,
 		boost::optional<uint64_t> _currentBlock
 	);
 
@@ -79,8 +78,6 @@ private:
 	unsigned m_workgroup_size;
 	bool m_opencl_1_1;
 
-	/// Force dag upload to GPU in a single chunk even if OpenCL thinks you can't do it. Use at your own risk.
-	static bool s_forceSingleChunk;
 	/// Allow CPU to appear as an OpenCL device or not. Default is false
 	static bool s_allowCPU;
 	/// GPU memory required for other things, like window rendering e.t.c.

--- a/libethcore/Ethash.cpp
+++ b/libethcore/Ethash.cpp
@@ -389,13 +389,12 @@ bool Ethash::GPUMiner::configureGPU(
 	unsigned _deviceId,
 	bool _allowCPU,
 	unsigned _extraGPUMemory,
-	bool _forceSingleChunk,
 	boost::optional<uint64_t> _currentBlock
 )
 {
 	s_platformId = _platformId;
 	s_deviceId = _deviceId;
-	return ethash_cl_miner::configureGPU(_allowCPU, _extraGPUMemory, _forceSingleChunk, _currentBlock);
+	return ethash_cl_miner::configureGPU(_allowCPU, _extraGPUMemory, _currentBlock);
 }
 
 #endif

--- a/libethcore/Ethash.h
+++ b/libethcore/Ethash.h
@@ -88,7 +88,7 @@ public:
 		static unsigned instances() { return s_numInstances > 0 ? s_numInstances : std::thread::hardware_concurrency(); }
 		static std::string platformInfo();
 		static void listDevices() {}
-		static bool configureGPU(unsigned, unsigned, bool, unsigned, bool, boost::optional<uint64_t>) { return false; }
+		static bool configureGPU(unsigned, unsigned, bool, unsigned,  boost::optional<uint64_t>) { return false; }
 		static void setNumInstances(unsigned _instances) { s_numInstances = std::min<unsigned>(_instances, std::thread::hardware_concurrency()); }
 	protected:
 		void kickOff() override
@@ -122,7 +122,6 @@ public:
 			unsigned _deviceId,
 			bool _allowCPU,
 			unsigned _extraGPUMemory,
-			bool _forceSingleChunk,
 			boost::optional<uint64_t> _currentBlock
 		);
 		static void setNumInstances(unsigned _instances) { s_numInstances = std::min<unsigned>(_instances, getNumDevices()); }


### PR DESCRIPTION
- Removed the `--force-single-chunk` option

- Always attempt to create a single chunk DAG buffer in the GPU. If that
  fails then and only then switch to multiple chunks.

This change is motivated by the fact that many GPUs appear to be able to
actually allocate a lot more than what CL_DEVICE_MAX_MEM_ALLOC_SIZE
returns which proves that the results of querying the CL API on this
basically can't be trusted.