### PR TITLE
Throw on FixedHash failure of String construction

### DIFF
--- a/libdevcore/FixedHash.h
+++ b/libdevcore/FixedHash.h
@@ -81,7 +81,7 @@ public:
 	explicit FixedHash(byte const* _bs, ConstructFromPointerType) { memcpy(m_data.data(), _bs, N); }
 
 	/// Explicitly construct, copying from a  string.
-	explicit FixedHash(std::string const& _s, ConstructFromStringType _t = FromHex, ConstructFromHashType _ht = FailIfDifferent): FixedHash(_t == FromHex ? fromHex(_s) : dev::asBytes(_s), _ht) {}
+	explicit FixedHash(std::string const& _s, ConstructFromStringType _t = FromHex, ConstructFromHashType _ht = FailIfDifferent): FixedHash(_t == FromHex ? fromHex(_s, WhenError::Throw) : dev::asBytes(_s), _ht) {}
 
 	/// Convert to arithmetic type.
 	operator Arith() const { return fromBigEndian<Arith>(m_data); }


### PR DESCRIPTION
I have had this bite me a few times when testing FixedHash with the
string constructor. A capital "X" in the 0x prefix, wrong number of hex
characters compared to the number of bytes the FixedHash has e.t.c. and there
was no warning. The hash had a 0 value while I was assuming it worked
fine.

Having it throw in case of error will guarantee that this won't happen again.