### PR TITLE
Error checking in resolveHost()

### DIFF
--- a/libweb3jsonrpc/WebThreeStubServerBase.cpp
+++ b/libweb3jsonrpc/WebThreeStubServerBase.cpp
@@ -545,6 +545,9 @@ bool WebThreeStubServerBase::admin_net_connect(std::string const& _node, std::st
 	}
 	else
 		ep = p2p::Network::resolveHost(_node);
+
+	if (ep == bi::tcp::endpoint())
+		return false;
 	network()->requirePeer(id, ep);
 	return true;
 }


### PR DESCRIPTION
- Properly check if what follows after ':' is a number and catch the
  exception thrown. Before this we were segfaulting with an uncaught
  exception

- Return an empty endpoint if we have an error so it can be detected by
  the calling web3 server code and show 'false' in the console instead
  of 'true'