### PR TITLE
ethcore should not depend on evmcore

### DIFF
--- a/libethcore/CMakeLists.txt
+++ b/libethcore/CMakeLists.txt
@@ -17,7 +17,6 @@ file(GLOB HEADERS "*.h")
 add_library(${EXECUTABLE} ${SRC_LIST} ${HEADERS})
 
 target_link_libraries(${EXECUTABLE} ethash)
-target_link_libraries(${EXECUTABLE} evmcore)
 if (ETHASHCL)
 	target_link_libraries(${EXECUTABLE} ethash-cl)
 endif ()


### PR DESCRIPTION
You can notice the problem when build the miner bundle

```
make  -j8

Scanning dependencies of target minerfarm.jsonstub

Scanning dependencies of target devcore                                                                                                                                                                                                                                                                           [234/535]
Scanning dependencies of target secp256k1
Scanning dependencies of target scrypt
Scanning dependencies of target ethash
Scanning dependencies of target minerphonehome.jsonstub
Scanning dependencies of target BuildInfo.h
[  1%] Building C object libscrypt/CMakeFiles/scrypt.dir/sha256.c.o
[  2%] Building C object libscrypt/CMakeFiles/scrypt.dir/crypto-scrypt-saltgen.c.o
[  4%] Building C object libethash/CMakeFiles/ethash.dir/io.c.o
[  5%] Building C object secp256k1/CMakeFiles/secp256k1.dir/secp256k1.c.o
Files "/home/lefteris/ew/cpp-ethereum/build/BuildInfo.h.tmp" to "/home/lefteris/ew/cpp-ethereum/build/BuildInfo.h" are different.
[  7%] Building CXX object libdevcore/CMakeFiles/devcore.dir/TransientDirectory.cpp.o
[  7%] Built target minerphonehome.jsonstub
[  7%] Built target minerfarm.jsonstub
[  8%] Building CXX object libdevcore/CMakeFiles/devcore.dir/Hash.cpp.o
[  8%] Built target BuildInfo.h
[ 10%] Building CXX object libdevcore/CMakeFiles/devcore.dir/TrieCommon.cpp.o
[ 11%] Building CXX object libdevcore/CMakeFiles/devcore.dir/Guards.cpp.o
[ 13%] Building CXX object libdevcore/CMakeFiles/devcore.dir/MemoryDB.cpp.o
[ 14%] Building C object libethash/CMakeFiles/ethash.dir/internal.c.o
[ 16%] Building C object libethash/CMakeFiles/ethash.dir/io_posix.c.o
[ 17%] Building CXX object libethash/CMakeFiles/ethash.dir/sha3_cryptopp.cpp.o
[ 19%] Building C object libscrypt/CMakeFiles/scrypt.dir/slowequals.c.o
[ 20%] Building C object libscrypt/CMakeFiles/scrypt.dir/crypto-mcf.c.o
[ 22%] Building C object libscrypt/CMakeFiles/scrypt.dir/crypto_scrypt-hash.c.o
[ 23%] Building C object libscrypt/CMakeFiles/scrypt.dir/crypto_scrypt-check.c.o
[ 25%] Building C object libscrypt/CMakeFiles/scrypt.dir/b64.c.o
[ 26%] Building C object libscrypt/CMakeFiles/scrypt.dir/crypto_scrypt-nosse.c.o
[ 27%] Building C object libscrypt/CMakeFiles/scrypt.dir/crypto_scrypt-hexconvert.c.o
[ 29%] Linking CXX shared library libethash.so
[ 30%] Linking C shared library libscrypt.so
[ 30%] Built target scrypt
[ 32%] Building CXX object libdevcore/CMakeFiles/devcore.dir/FileSystem.cpp.o
[ 32%] Built target ethash
[ 33%] Building CXX object libdevcore/CMakeFiles/devcore.dir/RLP.cpp.o
[ 35%] Linking C shared library libsecp256k1.so
[ 35%] Built target secp256k1
[ 36%] Building CXX object libdevcore/CMakeFiles/devcore.dir/Worker.cpp.o
[ 38%] Building CXX object libdevcore/CMakeFiles/devcore.dir/Log.cpp.o
[ 39%] Building CXX object libdevcore/CMakeFiles/devcore.dir/Base64.cpp.o
[ 41%] Building CXX object libdevcore/CMakeFiles/devcore.dir/CommonJS.cpp.o
[ 42%] Building CXX object libdevcore/CMakeFiles/devcore.dir/TrieDB.cpp.o
[ 44%] Building CXX object libdevcore/CMakeFiles/devcore.dir/CommonIO.cpp.o
[ 45%] Building CXX object libdevcore/CMakeFiles/devcore.dir/SHA3.cpp.o
[ 47%] Building CXX object libdevcore/CMakeFiles/devcore.dir/StructuredLogger.cpp.o
[ 48%] Building CXX object libdevcore/CMakeFiles/devcore.dir/Common.cpp.o
[ 50%] Building CXX object libdevcore/CMakeFiles/devcore.dir/CommonData.cpp.o
[ 51%] Building CXX object libdevcore/CMakeFiles/devcore.dir/RangeMask.cpp.o
[ 52%] Building CXX object libdevcore/CMakeFiles/devcore.dir/FixedHash.cpp.o
[ 54%] Building CXX object libdevcore/CMakeFiles/devcore.dir/TrieHash.cpp.o
[ 55%] Generating OpenCL Kernel Byte Array
Scanning dependencies of target ethash-cl
[ 57%] Building CXX object libethash-cl/CMakeFiles/ethash-cl.dir/ethash_cl_miner.cpp.o
[ 58%] Linking CXX shared library libethash-cl.so
[ 58%] Built target ethash-cl
[ 60%] Linking CXX shared library libdevcore.so
[ 60%] Built target devcore
Scanning dependencies of target devcrypto
[ 61%] Building CXX object libdevcrypto/CMakeFiles/devcrypto.dir/ECDHE.cpp.o
[ 63%] Building CXX object libdevcrypto/CMakeFiles/devcrypto.dir/OverlayDB.cpp.o
[ 64%] Building CXX object libdevcrypto/CMakeFiles/devcrypto.dir/AES.cpp.o
[ 66%] Building CXX object libdevcrypto/CMakeFiles/devcrypto.dir/SecretStore.cpp.o
[ 67%] Building CXX object libdevcrypto/CMakeFiles/devcrypto.dir/Common.cpp.o
[ 69%] Building CXX object libdevcrypto/CMakeFiles/devcrypto.dir/CryptoPP.cpp.o
[ 70%] Building CXX object libdevcrypto/CMakeFiles/devcrypto.dir/WordList.cpp.o
[ 72%] Linking CXX shared library libdevcrypto.so
[ 72%] Built target devcrypto
Scanning dependencies of target ethcore
[ 75%] Building CXX object libethcore/CMakeFiles/ethcore.dir/KeyManager.cpp.o
[ 75%] Building CXX object libethcore/CMakeFiles/ethcore.dir/EthashSealEngine.cpp.o
[ 76%] Building CXX object libethcore/CMakeFiles/ethcore.dir/EthashGPUMiner.cpp.o
[ 79%] Building CXX object libethcore/CMakeFiles/ethcore.dir/EthashCPUMiner.cpp.o
[ 79%] Building CXX object libethcore/CMakeFiles/ethcore.dir/Ethash.cpp.o
[ 80%] Building CXX object libethcore/CMakeFiles/ethcore.dir/Params.cpp.o
[ 82%] Building CXX object libethcore/CMakeFiles/ethcore.dir/ICAP.cpp.o
[ 83%] Building CXX object libethcore/CMakeFiles/ethcore.dir/EthashAux.cpp.o
[ 85%] Building CXX object libethcore/CMakeFiles/ethcore.dir/CommonJS.cpp.o
[ 86%] Building CXX object libethcore/CMakeFiles/ethcore.dir/Sealer.cpp.o
[ 88%] Building CXX object libethcore/CMakeFiles/ethcore.dir/ABI.cpp.o
[ 89%] Building CXX object libethcore/CMakeFiles/ethcore.dir/Transaction.cpp.o
[ 91%] Building CXX object libethcore/CMakeFiles/ethcore.dir/Miner.cpp.o
[ 92%] Building CXX object libethcore/CMakeFiles/ethcore.dir/BlockInfo.cpp.o
[ 94%] Building CXX object libethcore/CMakeFiles/ethcore.dir/BasicAuthority.cpp.o
[ 95%] Building CXX object libethcore/CMakeFiles/ethcore.dir/Common.cpp.o
[ 97%] Linking CXX shared library libethcore.so
/usr/bin/ld.gold: error: cannot find -levmcore
clang: error: linker command failed with exit code 1 (use -v to see invocation)
libethcore/CMakeFiles/ethcore.dir/build.make:498: recipe for target 'libethcore/libethcore.so' failed
make[2]: *** [libethcore/libethcore.so] Error 1
CMakeFiles/Makefile2:492: recipe for target 'libethcore/CMakeFiles/ethcore.dir/all' failed
make[1]: *** [libethcore/CMakeFiles/ethcore.dir/all] Error 2
Makefile:127: recipe for target 'all' failed
make: *** [all] Error 2
```