### PR TITLE
Fix deadlock in the mining code

### DIFF
--- a/libethcore/Farm.h
+++ b/libethcore/Farm.h
@@ -83,6 +83,10 @@ public:
 	 */
 	bool start(std::string const& _sealer)
 	{
+		// call empty setWork to make sure that all workers have stoppedWorking()
+		for (auto& miner: m_miners)
+			miner->setWork();
+
 		WriteGuard l(x_minerWork);
 		cdebug << "start()";
 		if (!m_miners.empty() && m_lastSealer == _sealer)

--- a/libethcore/Farm.h
+++ b/libethcore/Farm.h
@@ -66,6 +66,16 @@ public:
 	 */
 	void setWork(WorkPackage const& _wp)
 	{
+		std::vector<std::shared_ptr<Miner>> minersCopy;
+		{
+			WriteGuard l(x_minerWork);
+			minersCopy = m_miners;
+		}
+		// call empty setWork to make sure that all workers have stoppedWorking()
+		for (auto const& m: minersCopy)
+			m->setWork();
+
+
 		WriteGuard l(x_minerWork);
 		cdebug << "Farm::setWork()";
 		if (_wp.headerHash == m_work.headerHash)
@@ -83,10 +93,6 @@ public:
 	 */
 	bool start(std::string const& _sealer)
 	{
-		// call empty setWork to make sure that all workers have stoppedWorking()
-		for (auto& miner: m_miners)
-			miner->setWork();
-
 		WriteGuard l(x_minerWork);
 		cdebug << "start()";
 		if (!m_miners.empty() && m_lastSealer == _sealer)


### PR DESCRIPTION
A deadlock was introduced in the mining code. The `x_minerWork` lock was
being locked and then to release said lock, it was waiting for
stopWorking().

Afterwards various threads were also waiting on the `x_minerWork` to be
released and we went into a deadlock. Calling all miners before start with setWork()
of an empty WorkPackage will ensure that stopWorking() is called.

Relevant threads stack trace when the deadlock occurs:
```
Thread 9 (Thread 0x7fffd3fff700 (LWP 6938)):
#0  0x00007ffff671953d in nanosleep () at ../sysdeps/unix/syscall-template.S:81
#1  0x00007ffff6f9bd54 in sleep_for<long, std::ratio<1l, 1000000l> > (__rtime=...) at /usr/include/c++/4.9/thread:282
#2  dev::Worker::stopWorking (this=0xabaf88) at /home/minekraft/lefteris/cpp-ethereum/libdevcore/Worker.cpp:95
#3  0x000000000044928a in dev::eth::GenericMiner<dev::eth::EthashProofOfWork>::setWork (this=0xabaee0, _work=...) at /home/minekraft/lefteris/cpp-ethereum/eth/../libethcore/Miner.h:101
#4  0x0000000000457d8c in dev::eth::GenericFarm<dev::eth::EthashProofOfWork>::setWork (this=0x942470, _wp=...) at /home/minekraft/lefteris/cpp-ethereum/eth/../libethcore/Farm.h:75
#5  0x00007ffff72eb17a in dev::eth::EthashSealEngine::generateSeal (this=0x942400, _bi=...) at /home/minekraft/lefteris/cpp-ethereum/libethcore/EthashSealEngine.cpp:54
#6  0x00007ffff7667bee in dev::eth::Client::rejigMining (this=this@entry=0x915a50) at /home/minekraft/lefteris/cpp-ethereum/libethereum/Client.cpp:679
#7  0x00007ffff7668643 in dev::eth::Client::onPostStateChanged (this=this@entry=0x915a50) at /home/minekraft/lefteris/cpp-ethereum/libethereum/Client.cpp:654
#8  0x00007ffff766ece4 in dev::eth::Client::restartMining (this=this@entry=0x915a50) at /home/minekraft/lefteris/cpp-ethereum/libethereum/Client.cpp:623
#9  0x00007ffff766f67e in dev::eth::Client::onChainChanged (this=this@entry=0x915a50, _ir=...) at /home/minekraft/lefteris/cpp-ethereum/libethereum/Client.cpp:642
#10 0x00007ffff766fb57 in dev::eth::Client::syncBlockQueue (this=this@entry=0x915a50) at /home/minekraft/lefteris/cpp-ethereum/libethereum/Client.cpp:523
#11 0x00007ffff766fe99 in dev::eth::Client::doWork (this=0x915a50) at /home/minekraft/lefteris/cpp-ethereum/libethereum/Client.cpp:717
#12 0x00007ffff6f9bb68 in dev::Worker::workLoop (this=0x915f18) at /home/minekraft/lefteris/cpp-ethereum/libdevcore/Worker.cpp:120
#13 0x00007ffff6f9c3b5 in dev::Worker::<lambda()>::operator()(void) const (__closure=0xcaaac8) at /home/minekraft/lefteris/cpp-ethereum/libdevcore/Worker.cpp:56
#14 0x00007ffff64b4e30 in ?? () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#15 0x00007ffff67106aa in start_thread (arg=0x7fffd3fff700) at pthread_create.c:333
#16 0x00007ffff5c18eed in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:109

Thread 8 (Thread 0x7fffd37fe700 (LWP 6939)):
#0  0x00007ffff5c194f3 in epoll_wait () at ../sysdeps/unix/syscall-template.S:81
#1  0x00007ffff7411dad in boost::asio::detail::epoll_reactor::run (this=0x939f60, block=block@entry=true, ops=...) at /usr/include/boost/asio/detail/impl/epoll_reactor.ipp:392
#2  0x00007ffff7419c9c in do_run_one (ec=..., this_thread=..., lock=..., this=0x8d9240) at /usr/include/boost/asio/detail/impl/task_io_service.ipp:368
#3  boost::asio::detail::task_io_service::run (this=0x8d9240, ec=...) at /usr/include/boost/asio/detail/impl/task_io_service.ipp:153
#4  0x00007ffff7404a0e in run (this=0x7fffffffe040) at /usr/include/boost/asio/impl/io_service.ipp:59
#5  dev::p2p::Host::doWork (this=0x7fffffffdf50) at /home/minekraft/lefteris/cpp-ethereum/libp2p/Host.cpp:730
#6  0x00007ffff6f9bb68 in dev::Worker::workLoop (this=0x7fffffffdf50) at /home/minekraft/lefteris/cpp-ethereum/libdevcore/Worker.cpp:120
#7  0x00007ffff6f9c3b5 in dev::Worker::<lambda()>::operator()(void) const (__closure=0x8da888) at /home/minekraft/lefteris/cpp-ethereum/libdevcore/Worker.cpp:56
#8  0x00007ffff64b4e30 in ?? () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#9  0x00007ffff67106aa in start_thread (arg=0x7fffd37fe700) at pthread_create.c:333
#10 0x00007ffff5c18eed in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:109

Thread 7 (Thread 0x7fffd2ffd700 (LWP 6940)):
#0  0x00007ffff671953d in nanosleep () at ../sysdeps/unix/syscall-template.S:81
#1  0x00007ffff6f9bbcb in sleep_for<long, std::ratio<1l, 1000l> > (__rtime=...) at /usr/include/c++/4.9/thread:282
#2  dev::Worker::workLoop (this=0xc3e5e0) at /home/minekraft/lefteris/cpp-ethereum/libdevcore/Worker.cpp:119
#3  0x00007ffff6f9c3b5 in dev::Worker::<lambda()>::operator()(void) const (__closure=0x7fffc0000a08) at /home/minekraft/lefteris/cpp-ethereum/libdevcore/Worker.cpp:56
#4  0x00007ffff64b4e30 in ?? () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#5  0x00007ffff67106aa in start_thread (arg=0x7fffd2ffd700) at pthread_create.c:333

#6  0x00007ffff5c18eed in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:109

Thread 6 (Thread 0x7fffad5db700 (LWP 6941)):
#0  pthread_cond_wait@@GLIBC_2.3.2 () at ../sysdeps/unix/sysv/linux/x86_64/pthread_cond_wait.S:185
#1  0x00007ffff52533c3 in ?? () from /usr/lib/x86_64-linux-gnu/libleveldb.so.1
#2  0x00007ffff67106aa in start_thread (arg=0x7fffad5db700) at pthread_create.c:333
#3  0x00007ffff5c18eed in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:109

Thread 5 (Thread 0x7fff79a07700 (LWP 6942)):
#0  pthread_cond_wait@@GLIBC_2.3.2 () at ../sysdeps/unix/sysv/linux/x86_64/pthread_cond_wait.S:185
#1  0x000000000044c783 in boost::condition_variable::wait (this=0x9424a8, m=...) at /usr/include/boost/thread/pthread/condition_variable.hpp:73
#2  0x00007ffff72e9b6b in lock_shared (this=0x942478) at /usr/include/boost/thread/pthread/shared_mutex.hpp:191
#3  lock (this=<synthetic pointer>) at /usr/include/boost/thread/lock_types.hpp:645
#4  shared_lock (m_=..., this=<synthetic pointer>) at /usr/include/boost/thread/lock_types.hpp:520
#5  work (this=0x942470) at /home/minekraft/lefteris/cpp-ethereum/libethcore/Farm.h:160
#6  dev::eth::EthashSealEngine::<lambda(const dev::eth::EthashProofOfWork::Solution&)>::operator()(const dev::eth::EthashProofOfWork::Solution &) const (__closure=0x8de010, sol=...) at /home/minekraft/lefteris/cpp-ethereum/libethcore/EthashSealEngine.cpp:66
#7  0x000000000044bddf in operator() (__args#0=..., this=0x942780) at /usr/include/c++/4.9/functional:2439
#8  dev::eth::GenericFarm<dev::eth::EthashProofOfWork>::submitProof (this=0x942470, _s=..., _m=0xc3b200) at /home/minekraft/lefteris/cpp-ethereum/eth/../libethcore/Farm.h:171
#9  0x00007ffff732d48d in submitProof (_s=..., this=0xc3b200) at /home/minekraft/lefteris/cpp-ethereum/libethcore/Miner.h:142
#10 dev::eth::EthashCPUMiner::workLoop (this=<optimized out>) at /home/minekraft/lefteris/cpp-ethereum/libethcore/EthashCPUMiner.cpp:80
#11 0x00007ffff6f9c3b5 in dev::Worker::<lambda()>::operator()(void) const (__closure=0xcac218) at /home/minekraft/lefteris/cpp-ethereum/libdevcore/Worker.cpp:56
#12 0x00007ffff64b4e30 in ?? () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#13 0x00007ffff67106aa in start_thread (arg=0x7fff79a07700) at pthread_create.c:333
#14 0x00007ffff5c18eed in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:109

Thread 4 (Thread 0x7fff72691700 (LWP 6944)):
#0  pthread_cond_wait@@GLIBC_2.3.2 () at ../sysdeps/unix/sysv/linux/x86_64/pthread_cond_wait.S:185
#1  0x000000000044c783 in boost::condition_variable::wait (this=0x9424a8, m=...) at /usr/include/boost/thread/pthread/condition_variable.hpp:73
#2  0x00007ffff72e9b6b in lock_shared (this=0x942478) at /usr/include/boost/thread/pthread/shared_mutex.hpp:191
#3  lock (this=<synthetic pointer>) at /usr/include/boost/thread/lock_types.hpp:645
#4  shared_lock (m_=..., this=<synthetic pointer>) at /usr/include/boost/thread/lock_types.hpp:520
#5  work (this=0x942470) at /home/minekraft/lefteris/cpp-ethereum/libethcore/Farm.h:160
#6  dev::eth::EthashSealEngine::<lambda(const dev::eth::EthashProofOfWork::Solution&)>::operator()(const dev::eth::EthashProofOfWork::Solution &) const (__closure=0x8de010, sol=...) at /home/minekraft/lefteris/cpp-ethereum/libethcore/EthashSealEngine.cpp:66
#7  0x000000000044bddf in operator() (__args#0=..., this=0x942780) at /usr/include/c++/4.9/functional:2439
#8  dev::eth::GenericFarm<dev::eth::EthashProofOfWork>::submitProof (this=0x942470, _s=..., _m=0xc3b970) at /home/minekraft/lefteris/cpp-ethereum/eth/../libethcore/Farm.h:171
#9  0x00007ffff732d48d in submitProof (_s=..., this=0xc3b970) at /home/minekraft/lefteris/cpp-ethereum/libethcore/Miner.h:142
#10 dev::eth::EthashCPUMiner::workLoop (this=<optimized out>) at /home/minekraft/lefteris/cpp-ethereum/libethcore/EthashCPUMiner.cpp:80
#11 0x00007ffff6f9c3b5 in dev::Worker::<lambda()>::operator()(void) const (__closure=0xd17818) at /home/minekraft/lefteris/cpp-ethereum/libdevcore/Worker.cpp:56
#12 0x00007ffff64b4e30 in ?? () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#13 0x00007ffff67106aa in start_thread (arg=0x7fff72691700) at pthread_create.c:333
#14 0x00007ffff5c18eed in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:109

Thread 3 (Thread 0x7fff7144f700 (LWP 6945)):
#0  pthread_cond_wait@@GLIBC_2.3.2 () at ../sysdeps/unix/sysv/linux/x86_64/pthread_cond_wait.S:185
#1  0x000000000044c783 in boost::condition_variable::wait (this=0x9424a8, m=...) at /usr/include/boost/thread/pthread/condition_variable.hpp:73
#2  0x00007ffff72e9b6b in lock_shared (this=0x942478) at /usr/include/boost/thread/pthread/shared_mutex.hpp:191
#3  lock (this=<synthetic pointer>) at /usr/include/boost/thread/lock_types.hpp:645
#4  shared_lock (m_=..., this=<synthetic pointer>) at /usr/include/boost/thread/lock_types.hpp:520
#5  work (this=0x942470) at /home/minekraft/lefteris/cpp-ethereum/libethcore/Farm.h:160
#6  dev::eth::EthashSealEngine::<lambda(const dev::eth::EthashProofOfWork::Solution&)>::operator()(const dev::eth::EthashProofOfWork::Solution &) const (__closure=0x8de010, sol=...) at /home/minekraft/lefteris/cpp-ethereum/libethcore/EthashSealEngine.cpp:66
#7  0x000000000044bddf in operator() (__args#0=..., this=0x942780) at /usr/include/c++/4.9/functional:2439
#8  dev::eth::GenericFarm<dev::eth::EthashProofOfWork>::submitProof (this=0x942470, _s=..., _m=0xc3bd10) at /home/minekraft/lefteris/cpp-ethereum/eth/../libethcore/Farm.h:171
#9  0x00007ffff732d48d in submitProof (_s=..., this=0xc3bd10) at /home/minekraft/lefteris/cpp-ethereum/libethcore/Miner.h:142
#10 dev::eth::EthashCPUMiner::workLoop (this=<optimized out>) at /home/minekraft/lefteris/cpp-ethereum/libethcore/EthashCPUMiner.cpp:80
#11 0x00007ffff6f9c3b5 in dev::Worker::<lambda()>::operator()(void) const (__closure=0xc979f8) at /home/minekraft/lefteris/cpp-ethereum/libdevcore/Worker.cpp:56
#12 0x00007ffff64b4e30 in ?? () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#13 0x00007ffff67106aa in start_thread (arg=0x7fff7144f700) at pthread_create.c:333
#14 0x00007ffff5c18eed in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:109

Thread 2 (Thread 0x7fff70c4e700 (LWP 6946)):
#0  pthread_cond_wait@@GLIBC_2.3.2 () at ../sysdeps/unix/sysv/linux/x86_64/pthread_cond_wait.S:185
#1  0x000000000044c783 in boost::condition_variable::wait (this=0x9424a8, m=...) at /usr/include/boost/thread/pthread/condition_variable.hpp:73
#2  0x00007ffff72e9b6b in lock_shared (this=0x942478) at /usr/include/boost/thread/pthread/shared_mutex.hpp:191
#3  lock (this=<synthetic pointer>) at /usr/include/boost/thread/lock_types.hpp:645
#4  shared_lock (m_=..., this=<synthetic pointer>) at /usr/include/boost/thread/lock_types.hpp:520
#5  work (this=0x942470) at /home/minekraft/lefteris/cpp-ethereum/libethcore/Farm.h:160
#6  dev::eth::EthashSealEngine::<lambda(const dev::eth::EthashProofOfWork::Solution&)>::operator()(const dev::eth::EthashProofOfWork::Solution &) const (__closure=0x8de010, sol=...) at /home/minekraft/lefteris/cpp-ethereum/libethcore/EthashSealEngine.cpp:66
#7  0x000000000044bddf in operator() (__args#0=..., this=0x942780) at /usr/include/c++/4.9/functional:2439
#8  dev::eth::GenericFarm<dev::eth::EthashProofOfWork>::submitProof (this=0x942470, _s=..., _m=0xabaee0) at /home/minekraft/lefteris/cpp-ethereum/eth/../libethcore/Farm.h:171
#9  0x00007ffff732d48d in submitProof (_s=..., this=0xabaee0) at /home/minekraft/lefteris/cpp-ethereum/libethcore/Miner.h:142
#10 dev::eth::EthashCPUMiner::workLoop (this=<optimized out>) at /home/minekraft/lefteris/cpp-ethereum/libethcore/EthashCPUMiner.cpp:80
#11 0x00007ffff6f9c3b5 in dev::Worker::<lambda()>::operator()(void) const (__closure=0xd5bf78) at /home/minekraft/lefteris/cpp-ethereum/libdevcore/Worker.cpp:56
#12 0x00007ffff64b4e30 in ?? () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#13 0x00007ffff67106aa in start_thread (arg=0x7fff70c4e700) at pthread_create.c:333
#14 0x00007ffff5c18eed in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:109

Thread 1 (Thread 0x7fffebb05780 (LWP 6927)):
#0  pthread_cond_wait@@GLIBC_2.3.2 () at ../sysdeps/unix/sysv/linux/x86_64/pthread_cond_wait.S:185
#1  0x000000000044c783 in boost::condition_variable::wait (this=this@entry=0x9424a8, m=...) at /usr/include/boost/thread/pthread/condition_variable.hpp:73
#2  0x000000000044cb43 in lock_shared (this=0x942478) at /usr/include/boost/thread/pthread/shared_mutex.hpp:191
#3  boost::shared_lock<boost::shared_mutex>::lock (this=0x7fffffff43b0) at /usr/include/boost/thread/lock_types.hpp:645
#4  0x00007ffff72f24e8 in shared_lock (m_=..., this=0x7fffffff43b0) at /usr/include/boost/thread/lock_types.hpp:520
#5  miningProgress (this=0x942470) at /home/minekraft/lefteris/cpp-ethereum/libethcore/Farm.h:131
#6  dev::eth::Ethash::workingProgress (_engine=<optimized out>) at /home/minekraft/lefteris/cpp-ethereum/libethcore/Ethash.cpp:201
#7  0x00007ffff76658ec in dev::eth::Client::hashrate (this=0x915a50) at /home/minekraft/lefteris/cpp-ethereum/libethereum/Client.cpp:468
#8  0x000000000043608c in interactiveMode(dev::eth::Client*, std::shared_ptr<dev::eth::TrivialGasPricer>, dev::WebThreeDirect&, dev::eth::KeyManager&, std::string&, std::string&, std::function<std::string (std::string const&)>, std::function<std::string (dev::FixedHash<20u> const&)>, dev::p2p::NetworkPreferences, dev::FixedHash<20u>, dev::FixedHash<20u>, dev::eth::TransactionPriority) (c=c@entry=0x915a50, gasPricer=std::shared_ptr (count 3, weak 0) 0xca8af0, web3=..., keyManager=..., logbuf="", additional="Press Enter", getPassword=..., getAccountPassword=..., netPrefs=..., beneficiary=..., signingKey=..., 
    priority=dev::eth::TransactionPriority::Medium) at /home/minekraft/lefteris/cpp-ethereum/eth/main.cpp:378
#9  0x000000000042c9d0 in main (argc=<optimized out>, argv=<optimized out>) at /home/minekraft/lefteris/cpp-ethereum/eth/main.cpp:1751
```