### PR TITLE
After DAG load progress should be 100 to continue

### DIFF
--- a/libethcore/EthashAux.cpp
+++ b/libethcore/EthashAux.cpp
@@ -229,7 +229,7 @@ unsigned EthashAux::computeFull(h256 const& _seedHash, bool _createIfMissing)
 			cnote << "Loading full DAG of seedhash: " << _seedHash;
 			get()->full(_seedHash, true, [](unsigned p){ get()->m_fullProgress = p; return 0; });
 			cnote << "Full DAG loaded";
-			get()->m_fullProgress = 0;
+			get()->m_fullProgress = 100;
 			get()->m_generatingFullNumber = NotGenerating;
 		}));
 	}


### PR DESCRIPTION
Since the merging of the whizz branch we have serious problems with mining. This solves only one issue. Other problems still exist.

When the DAG already exists as a file, we never get inside the callback and as such never get to give the value of 100 to the progress variable.

This will allow us to continue with mining but it will still get stuck in the search loop, never finding a solution.

I am testing on a private chain with CPU mining to find solutions to the other issues too.