### PR TITLE
Use only a single stack slot for storage references.

### DIFF
--- a/libsolidity/ArrayUtils.h
+++ b/libsolidity/ArrayUtils.h
@@ -41,8 +41,8 @@ public:
 
 	/// Copies an array to an array in storage. The arrays can be of different types only if
 	/// their storage representation is the same.
-	/// Stack pre: source_reference [source_byte_offset/source_length] target_reference target_byte_offset
-	/// Stack post: target_reference target_byte_offset
+	/// Stack pre: source_reference [source_length] target_reference
+	/// Stack post: target_reference
 	void copyArrayToStorage(ArrayType const& _targetType, ArrayType const& _sourceType) const;
 	/// Copies the data part of an array (which cannot be dynamically nested) from anywhere
 	/// to a given position in memory.

--- a/libsolidity/Types.cpp
+++ b/libsolidity/Types.cpp
@@ -823,11 +823,9 @@ unsigned ArrayType::getSizeOnStack() const
 	if (m_location == DataLocation::CallData)
 		// offset [length] (stack top)
 		return 1 + (isDynamicallySized() ? 1 : 0);
-	else if (m_location == DataLocation::Storage)
-		// storage_key storage_offset
-		return 2;
 	else
-		// offset
+		// storage slot or memory offset
+		// byte offset inside storage value is omitted
 		return 1;
 }
 
@@ -1033,14 +1031,6 @@ bool StructType::canLiveOutsideStorage() const
 		if (!member.type->canLiveOutsideStorage())
 			return false;
 	return true;
-}
-
-unsigned StructType::getSizeOnStack() const
-{
-	if (location() == DataLocation::Storage)
-		return 2; // slot and offset
-	else
-		return 1;
 }
 
 string StructType::toString(bool _short) const

--- a/libsolidity/Types.h
+++ b/libsolidity/Types.h
@@ -298,7 +298,6 @@ public:
 
 	virtual bool canBeStored() const override { return false; }
 	virtual bool canLiveOutsideStorage() const override { return false; }
-	virtual unsigned getSizeOnStack() const override { return 1; }
 
 	virtual std::string toString(bool _short) const override;
 	virtual u256 literalValue(Literal const* _literal) const override;
@@ -580,7 +579,6 @@ public:
 	u256 memorySize() const;
 	virtual u256 getStorageSize() const override;
 	virtual bool canLiveOutsideStorage() const override;
-	virtual unsigned getSizeOnStack() const override;
 	virtual std::string toString(bool _short) const override;
 
 	virtual MemberList const& getMembers() const override;
@@ -616,7 +614,6 @@ public:
 	{
 		return externalType()->getCalldataEncodedSize(_padded);
 	}
-	virtual unsigned getSizeOnStack() const override { return 1; }
 	virtual unsigned getStorageBytes() const override;
 	virtual bool canLiveOutsideStorage() const override { return true; }
 	virtual std::string toString(bool _short) const override;
@@ -812,7 +809,6 @@ public:
 
 	virtual bool operator==(Type const& _other) const override;
 	virtual std::string toString(bool _short) const override;
-	virtual unsigned getSizeOnStack() const override { return 2; }
 	virtual bool canLiveOutsideStorage() const override { return false; }
 
 	TypePointer const& getKeyType() const { return m_keyType; }


### PR DESCRIPTION
Only struct or array types can persistently reference storage. Those types always align on a full stack slot, so it is not necessary to store the intra-slot byte offset. This doubles the possible number of local storage variables.