### PR TITLE
extdep/getstuff.bat downloads only x64 libs on windows

### DIFF
--- a/extdep/getstuff.bat
+++ b/extdep/getstuff.bat
@@ -27,13 +27,13 @@ set eth_version=%2
 
 cd download
 
-if not exist %eth_name%-%eth_version%.tar.gz (
-	for /f "tokens=2 delims={}" %%g in ('bitsadmin /create %eth_name%-%eth_version%.tar.gz') do (
-		bitsadmin /transfer {%%g} /download /priority normal %eth_server%/%eth_name%-%eth_version%.tar.gz %cd%\%eth_name%-%eth_version%.tar.gz
+if not exist %eth_name%-%eth_version%-x64.tar.gz (
+	for /f "tokens=2 delims={}" %%g in ('bitsadmin /create %eth_name%-%eth_version%-x64.tar.gz') do (
+		bitsadmin /transfer {%%g} /download /priority normal %eth_server%/%eth_name%-%eth_version%-x64.tar.gz %cd%\%eth_name%-%eth_version%-x64.tar.gz
 		bitsadmin /cancel {%%g}
 	)
 )
-if not exist %eth_name%-%eth_version% cmake -E tar -zxvf %eth_name%-%eth_version%.tar.gz
+if not exist %eth_name%-%eth_version% cmake -E tar -zxvf %eth_name%-%eth_version%-x64.tar.gz
 cmake -E copy_directory %eth_name%-%eth_version% ..\install\windows
 
 cd ..


### PR DESCRIPTION
I updated all precompiled dependencies archives for windows. The do not contain `Win32` libraries any more. New archives have `-x64` suffix. They are available [here](https://build.ethdev.com/builds/windows-precompiled/).


Please wait for windows buildbot to finish before merge