### PR TITLE
Only do out-of-order compatible verifications at verifier-thread time.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,7 +139,6 @@ elseif (BUNDLE STREQUAL "release")      # release builds
 	set(D_EVMJIT ON)
 	set(D_JSCONSOLE ON)
 	set(D_JSONRPC ON)
-	set(D_FRONTIER ON)
 	set(D_CMAKE_BUILD_TYPE "Release")
 endif ()
 

--- a/alethzero/Main.ui
+++ b/alethzero/Main.ui
@@ -223,6 +223,7 @@
     <addaction name="debugCurrent"/>
     <addaction name="debugDumpState"/>
     <addaction name="debugDumpStatePre"/>
+    <addaction name="dumpBlockState"/>
    </widget>
    <widget class="QMenu" name="menu_Config">
     <property name="title">
@@ -1817,6 +1818,11 @@ font-size: 14pt</string>
    </property>
    <property name="text">
     <string>&amp;Hermit Mode</string>
+   </property>
+  </action>
+  <action name="dumpBlockState">
+   <property name="text">
+    <string>Dump &amp;Block State as JSON...</string>
    </property>
   </action>
  </widget>

--- a/alethzero/MainWin.cpp
+++ b/alethzero/MainWin.cpp
@@ -1860,6 +1860,7 @@ std::string minHex(h256 const& _h)
 
 void Main::on_dumpBlockState_triggered()
 {
+#if ETH_FATDB || !ETH_TRUE
 	if (auto item = ui->blocks->currentItem())
 	{
 		auto hba = item->data(Qt::UserRole).toByteArray();
@@ -1887,6 +1888,7 @@ void Main::on_dumpBlockState_triggered()
 			js::write_stream(v, f, true);
 		}
 	}
+#endif
 }
 
 void Main::debugDumpState(int _add)

--- a/alethzero/MainWin.cpp
+++ b/alethzero/MainWin.cpp
@@ -1883,7 +1883,8 @@ void Main::on_dumpBlockState_triggered()
 				a["storage"] = st;
 				s[i.first.hex()] = a;
 			}
-			js::write_stream(s, f, true);
+			js::mValue v(s);
+			js::write_stream(v, f, true);
 		}
 	}
 }

--- a/alethzero/MainWin.h
+++ b/alethzero/MainWin.h
@@ -193,6 +193,7 @@ private slots:
 	void on_debugCurrent_triggered();
 	void on_debugDumpState_triggered() { debugDumpState(1); }
 	void on_debugDumpStatePre_triggered() { debugDumpState(0); }
+	void on_dumpBlockState_triggered();
 
 	// Whisper
 	void on_newIdentity_triggered();

--- a/libethcore/BlockInfo.h
+++ b/libethcore/BlockInfo.h
@@ -41,6 +41,7 @@ enum IncludeProof
 enum Strictness
 {
 	CheckEverything,
+	JustSeal,
 	QuickNonce,
 	IgnoreSeal,
 	CheckNothing

--- a/libethcore/Common.h
+++ b/libethcore/Common.h
@@ -127,7 +127,6 @@ struct ImportRequirements
 	enum
 	{
 		ValidSeal = 1, ///< Validate seal
-		DontHave = 2, ///< Avoid old blocks
 		UncleBasic = 4, ///< Check the basic structure of the uncles.
 		TransactionBasic = 8, ///< Check the basic structure of the transactions.
 		UncleSeals = 16, ///< Check the basic structure of the uncles.
@@ -136,9 +135,9 @@ struct ImportRequirements
 		UncleParent = 128, ///< Check uncle parent block header.
 		CheckUncles = UncleBasic | UncleSeals, ///< Check uncle seals.
 		CheckTransactions = TransactionBasic | TransactionSignatures, ///< Check transaction signatures.
-		OutOfOrderChecks = ValidSeal | DontHave | CheckUncles | CheckTransactions, ///< Do all checks that can be done independently of prior blocks having been imported.
+		OutOfOrderChecks = ValidSeal | CheckUncles | CheckTransactions, ///< Do all checks that can be done independently of prior blocks having been imported.
 		InOrderChecks = Parent | UncleParent, ///< Do all checks that cannot be done independently of prior blocks having been imported.
-		Everything = ValidSeal | DontHave | CheckUncles | CheckTransactions | Parent | UncleParent,
+		Everything = ValidSeal | CheckUncles | CheckTransactions | Parent | UncleParent,
 		None = 0
 	};
 };

--- a/libethcore/Common.h
+++ b/libethcore/Common.h
@@ -132,10 +132,13 @@ struct ImportRequirements
 		TransactionBasic = 8, ///< Check the basic structure of the transactions.
 		UncleSeals = 16, ///< Check the basic structure of the uncles.
 		TransactionSignatures = 32, ///< Check the basic structure of the transactions.
-		Parent = 64, ///< Check parent block header
-		CheckUncles = UncleBasic | UncleSeals, ///< Check uncle seals
-		CheckTransactions = TransactionBasic | TransactionSignatures, ///< Check transaction signatures
-		Everything = ValidSeal | DontHave | CheckUncles | CheckTransactions | Parent,
+		Parent = 64, ///< Check parent block header.
+		UncleParent = 128, ///< Check uncle parent block header.
+		CheckUncles = UncleBasic | UncleSeals, ///< Check uncle seals.
+		CheckTransactions = TransactionBasic | TransactionSignatures, ///< Check transaction signatures.
+		OutOfOrderChecks = ValidSeal | DontHave | CheckUncles | CheckTransactions, ///< Do all checks that can be done independently of prior blocks having been imported.
+		InOrderChecks = Parent | UncleParent, ///< Do all checks that cannot be done independently of prior blocks having been imported.
+		Everything = ValidSeal | DontHave | CheckUncles | CheckTransactions | Parent | UncleParent,
 		None = 0
 	};
 };

--- a/libethcore/Exceptions.h
+++ b/libethcore/Exceptions.h
@@ -70,6 +70,7 @@ DEV_SIMPLE_EXCEPTION(InvalidNonce);
 DEV_SIMPLE_EXCEPTION(InvalidBlockHeaderItemCount);
 DEV_SIMPLE_EXCEPTION(InvalidBlockNonce);
 DEV_SIMPLE_EXCEPTION(InvalidParentHash);
+DEV_SIMPLE_EXCEPTION(InvalidUncleParentHash);
 DEV_SIMPLE_EXCEPTION(InvalidNumber);
 DEV_SIMPLE_EXCEPTION(BlockNotFound);
 

--- a/libethereum/BlockChain.cpp
+++ b/libethereum/BlockChain.cpp
@@ -427,11 +427,11 @@ tuple<ImportRoute, bool, unsigned> BlockChain::sync(BlockQueue& _bq, OverlayDB c
 	return make_tuple(ImportRoute{dead, fresh, goodTransactions}, _bq.doneDrain(badBlocks), count);
 }
 
-pair<ImportResult, ImportRoute> BlockChain::attemptImport(bytes const& _block, OverlayDB const& _stateDB, ImportRequirements::value _ir) noexcept
+pair<ImportResult, ImportRoute> BlockChain::attemptImport(bytes const& _block, OverlayDB const& _stateDB, bool _mustBeNew) noexcept
 {
 	try
 	{
-		return make_pair(ImportResult::Success, import(verifyBlock(&_block, m_onBad, _ir), _stateDB, _ir | ImportRequirements::TransactionBasic));
+		return make_pair(ImportResult::Success, import(verifyBlock(&_block, m_onBad, ImportRequirements::OutOfOrderChecks), _stateDB, _mustBeNew));
 	}
 	catch (UnknownParent&)
 	{
@@ -453,7 +453,7 @@ pair<ImportResult, ImportRoute> BlockChain::attemptImport(bytes const& _block, O
 	}
 }
 
-ImportRoute BlockChain::import(bytes const& _block, OverlayDB const& _db, ImportRequirements::value _ir)
+ImportRoute BlockChain::import(bytes const& _block, OverlayDB const& _db, bool _mustBeNew)
 {
 	// VERIFY: populates from the block and checks the block is internally coherent.
 	VerifiedBlockRef block;
@@ -462,7 +462,7 @@ ImportRoute BlockChain::import(bytes const& _block, OverlayDB const& _db, Import
 	try
 #endif
 	{
-		block = verifyBlock(&_block, m_onBad, _ir | ImportRequirements::TransactionBasic);
+		block = verifyBlock(&_block, m_onBad, ImportRequirements::OutOfOrderChecks);
 	}
 #if ETH_CATCH
 	catch (Exception& ex)
@@ -474,10 +474,10 @@ ImportRoute BlockChain::import(bytes const& _block, OverlayDB const& _db, Import
 	}
 #endif
 
-	return import(block, _db, _ir);
+	return import(block, _db, _mustBeNew);
 }
 
-ImportRoute BlockChain::import(VerifiedBlockRef const& _block, OverlayDB const& _db, ImportRequirements::value _ir)
+ImportRoute BlockChain::import(VerifiedBlockRef const& _block, OverlayDB const& _db, bool _mustBeNew)
 {
 	//@tidy This is a behemoth of a method - could do to be split into a few smaller ones.
 
@@ -492,7 +492,7 @@ ImportRoute BlockChain::import(VerifiedBlockRef const& _block, OverlayDB const& 
 #endif
 
 	// Check block doesn't already exist first!
-	if (isKnown(_block.info.hash()) && (_ir & ImportRequirements::DontHave))
+	if (isKnown(_block.info.hash()) && _mustBeNew)
 	{
 		clog(BlockChainNote) << _block.info.hash() << ": Not new.";
 		BOOST_THROW_EXCEPTION(AlreadyHaveBlock());
@@ -527,6 +527,9 @@ ImportRoute BlockChain::import(VerifiedBlockRef const& _block, OverlayDB const& 
 		// Block has a timestamp in the future. This is no good.
 		BOOST_THROW_EXCEPTION(FutureTime());
 	}
+
+	// Verify parent-critical parts
+	verifyBlock(_block.block, m_onBad, ImportRequirements::InOrderChecks);
 
 	clog(BlockChainChat) << "Attempting import of " << _block.info.hash() << "...";
 

--- a/libethereum/BlockChain.cpp
+++ b/libethereum/BlockChain.cpp
@@ -761,7 +761,7 @@ ImportRoute BlockChain::import(VerifiedBlockRef const& _block, OverlayDB const& 
 	try
 	{
 		State canary(_db, BaseState::Empty);
-		canary.populateFromChain(*this, _block.info.hash(), ImportRequirements::DontHave);
+		canary.populateFromChain(*this, _block.info.hash());
 	}
 	catch (...)
 	{

--- a/libethereum/BlockQueue.cpp
+++ b/libethereum/BlockQueue.cpp
@@ -111,7 +111,7 @@ void BlockQueue::verifierBody()
 		swap(work.block, res.blockData);
 		try
 		{
-			res.verified = m_bc->verifyBlock(&res.blockData, m_onBad, ImportRequirements::Everything & ~ImportRequirements::Parent);
+			res.verified = m_bc->verifyBlock(&res.blockData, m_onBad, ImportRequirements::InOrderChecks);
 		}
 		catch (...)
 		{

--- a/libethereum/BlockQueue.cpp
+++ b/libethereum/BlockQueue.cpp
@@ -111,7 +111,7 @@ void BlockQueue::verifierBody()
 		swap(work.block, res.blockData);
 		try
 		{
-			res.verified = m_bc->verifyBlock(&res.blockData, m_onBad, ImportRequirements::InOrderChecks);
+			res.verified = m_bc->verifyBlock(&res.blockData, m_onBad, ImportRequirements::OutOfOrderChecks);
 		}
 		catch (...)
 		{

--- a/libethereum/CanonBlockChain.cpp
+++ b/libethereum/CanonBlockChain.cpp
@@ -111,7 +111,7 @@ unordered_map<Address, Account> CanonBlockChain<Ethash>::createGenesisState()
 	if (s_ret.empty())
 	{
 		js::mValue val;
-		json_spirit::read_string(s_genesisStateJSON.empty() ? c_genesisInfo : s_genesisStateJSON, val);
+		js::read_string(s_genesisStateJSON.empty() ? c_genesisInfo : s_genesisStateJSON, val);
 		for (auto account: val.get_obj()["alloc"].get_obj())
 		{
 			u256 balance;


### PR DESCRIPTION
Do other verifications at import time.
Fixed #2648