### PR TITLE
Eth submitWork() rate is now hex string

### DIFF
--- a/ethminer/FarmClient.h
+++ b/ethminer/FarmClient.h
@@ -34,7 +34,7 @@ class FarmClient : public jsonrpc::Client
             else
                 throw jsonrpc::JsonRpcException(jsonrpc::Errors::ERROR_CLIENT_INVALID_RESPONSE, result.toStyledString());
         }
-        bool eth_submitHashrate(int param1, const std::string& param2) throw (jsonrpc::JsonRpcException)
+        bool eth_submitHashrate(const std::string& param1, const std::string& param2) throw (jsonrpc::JsonRpcException)
         {
             Json::Value p;
             p.append(param1);

--- a/ethminer/MinerAux.h
+++ b/ethminer/MinerAux.h
@@ -37,6 +37,7 @@
 #include <libdevcore/StructuredLogger.h>
 #include <libethcore/Exceptions.h>
 #include <libdevcore/SHA3.h>
+#include <libdevcore/CommonJS.h>
 #include <libethcore/EthashAux.h>
 #include <libethcore/EthashGPUMiner.h>
 #include <libethcore/EthashCPUMiner.h>
@@ -515,7 +516,7 @@ private:
 					auto rate = mp.rate();
 					try
 					{
-						rpc.eth_submitHashrate(toHex((u256)rate, HexPrefix::Add), "0x" + id.hex());
+						rpc.eth_submitHashrate(toJS((u256)rate), "0x" + id.hex());
 					}
 					catch (jsonrpc::JsonRpcException const& _e)
 					{

--- a/ethminer/MinerAux.h
+++ b/ethminer/MinerAux.h
@@ -515,7 +515,7 @@ private:
 					auto rate = mp.rate();
 					try
 					{
-						rpc.eth_submitHashrate((int)rate, "0x" + id.hex());
+						rpc.eth_submitHashrate(toHex((u256)rate, HexPrefix::Add), "0x" + id.hex());
 					}
 					catch (jsonrpc::JsonRpcException const& _e)
 					{

--- a/ethminer/farm.json
+++ b/ethminer/farm.json
@@ -1,7 +1,7 @@
 [
 	{ "name": "eth_getWork", "params": [], "order": [], "returns": []},
 	{ "name": "eth_submitWork", "params": ["", "", ""], "order": [], "returns": true},
-	{ "name": "eth_submitHashrate", "params": [0, ""], "order": [], "returns": true},
+	{ "name": "eth_submitHashrate", "params": ["", ""], "order": [], "returns": true},
 	{ "name": "eth_awaitNewWork", "params": [], "order": [], "returns": []},
 	{ "name": "eth_progress", "params": [], "order": [], "returns": true}
 ]

--- a/libdevcore/CommonJS.h
+++ b/libdevcore/CommonJS.h
@@ -113,9 +113,7 @@ inline u256 jsToU256(std::string const& _s) { return jsToInt<32>(_s); }
 
 inline int jsToInt(std::string const& _s)
 {
-	if (_s.size() > 2 && _s.substr(0, 2).compare("0x") == 0)
-		return std::stoi(_s, nullptr, 16);
-	return std::stoi(_s, nullptr, 10);
+	return std::stoi(_s, nullptr, 0);
 }
 
 inline std::string jsToDecimal(std::string const& _s)

--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -507,9 +507,9 @@ WorkingProgress Client::miningProgress() const
 	return WorkingProgress();
 }
 
-uint64_t Client::hashrate() const
+u256 Client::hashrate() const
 {
-	uint64_t r = externalHashrate();
+	u256 r = externalHashrate();
 	if (Ethash::isWorking(m_sealEngine.get()))
 		r += Ethash::workingProgress(m_sealEngine.get()).rate();
 	return r;

--- a/libethereum/Client.h
+++ b/libethereum/Client.h
@@ -171,7 +171,7 @@ public:
 	/// Are we mining now?
 	bool wouldMine() const override { return m_wouldMine; }
 	/// The hashrate...
-	uint64_t hashrate() const override;
+	u256 hashrate() const override;
 	/// Check the progress of the mining.
 	WorkingProgress miningProgress() const override;
 	/// Get and clear the mining history.

--- a/libethereum/ClientBase.cpp
+++ b/libethereum/ClientBase.cpp
@@ -524,14 +524,14 @@ bool ClientBase::isKnownTransaction(h256 const& _blockHash, unsigned _i) const
 	return isKnown(_blockHash) && bc().transactions().size() > _i;
 }
 
-void ClientBase::submitExternalHashrate(int _rate, h256 const& _id)
+void ClientBase::submitExternalHashrate(u256 const& _rate, h256 const& _id)
 {
 	m_externalRates[_id] = make_pair(_rate, chrono::steady_clock::now());
 }
 
-uint64_t ClientBase::externalHashrate() const
+u256 ClientBase::externalHashrate() const
 {
-	uint64_t ret = 0;
+	u256 ret = 0;
 	for (auto i = m_externalRates.begin(); i != m_externalRates.end();)
 		if (chrono::steady_clock::now() - i->second.second > chrono::seconds(5))
 			i = m_externalRates.erase(i);

--- a/libethereum/ClientBase.h
+++ b/libethereum/ClientBase.h
@@ -164,10 +164,10 @@ public:
 	virtual void stopMining() override { BOOST_THROW_EXCEPTION(InterfaceNotSupported("ClientBase::stopMining")); }
 	virtual bool isMining() const override { BOOST_THROW_EXCEPTION(InterfaceNotSupported("ClientBase::isMining")); }
 	virtual bool wouldMine() const override { BOOST_THROW_EXCEPTION(InterfaceNotSupported("ClientBase::wouldMine")); }
-	virtual uint64_t hashrate() const override { BOOST_THROW_EXCEPTION(InterfaceNotSupported("ClientBase::hashrate")); }
+	virtual u256 hashrate() const override { BOOST_THROW_EXCEPTION(InterfaceNotSupported("ClientBase::hashrate")); }
 	virtual WorkingProgress miningProgress() const override { BOOST_THROW_EXCEPTION(InterfaceNotSupported("ClientBase::miningProgress")); }
 
-	virtual void submitExternalHashrate(int _rate, h256 const& _id) override;
+	virtual void submitExternalHashrate(u256 const& _rate, h256 const& _id) override;
 
 	Block asOf(BlockNumber _h) const;
 
@@ -182,7 +182,7 @@ protected:
 	virtual void prepareForTransaction() = 0;
 	/// }
 
-	uint64_t externalHashrate() const;
+	u256 externalHashrate() const;
 
 	TransactionQueue m_tq;							///< Maintains a list of incoming transactions not yet in a block on the blockchain.
 
@@ -194,7 +194,7 @@ protected:
 	std::map<unsigned, ClientWatch> m_watches;				///< Each and every watch - these reference a filter.
 	
 	// external hashrate
-	mutable std::unordered_map<h256, std::pair<uint64_t, std::chrono::steady_clock::time_point>> m_externalRates;
+	mutable std::unordered_map<h256, std::pair<u256, std::chrono::steady_clock::time_point>> m_externalRates;
 };
 
 }}

--- a/libethereum/Interface.h
+++ b/libethereum/Interface.h
@@ -211,14 +211,14 @@ public:
 	/// Would we like to mine now?
 	virtual bool wouldMine() const = 0;
 	/// Current hash rate.
-	virtual uint64_t hashrate() const = 0;
+	virtual u256 hashrate() const = 0;
 
 	/// Get hash of the current block to be mined minus the nonce (the 'work hash').
 	virtual std::tuple<h256, h256, h256> getEthashWork() { BOOST_THROW_EXCEPTION(InterfaceNotSupported("Interface::getEthashWork")); }
 	/// Submit the nonce for the proof-of-work.
 	virtual bool submitEthashWork(h256 const&, h64 const&) { BOOST_THROW_EXCEPTION(InterfaceNotSupported("Interface::submitEthashWork")); }
 	/// Submit the ongoing hashrate of a particular external miner.
-	virtual void submitExternalHashrate(int, h256 const&) { BOOST_THROW_EXCEPTION(InterfaceNotSupported("Interface::submitExternalHashrate")); }
+	virtual void submitExternalHashrate(u256 const&, h256 const&) { BOOST_THROW_EXCEPTION(InterfaceNotSupported("Interface::submitExternalHashrate")); }
 	/// Check the progress of the mining.
 	virtual WorkingProgress miningProgress() const = 0;
 

--- a/libweb3jsonrpc/WebThreeStubServerBase.cpp
+++ b/libweb3jsonrpc/WebThreeStubServerBase.cpp
@@ -780,9 +780,9 @@ bool WebThreeStubServerBase::eth_submitWork(string const& _nonce, string const&,
 	}
 }
 
-bool WebThreeStubServerBase::eth_submitHashrate(std::string const& _hashes, string const& _id)
+bool WebThreeStubServerBase::eth_submitHashrate(string const& _hashes, string const& _id)
 {
-	client()->submitExternalHashrate(std::stoi(_hashes, nullptr, 0), jsToFixed<32>(_id));
+	client()->submitExternalHashrate(stoi(_hashes, nullptr, 0), jsToFixed<32>(_id));
 	return true;
 }
 

--- a/libweb3jsonrpc/WebThreeStubServerBase.cpp
+++ b/libweb3jsonrpc/WebThreeStubServerBase.cpp
@@ -780,9 +780,9 @@ bool WebThreeStubServerBase::eth_submitWork(string const& _nonce, string const&,
 	}
 }
 
-bool WebThreeStubServerBase::eth_submitHashrate(int _hashes, string const& _id)
+bool WebThreeStubServerBase::eth_submitHashrate(std::string const& _hashes, string const& _id)
 {
-	client()->submitExternalHashrate(_hashes, jsToFixed<32>(_id));
+	client()->submitExternalHashrate(std::stoi(_hashes, nullptr, 0), jsToFixed<32>(_id));
 	return true;
 }
 

--- a/libweb3jsonrpc/WebThreeStubServerBase.cpp
+++ b/libweb3jsonrpc/WebThreeStubServerBase.cpp
@@ -782,7 +782,7 @@ bool WebThreeStubServerBase::eth_submitWork(string const& _nonce, string const&,
 
 bool WebThreeStubServerBase::eth_submitHashrate(string const& _hashes, string const& _id)
 {
-	client()->submitExternalHashrate(stoi(_hashes, nullptr, 0), jsToFixed<32>(_id));
+	client()->submitExternalHashrate(jsToInt(_hashes), jsToFixed<32>(_id));
 	return true;
 }
 

--- a/libweb3jsonrpc/WebThreeStubServerBase.cpp
+++ b/libweb3jsonrpc/WebThreeStubServerBase.cpp
@@ -782,7 +782,7 @@ bool WebThreeStubServerBase::eth_submitWork(string const& _nonce, string const&,
 
 bool WebThreeStubServerBase::eth_submitHashrate(string const& _hashes, string const& _id)
 {
-	client()->submitExternalHashrate(jsToInt(_hashes), jsToFixed<32>(_id));
+	client()->submitExternalHashrate(jsToInt<32>(_hashes), jsToFixed<32>(_id));
 	return true;
 }
 

--- a/libweb3jsonrpc/WebThreeStubServerBase.h
+++ b/libweb3jsonrpc/WebThreeStubServerBase.h
@@ -139,7 +139,7 @@ public:
 	virtual Json::Value eth_getLogsEx(Json::Value const& _json);
 	virtual Json::Value eth_getWork();
 	virtual bool eth_submitWork(std::string const& _nonce, std::string const&, std::string const& _mixHash);
-	virtual bool eth_submitHashrate(int _hashes, std::string const& _id);
+	virtual bool eth_submitHashrate(std::string const& _hashes, std::string const& _id);
 	virtual std::string eth_register(std::string const& _address);
 	virtual bool eth_unregister(std::string const& _accountId);
 	virtual Json::Value eth_fetchQueuedTransactions(std::string const& _accountId);

--- a/libweb3jsonrpc/abstractwebthreestubserver.h
+++ b/libweb3jsonrpc/abstractwebthreestubserver.h
@@ -60,7 +60,7 @@ class AbstractWebThreeStubServer : public jsonrpc::AbstractServer<AbstractWebThr
             this->bindAndAddMethod(jsonrpc::Procedure("eth_getLogsEx", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_ARRAY, "param1",jsonrpc::JSON_OBJECT, NULL), &AbstractWebThreeStubServer::eth_getLogsExI);
             this->bindAndAddMethod(jsonrpc::Procedure("eth_getWork", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_ARRAY,  NULL), &AbstractWebThreeStubServer::eth_getWorkI);
             this->bindAndAddMethod(jsonrpc::Procedure("eth_submitWork", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_BOOLEAN, "param1",jsonrpc::JSON_STRING,"param2",jsonrpc::JSON_STRING,"param3",jsonrpc::JSON_STRING, NULL), &AbstractWebThreeStubServer::eth_submitWorkI);
-            this->bindAndAddMethod(jsonrpc::Procedure("eth_submitHashrate", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_BOOLEAN, "param1",jsonrpc::JSON_INTEGER,"param2",jsonrpc::JSON_STRING, NULL), &AbstractWebThreeStubServer::eth_submitHashrateI);
+            this->bindAndAddMethod(jsonrpc::Procedure("eth_submitHashrate", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_BOOLEAN, "param1",jsonrpc::JSON_STRING,"param2",jsonrpc::JSON_STRING, NULL), &AbstractWebThreeStubServer::eth_submitHashrateI);
             this->bindAndAddMethod(jsonrpc::Procedure("eth_register", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_STRING, "param1",jsonrpc::JSON_STRING, NULL), &AbstractWebThreeStubServer::eth_registerI);
             this->bindAndAddMethod(jsonrpc::Procedure("eth_unregister", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_BOOLEAN, "param1",jsonrpc::JSON_STRING, NULL), &AbstractWebThreeStubServer::eth_unregisterI);
             this->bindAndAddMethod(jsonrpc::Procedure("eth_fetchQueuedTransactions", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_ARRAY, "param1",jsonrpc::JSON_STRING, NULL), &AbstractWebThreeStubServer::eth_fetchQueuedTransactionsI);
@@ -315,7 +315,7 @@ class AbstractWebThreeStubServer : public jsonrpc::AbstractServer<AbstractWebThr
         }
         inline virtual void eth_submitHashrateI(const Json::Value &request, Json::Value &response)
         {
-            response = this->eth_submitHashrate(request[0u].asInt(), request[1u].asString());
+            response = this->eth_submitHashrate(request[0u].asString(), request[1u].asString());
         }
         inline virtual void eth_registerI(const Json::Value &request, Json::Value &response)
         {
@@ -534,7 +534,7 @@ class AbstractWebThreeStubServer : public jsonrpc::AbstractServer<AbstractWebThr
         virtual Json::Value eth_getLogsEx(const Json::Value& param1) = 0;
         virtual Json::Value eth_getWork() = 0;
         virtual bool eth_submitWork(const std::string& param1, const std::string& param2, const std::string& param3) = 0;
-        virtual bool eth_submitHashrate(int param1, const std::string& param2) = 0;
+        virtual bool eth_submitHashrate(const std::string& param1, const std::string& param2) = 0;
         virtual std::string eth_register(const std::string& param1) = 0;
         virtual bool eth_unregister(const std::string& param1) = 0;
         virtual Json::Value eth_fetchQueuedTransactions(const std::string& param1) = 0;

--- a/libweb3jsonrpc/spec.json
+++ b/libweb3jsonrpc/spec.json
@@ -49,7 +49,7 @@
 { "name": "eth_getLogsEx", "params": [{}], "order": [], "returns": []},
 { "name": "eth_getWork", "params": [], "order": [], "returns": []},
 { "name": "eth_submitWork", "params": ["", "", ""], "order": [], "returns": true},
-{ "name": "eth_submitHashrate", "params": [0, ""], "order": [], "returns": true},
+{ "name": "eth_submitHashrate", "params": ["", ""], "order": [], "returns": true},
 { "name": "eth_register", "params": [""], "order": [], "returns": ""},
 { "name": "eth_unregister", "params": [""], "order": [], "returns": true},
 { "name": "eth_fetchQueuedTransactions", "params": [""], "order": [], "returns": []},

--- a/mix/MixClient.cpp
+++ b/mix/MixClient.cpp
@@ -370,7 +370,7 @@ bool MixClient::isMining() const
 	return false;
 }
 
-uint64_t MixClient::hashrate() const
+u256 MixClient::hashrate() const
 {
 	return 0;
 }

--- a/mix/MixClient.h
+++ b/mix/MixClient.h
@@ -95,7 +95,7 @@ public:
 	void startMining() override;
 	void stopMining() override;
 	bool isMining() const override;
-	uint64_t hashrate() const override;
+	u256 hashrate() const override;
 	eth::WorkingProgress miningProgress() const override;
 	virtual void flushTransactions() override {}
 

--- a/test/libweb3jsonrpc/webthreestubclient.h
+++ b/test/libweb3jsonrpc/webthreestubclient.h
@@ -506,7 +506,7 @@ class WebThreeStubClient : public jsonrpc::Client
             else
                 throw jsonrpc::JsonRpcException(jsonrpc::Errors::ERROR_CLIENT_INVALID_RESPONSE, result.toStyledString());
         }
-        bool eth_submitHashrate(int param1, const std::string& param2) throw (jsonrpc::JsonRpcException)
+        bool eth_submitHashrate(const std::string& param1, const std::string& param2) throw (jsonrpc::JsonRpcException)
         {
             Json::Value p;
             p.append(param1);


### PR DESCRIPTION
Is based on https://github.com/ethereum/cpp-ethereum/pull/2847.

As per the [JSON RPC API doc](https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_submithashrate) submitHashrate should accept hexadecimal strings.