### PR TITLE
make network test optional

### DIFF
--- a/test/TestHelper.cpp
+++ b/test/TestHelper.cpp
@@ -754,6 +754,8 @@ Options::Options()
 			checkState = true;
 		else if (arg == "--wallet")
 			wallet = true;
+		else if (arg == "--network")
+			network = true;
 		else if (arg == "--all")
 		{
 			performance = true;
@@ -761,7 +763,8 @@ Options::Options()
 			memory = true;
 			inputLimits = true;
 			bigData = true;
-			wallet= true;
+			wallet = true;
+			network = true;
 		}
 		else if (arg == "--singletest" && i + 1 < argc)
 		{

--- a/test/TestHelper.cpp
+++ b/test/TestHelper.cpp
@@ -754,8 +754,10 @@ Options::Options()
 			checkState = true;
 		else if (arg == "--wallet")
 			wallet = true;
-		else if (arg == "--network")
-			network = true;
+		else if (arg == "--nonetwork")
+			nonetwork = true;
+		else if (arg == "--nodag")
+			nodag = true;
 		else if (arg == "--all")
 		{
 			performance = true;
@@ -764,7 +766,6 @@ Options::Options()
 			inputLimits = true;
 			bigData = true;
 			wallet = true;
-			network = true;
 		}
 		else if (arg == "--singletest" && i + 1 < argc)
 		{

--- a/test/TestHelper.h
+++ b/test/TestHelper.h
@@ -223,6 +223,7 @@ public:
 	bool inputLimits = false;
 	bool bigData = false;
 	bool wallet = false;
+	bool network = false;
 	/// @}
 
 	/// Get reference to options

--- a/test/TestHelper.h
+++ b/test/TestHelper.h
@@ -223,7 +223,8 @@ public:
 	bool inputLimits = false;
 	bool bigData = false;
 	bool wallet = false;
-	bool network = false;
+	bool nonetwork = false;
+	bool nodag = false;
 	/// @}
 
 	/// Get reference to options

--- a/test/libethereum/stateOriginal.cpp
+++ b/test/libethereum/stateOriginal.cpp
@@ -27,7 +27,8 @@
 #include <libethereum/State.h>
 #include <libethcore/Farm.h>
 #include <libethereum/Defaults.h>
-#include "../TestHelper.h"
+#include <test/TestHelper.h>
+
 using namespace std;
 using namespace dev;
 using namespace dev::eth;
@@ -48,6 +49,9 @@ BOOST_AUTO_TEST_CASE(Basic)
 
 BOOST_AUTO_TEST_CASE(Complex)
 {
+	if (test::Options::get().nodag)
+		return;
+
 	cnote << "Testing State...";
 
 	KeyPair me = sha3("Gav Wood");

--- a/test/libp2p/capability.cpp
+++ b/test/libp2p/capability.cpp
@@ -27,6 +27,7 @@ along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 #include <libp2p/Session.h>
 #include <libp2p/Capability.h>
 #include <libp2p/HostCapability.h>
+#include <test/TestHelper.h>
 
 using namespace std;
 using namespace dev;
@@ -98,6 +99,9 @@ BOOST_FIXTURE_TEST_SUITE(p2pCapability, P2PFixture)
 
 BOOST_AUTO_TEST_CASE(capability)
 {
+	if (test::Options::get().nonetwork)
+		return;
+
 	VerbosityHolder verbosityHolder(10);
 	cnote << "Testing Capability...";
 

--- a/test/libp2p/net.cpp
+++ b/test/libp2p/net.cpp
@@ -26,6 +26,8 @@
 #include <libdevcrypto/Common.h>
 #include <libp2p/UDP.h>
 #include <libp2p/NodeTable.h>
+#include <test/TestHelper.h>
+
 using namespace std;
 using namespace dev;
 using namespace dev::p2p;
@@ -153,6 +155,9 @@ public:
 
 BOOST_AUTO_TEST_CASE(requestTimeout)
 {
+	if (test::Options::get().nonetwork)
+		return;
+
 	using TimePoint = std::chrono::steady_clock::time_point;
 	using RequestTimeout = std::pair<NodeId, TimePoint>;
 	
@@ -220,6 +225,9 @@ BOOST_AUTO_TEST_CASE(isIPAddressType)
 
 BOOST_AUTO_TEST_CASE(v2PingNodePacket)
 {
+	if (test::Options::get().nonetwork)
+		return;
+
 	// test old versino of pingNode packet w/new
 	RLPStream s;
 	s.appendList(3); s << "1.1.1.1" << 30303 << std::chrono::duration_cast<std::chrono::seconds>((std::chrono::system_clock::now() + chrono::seconds(60)).time_since_epoch()).count();
@@ -231,6 +239,9 @@ BOOST_AUTO_TEST_CASE(v2PingNodePacket)
 
 BOOST_AUTO_TEST_CASE(neighboursPacketLength)
 {
+	if (test::Options::get().nonetwork)
+		return;
+
 	KeyPair k = KeyPair::create();
 	std::vector<std::pair<KeyPair,unsigned>> testNodes(TestNodeTable::createTestNodes(16));
 	bi::udp::endpoint to(boost::asio::ip::address::from_string("127.0.0.1"), 30000);
@@ -256,6 +267,9 @@ BOOST_AUTO_TEST_CASE(neighboursPacketLength)
 
 BOOST_AUTO_TEST_CASE(neighboursPacket)
 {
+	if (test::Options::get().nonetwork)
+		return;
+
 	KeyPair k = KeyPair::create();
 	std::vector<std::pair<KeyPair,unsigned>> testNodes(TestNodeTable::createTestNodes(16));
 	bi::udp::endpoint to(boost::asio::ip::address::from_string("127.0.0.1"), 30000);
@@ -291,6 +305,9 @@ BOOST_AUTO_TEST_CASE(test_findnode_neighbours)
 
 BOOST_AUTO_TEST_CASE(kademlia)
 {
+	if (test::Options::get().nonetwork)
+		return;
+
 	// Not yet a 'real' test.
 	TestNodeTableHost node(8);
 	node.start();
@@ -324,6 +341,9 @@ BOOST_AUTO_TEST_CASE(kademlia)
 
 BOOST_AUTO_TEST_CASE(udpOnce)
 {
+	if (test::Options::get().nonetwork)
+		return;
+
 	UDPDatagram d(bi::udp::endpoint(boost::asio::ip::address::from_string("127.0.0.1"), 30300), bytes({65,65,65,65}));
 	TestUDPSocket a; a.m_socket->connect(); a.start();
 	a.m_socket->send(d);
@@ -337,6 +357,9 @@ BOOST_AUTO_TEST_SUITE(netTypes)
 
 BOOST_AUTO_TEST_CASE(unspecifiedNode)
 {
+	if (test::Options::get().nonetwork)
+		return;
+
 	Node n = UnspecifiedNode;
 	BOOST_REQUIRE(!n);
 	
@@ -350,6 +373,9 @@ BOOST_AUTO_TEST_CASE(unspecifiedNode)
 
 BOOST_AUTO_TEST_CASE(nodeTableReturnsUnspecifiedNode)
 {
+	if (test::Options::get().nonetwork)
+		return;
+
 	ba::io_service io;
 	NodeTable t(io, KeyPair::create(), NodeIPEndpoint(bi::address::from_string("127.0.0.1"), 30303, 30303));
 	if (Node n = t.node(NodeId()))

--- a/test/libp2p/peer.cpp
+++ b/test/libp2p/peer.cpp
@@ -24,6 +24,8 @@
 #include <chrono>
 #include <thread>
 #include <libp2p/Host.h>
+#include <test/TestHelper.h>
+
 using namespace std;
 using namespace dev;
 using namespace dev::p2p;
@@ -38,6 +40,9 @@ BOOST_FIXTURE_TEST_SUITE(p2p, P2PFixture)
 
 BOOST_AUTO_TEST_CASE(host)
 {
+	if (!test::Options::get().network)
+		return;
+
 	VerbosityHolder sentinel(10);
 	
 	NetworkPreferences host1prefs("127.0.0.1", 30301, false);
@@ -64,6 +69,9 @@ BOOST_AUTO_TEST_CASE(host)
 
 BOOST_AUTO_TEST_CASE(networkConfig)
 {
+	if (!test::Options::get().network)
+		return;
+
 	Host save("Test", NetworkPreferences(false));
 	bytes store(save.saveNetwork());
 	
@@ -73,6 +81,9 @@ BOOST_AUTO_TEST_CASE(networkConfig)
 
 BOOST_AUTO_TEST_CASE(saveNodes)
 {
+	if (!test::Options::get().network)
+		return;
+
 	VerbosityHolder reduceVerbosity(2);
 
 	std::list<Host*> hosts;

--- a/test/libp2p/peer.cpp
+++ b/test/libp2p/peer.cpp
@@ -40,7 +40,7 @@ BOOST_FIXTURE_TEST_SUITE(p2p, P2PFixture)
 
 BOOST_AUTO_TEST_CASE(host)
 {
-	if (!test::Options::get().network)
+	if (test::Options::get().nonetwork)
 		return;
 
 	VerbosityHolder sentinel(10);
@@ -69,7 +69,7 @@ BOOST_AUTO_TEST_CASE(host)
 
 BOOST_AUTO_TEST_CASE(networkConfig)
 {
-	if (!test::Options::get().network)
+	if (test::Options::get().nonetwork)
 		return;
 
 	Host save("Test", NetworkPreferences(false));
@@ -81,7 +81,7 @@ BOOST_AUTO_TEST_CASE(networkConfig)
 
 BOOST_AUTO_TEST_CASE(saveNodes)
 {
-	if (!test::Options::get().network)
+	if (test::Options::get().nonetwork)
 		return;
 
 	VerbosityHolder reduceVerbosity(2);
@@ -145,6 +145,9 @@ BOOST_FIXTURE_TEST_SUITE(p2pPeer, P2PFixture)
 
 BOOST_AUTO_TEST_CASE(requirePeer)
 {
+	if (test::Options::get().nonetwork)
+		return;
+
 	VerbosityHolder reduceVerbosity(10);
 
 	const char* const localhost = "127.0.0.1";
@@ -197,6 +200,9 @@ BOOST_AUTO_TEST_SUITE(peerTypes)
 
 BOOST_AUTO_TEST_CASE(emptySharedPeer)
 {
+	if (test::Options::get().nonetwork)
+		return;
+
 	shared_ptr<Peer> p;
 	BOOST_REQUIRE(!p);
 	

--- a/test/libwhisper/whisperTopic.cpp
+++ b/test/libwhisper/whisperTopic.cpp
@@ -25,6 +25,8 @@
 #include <libp2p/Host.h>
 #include <libwhisper/WhisperPeer.h>
 #include <libwhisper/WhisperHost.h>
+#include <test/TestHelper.h>
+
 using namespace std;
 using namespace dev;
 using namespace dev::p2p;
@@ -40,6 +42,9 @@ BOOST_FIXTURE_TEST_SUITE(whisper, P2PFixture)
 
 BOOST_AUTO_TEST_CASE(topic)
 {
+	if (test::Options::get().nonetwork)
+		return;
+
 	cnote << "Testing Whisper...";
 	VerbosityHolder setTemporaryLevel(0);
 
@@ -103,6 +108,9 @@ BOOST_AUTO_TEST_CASE(topic)
 
 BOOST_AUTO_TEST_CASE(forwarding)
 {
+	if (test::Options::get().nonetwork)
+		return;
+
 	cnote << "Testing Whisper forwarding...";
 	VerbosityHolder setTemporaryLevel(0);
 
@@ -203,6 +211,9 @@ BOOST_AUTO_TEST_CASE(forwarding)
 
 BOOST_AUTO_TEST_CASE(asyncforwarding)
 {
+	if (test::Options::get().nonetwork)
+		return;
+
 	cnote << "Testing Whisper async forwarding...";
 	VerbosityHolder setTemporaryLevel(2);
 


### PR DESCRIPTION
in order to run testeth on the build server network tests (as well ad DAG creating tests, due to time constraint) need be disabled.