### PR TITLE
Fixed segfault in JitWorker initialization

### DIFF
--- a/libevm/SmartVM.cpp
+++ b/libevm/SmartVM.cpp
@@ -61,8 +61,8 @@ namespace
 
 	class JitWorker
 	{
-		std::thread m_worker;
 		concurrent_queue<JitTask> m_queue;
+		std::thread m_worker; // Worker must be last to initialize
 
 		void work()
 		{


### PR DESCRIPTION
A race condition on accessing m_queue from work() in another thread before it is initialized