### PR TITLE
Fix build for gcc 5.2.0

### DIFF
--- a/alethzero/MainFace.h
+++ b/alethzero/MainFace.h
@@ -44,7 +44,7 @@ namespace az
 {
 
 #define DEV_AZ_NOTE_PLUGIN(ClassName) \
-	static bool s_notePlugin = [](){ MainFace::notePlugin([](MainFace* m){ return new ClassName(m); }); return true; }()
+	static bool s_notePlugin __attribute__((unused)) = [](){ MainFace::notePlugin([](MainFace* m){ return new ClassName(m); }); return true; }()
 
 class Plugin;
 class MainFace;

--- a/alethzero/MainFace.h
+++ b/alethzero/MainFace.h
@@ -43,8 +43,13 @@ namespace shh { class WhisperHost; }
 namespace az
 {
 
+#ifndef _MSC_VER // MSVC does not like gcc compiler attributes
 #define DEV_AZ_NOTE_PLUGIN(ClassName) \
 	static bool s_notePlugin __attribute__((unused)) = [](){ MainFace::notePlugin([](MainFace* m){ return new ClassName(m); }); return true; }()
+#else
+#define DEV_AZ_NOTE_PLUGIN(ClassName) \
+	static bool s_notePlugin = [](){ MainFace::notePlugin([](MainFace* m){ return new ClassName(m); }); return true; }()
+#endif
 
 class Plugin;
 class MainFace;


### PR DESCRIPTION
gcc 5.2.0 warns for the usage of `s_notePlugin` as unused. This is a way to get around that. It's basically a proper way to fix #2837 