### PR TITLE
Automatic guards.

### DIFF
--- a/alethzero/OurWebThreeStubServer.cpp
+++ b/alethzero/OurWebThreeStubServer.cpp
@@ -101,18 +101,17 @@ bool OurAccountHolder::showUnknownCallNotice(TransactionSkeleton const& _t, bool
 
 h256 OurAccountHolder::authenticate(TransactionSkeleton const& _t)
 {
-	Guard l(x_queued);
-	m_queued.push(_t);
+	m_queued->push(_t);
 	return h256();
 }
 
 void OurAccountHolder::doValidations()
 {
-	Guard l(x_queued);
-	while (!m_queued.empty())
+	auto queued(*m_queued);
+	while (!queued->empty())
 	{
-		auto t = m_queued.front();
-		m_queued.pop();
+		auto t = queued->front();
+		queued->pop();
 
 		bool proxy = isProxyAccount(t.from);
 		if (!proxy && !isRealAccount(t.from))

--- a/alethzero/OurWebThreeStubServer.h
+++ b/alethzero/OurWebThreeStubServer.h
@@ -53,8 +53,7 @@ private:
 
 	bool validateTransaction(dev::eth::TransactionSkeleton const& _t, bool _toProxy);
 
-	std::queue<dev::eth::TransactionSkeleton> m_queued;
-	dev::Mutex x_queued;
+	dev::LockedObject<std::queue<dev::eth::TransactionSkeleton>> m_queued;
 
 	Main* m_main;
 };

--- a/mix/CodeModel.cpp
+++ b/mix/CodeModel.cpp
@@ -236,7 +236,7 @@ void CodeModel::unregisterContractSrc(QString const& _documentId)
 
 void CodeModel::registerCodeChange(QString const& _documentId, QString const& _code)
 {
-	(**m_pendingContracts)[_documentId] = _code;
+	m_pendingContracts->at(_documentId) = _code;
 
 	// launch the background thread
 	m_compiling = true;

--- a/mix/CodeModel.h
+++ b/mix/CodeModel.h
@@ -292,8 +292,7 @@ private:
 	BackgroundWorker m_backgroundWorker;
 	int m_backgroundJobId = 0; //protects from starting obsolete compilation job
 	std::map<QString, dev::bytes> m_compiledContracts; //by name
-	dev::Mutex x_pendingContracts;
-	std::map<QString, QString> m_pendingContracts; //name to source
+	LockedObject<std::map<QString, QString>> m_pendingContracts; //name to source
 	bool m_optimizeCode = false;
 	friend class BackgroundWorker;
 };


### PR DESCRIPTION
This is an attempt at prohibiting non-guarded access to a shared object.
The pros are, in my view:
1. you do not need two members (`x_...` and `m_...`) for the simple use-case
2. it is harder to access the object in a non-locked state
The cons are:
1. the dereference and pointer semantics are a bit strange at first
2. it is less visible what actually happens and you need to know the lifetime of temporaries
2. a unique_ptr is allocated for each lock, though that might be avoidable