### PR TITLE
Fix QT 5.5 Build

### DIFF
--- a/alethzero/Context.h
+++ b/alethzero/Context.h
@@ -32,10 +32,10 @@ class QSpinBox;
 
 namespace dev { namespace eth { struct StateDiff; class KeyManager; } }
 
-#define Small "font-size: small; "
-#define Mono "font-family: Ubuntu Mono, Monospace, Lucida Console, Courier New; font-weight: bold; "
-#define Div(S) "<div style=\"" S "\">"
-#define Span(S) "<span style=\"" S "\">"
+#define ETH_HTML_SMALL "font-size: small; "
+#define ETH_HTML_MONO "font-family: Ubuntu Mono, Monospace, Lucida Console, Courier New; font-weight: bold; "
+#define ETH_HTML_DIV(S) "<div style=\"" S "\">"
+#define ETH_HTML_SPAN(S) "<span style=\"" S "\">"
 
 void initUnits(QComboBox* _b);
 void setValueUnits(QComboBox* _units, QSpinBox* _value, dev::u256 _v);

--- a/alethzero/MainWin.cpp
+++ b/alethzero/MainWin.cpp
@@ -594,7 +594,7 @@ void Main::eval(QString const& _js)
 void Main::addConsoleMessage(QString const& _js, QString const& _s)
 {
 	m_consoleHistory.push_back(qMakePair(_js, _s));
-	QString r = "<html><body style=\"margin: 0;\">" Div(Mono "position: absolute; bottom: 0; border: 0px; margin: 0px; width: 100%");
+	QString r = "<html><body style=\"margin: 0;\">" ETH_HTML_DIV(ETH_HTML_MONO "position: absolute; bottom: 0; border: 0px; margin: 0px; width: 100%");
 	for (auto const& i: m_consoleHistory)
 		r +=	"<div style=\"border-bottom: 1 solid #eee; width: 100%\"><span style=\"float: left; width: 1em; color: #888; font-weight: bold\">&gt;</span><span style=\"color: #35d\">" + i.first.toHtmlEscaped() + "</span></div>"
 				"<div style=\"border-bottom: 1 solid #eee; width: 100%\"><span style=\"float: left; width: 1em\">&nbsp;</span><span>" + i.second + "</span></div>";
@@ -1623,7 +1623,7 @@ void Main::on_transactionQueue_currentItemChanged()
 			if (tx.data().size())
 				s << dev::memDump(tx.data(), 16, true);
 		}
-		s << "<div>Hex: " Span(Mono) << toHex(tx.rlp()) << "</span></div>";
+		s << "<div>Hex: " ETH_HTML_SPAN(ETH_HTML_MONO) << toHex(tx.rlp()) << "</span></div>";
 		s << "<hr/>";
 		if (!!receipt.bloom())
 			s << "<div>Log Bloom: " << receipt.bloom() << "</div>";
@@ -1633,7 +1633,7 @@ void Main::on_transactionQueue_currentItemChanged()
 		s << "<div>End State: <b>" << receipt.stateRoot().abridged() << "</b></div>";
 		auto r = receipt.rlp();
 		s << "<div>Receipt: " << toString(RLP(r)) << "</div>";
-		s << "<div>Receipt-Hex: " Span(Mono) << toHex(receipt.rlp()) << "</span></div>";
+		s << "<div>Receipt-Hex: " ETH_HTML_SPAN(ETH_HTML_MONO) << toHex(receipt.rlp()) << "</span></div>";
 		s << renderDiff(ethereum()->diff(i, PendingBlock));
 //		s << "Pre: " << fs.rootHash() << "<br/>";
 //		s << "Post: <b>" << ts.rootHash() << "</b>";
@@ -1768,9 +1768,9 @@ void Main::on_blocks_currentItemChanged()
 				s << "<div>" << sha3(i.data()).abridged() << ": <b>" << receipts.receipts[ii].stateRoot() << "</b> [<b>" << receipts.receipts[ii].gasUsed() << "</b> used]" << "</div>";
 				++ii;
 			}
-			s << "<div>Post: <b>" << info.stateRoot() << "</b>" << "</div>";
-			s << "<div>Dump: " Span(Mono) << toHex(block[0].data()) << "</span>" << "</div>";
-			s << "<div>Receipts-Hex: " Span(Mono) << toHex(receipts.rlp()) << "</span></div>";
+			s << "<div>Post: <b>" << info.stateRoot << "</b>" << "</div>";
+			s << "<div>Dump: " ETH_HTML_SPAN(ETH_HTML_MONO) << toHex(block[0].data()) << "</span>" << "</div>";
+			s << "<div>Receipts-Hex: " ETH_HTML_SPAN(ETH_HTML_MONO) << toHex(receipts.rlp()) << "</span></div>";
 		}
 		else
 		{
@@ -1801,7 +1801,7 @@ void Main::on_blocks_currentItemChanged()
 				else
 					s << "<h4>Data</h4>" << dev::memDump(tx.data(), 16, true);
 			}
-			s << "<div>Hex: " Span(Mono) << toHex(block[1][txi].data()) << "</span></div>";
+			s << "<div>Hex: " ETH_HTML_SPAN(ETH_HTML_MONO) << toHex(block[1][txi].data()) << "</span></div>";
 			s << "<hr/>";
 			if (!!receipt.bloom())
 				s << "<div>Log Bloom: " << receipt.bloom() << "</div>";
@@ -1811,7 +1811,7 @@ void Main::on_blocks_currentItemChanged()
 			s << "<div>End State: <b>" << receipt.stateRoot().abridged() << "</b></div>";
 			auto r = receipt.rlp();
 			s << "<div>Receipt: " << toString(RLP(r)) << "</div>";
-			s << "<div>Receipt-Hex: " Span(Mono) << toHex(receipt.rlp()) << "</span></div>";
+			s << "<div>Receipt-Hex: " ETH_HTML_SPAN(ETH_HTML_MONO) << toHex(receipt.rlp()) << "</span></div>";
 			s << "<h4>Diff</h4>" << renderDiff(ethereum()->diff(txi, h));
 			ui->debugCurrent->setEnabled(true);
 			ui->debugDumpState->setEnabled(true);
@@ -1881,7 +1881,7 @@ void Main::on_accounts_currentItemChanged()
 			for (auto const& i: storage)
 				s << "@" << showbase << hex << prettyU256(i.first) << "&nbsp;&nbsp;&nbsp;&nbsp;" << showbase << hex << prettyU256(i.second) << "<br/>";
 			s << "<h4>Body Code (" << sha3(ethereum()->codeAt(address)).abridged() << ")</h4>" << disassemble(ethereum()->codeAt(address));
-			s << Div(Mono) << toHex(ethereum()->codeAt(address)) << "</div>";
+			s << ETH_HTML_DIV(ETH_HTML_MONO) << toHex(ethereum()->codeAt(address)) << "</div>";
 			ui->accountInfo->appendHtml(QString::fromStdString(s.str()));
 		}
 		catch (dev::InvalidTrie)

--- a/alethzero/Transact.cpp
+++ b/alethzero/Transact.cpp
@@ -346,7 +346,7 @@ void Transact::rejigData()
 		htmlInfo = "<h4>Dump</h4>" + QString::fromStdString(dev::memDump(m_data, 8, true));
 	}
 
-	htmlInfo += "<h4>Hex</h4>" + QString(Div(Mono)) + QString::fromStdString(toHex(m_data)) + "</div>";
+	htmlInfo += "<h4>Hex</h4>" + QString(ETH_HTML_DIV(ETH_HTML_MONO)) + QString::fromStdString(toHex(m_data)) + "</div>";
 
 	// Determine the minimum amount of gas we need to play...
 	qint64 baseGas = (qint64)Transaction::gasRequired(m_data, 0);


### PR DESCRIPTION
In QT 5.5 `Mono` is a reserved preprocessor define and as such building
with it fails.

```
In file included from /usr/include/qt/QtGui/qvalidator.h:42:
/usr/include/qt/QtCore/qlocale.h:407:9: error: expected identifier
        Mono = 337,
        ^
/home/lefteris/ew/cpp-ethereum/alethzero/Context.h:36:14: note: expanded from macro 'Mono'
#define Mono "font-family: Ubuntu Mono, Monospace, Lucida Console, Courier New; font-weight: bold; "
             ^
1 error generated.
alethzero/CMakeFiles/alethzero.dir/build.make:158: recipe for target 'alethzero/CMakeFiles/alethzero.dir/Context.cpp.o' failed
make[2]: *** [alethzero/CMakeFiles/alethzero.dir/Context.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
```

Switching the macros in `alethzero/Context.h` to follow Coding Standards
fixes this discrepancy and allows us to build with QT 5.5.