### PR TITLE
Sol mappings in memory structs

### DIFF
--- a/libsolidity/Types.h
+++ b/libsolidity/Types.h
@@ -574,14 +574,14 @@ class StructType: public ReferenceType
 {
 public:
 	virtual Category getCategory() const override { return Category::Struct; }
-	explicit StructType(StructDefinition const& _struct):
-		ReferenceType(DataLocation::Storage), m_struct(_struct) {}
+	explicit StructType(StructDefinition const& _struct, DataLocation _location = DataLocation::Storage):
+		ReferenceType(_location), m_struct(_struct) {}
 	virtual bool isImplicitlyConvertibleTo(const Type& _convertTo) const override;
 	virtual bool operator==(Type const& _other) const override;
 	virtual unsigned getCalldataEncodedSize(bool _padded) const override;
 	u256 memorySize() const;
 	virtual u256 getStorageSize() const override;
-	virtual bool canLiveOutsideStorage() const override;
+	virtual bool canLiveOutsideStorage() const override { return true; }
 	virtual std::string toString(bool _short) const override;
 
 	virtual MemberList const& getMembers() const override;
@@ -596,6 +596,9 @@ public:
 	u256 memoryOffsetOfMember(std::string const& _name) const;
 
 	StructDefinition const& structDefinition() const { return m_struct; }
+
+	/// @returns the set of all members that are removed in the memory version (typically mappings).
+	std::set<std::string> membersMissingInMemory() const;
 
 private:
 	StructDefinition const& m_struct;

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -5034,6 +5034,29 @@ BOOST_AUTO_TEST_CASE(literal_strings)
 }
 
 
+BOOST_AUTO_TEST_CASE(memory_structs_with_mappings)
+{
+	char const* sourceCode = R"(
+		contract Test {
+			struct S { uint8 a; mapping(uint => uint) b; uint8 c; }
+			S s;
+			function f() returns (uint) {
+				S memory x;
+				if (x.a != 0 || x.c != 0) return 1;
+				x.a = 4; x.c = 5;
+				s = x;
+				if (s.a != 4 || s.c != 5) return 2;
+				x = S(2, 3);
+				if (x.a != 2 || x.c != 3) return 3;
+				x = s;
+				if (s.a != 4 || s.c != 5) return 4;
+			}
+		}
+	)";
+	compileAndRun(sourceCode, 0, "Test");
+	BOOST_CHECK(callContractFunction("f()") == encodeArgs(u256(0)));
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 }

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -2134,6 +2134,21 @@ BOOST_AUTO_TEST_CASE(invalid_integer_literal_exp)
 	BOOST_CHECK_THROW(parseTextAndResolveNames(text), TypeError);
 }
 
+BOOST_AUTO_TEST_CASE(memory_structs_with_mappings)
+{
+	char const* text = R"(
+		contract Test {
+			struct S { uint8 a; mapping(uint => uint) b; uint8 c; }
+			S s;
+			function f() {
+				S memory x;
+				x.b[1];
+			}
+		}
+	)";
+	BOOST_CHECK_THROW(parseTextAndResolveNames(text), TypeError);
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 }


### PR DESCRIPTION
Mappings cannot be in memory because their keys are unknown and they might also be too large.
As mappings are also simply skipped when structs are copied inside storage, this change modifies memory-bound structs to ignore all mapping members. This allows structs containing mappings to reside in memory in the first place but also to construct such structs inline as `x = StructName({a: 1, b: 2})`.