### PR TITLE
Reimplement InsertPointGuard to avoid LLVM ABI incompatibility.

### DIFF
--- a/evmjit/libevmjit/CompilerHelper.h
+++ b/evmjit/libevmjit/CompilerHelper.h
@@ -56,7 +56,7 @@ struct InsertPointGuard
 
 private:
 	llvm::IRBuilderBase& m_builder;
-	decltype(m_builder.saveIP()) m_insertPoint;
+	llvm::IRBuilderBase::InsertPoint m_insertPoint;
 };
 
 }

--- a/evmjit/libevmjit/CompilerHelper.h
+++ b/evmjit/libevmjit/CompilerHelper.h
@@ -49,7 +49,15 @@ private:
 	RuntimeManager& m_runtimeManager;
 };
 
-using InsertPointGuard = llvm::IRBuilderBase::InsertPointGuard;
+struct InsertPointGuard
+{
+	explicit InsertPointGuard(llvm::IRBuilderBase& _builder): m_builder(_builder), m_insertPoint(_builder.saveIP()) {}
+	~InsertPointGuard() { m_builder.restoreIP(m_insertPoint); }
+
+private:
+	llvm::IRBuilderBase& m_builder;
+	decltype(m_builder.saveIP()) m_insertPoint;
+};
 
 }
 }

--- a/evmjit/libevmjit/preprocessor/llvm_includes_start.h
+++ b/evmjit/libevmjit/preprocessor/llvm_includes_start.h
@@ -1,6 +1,6 @@
 #if defined(_MSC_VER)
 	#pragma warning(push)
-	#pragma warning(disable: 4267 4244 4800)
+	#pragma warning(disable: 4267 4244 4800 4624)
 #elif defined(__clang__)
 	#pragma clang diagnostic push
 	#pragma clang diagnostic ignored "-Wunused-parameter"


### PR DESCRIPTION
In general, the NDEBUG flag should match cpp-ethereum and LLVM builds. But this is hard to satisfy as we usually have one system-wide build of LLVM and different builds of cpp-ethereum. This ABI incompatibility hit OSX only in release builds as LLVM is built by homebrew with assertions by default.