### PR TITLE
Check whether a literal is a valid literal before using it.

### DIFF
--- a/libsolidity/Types.cpp
+++ b/libsolidity/Types.cpp
@@ -210,6 +210,8 @@ TypePointer Type::forLiteral(Literal const& _literal)
 	case Token::FalseLiteral:
 		return make_shared<BoolType>();
 	case Token::Number:
+		if (!IntegerConstantType::isValidLiteral(_literal))
+			return TypePointer();
 		return make_shared<IntegerConstantType>(_literal);
 	case Token::StringLiteral:
 		return make_shared<StringLiteralType>(_literal);
@@ -320,6 +322,19 @@ const MemberList IntegerType::AddressMemberList({
 	{"callcode", make_shared<FunctionType>(strings(), strings{"bool"}, FunctionType::Location::BareCallCode, true)},
 	{"send", make_shared<FunctionType>(strings{"uint"}, strings{"bool"}, FunctionType::Location::Send)}
 });
+
+bool IntegerConstantType::isValidLiteral(const Literal& _literal)
+{
+	try
+	{
+		bigint x(_literal.getValue());
+	}
+	catch (...)
+	{
+		return false;
+	}
+	return true;
+}
 
 IntegerConstantType::IntegerConstantType(Literal const& _literal)
 {

--- a/libsolidity/Types.h
+++ b/libsolidity/Types.h
@@ -286,6 +286,9 @@ class IntegerConstantType: public Type
 public:
 	virtual Category getCategory() const override { return Category::IntegerConstant; }
 
+	/// @returns true if the literal is a valid integer.
+	static bool isValidLiteral(Literal const& _literal);
+
 	explicit IntegerConstantType(Literal const& _literal);
 	explicit IntegerConstantType(bigint _value): m_value(_value) {}
 

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -2110,6 +2110,30 @@ BOOST_AUTO_TEST_CASE(literal_strings)
 	BOOST_CHECK_NO_THROW(parseTextAndResolveNames(text));
 }
 
+BOOST_AUTO_TEST_CASE(invalid_integer_literal_fraction)
+{
+	char const* text = R"(
+		contract Foo {
+			function f() {
+				var x = 1.20;
+			}
+		}
+	)";
+	BOOST_CHECK_THROW(parseTextAndResolveNames(text), TypeError);
+}
+
+BOOST_AUTO_TEST_CASE(invalid_integer_literal_exp)
+{
+	char const* text = R"(
+		contract Foo {
+			function f() {
+				var x = 1e2;
+			}
+		}
+	)";
+	BOOST_CHECK_THROW(parseTextAndResolveNames(text), TypeError);
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 }


### PR DESCRIPTION
Fixes #2078