### PR TITLE
Clone contracts

### DIFF
--- a/libsolidity/CompilerStack.cpp
+++ b/libsolidity/CompilerStack.cpp
@@ -166,7 +166,13 @@ void CompilerStack::compile(bool _optimize, unsigned _runs)
 				compiledContract.bytecode = compiler->getAssembledBytecode();
 				compiledContract.runtimeBytecode = compiler->getRuntimeBytecode();
 				compiledContract.compiler = move(compiler);
+				compiler = make_shared<Compiler>(_optimize, _runs);
+				compiler->compileContract(*contract, contractBytecode);
 				contractBytecode[compiledContract.contract] = &compiledContract.bytecode;
+
+				Compiler cloneCompiler(_optimize, _runs);
+				cloneCompiler.compileClone(*contract, contractBytecode);
+				compiledContract.cloneBytecode = cloneCompiler.getAssembledBytecode();
 			}
 }
 
@@ -197,6 +203,11 @@ bytes const& CompilerStack::getBytecode(string const& _contractName) const
 bytes const& CompilerStack::getRuntimeBytecode(string const& _contractName) const
 {
 	return getContract(_contractName).runtimeBytecode;
+}
+
+bytes const& CompilerStack::getCloneBytecode(string const& _contractName) const
+{
+	return getContract(_contractName).cloneBytecode;
 }
 
 dev::h256 CompilerStack::getContractCodeHash(string const& _contractName) const

--- a/libsolidity/CompilerStack.h
+++ b/libsolidity/CompilerStack.h
@@ -99,6 +99,11 @@ public:
 	bytes const& getBytecode(std::string const& _contractName = "") const;
 	/// @returns the runtime bytecode for the contract, i.e. the code that is returned by the constructor.
 	bytes const& getRuntimeBytecode(std::string const& _contractName = "") const;
+	/// @returns the bytecode of a contract that uses an already deployed contract via CALLCODE.
+	/// The returned bytes will contain a sequence of 20 bytes of the format "XXX...XXX" which have to
+	/// substituted by the actual address. Note that this sequence starts end ends in three X
+	/// characters but can contain anything in between.
+	bytes const& getCloneBytecode(std::string const& _contractName = "") const;
 	/// @returns normal contract assembly items
 	eth::AssemblyItems const* getAssemblyItems(std::string const& _contractName = "") const;
 	/// @returns runtime contract assembly items
@@ -167,6 +172,7 @@ private:
 		std::shared_ptr<Compiler> compiler;
 		bytes bytecode;
 		bytes runtimeBytecode;
+		bytes cloneBytecode;
 		std::shared_ptr<InterfaceHandler> interfaceHandler;
 		mutable std::unique_ptr<std::string const> interface;
 		mutable std::unique_ptr<std::string const> solidityInterface;


### PR DESCRIPTION
This provides the ability to create a "clone" of a contract, which is only a stub that CALLCODEs into the original already deployed contract. The clone contains all creation-time code and behaves identical to the actual contract at runtime.
This is not fully implemented yet: It is only able to return at most 32 bytes for now.