### PR TITLE
Restore the old default value of global work size

### DIFF
--- a/libethash-cl/ethash_cl_miner.h
+++ b/libethash-cl/ethash_cl_miner.h
@@ -20,7 +20,7 @@
 class ethash_cl_miner
 {
 private:
-	enum { c_maxSearchResults = 63, c_bufferCount = 2, c_hashBatchSize = 1024, c_searchBatchSize = 1024 * 16 };
+	enum { c_maxSearchResults = 63, c_bufferCount = 2, c_hashBatchSize = 1024 };
 
 public:
 	struct search_hook

--- a/libethcore/Ethash.cpp
+++ b/libethcore/Ethash.cpp
@@ -55,7 +55,7 @@ namespace eth
 {
 
 const unsigned Ethash::defaultLocalWorkSize = 64;
-const unsigned Ethash::defaultGlobalWorkSizeMultiplier = 512; // * CL_DEFAULT_LOCAL_WORK_SIZE
+const unsigned Ethash::defaultGlobalWorkSizeMultiplier = 4096; // * CL_DEFAULT_LOCAL_WORK_SIZE
 const unsigned Ethash::defaultMSPerBatch = 0;
 const Ethash::WorkPackage Ethash::NullWorkPackage = Ethash::WorkPackage();
 


### PR DESCRIPTION
It used to be 64 (local size) * 4096 (global multiplier). Miners
reported a lot better results with those old defaults and as such we are
bringing them back.

The change had occured, maybe by mistake, in [this](https://github.com/ethereum/cpp-ethereum/commit/a8eb96755cdffdc7e2c6f59003bc8cb9cc971166) commit.