### PR TITLE
Update m_working Client state for private chain mining

### DIFF
--- a/libethcore/EthashAux.cpp
+++ b/libethcore/EthashAux.cpp
@@ -229,7 +229,7 @@ unsigned EthashAux::computeFull(h256 const& _seedHash, bool _createIfMissing)
 			cnote << "Loading full DAG of seedhash: " << _seedHash;
 			get()->full(_seedHash, true, [](unsigned p){ get()->m_fullProgress = p; return 0; });
 			cnote << "Full DAG loaded";
-			get()->m_fullProgress = 0;
+			get()->m_fullProgress = 100;
 			get()->m_generatingFullNumber = NotGenerating;
 		}));
 	}

--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -651,6 +651,8 @@ void Client::onPostStateChanged()
 void Client::startMining()
 {
 	m_wouldMine = true;
+	DEV_WRITE_GUARDED(x_working)
+		m_working = m_preMine;
 	rejigMining();
 }
 

--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -651,8 +651,6 @@ void Client::onPostStateChanged()
 void Client::startMining()
 {
 	m_wouldMine = true;
-	DEV_WRITE_GUARDED(x_working)
-		m_working = m_preMine;
 	rejigMining();
 }
 
@@ -661,6 +659,11 @@ void Client::rejigMining()
 	if ((wouldMine() || remoteActive()) && !isMajorSyncing() && (!isChainBad() || mineOnBadChain()) /*&& (forceMining() || transactionsWaiting())*/)
 	{
 		clog(ClientTrace) << "Rejigging mining...";
+		DEV_READ_GUARDED(x_preMine)
+		{
+			DEV_WRITE_GUARDED(x_working)
+				m_working = m_preMine;
+		}
 		DEV_WRITE_GUARDED(x_working)
 			m_working.commitToMine(bc(), m_extraData);
 		DEV_READ_GUARDED(x_working)


### PR DESCRIPTION
When mining on a private chain, mining would get stuck and not
start. The reason is that the difficulty was zero. If we move the
mining state from m_premine to m_working the difficulty will get updated
properly and we will be able to mine in a private chain.

Based on #2535 