### PR TITLE
Fixed destruction order for BlockChain and BlockQueue

### DIFF
--- a/libethereum/BlockQueue.cpp
+++ b/libethereum/BlockQueue.cpp
@@ -61,10 +61,16 @@ BlockQueue::BlockQueue():
 
 BlockQueue::~BlockQueue()
 {
+	stop();
+}
+
+void BlockQueue::stop()
+{
 	m_deleting = true;
 	m_moreToVerify.notify_all();
 	for (auto& i: m_verifiers)
 		i.join();
+	m_verifiers.clear();
 }
 
 void BlockQueue::clear()

--- a/libethereum/BlockQueue.h
+++ b/libethereum/BlockQueue.h
@@ -104,6 +104,9 @@ public:
 	/// Clear everything.
 	void clear();
 
+	/// Stop all activity, leaves the class in limbo, waiting for destruction
+	void stop();
+
 	/// Return first block with an unknown parent.
 	h256 firstUnknown() const { ReadGuard l(m_lock); return m_unknownSet.size() ? *m_unknownSet.begin() : h256(); }
 

--- a/libethereum/Client.h
+++ b/libethereum/Client.h
@@ -366,7 +366,7 @@ public:
 		init(_host, _dbPath, _forceAction, _networkId);
 	}
 
-	virtual ~SpecialisedClient() { stopWorking(); }
+	virtual ~SpecialisedClient() { m_bq.stop(); stopWorking(); }
 
 	/// Get the object representing the current canonical blockchain.
 	CanonBlockChain<Sealer> const& blockChain() const { return m_bc; }

--- a/libethereum/TransactionQueue.h
+++ b/libethereum/TransactionQueue.h
@@ -36,8 +36,6 @@ namespace dev
 namespace eth
 {
 
-class BlockChain;
-
 struct TransactionQueueChannel: public LogChannel { static const char* name(); static const int verbosity = 4; };
 struct TransactionQueueTraceChannel: public LogChannel { static const char* name(); static const int verbosity = 7; };
 #define ctxq dev::LogOutputStream<dev::eth::TransactionQueueTraceChannel, true>()


### PR DESCRIPTION
Before recent changes BlockQueue was destroyed before the BlockChain on exit. Now this is reversed and causes segfault if verification threads are still active.