### PR TITLE
Disable auto adjust of batch size by default

### DIFF
--- a/libethcore/Ethash.cpp
+++ b/libethcore/Ethash.cpp
@@ -56,7 +56,7 @@ namespace eth
 
 const unsigned Ethash::defaultLocalWorkSize = 64;
 const unsigned Ethash::defaultGlobalWorkSizeMultiplier = 512; // * CL_DEFAULT_LOCAL_WORK_SIZE
-const unsigned Ethash::defaultMSPerBatch = 100;
+const unsigned Ethash::defaultMSPerBatch = 0;
 const Ethash::WorkPackage Ethash::NullWorkPackage = Ethash::WorkPackage();
 
 std::string Ethash::name()


### PR DESCRIPTION
After reports from many miners the whole auto adjusting idea may or may not
work depending the user's hardware. A much safer default value is 0 (to
disable auto adjustment).