### PR TITLE
Adjust CL miner work batch size properly

### DIFF
--- a/ethminer/MinerAux.h
+++ b/ethminer/MinerAux.h
@@ -39,7 +39,6 @@
 #include <libdevcore/SHA3.h>
 #include <libethcore/ProofOfWork.h>
 #include <libethcore/EthashAux.h>
-#include <libethash-cl/ethash_cl_miner.h>
 #include <libethcore/Farm.h>
 #if ETH_JSONRPC || !ETH_TRUE
 #include <libweb3jsonrpc/WebThreeStubServer.h>

--- a/ethminer/MinerAux.h
+++ b/ethminer/MinerAux.h
@@ -345,9 +345,9 @@ public:
 			<< "    --list-devices List the detected OpenCL devices and exit." << endl
 			<< "    --current-block Let the miner know the current block number at configuration time. Will help determine DAG size and required GPU memory." << endl
 			<< "    --cl-extragpu-mem Set the memory (in MB) you believe your GPU requires for stuff other than mining. Windows rendering e.t.c.." << endl
-			<< "    --cl-local-work Set the OpenCL local work size. Default is " << toString(CL_DEFAULT_LOCAL_WORK_SIZE) << endl
-			<< "    --cl-global-work Set the OpenCL global work size as a multiple of the local work size. Default is " << toString(CL_DEFAULT_GLOBAL_WORK_SIZE_MULTIPLIER) << " * " << toString(CL_DEFAULT_LOCAL_WORK_SIZE) << endl
-			<< "    --cl-ms-per-batch Set the OpenCL target milliseconds per batch (global workgroup size). Default is " << toString(CL_DEFAULT_MS_PER_BATCH) << ". If 0 is given then no autoadjustment of global work size will happen" << endl
+			<< "    --cl-local-work Set the OpenCL local work size. Default is " << toString(dev::eth::Ethash::defaultLocalWorkSize) << endl
+			<< "    --cl-global-work Set the OpenCL global work size as a multiple of the local work size. Default is " << toString(dev::eth::Ethash::defaultGlobalWorkSizeMultiplier) << " * " << toString(dev::eth::Ethash::defaultLocalWorkSize) << endl
+			<< "    --cl-ms-per-batch Set the OpenCL target milliseconds per batch (global workgroup size). Default is " << toString(dev::eth::Ethash::defaultMSPerBatch) << ". If 0 is given then no autoadjustment of global work size will happen" << endl
 			;
 	}
 
@@ -536,9 +536,9 @@ private:
 	unsigned m_miningThreads = UINT_MAX;
 	bool m_shouldListDevices = false;
 	bool m_clAllowCPU = false;
-	unsigned m_globalWorkSizeMultiplier = CL_DEFAULT_GLOBAL_WORK_SIZE_MULTIPLIER;
-	unsigned m_localWorkSize = CL_DEFAULT_LOCAL_WORK_SIZE;
-	unsigned m_msPerBatch = CL_DEFAULT_MS_PER_BATCH;
+	unsigned m_globalWorkSizeMultiplier = dev::eth::Ethash::defaultGlobalWorkSizeMultiplier;
+	unsigned m_localWorkSize = dev::eth::Ethash::defaultLocalWorkSize;
+	unsigned m_msPerBatch = dev::eth::Ethash::defaultMSPerBatch;
 	boost::optional<uint64_t> m_currentBlock;
 	// default value is 350MB of GPU memory for other stuff (windows system rendering, e.t.c.)
 	unsigned m_extraGPUMemory = 350000000;

--- a/ethminer/MinerAux.h
+++ b/ethminer/MinerAux.h
@@ -129,9 +129,18 @@ public:
 				cerr << "Bad " << arg << " option: " << argv[i] << endl;
 				BOOST_THROW_EXCEPTION(BadArgument());
 			}
-		else if (arg == "--cl-global-work-size" && i + 1 < argc)
+		else if (arg == "--cl-global-work" && i + 1 < argc)
 			try {
-				m_globalWorkSize = stol(argv[++i]);
+				m_globalWorkSizeMultiplier = stol(argv[++i]);
+			}
+			catch (...)
+			{
+				cerr << "Bad " << arg << " option: " << argv[i] << endl;
+				BOOST_THROW_EXCEPTION(BadArgument());
+			}
+		else if (arg == "--cl-local-work" && i + 1 < argc)
+			try {
+				m_localWorkSize = stol(argv[++i]);
 			}
 			catch (...)
 			{
@@ -285,7 +294,8 @@ public:
 		else if (m_minerType == MinerType::GPU)
 		{
 			if (!ProofOfWork::GPUMiner::configureGPU(
-					m_globalWorkSize,
+					m_localWorkSize,
+					m_globalWorkSizeMultiplier,
 					m_msPerBatch,
 					m_openclPlatform,
 					m_openclDevice,
@@ -293,10 +303,7 @@ public:
 					m_extraGPUMemory,
 					m_currentBlock
 				))
-			{
-				cout << "No GPU device with sufficient memory was found. Can't GPU mine. Remove the -G argument" << endl;
 				exit(1);
-			}
 			ProofOfWork::GPUMiner::setNumInstances(m_miningThreads);
 		}
 		if (mode == OperationMode::DAGInit)
@@ -339,7 +346,8 @@ public:
 			<< "    --list-devices List the detected OpenCL devices and exit." << endl
 			<< "    --current-block Let the miner know the current block number at configuration time. Will help determine DAG size and required GPU memory." << endl
 			<< "    --cl-extragpu-mem Set the memory (in MB) you believe your GPU requires for stuff other than mining. Windows rendering e.t.c.." << endl
-			<< "    --cl-global-work Set the OpenCL global work size. Default is " << toString(CL_DEFAULT_GLOBAL_WORK_SIZE) << endl
+			<< "    --cl-local-work Set the OpenCL local work size. Default is " << toString(CL_DEFAULT_LOCAL_WORK_SIZE) << endl
+			<< "    --cl-global-work Set the OpenCL global work size as a multiple of the local work size. Default is " << toString(CL_DEFAULT_GLOBAL_WORK_SIZE_MULTIPLIER) << " * " << toString(CL_DEFAULT_LOCAL_WORK_SIZE) << endl
 			<< "    --cl-ms-per-batch Set the OpenCL target milliseconds per batch (global workgroup size). Default is " << toString(CL_DEFAULT_MS_PER_BATCH) << ". If 0 is given then no autoadjustment of global work size will happen" << endl
 			;
 	}
@@ -529,7 +537,8 @@ private:
 	unsigned m_miningThreads = UINT_MAX;
 	bool m_shouldListDevices = false;
 	bool m_clAllowCPU = false;
-	unsigned m_globalWorkSize = CL_DEFAULT_GLOBAL_WORK_SIZE;
+	unsigned m_globalWorkSizeMultiplier = CL_DEFAULT_GLOBAL_WORK_SIZE_MULTIPLIER;
+	unsigned m_localWorkSize = CL_DEFAULT_LOCAL_WORK_SIZE;
 	unsigned m_msPerBatch = CL_DEFAULT_MS_PER_BATCH;
 	boost::optional<uint64_t> m_currentBlock;
 	// default value is 350MB of GPU memory for other stuff (windows system rendering, e.t.c.)

--- a/libethash-cl/ethash_cl_miner.cpp
+++ b/libethash-cl/ethash_cl_miner.cpp
@@ -33,6 +33,7 @@
 #include <vector>
 #include <libethash/util.h>
 #include <libethash/ethash.h>
+#include <libethcore/Ethash.h>
 #include <libethash/internal.h>
 #include "ethash_cl_miner.h"
 #include "ethash_cl_miner_kernel.h"
@@ -49,6 +50,7 @@
 #undef max
 
 using namespace std;
+using namespace dev::eth;
 
 // TODO: If at any point we can use libdevcore in here then we should switch to using a LogChannel
 #define ETHCL_LOG(_contents) cout << "[OPENCL]:" << _contents << endl
@@ -181,9 +183,9 @@ bool ethash_cl_miner::configureGPU(
 
 bool ethash_cl_miner::s_allowCPU = false;
 unsigned ethash_cl_miner::s_extraRequiredGPUMem;
-unsigned ethash_cl_miner::s_msPerBatch = CL_DEFAULT_MS_PER_BATCH;
-unsigned ethash_cl_miner::s_workgroupSize = CL_DEFAULT_LOCAL_WORK_SIZE;
-unsigned ethash_cl_miner::s_initialGlobalWorkSize = CL_DEFAULT_GLOBAL_WORK_SIZE_MULTIPLIER * CL_DEFAULT_LOCAL_WORK_SIZE;
+unsigned ethash_cl_miner::s_msPerBatch = Ethash::defaultMSPerBatch;
+unsigned ethash_cl_miner::s_workgroupSize = Ethash::defaultLocalWorkSize;
+unsigned ethash_cl_miner::s_initialGlobalWorkSize = Ethash::defaultGlobalWorkSizeMultiplier * Ethash::defaultLocalWorkSize;
 
 bool ethash_cl_miner::searchForAllDevices(function<bool(cl::Device const&)> _callback)
 {

--- a/libethash-cl/ethash_cl_miner.cpp
+++ b/libethash-cl/ethash_cl_miner.cpp
@@ -461,7 +461,7 @@ void ethash_cl_miner::search(uint8_t const* header, uint64_t target, search_hook
 		uint64_t start_nonce = uniform_int_distribution<uint64_t>()(engine);
 		for (;; start_nonce += m_globalWorkSize)
 		{
-			chrono::high_resolution_clock::time_point t = chrono::high_resolution_clock::now();
+			auto t = chrono::high_resolution_clock::now();
 			// supply output buffer to kernel
 			m_searchKernel.setArg(0, m_searchBuffer[buf]);
 			if (m_dagChunksCount == 1)
@@ -518,6 +518,8 @@ void ethash_cl_miner::search(uint8_t const* header, uint64_t target, search_hook
 				{
 					// cerr << "Batch of " << m_globalWorkSize << " took " << chrono::duration_cast<chrono::milliseconds>(d).count() << " ms, << " << _msPerBatch << " ms." << endl;
 					m_globalWorkSize = min<unsigned>(pow(2, m_deviceBits) - 1, m_globalWorkSize - m_workgroupSize);
+					// Global work size should never be less than the workgroup size
+					m_globalWorkSize = max<unsigned>(m_workgroupSize,  m_globalWorkSize);
 					// cerr << "New global work size" << m_globalWorkSize << endl;
 				}
 			}

--- a/libethash-cl/ethash_cl_miner.h
+++ b/libethash-cl/ethash_cl_miner.h
@@ -17,13 +17,6 @@
 #include <functional>
 #include <libethash/ethash.h>
 
-/// Default value of the local work size. Also known as workgroup size.
-#define CL_DEFAULT_LOCAL_WORK_SIZE 64
-/// Default value of the global work size as a multiplier of the local work size
-#define CL_DEFAULT_GLOBAL_WORK_SIZE_MULTIPLIER 512 // * CL_DEFAULT_LOCAL_WORK_SIZE
-/// Default value of the milliseconds per global work size (per batch)
-#define CL_DEFAULT_MS_PER_BATCH 100
-
 class ethash_cl_miner
 {
 private:

--- a/libethash-cl/ethash_cl_miner.h
+++ b/libethash-cl/ethash_cl_miner.h
@@ -77,8 +77,9 @@ private:
 	cl::Buffer m_hashBuffer[c_bufferCount];
 	cl::Buffer m_searchBuffer[c_bufferCount];
 	unsigned m_workgroupSize;
-	unsigned m_batchSize = c_searchBatchSize;
+	unsigned m_globalWorkSize = c_searchBatchSize;
 	bool m_openclOnePointOne;
+	unsigned m_deviceBits;
 
 	/// Allow CPU to appear as an OpenCL device or not. Default is false
 	static bool s_allowCPU;

--- a/libethash-cl/ethash_cl_miner.h
+++ b/libethash-cl/ethash_cl_miner.h
@@ -17,6 +17,9 @@
 #include <functional>
 #include <libethash/ethash.h>
 
+#define CL_DEFAULT_GLOBAL_WORK_SIZE 1024 * 16
+#define CL_DEFAULT_MS_PER_BATCH 100
+
 class ethash_cl_miner
 {
 private:
@@ -45,6 +48,8 @@ public:
 	static void listDevices();
 	static bool configureGPU(
 		unsigned _platformId,
+		unsigned _globalWorkSize,
+		unsigned _msPerBatch,
 		bool _allowCPU,
 		unsigned _extraGPUMemory,
 		boost::optional<uint64_t> _currentBlock
@@ -58,7 +63,7 @@ public:
 		unsigned _deviceId = 0
 	);
 	void finish();
-	void search(uint8_t const* _header, uint64_t _target, search_hook& _hook, unsigned _msPerBatch = 100);
+	void search(uint8_t const* _header, uint64_t _target, search_hook& _hook);
 
 	void hash_chunk(uint8_t* _ret, uint8_t const* _header, uint64_t _nonce, unsigned _count);
 	void search_chunk(uint8_t const*_header, uint64_t _target, search_hook& _hook);
@@ -77,10 +82,14 @@ private:
 	cl::Buffer m_hashBuffer[c_bufferCount];
 	cl::Buffer m_searchBuffer[c_bufferCount];
 	unsigned m_workgroupSize;
-	unsigned m_globalWorkSize = c_searchBatchSize;
+	unsigned m_globalWorkSize;
 	bool m_openclOnePointOne;
 	unsigned m_deviceBits;
 
+	/// The initial global work size for the searches
+	static unsigned s_initialGlobalWorkSize;
+	/// The target milliseconds per batch for the search. If 0, then no adjustment will happen
+	static unsigned s_msPerBatch;
 	/// Allow CPU to appear as an OpenCL device or not. Default is false
 	static bool s_allowCPU;
 	/// GPU memory required for other things, like window rendering e.t.c.

--- a/libethash-cl/ethash_cl_miner.h
+++ b/libethash-cl/ethash_cl_miner.h
@@ -17,7 +17,11 @@
 #include <functional>
 #include <libethash/ethash.h>
 
-#define CL_DEFAULT_GLOBAL_WORK_SIZE 1024 * 16
+/// Default value of the local work size. Also known as workgroup size.
+#define CL_DEFAULT_LOCAL_WORK_SIZE 64
+/// Default value of the global work size as a multiplier of the local work size
+#define CL_DEFAULT_GLOBAL_WORK_SIZE_MULTIPLIER 512 // * CL_DEFAULT_LOCAL_WORK_SIZE
+/// Default value of the milliseconds per global work size (per batch)
 #define CL_DEFAULT_MS_PER_BATCH 100
 
 class ethash_cl_miner
@@ -48,6 +52,7 @@ public:
 	static void listDevices();
 	static bool configureGPU(
 		unsigned _platformId,
+		unsigned _localWorkSize,
 		unsigned _globalWorkSize,
 		unsigned _msPerBatch,
 		bool _allowCPU,
@@ -58,7 +63,6 @@ public:
 	bool init(
 		uint8_t const* _dag,
 		uint64_t _dagSize,
-		unsigned _workgroupSize = 64,
 		unsigned _platformId = 0,
 		unsigned _deviceId = 0
 	);
@@ -81,11 +85,12 @@ private:
 	cl::Buffer m_header;
 	cl::Buffer m_hashBuffer[c_bufferCount];
 	cl::Buffer m_searchBuffer[c_bufferCount];
-	unsigned m_workgroupSize;
 	unsigned m_globalWorkSize;
 	bool m_openclOnePointOne;
 	unsigned m_deviceBits;
 
+	/// The local work size for the search
+	static unsigned s_workgroupSize;
 	/// The initial global work size for the searches
 	static unsigned s_initialGlobalWorkSize;
 	/// The target milliseconds per batch for the search. If 0, then no adjustment will happen

--- a/libethcore/Ethash.cpp
+++ b/libethcore/Ethash.cpp
@@ -54,6 +54,9 @@ namespace dev
 namespace eth
 {
 
+const unsigned Ethash::defaultLocalWorkSize = 64;
+const unsigned Ethash::defaultGlobalWorkSizeMultiplier = 512; // * CL_DEFAULT_LOCAL_WORK_SIZE
+const unsigned Ethash::defaultMSPerBatch = 100;
 const Ethash::WorkPackage Ethash::NullWorkPackage = Ethash::WorkPackage();
 
 std::string Ethash::name()

--- a/libethcore/Ethash.cpp
+++ b/libethcore/Ethash.cpp
@@ -429,6 +429,7 @@ bool Ethash::GPUMiner::configureGPU(
 	}
 	
 	if (!ethash_cl_miner::configureGPU(
+			_platformId,
 			_localWorkSize,
 			_globalWorkSizeMultiplier * _localWorkSize,
 			_msPerBatch,

--- a/libethcore/Ethash.cpp
+++ b/libethcore/Ethash.cpp
@@ -409,6 +409,8 @@ void Ethash::GPUMiner::listDevices()
 }
 
 bool Ethash::GPUMiner::configureGPU(
+	unsigned _globalWorkSize,
+	unsigned _msPerBatch,
 	unsigned _platformId,
 	unsigned _deviceId,
 	bool _allowCPU,
@@ -418,7 +420,7 @@ bool Ethash::GPUMiner::configureGPU(
 {
 	s_platformId = _platformId;
 	s_deviceId = _deviceId;
-	return ethash_cl_miner::configureGPU(_platformId, _allowCPU, _extraGPUMemory, _currentBlock);
+	return ethash_cl_miner::configureGPU(_globalWorkSize, _msPerBatch, _allowCPU, _extraGPUMemory, _currentBlock);
 }
 
 #endif

--- a/libethcore/Ethash.h
+++ b/libethcore/Ethash.h
@@ -31,13 +31,6 @@
 #include "BlockInfo.h"
 #include "Miner.h"
 
-/// Default value of the local work size. Also known as workgroup size.
-#define CL_DEFAULT_LOCAL_WORK_SIZE 64
-/// Default value of the global work size as a multiplier of the local work size
-#define CL_DEFAULT_GLOBAL_WORK_SIZE_MULTIPLIER 512 // * CL_DEFAULT_LOCAL_WORK_SIZE
-/// Default value of the milliseconds per global work size (per batch)
-#define CL_DEFAULT_MS_PER_BATCH 100
-
 class ethash_cl_miner;
 
 namespace dev
@@ -157,6 +150,12 @@ public:
 #else
 	using GPUMiner = CPUMiner;
 #endif
+	/// Default value of the local work size. Also known as workgroup size.
+	static const unsigned defaultLocalWorkSize;
+	/// Default value of the global work size as a multiplier of the local work size
+	static const unsigned defaultGlobalWorkSizeMultiplier;
+	/// Default value of the milliseconds per global work size (per batch)
+	static const unsigned defaultMSPerBatch;
 };
 
 }

--- a/libethcore/Ethash.h
+++ b/libethcore/Ethash.h
@@ -31,6 +31,13 @@
 #include "BlockInfo.h"
 #include "Miner.h"
 
+/// Default value of the local work size. Also known as workgroup size.
+#define CL_DEFAULT_LOCAL_WORK_SIZE 64
+/// Default value of the global work size as a multiplier of the local work size
+#define CL_DEFAULT_GLOBAL_WORK_SIZE_MULTIPLIER 512 // * CL_DEFAULT_LOCAL_WORK_SIZE
+/// Default value of the milliseconds per global work size (per batch)
+#define CL_DEFAULT_MS_PER_BATCH 100
+
 class ethash_cl_miner;
 
 namespace dev

--- a/libethcore/Ethash.h
+++ b/libethcore/Ethash.h
@@ -88,7 +88,7 @@ public:
 		static unsigned instances() { return s_numInstances > 0 ? s_numInstances : std::thread::hardware_concurrency(); }
 		static std::string platformInfo();
 		static void listDevices() {}
-		static bool configureGPU(unsigned, unsigned, unsigned, unsigned, bool, unsigned,  boost::optional<uint64_t>) { return false; }
+		static bool configureGPU(unsigned, unsigned, unsigned, unsigned, unsigned, bool, unsigned,  boost::optional<uint64_t>) { return false; }
 		static void setNumInstances(unsigned _instances) { s_numInstances = std::min<unsigned>(_instances, std::thread::hardware_concurrency()); }
 	protected:
 		void kickOff() override
@@ -118,7 +118,8 @@ public:
 		static unsigned getNumDevices();
 		static void listDevices();
 		static bool configureGPU(
-			unsigned _globalWorkSize,
+			unsigned _localWorkSize,
+			unsigned _globalWorkSizeMultiplier,
 			unsigned _msPerBatch,
 			unsigned _platformId,
 			unsigned _deviceId,

--- a/libethcore/Ethash.h
+++ b/libethcore/Ethash.h
@@ -88,7 +88,7 @@ public:
 		static unsigned instances() { return s_numInstances > 0 ? s_numInstances : std::thread::hardware_concurrency(); }
 		static std::string platformInfo();
 		static void listDevices() {}
-		static bool configureGPU(unsigned, unsigned, bool, unsigned,  boost::optional<uint64_t>) { return false; }
+		static bool configureGPU(unsigned, unsigned, unsigned, unsigned, bool, unsigned,  boost::optional<uint64_t>) { return false; }
 		static void setNumInstances(unsigned _instances) { s_numInstances = std::min<unsigned>(_instances, std::thread::hardware_concurrency()); }
 	protected:
 		void kickOff() override
@@ -118,6 +118,8 @@ public:
 		static unsigned getNumDevices();
 		static void listDevices();
 		static bool configureGPU(
+			unsigned _globalWorkSize,
+			unsigned _msPerBatch,
 			unsigned _platformId,
 			unsigned _deviceId,
 			bool _allowCPU,


### PR DESCRIPTION
We are now propery adjusting the batch size of the OpenCL miner
depending on the execution time of the last search.