### PR TITLE
ethminer no longer depends on boost

### DIFF
--- a/ethminer/MinerAux.h
+++ b/ethminer/MinerAux.h
@@ -211,10 +211,7 @@ public:
 		else if (arg == "-G" || arg == "--opencl")
 			m_minerType = MinerType::GPU;
 		else if (arg == "--current-block" && i + 1 < argc)
-		{
 			m_currentBlock = stol(argv[++i]);
-			m_currentBlockGiven = true;
-		}
 		else if (arg == "--no-precompute")
 		{
 			m_precompute = false;
@@ -309,7 +306,6 @@ public:
 					m_openclDevice,
 					m_clAllowCPU,
 					m_extraGPUMemory,
-					m_currentBlockGiven,
 					m_currentBlock
 				))
 				exit(1);

--- a/ethminer/MinerAux.h
+++ b/ethminer/MinerAux.h
@@ -211,7 +211,10 @@ public:
 		else if (arg == "-G" || arg == "--opencl")
 			m_minerType = MinerType::GPU;
 		else if (arg == "--current-block" && i + 1 < argc)
+		{
 			m_currentBlock = stol(argv[++i]);
+			m_currentBlockGiven = true;
+		}
 		else if (arg == "--no-precompute")
 		{
 			m_precompute = false;
@@ -306,6 +309,7 @@ public:
 					m_openclDevice,
 					m_clAllowCPU,
 					m_extraGPUMemory,
+					m_currentBlockGiven,
 					m_currentBlock
 				))
 				exit(1);
@@ -553,7 +557,7 @@ private:
 	unsigned m_localWorkSize = ethash_cl_miner::c_defaultLocalWorkSize;
 	unsigned m_msPerBatch = ethash_cl_miner::c_defaultMSPerBatch;
 #endif
-	boost::optional<uint64_t> m_currentBlock;
+	uint64_t m_currentBlock = 0;
 	// default value is 350MB of GPU memory for other stuff (windows system rendering, e.t.c.)
 	unsigned m_extraGPUMemory = 350000000;
 

--- a/libethash-cl/ethash_cl_miner.cpp
+++ b/libethash-cl/ethash_cl_miner.cpp
@@ -149,7 +149,6 @@ bool ethash_cl_miner::configureGPU(
 	unsigned _msPerBatch,
 	bool _allowCPU,
 	unsigned _extraGPUMemory,
-	bool _currentBlockGiven,
 	uint64_t _currentBlock
 )
 {
@@ -159,7 +158,7 @@ bool ethash_cl_miner::configureGPU(
 	s_allowCPU = _allowCPU;
 	s_extraRequiredGPUMem = _extraGPUMemory;
 	// by default let's only consider the DAG of the first epoch
-	uint64_t dagSize = _currentBlockGiven ? ethash_get_datasize(_currentBlock) : 1073739904U;
+	uint64_t dagSize = ethash_get_datasize(_currentBlock);
 	uint64_t requiredSize =  dagSize + _extraGPUMemory;
 	return searchForAllDevices(_platformId, [&requiredSize](cl::Device const _device) -> bool
 		{

--- a/libethash-cl/ethash_cl_miner.cpp
+++ b/libethash-cl/ethash_cl_miner.cpp
@@ -149,7 +149,8 @@ bool ethash_cl_miner::configureGPU(
 	unsigned _msPerBatch,
 	bool _allowCPU,
 	unsigned _extraGPUMemory,
-	boost::optional<uint64_t> _currentBlock
+	bool _currentBlockGiven,
+	uint64_t _currentBlock
 )
 {
 	s_workgroupSize = _localWorkSize;
@@ -158,7 +159,7 @@ bool ethash_cl_miner::configureGPU(
 	s_allowCPU = _allowCPU;
 	s_extraRequiredGPUMem = _extraGPUMemory;
 	// by default let's only consider the DAG of the first epoch
-	uint64_t dagSize = _currentBlock ? ethash_get_datasize(*_currentBlock) : 1073739904U;
+	uint64_t dagSize = _currentBlockGiven ? ethash_get_datasize(_currentBlock) : 1073739904U;
 	uint64_t requiredSize =  dagSize + _extraGPUMemory;
 	return searchForAllDevices(_platformId, [&requiredSize](cl::Device const _device) -> bool
 		{

--- a/libethash-cl/ethash_cl_miner.h
+++ b/libethash-cl/ethash_cl_miner.h
@@ -49,7 +49,6 @@ public:
 		unsigned _msPerBatch,
 		bool _allowCPU,
 		unsigned _extraGPUMemory,
-		bool _currentBlockGiven,
 		uint64_t _currentBlock
 	);
 

--- a/libethash-cl/ethash_cl_miner.h
+++ b/libethash-cl/ethash_cl_miner.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#define __CL_ENABLE_EXCEPTIONS 
+#define __CL_ENABLE_EXCEPTIONS
 #define CL_USE_DEPRECATED_OPENCL_2_0_APIS
 
 #if defined(__clang__)
@@ -12,7 +12,6 @@
 #include "cl.hpp"
 #endif
 
-#include <boost/optional.hpp>
 #include <time.h>
 #include <functional>
 #include <libethash/ethash.h>
@@ -50,7 +49,8 @@ public:
 		unsigned _msPerBatch,
 		bool _allowCPU,
 		unsigned _extraGPUMemory,
-		boost::optional<uint64_t> _currentBlock
+		bool _currentBlockGiven,
+		uint64_t _currentBlock
 	);
 
 	bool init(

--- a/libethcore/Ethash.cpp
+++ b/libethcore/Ethash.cpp
@@ -416,7 +416,8 @@ bool Ethash::GPUMiner::configureGPU(
 	unsigned _deviceId,
 	bool _allowCPU,
 	unsigned _extraGPUMemory,
-	boost::optional<uint64_t> _currentBlock
+	bool _currentBlockGiven,
+	uint64_t _currentBlock
 )
 {
 	s_platformId = _platformId;
@@ -435,6 +436,7 @@ bool Ethash::GPUMiner::configureGPU(
 			_msPerBatch,
 			_allowCPU,
 			_extraGPUMemory,
+			_currentBlockGiven,
 			_currentBlock)
 	)
 	{

--- a/libethcore/Ethash.cpp
+++ b/libethcore/Ethash.cpp
@@ -416,7 +416,6 @@ bool Ethash::GPUMiner::configureGPU(
 	unsigned _deviceId,
 	bool _allowCPU,
 	unsigned _extraGPUMemory,
-	bool _currentBlockGiven,
 	uint64_t _currentBlock
 )
 {
@@ -436,7 +435,6 @@ bool Ethash::GPUMiner::configureGPU(
 			_msPerBatch,
 			_allowCPU,
 			_extraGPUMemory,
-			_currentBlockGiven,
 			_currentBlock)
 	)
 	{

--- a/libethcore/Ethash.h
+++ b/libethcore/Ethash.h
@@ -88,7 +88,7 @@ public:
 		static unsigned instances() { return s_numInstances > 0 ? s_numInstances : std::thread::hardware_concurrency(); }
 		static std::string platformInfo();
 		static void listDevices() {}
-		static bool configureGPU(unsigned, unsigned, unsigned, unsigned, unsigned, bool, unsigned,  boost::optional<uint64_t>) { return false; }
+		static bool configureGPU(unsigned, unsigned, unsigned, unsigned, unsigned, bool, unsigned, bool, uint64_t) { return false; }
 		static void setNumInstances(unsigned _instances) { s_numInstances = std::min<unsigned>(_instances, std::thread::hardware_concurrency()); }
 	protected:
 		void kickOff() override
@@ -125,7 +125,8 @@ public:
 			unsigned _deviceId,
 			bool _allowCPU,
 			unsigned _extraGPUMemory,
-			boost::optional<uint64_t> _currentBlock
+			bool _currentBlockGiven,
+			uint64_t _currentBlock
 		);
 		static void setNumInstances(unsigned _instances) { s_numInstances = std::min<unsigned>(_instances, getNumDevices()); }
 

--- a/libethcore/Ethash.h
+++ b/libethcore/Ethash.h
@@ -88,7 +88,7 @@ public:
 		static unsigned instances() { return s_numInstances > 0 ? s_numInstances : std::thread::hardware_concurrency(); }
 		static std::string platformInfo();
 		static void listDevices() {}
-		static bool configureGPU(unsigned, unsigned, unsigned, unsigned, unsigned, bool, unsigned, bool, uint64_t) { return false; }
+		static bool configureGPU(unsigned, unsigned, unsigned, unsigned, unsigned, bool, unsigned, uint64_t) { return false; }
 		static void setNumInstances(unsigned _instances) { s_numInstances = std::min<unsigned>(_instances, std::thread::hardware_concurrency()); }
 	protected:
 		void kickOff() override
@@ -125,7 +125,6 @@ public:
 			unsigned _deviceId,
 			bool _allowCPU,
 			unsigned _extraGPUMemory,
-			bool _currentBlockGiven,
 			uint64_t _currentBlock
 		);
 		static void setNumInstances(unsigned _instances) { s_numInstances = std::min<unsigned>(_instances, getNumDevices()); }


### PR DESCRIPTION
Introducing an extra boolean argument to remove the boost::optional
dependency. Too bad we have to wait for C++17 to get an std::optional