### PR TITLE
rpc eth_sendTransaction returns always transaction hash

### DIFF
--- a/alethzero/OurWebThreeStubServer.cpp
+++ b/alethzero/OurWebThreeStubServer.cpp
@@ -99,10 +99,11 @@ bool OurAccountHolder::showUnknownCallNotice(TransactionSkeleton const& _t, bool
 		"REJECT UNLESS YOU REALLY KNOW WHAT YOU ARE DOING!");
 }
 
-void OurAccountHolder::authenticate(TransactionSkeleton const& _t)
+h256 OurAccountHolder::authenticate(TransactionSkeleton const& _t)
 {
 	Guard l(x_queued);
 	m_queued.push(_t);
+	return h256();
 }
 
 void OurAccountHolder::doValidations()

--- a/alethzero/OurWebThreeStubServer.h
+++ b/alethzero/OurWebThreeStubServer.h
@@ -43,7 +43,7 @@ protected:
 	// easiest to return keyManager.addresses();
 	virtual dev::AddressHash realAccounts() const override;
 	// use web3 to submit a signed transaction to accept
-	virtual void authenticate(dev::eth::TransactionSkeleton const& _t) override;
+	virtual dev::h256 authenticate(dev::eth::TransactionSkeleton const& _t) override;
 
 private:
 	bool showAuthenticationPopup(std::string const& _title, std::string const& _text);

--- a/libdevcrypto/Common.cpp
+++ b/libdevcrypto/Common.cpp
@@ -29,6 +29,7 @@
 #include <libdevcore/Guards.h>
 #include <libdevcore/SHA3.h>
 #include <libdevcore/FileSystem.h>
+#include <libdevcore/RLP.h>
 #if ETH_HAVE_SECP256K1
 #include <secp256k1/secp256k1.h>
 #endif
@@ -88,6 +89,11 @@ Address dev::toAddress(Secret const& _secret)
 	Public p;
 	s_secp256k1pp.toPublic(_secret, p);
 	return toAddress(p);
+}
+
+Address dev::toAddress(Address const& _from, u256 const& _nonce)
+{
+	return right160(sha3(rlpList(_from, _nonce)));
 }
 
 void dev::encrypt(Public const& _k, bytesConstRef _plain, bytes& o_cipher)

--- a/libdevcrypto/Common.h
+++ b/libdevcrypto/Common.h
@@ -85,6 +85,9 @@ Address toAddress(Public const& _public);
 /// @returns 0 if it's not a valid secret key.
 Address toAddress(Secret const& _secret);
 
+// Convert transaction from and nonce to address.
+Address toAddress(Address const& _from, u256 const& _nonce);
+
 /// Encrypts plain text using Public key.
 void encrypt(Public const& _k, bytesConstRef _plain, bytes& o_cipher);
 

--- a/libethereum/ClientBase.cpp
+++ b/libethereum/ClientBase.cpp
@@ -45,7 +45,7 @@ State ClientBase::asOf(BlockNumber _h) const
 	return asOf(bc().numberHash(_h));
 }
 
-Address ClientBase::submitTransaction(TransactionSkeleton const& _t, Secret const& _secret)
+h256 ClientBase::submitTransaction(TransactionSkeleton const& _t, Secret const& _secret)
 {
 	prepareForTransaction();
 	
@@ -59,7 +59,7 @@ Address ClientBase::submitTransaction(TransactionSkeleton const& _t, Secret cons
 	StructuredLogger::transactionReceived(t.sha3().abridged(), t.sender().abridged());
 	cnote << "New transaction " << t;
 	
-	return _t.creation ? right160(sha3(rlpList(ts.from, ts.nonce))) : Address();
+	return t.sha3();
 }
 
 // TODO: remove try/catch, allow exceptions

--- a/libethereum/ClientBase.h
+++ b/libethereum/ClientBase.h
@@ -76,7 +76,7 @@ public:
 	virtual ~ClientBase() {}
 
 	/// Submits the given transaction.
-	/// @returns the new contract's address (assuming it all goes through).
+	/// @returns the new transaction's hash.
 	virtual h256 submitTransaction(TransactionSkeleton const& _t, Secret const& _secret) override;
 	using Interface::submitTransaction;
 

--- a/libethereum/ClientBase.h
+++ b/libethereum/ClientBase.h
@@ -77,7 +77,7 @@ public:
 
 	/// Submits the given transaction.
 	/// @returns the new contract's address (assuming it all goes through).
-	virtual Address submitTransaction(TransactionSkeleton const& _t, Secret const& _secret) override;
+	virtual h256 submitTransaction(TransactionSkeleton const& _t, Secret const& _secret) override;
 	using Interface::submitTransaction;
 
 	/// Makes the given call. Nothing is recorded into the state.

--- a/libethereum/Interface.cpp
+++ b/libethereum/Interface.cpp
@@ -46,5 +46,6 @@ Address Interface::submitTransaction(Secret const& _secret, u256 const& _endowme
 	ts.gas = _gas;
 	ts.gasPrice = _gasPrice;
 	ts.nonce = _nonce;
-	return submitTransaction(ts, _secret);
+	submitTransaction(ts, _secret);
+	return toAddress(toAddress(_secret), _nonce);
 }

--- a/libethereum/Interface.h
+++ b/libethereum/Interface.h
@@ -66,7 +66,7 @@ public:
 	// [TRANSACTION API]
 
 	/// Submits a new transaction.
-	/// @returns the new contract's address (assuming it all goes through and it's contract creation).
+	/// @returns the transaction's hash.
 	virtual h256 submitTransaction(TransactionSkeleton const& _t, Secret const& _secret) = 0;
 
 	/// Submits the given message-call transaction.

--- a/libethereum/Interface.h
+++ b/libethereum/Interface.h
@@ -67,7 +67,7 @@ public:
 
 	/// Submits a new transaction.
 	/// @returns the new contract's address (assuming it all goes through and it's contract creation).
-	virtual Address submitTransaction(TransactionSkeleton const& _t, Secret const& _secret) = 0;
+	virtual h256 submitTransaction(TransactionSkeleton const& _t, Secret const& _secret) = 0;
 
 	/// Submits the given message-call transaction.
 	void submitTransaction(Secret const& _secret, u256 const& _value, Address const& _dest, bytes const& _data = bytes(), u256 const& _gas = 10000, u256 const& _gasPrice = 10 * szabo, u256 const& _nonce = UndefinedU256);

--- a/libweb3jsonrpc/AccountHolder.cpp
+++ b/libweb3jsonrpc/AccountHolder.cpp
@@ -106,20 +106,22 @@ AddressHash SimpleAccountHolder::realAccounts() const
 	return m_keyManager.accountsHash();
 }
 
-void SimpleAccountHolder::authenticate(dev::eth::TransactionSkeleton const& _t)
+h256 SimpleAccountHolder::authenticate(dev::eth::TransactionSkeleton const& _t)
 {
 	if (isRealAccount(_t.from))
-		m_client()->submitTransaction(_t, m_keyManager.secret(_t.from, [&](){ return m_getPassword(_t.from); }));
+		return m_client()->submitTransaction(_t, m_keyManager.secret(_t.from, [&](){ return m_getPassword(_t.from); }));
 	else if (isProxyAccount(_t.from))
 		queueTransaction(_t);
+	return h256();
 }
 
-void FixedAccountHolder::authenticate(dev::eth::TransactionSkeleton const& _t)
+h256 FixedAccountHolder::authenticate(dev::eth::TransactionSkeleton const& _t)
 {
 	if (isRealAccount(_t.from))
-		m_client()->submitTransaction(_t, m_accounts[_t.from]);
+		return m_client()->submitTransaction(_t, m_accounts[_t.from]);
 	else if (isProxyAccount(_t.from))
 		queueTransaction(_t);
+	return h256();
 }
 
 

--- a/libweb3jsonrpc/AccountHolder.h
+++ b/libweb3jsonrpc/AccountHolder.h
@@ -51,7 +51,7 @@ public:
 	virtual AddressHash realAccounts() const = 0;
 	// use m_web3's submitTransaction
 	// or use AccountHolder::queueTransaction(_t) to accept
-	virtual void authenticate(dev::eth::TransactionSkeleton const& _t) = 0;
+	virtual h256 authenticate(dev::eth::TransactionSkeleton const& _t) = 0;
 
 	Addresses allAccounts() const;
 	bool isRealAccount(Address const& _account) const { return realAccounts().count(_account) > 0; }
@@ -85,7 +85,7 @@ public:
 	{}
 
 	AddressHash realAccounts() const override;
-	void authenticate(dev::eth::TransactionSkeleton const& _t) override;
+	h256 authenticate(dev::eth::TransactionSkeleton const& _t) override;
 
 private:
 	std::function<std::string(Address)> m_getPassword;
@@ -117,7 +117,7 @@ public:
 
 	// use m_web3's submitTransaction
 	// or use AccountHolder::queueTransaction(_t) to accept
-	void authenticate(dev::eth::TransactionSkeleton const& _t) override;
+	h256 authenticate(dev::eth::TransactionSkeleton const& _t) override;
 
 private:
 	std::unordered_map<dev::Address, dev::Secret> m_accounts;

--- a/libweb3jsonrpc/WebThreeStubServerBase.cpp
+++ b/libweb3jsonrpc/WebThreeStubServerBase.cpp
@@ -242,21 +242,16 @@ string WebThreeStubServerBase::eth_sendTransaction(Json::Value const& _json)
 {
 	try
 	{
-		string ret;
 		TransactionSkeleton t = toTransactionSkeleton(_json);
 	
 		if (!t.from)
 			t.from = m_ethAccounts->defaultTransactAccount();
-		if (t.creation)
-			ret = toJS(right160(sha3(rlpList(t.from, client()->countAt(t.from)))));
 		if (t.gasPrice == UndefinedU256)
 			t.gasPrice = 10 * dev::eth::szabo;		// TODO: should be determined by user somehow.
 		if (t.gas == UndefinedU256)
 			t.gas = min<u256>(client()->gasLimitRemaining() / 5, client()->balanceAt(t.from) / t.gasPrice);
 
-		m_ethAccounts->authenticate(t);
-	
-		return ret;
+		return toJS(m_ethAccounts->authenticate(t));
 	}
 	catch (...)
 	{
@@ -268,13 +263,10 @@ string WebThreeStubServerBase::eth_signTransaction(Json::Value const& _json)
 {
 	try
 	{
-		string ret;
 		TransactionSkeleton t = toTransactionSkeleton(_json);
 
 		if (!t.from)
 			t.from = m_ethAccounts->defaultTransactAccount();
-		if (t.creation)
-			ret = toJS(right160(sha3(rlpList(t.from, client()->countAt(t.from)))));;
 		if (t.gasPrice == UndefinedU256)
 			t.gasPrice = 10 * dev::eth::szabo;		// TODO: should be determined by user somehow.
 		if (t.gas == UndefinedU256)

--- a/mix/MixClient.cpp
+++ b/mix/MixClient.cpp
@@ -303,14 +303,14 @@ State MixClient::asOf(h256 const& _block) const
 	return ret;
 }
 
-Address MixClient::submitTransaction(eth::TransactionSkeleton const& _ts, Secret const& _secret, bool _gasAuto)
+h256 MixClient::submitTransaction(eth::TransactionSkeleton const& _ts, Secret const& _secret, bool _gasAuto)
 {
 	WriteGuard l(x_state);
 	TransactionSkeleton ts = _ts;
 	ts.nonce = m_state.transactionsFrom(toAddress(_secret));
 	eth::Transaction t(ts, _secret);
 	executeTransaction(t, m_state, false, _gasAuto, _secret);
-	return _ts.creation ? right160(sha3(rlpList(ts.to, ts.nonce))) : Address();
+	return t.sha3();
 }
 
 dev::eth::ExecutionResult MixClient::call(Address const& _from, u256 _value, Address _dest, bytes const& _data, u256 _gas, u256 _gasPrice, BlockNumber _blockNumber, bool _gasAuto, FudgeFactor _ff)

--- a/mix/MixClient.h
+++ b/mix/MixClient.h
@@ -58,8 +58,8 @@ public:
 	dev::eth::ExecutionResult create(Address const& _secret, u256 _value, bytes const& _data = bytes(), u256 _gas = 10000, u256 _gasPrice = 10 * eth::szabo, eth::BlockNumber _blockNumber = eth::PendingBlock, eth::FudgeFactor _ff = eth::FudgeFactor::Strict) override;
 
 	using ClientBase::submitTransaction;
-	virtual Address submitTransaction(eth::TransactionSkeleton const& _ts, Secret const& _secret) override { return submitTransaction(_ts, _secret, false); }
-	Address submitTransaction(eth::TransactionSkeleton const& _ts, Secret const& _secret, bool _gasAuto);
+	virtual h256 submitTransaction(eth::TransactionSkeleton const& _ts, Secret const& _secret) override { return submitTransaction(_ts, _secret, false); }
+	h256 submitTransaction(eth::TransactionSkeleton const& _ts, Secret const& _secret, bool _gasAuto);
 	dev::eth::ExecutionResult call(Address const& _secret, u256 _value, Address _dest, bytes const& _data, u256 _gas, u256 _gasPrice, eth::BlockNumber _blockNumber, bool _gasAuto, eth::FudgeFactor _ff = eth::FudgeFactor::Strict);
 
 	void setAddress(Address _us) override;


### PR DESCRIPTION
[geth](https://github.com/ethereum/go-ethereum/issues/1422)  changed it's behaviour yesterday