### PR TITLE
Fix Deadlock in Ethashcl code

### DIFF
--- a/libethcore/Ethash.cpp
+++ b/libethcore/Ethash.cpp
@@ -256,7 +256,6 @@ public:
 
 	void abort()
 	{
-		UniqueGuard l(x_all);
 		if (m_aborted)
 			return;
 //		cdebug << "Attempting to abort";


### PR DESCRIPTION
The `x_all` mutex was attempted to be acquired both by the `abort()` and the `search()`
function, and with the new` m_aborted` notifier type of lock this is
causing a deadlock

Stack trace of the 2 offending threads:

```
Thread 8 (Thread 0x7fffe4de7700 (LWP 5950)):
#0  pthread_cond_wait@@GLIBC_2.3.2 () at ../sysdeps/unix/sysv/linux/x86_64/pthread_cond_wait.S:185
#1  0x00007ffff58acd1c in std::condition_variable::wait(std::unique_lock<std::mutex>&) () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#2  0x00007ffff6ad31cb in std::condition_variable::wait<dev::eth::Notified<bool>::wait(bool const&) const::{lambda()#1}>(std::unique_lock<std::mutex>&, dev::eth::Notified<bool>::wait(bool const&) const::{lambda()#1}) (this=0xccb128, __lock=..., __p=...) at /usr/include/c++/4.9/condition_variable:98
#3  0x00007ffff6ad10f9 in dev::eth::Notified<bool>::wait (this=0xccb100, _v=@0x7fffe4de54df: true) at /home/minekraft/lefteris/cpp-ethereum/libethcore/Ethash.cpp:242
#4  0x00007ffff6acec6f in dev::eth::EthashCLHook::abort (this=0xccb0c0) at /home/minekraft/lefteris/cpp-ethereum/libethcore/Ethash.cpp:268
#5  0x00007ffff6acd6d3 in dev::eth::Ethash::GPUMiner::pause (this=0xccaf90) at /home/minekraft/lefteris/cpp-ethereum/libethcore/Ethash.cpp:390
#6  0x000000000050893c in dev::eth::GenericMiner<dev::eth::Ethash>::setWork (this=0xccaf90, _work=...) at /home/minekraft/lefteris/cpp-ethereum/eth/../libethcore/Miner.h:111
#7  0x00000000004f6ca1 in dev::eth::GenericFarm<dev::eth::Ethash>::setWork (this=0x8f5590, _wp=...) at /home/minekraft/lefteris/cpp-ethereum/eth/../libethcore/Farm.h:76
#8  0x00000000004f4f67 in dev::eth::GenericFarm<dev::eth::Ethash>::setWork (this=0x8f5590, _bi=...) at /home/minekraft/lefteris/cpp-ethereum/eth/../libethcore/Farm.h:62
#9  0x00007ffff75348e3 in dev::eth::Client::rejigMining (this=0x8f1b70) at /home/minekraft/lefteris/cpp-ethereum/libethereum/Client.cpp:805
#10 0x00007ffff753460b in dev::eth::Client::onPostStateChanged (this=0x8f1b70) at /home/minekraft/lefteris/cpp-ethereum/libethereum/Client.cpp:779
#11 0x00007ffff75342b4 in dev::eth::Client::onChainChanged (this=0x8f1b70, _ir=...) at /home/minekraft/lefteris/cpp-ethereum/libethereum/Client.cpp:760
#12 0x00007ffff753326d in dev::eth::Client::syncBlockQueue (this=0x8f1b70) at /home/minekraft/lefteris/cpp-ethereum/libethereum/Client.cpp:658
#13 0x00007ffff75350b3 in dev::eth::Client::doWork (this=0x8f1b70) at /home/minekraft/lefteris/cpp-ethereum/libethereum/Client.cpp:851
#14 0x00007ffff641d2ec in dev::Worker::workLoop (this=0x8f1f00) at /home/minekraft/lefteris/cpp-ethereum/libdevcore/Worker.cpp:115
#15 0x00007ffff641ca21 in dev::Worker::<lambda()>::operator()(void) const (__closure=0xcd1b48) at /home/minekraft/lefteris/cpp-ethereum/libdevcore/Worker.cpp:55
#16 0x00007ffff641e5aa in std::_Bind_simple<dev::Worker::startWorking()::<lambda()>()>::_M_invoke<>(std::_Index_tuple<>) (this=0xcd1b48) at /usr/include/c++/4.9/functional:1700
#17 0x00007ffff641e4dc in std::_Bind_simple<dev::Worker::startWorking()::<lambda()>()>::operator()(void) (this=0xcd1b48) at /usr/include/c++/4.9/functional:1688
#18 0x00007ffff641e44a in std::thread::_Impl<std::_Bind_simple<dev::Worker::startWorking()::<lambda()>()> >::_M_run(void) (this=0xcd1b30) at /usr/include/c++/4.9/thread:115
#19 0x00007ffff58b0e30 in ?? () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#20 0x00007ffff5b0c6aa in start_thread (arg=0x7fffe4de7700) at pthread_create.c:333
#21 0x00007ffff5014eed in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:109


Thread 3 (Thread 0x7fff48967700 (LWP 5955)):
#0  __lll_lock_wait () at ../sysdeps/unix/sysv/linux/x86_64/lowlevellock.S:135
#1  0x00007ffff5b0ecfd in __GI___pthread_mutex_lock (mutex=0xccb0c8) at ../nptl/pthread_mutex_lock.c:80
#2  0x00000000004c7fdb in __gthread_mutex_lock (__mutex=0xccb0c8) at /usr/include/x86_64-linux-gnu/c++/4.9/bits/gthr-default.h:748
#3  0x00000000004dfede in std::mutex::lock (this=0xccb0c8) at /usr/include/c++/4.9/mutex:135
#4  0x00007ffff7457b43 in std::unique_lock<std::mutex>::lock (this=0x7fff48964f80) at /usr/include/c++/4.9/mutex:474
#5  0x00007ffff7453e8d in std::unique_lock<std::mutex>::unique_lock (this=0x7fff48964f80, __m=...) at /usr/include/c++/4.9/mutex:406
#6  0x00007ffff6acee4e in dev::eth::EthashCLHook::searched (this=0xccb0c0, _startNonce=6992781895807136693, _count=1876766) at /home/minekraft/lefteris/cpp-ethereum/libethcore/Ethash.cpp:293
#7  0x00007ffff29070c7 in ethash_cl_miner::search (this=0x7fff40000ca0, header=0x7fff48966c00 "5\316א\274\f\250\365\004=\236\177\202\r[\350\r4\332\355\253\026\342\366\"@\036x\206\213ۘ\333\373\212\321g\003\307b\322D\343\312c\276\302\066\267\371g\003l3E\245\330!6b\235\366", <incomplete sequence \347>, 
    target=1607315002, hook=..., _msPerBatch=100) at /home/minekraft/lefteris/cpp-ethereum/libethash-cl/ethash_cl_miner.cpp:491
#8  0x00007ffff6acd491 in dev::eth::Ethash::GPUMiner::workLoop (this=0xccaf90) at /home/minekraft/lefteris/cpp-ethereum/libethcore/Ethash.cpp:378
#9  0x00007ffff641ca21 in dev::Worker::<lambda()>::operator()(void) const (__closure=0x8418a8) at /home/minekraft/lefteris/cpp-ethereum/libdevcore/Worker.cpp:55
#10 0x00007ffff641e5aa in std::_Bind_simple<dev::Worker::startWorking()::<lambda()>()>::_M_invoke<>(std::_Index_tuple<>) (this=0x8418a8) at /usr/include/c++/4.9/functional:1700
#11 0x00007ffff641e4dc in std::_Bind_simple<dev::Worker::startWorking()::<lambda()>()>::operator()(void) (this=0x8418a8) at /usr/include/c++/4.9/functional:1688
#12 0x00007ffff641e44a in std::thread::_Impl<std::_Bind_simple<dev::Worker::startWorking()::<lambda()>()> >::_M_run(void) (this=0x841890) at /usr/include/c++/4.9/thread:115
#13 0x00007ffff58b0e30 in ?? () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#14 0x00007ffff5b0c6aa in start_thread (arg=0x7fff48967700) at pthread_create.c:333
#15 0x00007ffff5014eed in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:109
```

The 2 functions where the lock was acquired causing the deadlock:

```c++
	void abort()
	{
		UniqueGuard l(x_all);
		if (m_aborted)
			return;
//		cdebug << "Attempting to abort";

		m_abort = true;
		// m_abort is true so now searched()/found() will return true to abort the search.
		// we hang around on this thread waiting for them to point out that they have aborted since
		// otherwise we may end up deleting this object prior to searched()/found() being called.
		m_aborted.wait(true);
//		for (unsigned timeout = 0; timeout < 100 && !m_aborted; ++timeout)
//			std::this_thread::sleep_for(chrono::milliseconds(30));
//		if (!m_aborted)
//			cwarn << "Couldn't abort. Abandoning OpenCL process.";
	}
```

```c++
	virtual bool searched(uint64_t _startNonce, uint32_t _count) override
	{
		UniqueGuard l(x_all);
//		std::cerr << "Searched " << _count << " from " << _startNonce << std::endl;
		m_owner->accumulateHashes(_count);
		m_last = _startNonce + _count;
		if (m_abort || m_owner->shouldStop())
			return (m_aborted = true);
		return false;
	}
```
What's happening is that `abort()` acquires the lock and waits for the `m_aborted` while `search()` is waiting on the `x_all` lock and never gets to change `m_aborted`.

To fix the deadlock I simply removed the acquiring of the `x_all` lock from the `abort()` function since it also waits on the m_aborted notifier. @gavofyork would that be close to what you intended? If not please suggest an alternative.