### PR TITLE
BlockQueue::import() spams only under specific verbosity

### DIFF
--- a/libethereum/BlockQueue.cpp
+++ b/libethereum/BlockQueue.cpp
@@ -184,7 +184,7 @@ void BlockQueue::drainVerified_WITH_BOTH_LOCKS()
 
 ImportResult BlockQueue::import(bytesConstRef _block, BlockChain const& _bc, bool _isOurs)
 {
-	cdebug << std::this_thread::get_id();
+	clog(BlockQueueTraceChannel) << std::this_thread::get_id();
 	// Check if we already know this block.
 	h256 h = BlockInfo::headerHash(_block);
 


### PR DESCRIPTION
I am getting the thread id even with verbosity = 0 which can make it
really difficult to debug anything else if I am not interested in said
thread's ID