### PR TITLE
Detect unavailable items and do not optimise the chunk in that case.

### DIFF
--- a/libevmasm/Assembly.cpp
+++ b/libevmasm/Assembly.cpp
@@ -337,6 +337,11 @@ Assembly& Assembly::optimise(bool _enable, bool _isCreation, size_t _runs)
 						// This might happen if the opcode reconstruction is not as efficient
 						// as the hand-crafted code.
 					}
+					catch (ItemNotAvailableException const&)
+					{
+						// This might happen if e.g. associativity and commutativity rules
+						// reorganise the expression tree, but not all leaves are available.
+					}
 
 					if (shouldReplace)
 					{

--- a/libevmasm/CommonSubexpressionEliminator.cpp
+++ b/libevmasm/CommonSubexpressionEliminator.cpp
@@ -220,6 +220,12 @@ void CSECodeGenerator::addDependencies(Id _c)
 	if (m_neededBy.count(_c))
 		return; // we already computed the dependencies for _c
 	ExpressionClasses::Expression expr = m_expressionClasses.representative(_c);
+	if (expr.item->type() == UndefinedItem)
+		BOOST_THROW_EXCEPTION(
+			// If this exception happens, we need to find a different way to generate the
+			// compound expression.
+			ItemNotAvailableException() << errinfo_comment("Undefined item requested but not available.")
+		);
 	for (Id argument: expr.arguments)
 	{
 		addDependencies(argument);
@@ -317,6 +323,11 @@ void CSECodeGenerator::generateClassElement(Id _c, bool _allowSequenced)
 		"Sequence constrained operation requested out of sequence."
 	);
 	assertThrow(expr.item, OptimizerException, "Non-generated expression without item.");
+	assertThrow(
+		expr.item->type() != UndefinedItem,
+		OptimizerException,
+		"Undefined item requested but not available."
+	);
 	vector<Id> const& arguments = expr.arguments;
 	for (Id arg: boost::adaptors::reverse(arguments))
 		generateClassElement(arg);

--- a/libevmasm/Exceptions.h
+++ b/libevmasm/Exceptions.h
@@ -31,6 +31,7 @@ namespace eth
 struct AssemblyException: virtual Exception {};
 struct OptimizerException: virtual AssemblyException {};
 struct StackTooDeepException: virtual OptimizerException {};
+struct ItemNotAvailableException: virtual OptimizerException {};
 
 }
 }


### PR DESCRIPTION
Fixes #2762 
The reason for the bug was that the code generator for the common subexpression eliminator had to generate the expression (A + B) + C and simplified that to A + (B + C), but at the time the expression had to be generated, only C and (A + B) were available, but not A alone.
The optimiser detects the situation now and simply uses the unoptimized code for that block.
Stories are already planned to circumvent this situation and generate optimised code nevertheless (by 1. remembering other ways of generating expressions and 2. carrying dependencies across basic blocks).