### PR TITLE
fixed cmake policy CMP0042, MACOSX RPATH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 2.8.12)
 
 set(PROJECT_VERSION "0.9.38")
 if (${CMAKE_VERSION} VERSION_GREATER 3.0)
+	cmake_policy(SET CMP0042 NEW) 	# fix MACOSX_RPATH
 	cmake_policy(SET CMP0048 NEW) 	# allow VERSION argument in project()
 	project(ethereum VERSION ${PROJECT_VERSION})
 else()

--- a/evmjit/CMakeLists.txt
+++ b/evmjit/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 2.8.12)
 
 if (${CMAKE_VERSION} VERSION_GREATER 3.0)
+	cmake_policy(SET CMP0042 NEW) 	# fix MACOSX_RPATH
 	cmake_policy(SET CMP0048 NEW) 	# allow VERSION argument in project()
 	project(EVMJIT VERSION 0.9.0 LANGUAGES CXX)
 else()

--- a/libdevcore/CMakeLists.txt
+++ b/libdevcore/CMakeLists.txt
@@ -1,11 +1,4 @@
 cmake_policy(SET CMP0015 NEW)
-# this policy was introduced in cmake 3.0
-# remove if, once 3.0 will be used on unix
-if (${CMAKE_MAJOR_VERSION} GREATER 2)
-	# old policy do not use MACOSX_RPATH
-	cmake_policy(SET CMP0042 OLD)
-endif()
-
 set(CMAKE_AUTOMOC OFF)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DSTATICLIB")

--- a/libdevcrypto/CMakeLists.txt
+++ b/libdevcrypto/CMakeLists.txt
@@ -1,10 +1,4 @@
 cmake_policy(SET CMP0015 NEW)
-# this policy was introduced in cmake 3.0
-# remove if, once 3.0 will be used on unix
-if (${CMAKE_MAJOR_VERSION} GREATER 2)
-	# old policy do not use MACOSX_RPATH
-	cmake_policy(SET CMP0042 OLD)
-endif()
 set(CMAKE_AUTOMOC OFF)
 
 aux_source_directory(. SRC_LIST)

--- a/libethcore/CMakeLists.txt
+++ b/libethcore/CMakeLists.txt
@@ -1,10 +1,4 @@
 cmake_policy(SET CMP0015 NEW)
-# this policy was introduced in cmake 3.0
-# remove if, once 3.0 will be used on unix
-if (${CMAKE_MAJOR_VERSION} GREATER 2)
-	# old policy do not use MACOSX_RPATH
-	cmake_policy(SET CMP0042 OLD)
-endif()
 set(CMAKE_AUTOMOC OFF)
 
 aux_source_directory(. SRC_LIST)

--- a/libethereum/CMakeLists.txt
+++ b/libethereum/CMakeLists.txt
@@ -1,10 +1,4 @@
 cmake_policy(SET CMP0015 NEW)
-# this policy was introduced in cmake 3.0
-# remove if, once 3.0 will be used on unix
-if (${CMAKE_MAJOR_VERSION} GREATER 2)
-	# old policy do not use MACOSX_RPATH
-	cmake_policy(SET CMP0042 OLD)
-endif()
 set(CMAKE_AUTOMOC OFF)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DSTATICLIB")

--- a/libevm/CMakeLists.txt
+++ b/libevm/CMakeLists.txt
@@ -1,10 +1,4 @@
 cmake_policy(SET CMP0015 NEW)
-# this policy was introduced in cmake 3.0
-# remove if, once 3.0 will be used on unix
-if (${CMAKE_MAJOR_VERSION} GREATER 2)
-	# old policy do not use MACOSX_RPATH
-	cmake_policy(SET CMP0042 OLD)
-endif()
 set(CMAKE_AUTOMOC OFF)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DSTATICLIB")

--- a/libevmasm/CMakeLists.txt
+++ b/libevmasm/CMakeLists.txt
@@ -1,10 +1,4 @@
 cmake_policy(SET CMP0015 NEW)
-# this policy was introduced in cmake 3.0
-# remove if, once 3.0 will be used on unix
-if (${CMAKE_MAJOR_VERSION} GREATER 2)
-	# old policy do not use MACOSX_RPATH
-	cmake_policy(SET CMP0042 OLD)
-endif()
 set(CMAKE_AUTOMOC OFF)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DSTATICLIB")

--- a/libevmcore/CMakeLists.txt
+++ b/libevmcore/CMakeLists.txt
@@ -1,10 +1,4 @@
 cmake_policy(SET CMP0015 NEW)
-# this policy was introduced in cmake 3.0
-# remove if, once 3.0 will be used on unix
-if (${CMAKE_MAJOR_VERSION} GREATER 2)
-	# old policy do not use MACOSX_RPATH
-	cmake_policy(SET CMP0042 OLD)
-endif()
 set(CMAKE_AUTOMOC OFF)
 
 aux_source_directory(. SRC_LIST)

--- a/libjsconsole/CMakeLists.txt
+++ b/libjsconsole/CMakeLists.txt
@@ -1,11 +1,4 @@
 cmake_policy(SET CMP0015 NEW)
-# this policy was introduced in cmake 3.0
-# remove if, once 3.0 will be used on unix
-if (${CMAKE_MAJOR_VERSION} GREATER 2)
-	# old policy do not use MACOSX_RPATH
-	cmake_policy(SET CMP0042 OLD)
-endif()
-
 set(CMAKE_AUTOMOC OFF)
 
 aux_source_directory(. SRC_LIST)

--- a/libjsengine/CMakeLists.txt
+++ b/libjsengine/CMakeLists.txt
@@ -1,11 +1,4 @@
 cmake_policy(SET CMP0015 NEW)
-# this policy was introduced in cmake 3.0
-# remove if, once 3.0 will be used on unix
-if (${CMAKE_MAJOR_VERSION} GREATER 2)
-	# old policy do not use MACOSX_RPATH
-	cmake_policy(SET CMP0042 OLD)
-endif()
-
 set(CMAKE_AUTOMOC OFF)
 
 aux_source_directory(. SRC_LIST)

--- a/liblll/CMakeLists.txt
+++ b/liblll/CMakeLists.txt
@@ -1,10 +1,4 @@
 cmake_policy(SET CMP0015 NEW)
-# this policy was introduced in cmake 3.0
-# remove if, once 3.0 will be used on unix
-if (${CMAKE_MAJOR_VERSION} GREATER 2)
-	# old policy do not use MACOSX_RPATH
-	cmake_policy(SET CMP0042 OLD)
-endif()
 set(CMAKE_AUTOMOC OFF)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DSTATICLIB")

--- a/libnatspec/CMakeLists.txt
+++ b/libnatspec/CMakeLists.txt
@@ -4,8 +4,6 @@ cmake_policy(SET CMP0020 NEW)
 # this policy was introduced in cmake 3.0
 # remove if, once 3.0 will be used on unix
 if (${CMAKE_MAJOR_VERSION} GREATER 2)
-	# old policy do not use MACOSX_RPATH
-	cmake_policy(SET CMP0042 OLD)
 	cmake_policy(SET CMP0043 OLD)
 endif()
 set(CMAKE_AUTOMOC OFF)

--- a/libp2p/CMakeLists.txt
+++ b/libp2p/CMakeLists.txt
@@ -1,10 +1,4 @@
 cmake_policy(SET CMP0015 NEW)
-# this policy was introduced in cmake 3.0
-# remove if, once 3.0 will be used on unix
-if (${CMAKE_MAJOR_VERSION} GREATER 2)
-	# old policy do not use MACOSX_RPATH
-	cmake_policy(SET CMP0042 OLD)
-endif()
 set(CMAKE_AUTOMOC OFF)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DSTATICLIB")

--- a/libscrypt/CMakeLists.txt
+++ b/libscrypt/CMakeLists.txt
@@ -1,10 +1,4 @@
 cmake_policy(SET CMP0015 NEW)
-# this policy was introduced in cmake 3.0
-# remove if, once 3.0 will be used on unix
-if (${CMAKE_MAJOR_VERSION} GREATER 2)
-	# old policy do not use MACOSX_RPATH
-	cmake_policy(SET CMP0042 OLD)
-endif()
 set(CMAKE_AUTOMOC OFF)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DSTATICLIB")

--- a/libserpent/CMakeLists.txt
+++ b/libserpent/CMakeLists.txt
@@ -1,10 +1,4 @@
 cmake_policy(SET CMP0015 NEW)
-# this policy was introduced in cmake 3.0
-# remove if, once 3.0 will be used on unix
-if (${CMAKE_MAJOR_VERSION} GREATER 2)
-	# old policy do not use MACOSX_RPATH
-	cmake_policy(SET CMP0042 OLD)
-endif()
 set(CMAKE_AUTOMOC OFF)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DSTATICLIB")

--- a/libsolidity/CMakeLists.txt
+++ b/libsolidity/CMakeLists.txt
@@ -1,10 +1,4 @@
 cmake_policy(SET CMP0015 NEW)
-# this policy was introduced in cmake 3.0
-# remove if, once 3.0 will be used on unix
-if (${CMAKE_MAJOR_VERSION} GREATER 2)
-	# old policy do not use MACOSX_RPATH
-	cmake_policy(SET CMP0042 OLD)
-endif()
 set(CMAKE_AUTOMOC OFF)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DSTATICLIB")

--- a/libtestutils/CMakeLists.txt
+++ b/libtestutils/CMakeLists.txt
@@ -1,10 +1,4 @@
 cmake_policy(SET CMP0015 NEW)
-# this policy was introduced in cmake 3.0
-# remove if, once 3.0 will be used on unix
-if (${CMAKE_MAJOR_VERSION} GREATER 2)
-	# old policy do not use MACOSX_RPATH
-	cmake_policy(SET CMP0042 OLD)
-endif()
 set(CMAKE_AUTOMOC OFF)
 
 aux_source_directory(. SRC_LIST)

--- a/libweb3jsonrpc/CMakeLists.txt
+++ b/libweb3jsonrpc/CMakeLists.txt
@@ -1,10 +1,4 @@
 cmake_policy(SET CMP0015 NEW)
-# this policy was introduced in cmake 3.0
-# remove if, once 3.0 will be used on unix
-if (${CMAKE_MAJOR_VERSION} GREATER 2)
-	# old policy do not use MACOSX_RPATH
-	cmake_policy(SET CMP0042 OLD)
-endif()
 set(CMAKE_AUTOMOC OFF)
 
 aux_source_directory(. SRC_LIST)

--- a/libwebthree/CMakeLists.txt
+++ b/libwebthree/CMakeLists.txt
@@ -1,10 +1,4 @@
 cmake_policy(SET CMP0015 NEW)
-# this policy was introduced in cmake 3.0
-# remove if, once 3.0 will be used on unix
-if (${CMAKE_MAJOR_VERSION} GREATER 2)
-	# old policy do not use MACOSX_RPATH
-	cmake_policy(SET CMP0042 OLD)
-endif()
 set(CMAKE_AUTOMOC OFF)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DSTATICLIB")

--- a/libwhisper/CMakeLists.txt
+++ b/libwhisper/CMakeLists.txt
@@ -1,10 +1,4 @@
 cmake_policy(SET CMP0015 NEW)
-# this policy was introduced in cmake 3.0
-# remove if, once 3.0 will be used on unix
-if (${CMAKE_MAJOR_VERSION} GREATER 2)
-	# old policy do not use MACOSX_RPATH
-	cmake_policy(SET CMP0042 OLD)
-endif()
 set(CMAKE_AUTOMOC OFF)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DSTATICLIB")

--- a/secp256k1/CMakeLists.txt
+++ b/secp256k1/CMakeLists.txt
@@ -1,10 +1,4 @@
 cmake_policy(SET CMP0015 NEW)
-# this policy was introduced in cmake 3.0
-# remove if, once 3.0 will be used on unix
-if (${CMAKE_MAJOR_VERSION} GREATER 2)
-	# old policy do not use MACOSX_RPATH
-	cmake_policy(SET CMP0042 OLD)
-endif()
 set(CMAKE_AUTOMOC OFF)
 
 set(EXECUTABLE secp256k1)


### PR DESCRIPTION
cmake_policy CMP0042 is set to NEW globally. There are no more warnings after running cmake on osx.


