### PR TITLE
Fix AES Test

### DIFF
--- a/test/libdevcrypto/AES.cpp
+++ b/test/libdevcrypto/AES.cpp
@@ -79,7 +79,7 @@ BOOST_AUTO_TEST_CASE(AuthenticatedStreamConstructor)
 {
 	cout << "AuthenticatedStreamConstructor" << endl;
 
-	Secret const sec("test");
+	Secret const sec(dev::sha3("test"));
 	crypto::aes::AuthenticatedStream as(crypto::aes::Encrypt, sec, 0);
 	BOOST_CHECK(as.getMacInterval() == 0);
 	as.adjustInterval(1);


### PR DESCRIPTION
One of the AES tests was making an incorrect assumption about the string
constructor of FixedHash. Said constructor only works with hexadecimal
string representations