### PR TITLE
Strings in constructor and memory-storage copy.

### DIFF
--- a/libsolidity/CompilerUtils.cpp
+++ b/libsolidity/CompilerUtils.cpp
@@ -135,7 +135,7 @@ void CompilerUtils::storeInMemoryDynamic(Type const& _type, bool _padToWordBound
 			m_context << u256(0) << u256(identityContractAddress);
 			//@TODO do not use ::CALL if less than 32 bytes?
 			//@todo in production, we should not have to pair c_callNewAccountGas.
-			m_context << u256(eth::c_callGas + 10 + eth::c_callNewAccountGas) << eth::Instruction::GAS;
+			m_context << u256(eth::c_callGas + 15 + eth::c_callNewAccountGas) << eth::Instruction::GAS;
 			m_context << eth::Instruction::SUB << eth::Instruction::CALL;
 			m_context << eth::Instruction::POP; // ignore return value
 

--- a/libsolidity/ExpressionCompiler.cpp
+++ b/libsolidity/ExpressionCompiler.cpp
@@ -724,8 +724,8 @@ void ExpressionCompiler::endVisit(MemberAccess const& _memberAccess)
 			case DataLocation::Storage:
 				setLValue<StorageArrayLength>(_memberAccess, type);
 				break;
-			default:
-				solAssert(false, "Unsupported array location.");
+			case DataLocation::Memory:
+				m_context << eth::Instruction::MLOAD;
 				break;
 			}
 		break;

--- a/libsolidity/ExpressionCompiler.cpp
+++ b/libsolidity/ExpressionCompiler.cpp
@@ -457,6 +457,7 @@ bool ExpressionCompiler::visit(FunctionCall const& _functionCall)
 					strings(),
 					Location::Bare,
 					false,
+					nullptr,
 					true,
 					true
 				),
@@ -1004,9 +1005,14 @@ void ExpressionCompiler::appendExternalFunctionCall(
 		_functionType.getReturnParameterTypes().empty() ?
 		nullptr :
 		_functionType.getReturnParameterTypes().front().get();
-	unsigned retSize = firstReturnType ? firstReturnType->getCalldataEncodedSize() : 0;
+	unsigned retSize = 0;
 	if (returnSuccessCondition)
 		retSize = 0; // return value actually is success condition
+	else if (firstReturnType)
+	{
+		retSize = firstReturnType->getCalldataEncodedSize();
+		solAssert(retSize > 0, "Unable to return dynamic type from external call.");
+	}
 
 	// Evaluate arguments.
 	TypePointers argumentTypes;
@@ -1123,6 +1129,7 @@ void ExpressionCompiler::appendExternalFunctionCall(
 		//@todo manually update free memory pointer if we accept returning memory-stored objects
 		utils().fetchFreeMemoryPointer();
 		utils().loadFromMemoryDynamic(*firstReturnType, false, true, false);
+
 	}
 }
 

--- a/libsolidity/Types.h
+++ b/libsolidity/Types.h
@@ -669,17 +669,19 @@ public:
 		strings _returnParameterNames = strings(),
 		Location _location = Location::Internal,
 		bool _arbitraryParameters = false,
+		Declaration const* _declaration = nullptr,
 		bool _gasSet = false,
 		bool _valueSet = false
 	):
-		m_parameterTypes (_parameterTypes),
-		m_returnParameterTypes (_returnParameterTypes),
-		m_parameterNames (_parameterNames),
-		m_returnParameterNames (_returnParameterNames),
-		m_location (_location),
-		m_arbitraryParameters (_arbitraryParameters),
-		m_gasSet (_gasSet),
-		m_valueSet (_valueSet)
+		m_parameterTypes(_parameterTypes),
+		m_returnParameterTypes(_returnParameterTypes),
+		m_parameterNames(_parameterNames),
+		m_returnParameterNames(_returnParameterNames),
+		m_location(_location),
+		m_arbitraryParameters(_arbitraryParameters),
+		m_gasSet(_gasSet),
+		m_valueSet(_valueSet),
+		m_declaration(_declaration)
 	{}
 
 	TypePointers const& getParameterTypes() const { return m_parameterTypes; }
@@ -732,6 +734,11 @@ public:
 	/// @returns a copy of this type, where gas or value are set manually. This will never set one
 	/// of the parameters to fals.
 	TypePointer copyAndSetGasOrValue(bool _setGas, bool _setValue) const;
+
+	/// @returns a copy of this function type where all return parameters of dynamic size are removed.
+	/// This is needed if external functions are called internally, as they cannot return dynamic
+	/// values.
+	FunctionTypePointer removeDynamicReturnTypes() const;
 
 private:
 	static TypePointers parseElementaryTypeVector(strings const& _types);

--- a/libsolidity/Types.h
+++ b/libsolidity/Types.h
@@ -735,10 +735,11 @@ public:
 	/// of the parameters to fals.
 	TypePointer copyAndSetGasOrValue(bool _setGas, bool _setValue) const;
 
-	/// @returns a copy of this function type where all return parameters of dynamic size are removed.
-	/// This is needed if external functions are called internally, as they cannot return dynamic
-	/// values.
-	FunctionTypePointer removeDynamicReturnTypes() const;
+	/// @returns a copy of this function type where all return parameters of dynamic size are
+	/// removed and the location of reference types is changed from CallData to Memory.
+	/// This is needed if external functions are called on other contracts, as they cannot return
+	/// dynamic values.
+	FunctionTypePointer asMemberFunction() const;
 
 private:
 	static TypePointers parseElementaryTypeVector(strings const& _types);

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -4401,38 +4401,6 @@ BOOST_AUTO_TEST_CASE(bytes_in_function_calls)
 		}
 }
 
-BOOST_AUTO_TEST_CASE(return_bytes_external)
-{
-	char const* sourceCode = R"(
-		contract Main {
-			bytes s1;
-			function set(bytes _s1) external returns (uint _r, bytes _r1) {
-				_r = _s1.length;
-				s1 = this.setStageTwo(_s1);
-				_r1 = s1;
-			}
-			function setStageTwo(bytes _s1) returns (bytes) {
-				return this.setStageThree(_s1);
-			}
-			function setStageThree(bytes _s1) external returns (bytes) {
-				return _s1;
-			}
-		}
-	)";
-	compileAndRun(sourceCode, 0, "Main");
-	string s1("abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz");
-	vector<size_t> lengthes{0, 31, 64, 65};
-	for (auto l1: lengthes)
-	{
-		bytes dyn1 = encodeArgs(u256(l1), s1.substr(0, l1));
-		bytes args1 = encodeArgs(u256(0x20)) + dyn1;
-		BOOST_REQUIRE(
-			callContractFunction("set(bytes)", asString(args1)) ==
-			encodeArgs(u256(l1), u256(0x40)) + dyn1
-		);
-	}
-}
-
 BOOST_AUTO_TEST_CASE(return_bytes_internal)
 {
 	char const* sourceCode = R"(

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -4355,6 +4355,174 @@ BOOST_AUTO_TEST_CASE(accessor_involving_strings)
 	BOOST_REQUIRE(callContractFunction("data(uint256,uint256)", x, y) == result);
 }
 
+BOOST_AUTO_TEST_CASE(bytes_in_function_calls)
+{
+	char const* sourceCode = R"(
+		contract Main {
+			string public s1;
+			string public s2;
+			function set(string _s1, uint x, string _s2) returns (uint) {
+				s1 = _s1;
+				s2 = _s2;
+				return x;
+			}
+			function setIndirectFromMemory(string _s1, uint x, string _s2) returns (uint) {
+				return this.set(_s1, x, _s2);
+			}
+			function setIndirectFromCalldata(string _s1, uint x, string _s2) external returns (uint) {
+				return this.set(_s1, x, _s2);
+			}
+		}
+	)";
+	compileAndRun(sourceCode, 0, "Main");
+	string s1("abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz");
+	string s2("ABCDEFGHIJKLMNOPQRSTUVXYZABCDEFGHIJKLMNOPQRSTUVXYZABCDEFGHIJKLMNOPQRSTUVXYZ");
+	vector<size_t> lengthes{0, 31, 64, 65};
+	for (auto l1: lengthes)
+		for (auto l2: lengthes)
+		{
+			bytes dyn1 = encodeArgs(u256(l1), s1.substr(0, l1));
+			bytes dyn2 = encodeArgs(u256(l2), s2.substr(0, l2));
+			bytes args1 = encodeArgs(u256(0x60), u256(l1), u256(0x60 + dyn1.size())) + dyn1 + dyn2;
+			BOOST_REQUIRE(
+				callContractFunction("setIndirectFromMemory(string,uint256,string)", asString(args1)) ==
+				encodeArgs(u256(l1))
+			);
+			BOOST_CHECK(callContractFunction("s1()") == encodeArgs(0x20) + dyn1);
+			BOOST_CHECK(callContractFunction("s2()") == encodeArgs(0x20) + dyn2);
+			// swapped
+			bytes args2 = encodeArgs(u256(0x60), u256(l1), u256(0x60 + dyn2.size())) + dyn2 + dyn1;
+			BOOST_REQUIRE(
+				callContractFunction("setIndirectFromCalldata(string,uint256,string)", asString(args2)) ==
+				encodeArgs(u256(l1))
+			);
+			BOOST_CHECK(callContractFunction("s1()") == encodeArgs(0x20) + dyn2);
+			BOOST_CHECK(callContractFunction("s2()") == encodeArgs(0x20) + dyn1);
+		}
+}
+
+BOOST_AUTO_TEST_CASE(return_bytes_external)
+{
+	char const* sourceCode = R"(
+		contract Main {
+			bytes s1;
+			function set(bytes _s1) external returns (uint _r, bytes _r1) {
+				_r = _s1.length;
+				s1 = this.setStageTwo(_s1);
+				_r1 = s1;
+			}
+			function setStageTwo(bytes _s1) returns (bytes) {
+				return this.setStageThree(_s1);
+			}
+			function setStageThree(bytes _s1) external returns (bytes) {
+				return _s1;
+			}
+		}
+	)";
+	compileAndRun(sourceCode, 0, "Main");
+	string s1("abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz");
+	vector<size_t> lengthes{0, 31, 64, 65};
+	for (auto l1: lengthes)
+	{
+		bytes dyn1 = encodeArgs(u256(l1), s1.substr(0, l1));
+		bytes args1 = encodeArgs(u256(0x20)) + dyn1;
+		BOOST_REQUIRE(
+			callContractFunction("set(bytes)", asString(args1)) ==
+			encodeArgs(u256(l1), u256(0x40)) + dyn1
+		);
+	}
+}
+
+BOOST_AUTO_TEST_CASE(return_bytes_internal)
+{
+	char const* sourceCode = R"(
+		contract Main {
+			bytes s1;
+			function doSet(bytes _s1) returns (bytes _r1) {
+				s1 = _s1;
+				_r1 = s1;
+			}
+			function set(bytes _s1) external returns (uint _r, bytes _r1) {
+				_r1 = doSet(_s1);
+				_r = _r1.length;
+			}
+		}
+	)";
+	compileAndRun(sourceCode, 0, "Main");
+	string s1("abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz");
+	vector<size_t> lengthes{0, 31, 64, 65};
+	for (auto l1: lengthes)
+	{
+		bytes dyn1 = encodeArgs(u256(l1), s1.substr(0, l1));
+		bytes args1 = encodeArgs(u256(0x20)) + dyn1;
+		BOOST_REQUIRE(
+			callContractFunction("set(bytes)", asString(args1)) ==
+			encodeArgs(u256(l1), u256(0x40)) + dyn1
+		);
+	}
+}
+
+BOOST_AUTO_TEST_CASE(bytes_index_access_memory)
+{
+	char const* sourceCode = R"(
+		contract Main {
+			function f(bytes _s1, uint i1, uint i2, uint i3) returns (byte c1, byte c2, byte c3) {
+				c1 = _s1[i1];
+				c2 = intern(_s1, i2);
+				c3 = internIndirect(_s1)[i3];
+			}
+			function intern(bytes _s1, uint i) returns (byte c) {
+				return _s1[i];
+			}
+			function internIndirect(bytes _s1) returns (bytes) {
+				return _s1;
+			}
+		}
+	)";
+	compileAndRun(sourceCode, 0, "Main");
+	string s1("abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz");
+	bytes dyn1 = encodeArgs(u256(s1.length()), s1);
+	bytes args1 = encodeArgs(u256(0x80), u256(3), u256(4), u256(5)) + dyn1;
+	BOOST_REQUIRE(
+		callContractFunction("f(bytes,uint256,uint256,uint256)", asString(args1)) ==
+		encodeArgs(string{s1[3]}, string{s1[4]}, string{s1[5]})
+	);
+}
+
+BOOST_AUTO_TEST_CASE(bytes_in_constructors)
+{
+	char const* sourceCode = R"(
+		contract Base {
+			uint public m_x;
+			bytes public m_s;
+			function Base(uint x, bytes s) {
+				m_x = x;
+				m_s = s;
+			}
+		}
+		contract Main is Base {
+			function Main(bytes s, uint x) Base(x, f(s)) {}
+			function f(bytes s) returns (bytes) { return s; }
+		}
+		contract Creator {
+			function f(uint x, bytes s) returns (uint r, bytes b) {
+				var c = new Main(s, x);
+				r = c.m_x();
+				b = c.m_s();
+			}
+		}
+	)";
+	compileAndRun(sourceCode, 0, "Creator");
+	string s1("abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz");
+	bytes dyn1 = encodeArgs(u256(s1.length()), s1);
+	u256 x = 7;
+	bytes args1 = encodeArgs(x, u256(0x40)) + dyn1;
+	BOOST_REQUIRE(
+		callContractFunction("f(uint256,bytes)", asString(args1)) ==
+		encodeArgs(x, u256(0x40), dyn1)
+	);
+}
+
 BOOST_AUTO_TEST_CASE(storage_array_ref)
 {
 	char const* sourceCode = R"(

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -1987,6 +1987,19 @@ BOOST_AUTO_TEST_CASE(mem_array_assignment_changes_base_type)
 	BOOST_CHECK_THROW(parseTextAndResolveNames(sourceCode), TypeError);
 }
 
+BOOST_AUTO_TEST_CASE(dynamic_return_types_not_possible)
+{
+	char const* sourceCode = R"(
+		contract C {
+			function f(uint) returns (string);
+			function g() {
+				var x = this.f(2);
+			}
+		}
+	)";
+	BOOST_CHECK_THROW(parseTextAndResolveNames(sourceCode), TypeError);
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 }


### PR DESCRIPTION
This change adds support for strings as (base) constructor arguments.
Furthermore, a restriction is added, which is not yet shown nicely in error messages: Externally called functions cannot return dynamic types (because we do not know their size beforehand). Such types are just replaced by `void` for now. Once we have destructuring assignments, this functionality will be extended (a new type will be introduced for them), so that at least the non-dynamic part of the return value can be accessed.