### PR TITLE
search for llvm head on osx

### DIFF
--- a/cmake/EthDependencies.cmake
+++ b/cmake/EthDependencies.cmake
@@ -32,6 +32,7 @@ endif()
 
 # homebrew installs qts in opt
 if (APPLE)
+	set (CMAKE_PREFIX_PATH "/usr/local/Cellar/llvm/HEAD" ${CMAKE_PREFIX_PATH})
 	set (CMAKE_PREFIX_PATH "/usr/local/opt/qt5" ${CMAKE_PREFIX_PATH})
 	set (CMAKE_PREFIX_PATH "/usr/local/opt/v8-315" ${CMAKE_PREFIX_PATH})
 endif()


### PR DESCRIPTION
this pr fixes the following error:

```
CMake Error at evmjit/CMakeLists.txt:50 (find_package):
  Could not find a package configuration file provided by "LLVM" with any of
  the following names:

    LLVMConfig.cmake
    llvm-config.cmake

  Add the installation prefix of "LLVM" to CMAKE_PREFIX_PATH or set
  "LLVM_DIR" to a directory containing one of the above files.  If "LLVM"
  provides a separate development package or SDK, be sure it has been
  installed.

-- Configuring incomplete, errors occurred!
```

xcode's llvm is at most 3.6 whereas we require at least 3.7. Let's try to find it in default dir on osx.