### PR TITLE
Add support for clang sanitizer

### DIFF
--- a/cmake/EthCompilerSettings.cmake
+++ b/cmake/EthCompilerSettings.cmake
@@ -19,6 +19,7 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
 
 	set(CMAKE_CXX_FLAGS "-std=c++11 -Wall -Wno-unknown-pragmas -Wextra -DSHAREDLIB -fPIC")
 	set(CMAKE_CXX_FLAGS_DEBUG          "-O0 -g -DETH_DEBUG")
+	set(CMAKE_CXX_FLAGS_DEBUGSAN       "-O1 -g -fsanitize=address,integer,undefined -fsanitize-blacklist=${CMAKE_SOURCE_DIR}/sanitizer-blacklist.txt -fno-omit-frame-pointer -DETH_DEBUG")
 	set(CMAKE_CXX_FLAGS_MINSIZEREL     "-Os -DNDEBUG -DETH_RELEASE")
 	set(CMAKE_CXX_FLAGS_RELEASE        "-O3 -DNDEBUG -DETH_RELEASE")
 	set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g -DETH_RELEASE")

--- a/evmjit/CMakeLists.txt
+++ b/evmjit/CMakeLists.txt
@@ -10,7 +10,7 @@ else()
 	set(CMAKE_CXX_FLAGS "-std=c++11 -Wall -Wextra -Wconversion -Wno-sign-conversion -Wno-unknown-pragmas ${CMAKE_CXX_FLAGS}")
 endif()
 
-if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux" AND NOT ${CMAKE_BUILD_TYPE} STREQUAL "DebugSan")
 	# Do not allow unresovled symbols in shared library (default on linux)
 	set(CMAKE_SHARED_LINKER_FLAGS "-Wl,--no-undefined")
 endif()

--- a/sanitizer-blacklist.txt
+++ b/sanitizer-blacklist.txt
@@ -1,0 +1,8 @@
+# Ignore standard library headers.
+src:*/include/c\+\+/*
+
+# Ignore boost libraries headers.
+src:*/include/boost/*
+
+# Ignore Crypto++ library. We plan to remove it in the future. It exploits interger overflow and uses memcpy incorrectly.
+src:*/include/cryptopp/*


### PR DESCRIPTION
To build with the sanitizer support use clang compiler and set CMAKE_BUILD_TYPE to "DebugSan".
More info: http://clang.llvm.org/docs/AddressSanitizer.html.