### PR TITLE
create directory if not existent when writing to file

### DIFF
--- a/libdevcore/CommonIO.cpp
+++ b/libdevcore/CommonIO.cpp
@@ -98,9 +98,9 @@ string dev::contentsString(string const& _file)
 
 void dev::writeFile(std::string const& _file, bytesConstRef _data, bool _writeDeleteRename)
 {
+	namespace fs = boost::filesystem;
 	if (_writeDeleteRename)
 	{
-		namespace fs = boost::filesystem;
 		fs::path tempPath = fs::unique_path(_file + "-%%%%%%");
 		writeFile(tempPath.string(), _data, false);
 		// will delete _file if it exists
@@ -108,10 +108,14 @@ void dev::writeFile(std::string const& _file, bytesConstRef _data, bool _writeDe
 	}
 	else
 	{
+		// create directory if not existent
+		fs::path p(_file);
+		fs::create_directories(p.parent_path());
+
 		ofstream s(_file, ios::trunc | ios::binary);
 		s.write(reinterpret_cast<char const*>(_data.data()), _data.size());
 		if (!s)
-			BOOST_THROW_EXCEPTION(FileError());
+			BOOST_THROW_EXCEPTION(FileError() << errinfo_comment("Could not write to file: " + _file));
 	}
 }
 


### PR DESCRIPTION
currently, when starting eth, it is aborting with an "FileError" exception when .ethereum does not exist. Because he can not write to a file in a not existing directory.