### PR TITLE
ethashcl doesnt depend on ethcore

### DIFF
--- a/ethminer/MinerAux.h
+++ b/ethminer/MinerAux.h
@@ -40,6 +40,9 @@
 #include <libethcore/ProofOfWork.h>
 #include <libethcore/EthashAux.h>
 #include <libethcore/Farm.h>
+#if ETH_ETHASHCL || !ETH_TRUE
+#include <libethash-cl/ethash_cl_miner.h>
+#endif
 #if ETH_JSONRPC || !ETH_TRUE
 #include <libweb3jsonrpc/WebThreeStubServer.h>
 #include <jsonrpccpp/server/connectors/httpserver.h>
@@ -128,6 +131,7 @@ public:
 				cerr << "Bad " << arg << " option: " << argv[i] << endl;
 				BOOST_THROW_EXCEPTION(BadArgument());
 			}
+#if ETH_ETHASHCL || !ETH_TRUE
 		else if (arg == "--cl-global-work" && i + 1 < argc)
 			try {
 				m_globalWorkSizeMultiplier = stol(argv[++i]);
@@ -155,6 +159,7 @@ public:
 				cerr << "Bad " << arg << " option: " << argv[i] << endl;
 				BOOST_THROW_EXCEPTION(BadArgument());
 			}
+#endif
 		else if (arg == "--list-devices")
 			m_shouldListDevices = true;
 		else if (arg == "--allow-opencl-cpu")
@@ -292,6 +297,7 @@ public:
 			ProofOfWork::CPUMiner::setNumInstances(m_miningThreads);
 		else if (m_minerType == MinerType::GPU)
 		{
+#if ETH_ETHASHCL || !ETH_TRUE
 			if (!ProofOfWork::GPUMiner::configureGPU(
 					m_localWorkSize,
 					m_globalWorkSizeMultiplier,
@@ -304,6 +310,10 @@ public:
 				))
 				exit(1);
 			ProofOfWork::GPUMiner::setNumInstances(m_miningThreads);
+#else
+			cerr << "Selected GPU mining without having compiled with -DETHASHCL=1" << endl;
+			exit(1);
+#endif
 		}
 		if (mode == OperationMode::DAGInit)
 			doInitDAG(m_initDAG);
@@ -344,10 +354,12 @@ public:
 			<< "    --allow-opencl-cpu Allows CPU to be considered as an OpenCL device if the OpenCL platform supports it." << endl
 			<< "    --list-devices List the detected OpenCL devices and exit." << endl
 			<< "    --current-block Let the miner know the current block number at configuration time. Will help determine DAG size and required GPU memory." << endl
+#if ETH_ETHASHCL || !ETH_TRUE
 			<< "    --cl-extragpu-mem Set the memory (in MB) you believe your GPU requires for stuff other than mining. Windows rendering e.t.c.." << endl
-			<< "    --cl-local-work Set the OpenCL local work size. Default is " << toString(dev::eth::Ethash::defaultLocalWorkSize) << endl
-			<< "    --cl-global-work Set the OpenCL global work size as a multiple of the local work size. Default is " << toString(dev::eth::Ethash::defaultGlobalWorkSizeMultiplier) << " * " << toString(dev::eth::Ethash::defaultLocalWorkSize) << endl
-			<< "    --cl-ms-per-batch Set the OpenCL target milliseconds per batch (global workgroup size). Default is " << toString(dev::eth::Ethash::defaultMSPerBatch) << ". If 0 is given then no autoadjustment of global work size will happen" << endl
+			<< "    --cl-local-work Set the OpenCL local work size. Default is " << toString(ethash_cl_miner::defaultLocalWorkSize) << endl
+			<< "    --cl-global-work Set the OpenCL global work size as a multiple of the local work size. Default is " << toString(ethash_cl_miner::defaultGlobalWorkSizeMultiplier) << " * " << toString(ethash_cl_miner::defaultLocalWorkSize) << endl
+			<< "    --cl-ms-per-batch Set the OpenCL target milliseconds per batch (global workgroup size). Default is " << toString(ethash_cl_miner::defaultMSPerBatch) << ". If 0 is given then no autoadjustment of global work size will happen" << endl
+#endif
 			;
 	}
 
@@ -536,9 +548,11 @@ private:
 	unsigned m_miningThreads = UINT_MAX;
 	bool m_shouldListDevices = false;
 	bool m_clAllowCPU = false;
-	unsigned m_globalWorkSizeMultiplier = dev::eth::Ethash::defaultGlobalWorkSizeMultiplier;
-	unsigned m_localWorkSize = dev::eth::Ethash::defaultLocalWorkSize;
-	unsigned m_msPerBatch = dev::eth::Ethash::defaultMSPerBatch;
+#if ETH_ETHASHCL || !ETH_TRUE
+	unsigned m_globalWorkSizeMultiplier = ethash_cl_miner::defaultGlobalWorkSizeMultiplier;
+	unsigned m_localWorkSize = ethash_cl_miner::defaultLocalWorkSize;
+	unsigned m_msPerBatch = ethash_cl_miner::defaultMSPerBatch;
+#endif
 	boost::optional<uint64_t> m_currentBlock;
 	// default value is 350MB of GPU memory for other stuff (windows system rendering, e.t.c.)
 	unsigned m_extraGPUMemory = 350000000;

--- a/ethminer/MinerAux.h
+++ b/ethminer/MinerAux.h
@@ -356,9 +356,9 @@ public:
 			<< "    --current-block Let the miner know the current block number at configuration time. Will help determine DAG size and required GPU memory." << endl
 #if ETH_ETHASHCL || !ETH_TRUE
 			<< "    --cl-extragpu-mem Set the memory (in MB) you believe your GPU requires for stuff other than mining. Windows rendering e.t.c.." << endl
-			<< "    --cl-local-work Set the OpenCL local work size. Default is " << toString(ethash_cl_miner::defaultLocalWorkSize) << endl
-			<< "    --cl-global-work Set the OpenCL global work size as a multiple of the local work size. Default is " << toString(ethash_cl_miner::defaultGlobalWorkSizeMultiplier) << " * " << toString(ethash_cl_miner::defaultLocalWorkSize) << endl
-			<< "    --cl-ms-per-batch Set the OpenCL target milliseconds per batch (global workgroup size). Default is " << toString(ethash_cl_miner::defaultMSPerBatch) << ". If 0 is given then no autoadjustment of global work size will happen" << endl
+			<< "    --cl-local-work Set the OpenCL local work size. Default is " << toString(ethash_cl_miner::c_defaultLocalWorkSize) << endl
+			<< "    --cl-global-work Set the OpenCL global work size as a multiple of the local work size. Default is " << toString(ethash_cl_miner::c_defaultGlobalWorkSizeMultiplier) << " * " << toString(ethash_cl_miner::c_defaultLocalWorkSize) << endl
+			<< "    --cl-ms-per-batch Set the OpenCL target milliseconds per batch (global workgroup size). Default is " << toString(ethash_cl_miner::c_defaultMSPerBatch) << ". If 0 is given then no autoadjustment of global work size will happen" << endl
 #endif
 			;
 	}
@@ -549,9 +549,9 @@ private:
 	bool m_shouldListDevices = false;
 	bool m_clAllowCPU = false;
 #if ETH_ETHASHCL || !ETH_TRUE
-	unsigned m_globalWorkSizeMultiplier = ethash_cl_miner::defaultGlobalWorkSizeMultiplier;
-	unsigned m_localWorkSize = ethash_cl_miner::defaultLocalWorkSize;
-	unsigned m_msPerBatch = ethash_cl_miner::defaultMSPerBatch;
+	unsigned m_globalWorkSizeMultiplier = ethash_cl_miner::c_defaultGlobalWorkSizeMultiplier;
+	unsigned m_localWorkSize = ethash_cl_miner::c_defaultLocalWorkSize;
+	unsigned m_msPerBatch = ethash_cl_miner::c_defaultMSPerBatch;
 #endif
 	boost::optional<uint64_t> m_currentBlock;
 	// default value is 350MB of GPU memory for other stuff (windows system rendering, e.t.c.)

--- a/libethash-cl/ethash_cl_miner.cpp
+++ b/libethash-cl/ethash_cl_miner.cpp
@@ -50,9 +50,9 @@
 
 using namespace std;
 
-const unsigned ethash_cl_miner::defaultLocalWorkSize = 64;
-const unsigned ethash_cl_miner::defaultGlobalWorkSizeMultiplier = 4096; // * CL_DEFAULT_LOCAL_WORK_SIZE
-const unsigned ethash_cl_miner::defaultMSPerBatch = 0;
+const unsigned ethash_cl_miner::c_defaultLocalWorkSize = 64;
+const unsigned ethash_cl_miner::c_defaultGlobalWorkSizeMultiplier = 4096; // * CL_DEFAULT_LOCAL_WORK_SIZE
+const unsigned ethash_cl_miner::c_defaultMSPerBatch = 0;
 
 // TODO: If at any point we can use libdevcore in here then we should switch to using a LogChannel
 #define ETHCL_LOG(_contents) cout << "[OPENCL]:" << _contents << endl
@@ -185,9 +185,9 @@ bool ethash_cl_miner::configureGPU(
 
 bool ethash_cl_miner::s_allowCPU = false;
 unsigned ethash_cl_miner::s_extraRequiredGPUMem;
-unsigned ethash_cl_miner::s_msPerBatch = ethash_cl_miner::defaultMSPerBatch;
-unsigned ethash_cl_miner::s_workgroupSize = ethash_cl_miner::defaultLocalWorkSize;
-unsigned ethash_cl_miner::s_initialGlobalWorkSize = ethash_cl_miner::defaultGlobalWorkSizeMultiplier * ethash_cl_miner::defaultLocalWorkSize;
+unsigned ethash_cl_miner::s_msPerBatch = ethash_cl_miner::c_defaultMSPerBatch;
+unsigned ethash_cl_miner::s_workgroupSize = ethash_cl_miner::c_defaultLocalWorkSize;
+unsigned ethash_cl_miner::s_initialGlobalWorkSize = ethash_cl_miner::c_defaultGlobalWorkSizeMultiplier * ethash_cl_miner::c_defaultLocalWorkSize;
 
 bool ethash_cl_miner::searchForAllDevices(function<bool(cl::Device const&)> _callback)
 {

--- a/libethash-cl/ethash_cl_miner.cpp
+++ b/libethash-cl/ethash_cl_miner.cpp
@@ -33,7 +33,6 @@
 #include <vector>
 #include <libethash/util.h>
 #include <libethash/ethash.h>
-#include <libethcore/Ethash.h>
 #include <libethash/internal.h>
 #include "ethash_cl_miner.h"
 #include "ethash_cl_miner_kernel.h"
@@ -50,7 +49,10 @@
 #undef max
 
 using namespace std;
-using namespace dev::eth;
+
+const unsigned ethash_cl_miner::defaultLocalWorkSize = 64;
+const unsigned ethash_cl_miner::defaultGlobalWorkSizeMultiplier = 4096; // * CL_DEFAULT_LOCAL_WORK_SIZE
+const unsigned ethash_cl_miner::defaultMSPerBatch = 0;
 
 // TODO: If at any point we can use libdevcore in here then we should switch to using a LogChannel
 #define ETHCL_LOG(_contents) cout << "[OPENCL]:" << _contents << endl
@@ -183,9 +185,9 @@ bool ethash_cl_miner::configureGPU(
 
 bool ethash_cl_miner::s_allowCPU = false;
 unsigned ethash_cl_miner::s_extraRequiredGPUMem;
-unsigned ethash_cl_miner::s_msPerBatch = Ethash::defaultMSPerBatch;
-unsigned ethash_cl_miner::s_workgroupSize = Ethash::defaultLocalWorkSize;
-unsigned ethash_cl_miner::s_initialGlobalWorkSize = Ethash::defaultGlobalWorkSizeMultiplier * Ethash::defaultLocalWorkSize;
+unsigned ethash_cl_miner::s_msPerBatch = ethash_cl_miner::defaultMSPerBatch;
+unsigned ethash_cl_miner::s_workgroupSize = ethash_cl_miner::defaultLocalWorkSize;
+unsigned ethash_cl_miner::s_initialGlobalWorkSize = ethash_cl_miner::defaultGlobalWorkSizeMultiplier * ethash_cl_miner::defaultLocalWorkSize;
 
 bool ethash_cl_miner::searchForAllDevices(function<bool(cl::Device const&)> _callback)
 {

--- a/libethash-cl/ethash_cl_miner.cpp
+++ b/libethash-cl/ethash_cl_miner.cpp
@@ -50,9 +50,9 @@
 
 using namespace std;
 
-const unsigned ethash_cl_miner::c_defaultLocalWorkSize = 64;
-const unsigned ethash_cl_miner::c_defaultGlobalWorkSizeMultiplier = 4096; // * CL_DEFAULT_LOCAL_WORK_SIZE
-const unsigned ethash_cl_miner::c_defaultMSPerBatch = 0;
+unsigned const ethash_cl_miner::c_defaultLocalWorkSize = 64;
+unsigned const ethash_cl_miner::c_defaultGlobalWorkSizeMultiplier = 4096; // * CL_DEFAULT_LOCAL_WORK_SIZE
+unsigned const ethash_cl_miner::c_defaultMSPerBatch = 0;
 
 // TODO: If at any point we can use libdevcore in here then we should switch to using a LogChannel
 #define ETHCL_LOG(_contents) cout << "[OPENCL]:" << _contents << endl

--- a/libethash-cl/ethash_cl_miner.h
+++ b/libethash-cl/ethash_cl_miner.h
@@ -65,6 +65,14 @@ public:
 	void hash_chunk(uint8_t* _ret, uint8_t const* _header, uint64_t _nonce, unsigned _count);
 	void search_chunk(uint8_t const*_header, uint64_t _target, search_hook& _hook);
 
+	/* -- default values -- */
+	/// Default value of the local work size. Also known as workgroup size.
+	static const unsigned defaultLocalWorkSize;
+	/// Default value of the global work size as a multiplier of the local work size
+	static const unsigned defaultGlobalWorkSizeMultiplier;
+	/// Default value of the milliseconds per global work size (per batch)
+	static const unsigned defaultMSPerBatch;
+
 private:
 
 	static std::vector<cl::Device> getDevices(std::vector<cl::Platform> const& _platforms, unsigned _platformId);

--- a/libethash-cl/ethash_cl_miner.h
+++ b/libethash-cl/ethash_cl_miner.h
@@ -67,11 +67,11 @@ public:
 
 	/* -- default values -- */
 	/// Default value of the local work size. Also known as workgroup size.
-	static const unsigned defaultLocalWorkSize;
+	static const unsigned c_defaultLocalWorkSize;
 	/// Default value of the global work size as a multiplier of the local work size
-	static const unsigned defaultGlobalWorkSizeMultiplier;
+	static const unsigned c_defaultGlobalWorkSizeMultiplier;
 	/// Default value of the milliseconds per global work size (per batch)
-	static const unsigned defaultMSPerBatch;
+	static const unsigned c_defaultMSPerBatch;
 
 private:
 

--- a/libethash-cl/ethash_cl_miner.h
+++ b/libethash-cl/ethash_cl_miner.h
@@ -67,11 +67,11 @@ public:
 
 	/* -- default values -- */
 	/// Default value of the local work size. Also known as workgroup size.
-	static const unsigned c_defaultLocalWorkSize;
+	static unsigned const c_defaultLocalWorkSize;
 	/// Default value of the global work size as a multiplier of the local work size
-	static const unsigned c_defaultGlobalWorkSizeMultiplier;
+	static unsigned const c_defaultGlobalWorkSizeMultiplier;
 	/// Default value of the milliseconds per global work size (per batch)
-	static const unsigned c_defaultMSPerBatch;
+	static unsigned const c_defaultMSPerBatch;
 
 private:
 

--- a/libethcore/Ethash.cpp
+++ b/libethcore/Ethash.cpp
@@ -54,9 +54,6 @@ namespace dev
 namespace eth
 {
 
-const unsigned Ethash::defaultLocalWorkSize = 64;
-const unsigned Ethash::defaultGlobalWorkSizeMultiplier = 4096; // * CL_DEFAULT_LOCAL_WORK_SIZE
-const unsigned Ethash::defaultMSPerBatch = 0;
 const Ethash::WorkPackage Ethash::NullWorkPackage = Ethash::WorkPackage();
 
 std::string Ethash::name()

--- a/libethcore/Ethash.h
+++ b/libethcore/Ethash.h
@@ -150,12 +150,6 @@ public:
 #else
 	using GPUMiner = CPUMiner;
 #endif
-	/// Default value of the local work size. Also known as workgroup size.
-	static const unsigned defaultLocalWorkSize;
-	/// Default value of the global work size as a multiplier of the local work size
-	static const unsigned defaultGlobalWorkSizeMultiplier;
-	/// Default value of the milliseconds per global work size (per batch)
-	static const unsigned defaultMSPerBatch;
 };
 
 }


### PR DESCRIPTION
At least not anymore. Moved global constants into ethash_cl_miner class
instead of being in Ethash class.

Also `#ifdefed` some openCL related stuff to only compile when `ETHASHCL` is active.