### PR TITLE
use new nonce to calc contract address

### DIFF
--- a/libethereum/ClientBase.cpp
+++ b/libethereum/ClientBase.cpp
@@ -45,14 +45,14 @@ State ClientBase::asOf(BlockNumber _h) const
 	return asOf(bc().numberHash(_h));
 }
 
-h256 ClientBase::submitTransaction(TransactionSkeleton const& _t, Secret const& _secret)
+h256 ClientBase::submitTransaction(TransactionSkeleton const& _t, Secret const& _secret, u256 o_nonce)
 {
 	prepareForTransaction();
 	
 	TransactionSkeleton ts(_t);
 	ts.from = toAddress(_secret);
 	if (_t.nonce == UndefinedU256)
-		ts.nonce = max<u256>(postMine().transactionsFrom(ts.from), m_tq.maxNonce(ts.from));
+		o_nonce = ts.nonce = max<u256>(postMine().transactionsFrom(ts.from), m_tq.maxNonce(ts.from));
 
 	Transaction t(ts, _secret);
 	m_tq.import(t.rlp());

--- a/libethereum/ClientBase.h
+++ b/libethereum/ClientBase.h
@@ -77,7 +77,7 @@ public:
 
 	/// Submits the given transaction.
 	/// @returns the new transaction's hash.
-	virtual h256 submitTransaction(TransactionSkeleton const& _t, Secret const& _secret) override;
+	virtual h256 submitTransaction(TransactionSkeleton const& _t, Secret const& _secret, u256 o_nonce = UndefinedU256) override;
 	using Interface::submitTransaction;
 
 	/// Makes the given call. Nothing is recorded into the state.

--- a/libethereum/Interface.cpp
+++ b/libethereum/Interface.cpp
@@ -46,6 +46,6 @@ Address Interface::submitTransaction(Secret const& _secret, u256 const& _endowme
 	ts.gas = _gas;
 	ts.gasPrice = _gasPrice;
 	ts.nonce = _nonce;
-	submitTransaction(ts, _secret);
-	return toAddress(toAddress(_secret), _nonce);
+	submitTransaction(ts, _secret, ts.nonce);
+	return toAddress(toAddress(_secret), ts.nonce);
 }

--- a/libethereum/Interface.h
+++ b/libethereum/Interface.h
@@ -67,7 +67,7 @@ public:
 
 	/// Submits a new transaction.
 	/// @returns the transaction's hash.
-	virtual h256 submitTransaction(TransactionSkeleton const& _t, Secret const& _secret) = 0;
+	virtual h256 submitTransaction(TransactionSkeleton const& _t, Secret const& _secret, u256 o_nonce = UndefinedU256) = 0;
 
 	/// Submits the given message-call transaction.
 	void submitTransaction(Secret const& _secret, u256 const& _value, Address const& _dest, bytes const& _data = bytes(), u256 const& _gas = 10000, u256 const& _gasPrice = 10 * szabo, u256 const& _nonce = UndefinedU256);

--- a/mix/MixClient.h
+++ b/mix/MixClient.h
@@ -58,7 +58,7 @@ public:
 	dev::eth::ExecutionResult create(Address const& _secret, u256 _value, bytes const& _data = bytes(), u256 _gas = 10000, u256 _gasPrice = 10 * eth::szabo, eth::BlockNumber _blockNumber = eth::PendingBlock, eth::FudgeFactor _ff = eth::FudgeFactor::Strict) override;
 
 	using ClientBase::submitTransaction;
-	virtual h256 submitTransaction(eth::TransactionSkeleton const& _ts, Secret const& _secret) override { return submitTransaction(_ts, _secret, false); }
+	virtual h256 submitTransaction(eth::TransactionSkeleton const& _ts, Secret const& _secret, u256 o_nonce = UndefinedU256) override {(void)o_nonce; return submitTransaction(_ts, _secret, false); }
 	h256 submitTransaction(eth::TransactionSkeleton const& _ts, Secret const& _secret, bool _gasAuto);
 	dev::eth::ExecutionResult call(Address const& _secret, u256 _value, Address _dest, bytes const& _data, u256 _gas, u256 _gasPrice, eth::BlockNumber _blockNumber, bool _gasAuto, eth::FudgeFactor _ff = eth::FudgeFactor::Strict);
 


### PR DESCRIPTION
Currently, when no nonce is given, we calculate a nonce here https://github.com/ethereum/cpp-ethereum/blob/develop/libethereum/ClientBase.cpp#L55 .
But for calculating the address of the new contract we use the `UndefinedU256` and therefore always returning the wrong contract address. This PR fixes this by returning the new nonce through a function parameter.