### PR TITLE
Replace usage of time(0) by UTC equivalent

### DIFF
--- a/libdevcore/Common.cpp
+++ b/libdevcore/Common.cpp
@@ -57,4 +57,9 @@ TimerHelper::~TimerHelper()
 		clog(TimerChannel) << m_id << chrono::duration_cast<chrono::milliseconds>(e).count() << "ms";
 }
 
+uint64_t utcTime()
+{
+    return mktime(gmtime((const time_t*)time(0)));
+}
+
 }

--- a/libdevcore/Common.h
+++ b/libdevcore/Common.h
@@ -293,10 +293,8 @@ enum class WithExisting: int
 };
 
 /// Get the current time in seconds since the epoch in UTC
-inline time_t getNowUTC()
-{
-    return mktime(gmtime((const time_t*)time(0)));
-}
+uint64_t utcTime();
+
 
 }
 

--- a/libdevcore/Common.h
+++ b/libdevcore/Common.h
@@ -292,6 +292,12 @@ enum class WithExisting: int
 	Kill
 };
 
+/// Get the current time in seconds since the epoch in UTC
+inline time_t getNowUTC()
+{
+    return mktime(gmtime((const time_t*)time(0)));
+}
+
 }
 
 namespace std

--- a/libdevcore/Common.h
+++ b/libdevcore/Common.h
@@ -295,7 +295,6 @@ enum class WithExisting: int
 /// Get the current time in seconds since the epoch in UTC
 uint64_t utcTime();
 
-
 }
 
 namespace std

--- a/libethcore/EthashCPUMiner.cpp
+++ b/libethcore/EthashCPUMiner.cpp
@@ -77,7 +77,7 @@ void EthashCPUMiner::pause()
 void EthashCPUMiner::workLoop()
 {
 	auto tid = std::this_thread::get_id();
-	static std::mt19937_64 s_eng((getNowUTC() + std::hash<decltype(tid)>()(tid)));
+	static std::mt19937_64 s_eng((utcTime() + std::hash<decltype(tid)>()(tid)));
 
 	uint64_t tryNonce = s_eng();
 	ethash_return_value ethashReturn;

--- a/libethcore/EthashCPUMiner.cpp
+++ b/libethcore/EthashCPUMiner.cpp
@@ -77,7 +77,7 @@ void EthashCPUMiner::pause()
 void EthashCPUMiner::workLoop()
 {
 	auto tid = std::this_thread::get_id();
-	static std::mt19937_64 s_eng((time(0) + std::hash<decltype(tid)>()(tid)));
+	static std::mt19937_64 s_eng((getNowUTC() + std::hash<decltype(tid)>()(tid)));
 
 	uint64_t tryNonce = s_eng();
 	ethash_return_value ethashReturn;

--- a/libethereum/Block.cpp
+++ b/libethereum/Block.cpp
@@ -104,7 +104,7 @@ void Block::resetCurrent()
 	m_transactionSet.clear();
 	m_currentBlock = BlockInfo();
 	m_currentBlock.setCoinbaseAddress(m_beneficiary);
-	m_currentBlock.setTimestamp(max(m_previousBlock.timestamp() + 1, (u256)getNowUTC()));
+	m_currentBlock.setTimestamp(max(m_previousBlock.timestamp() + 1, (u256)utcTime()));
 	m_currentBlock.populateFromParent(m_previousBlock);
 
 	// TODO: check.

--- a/libethereum/Block.cpp
+++ b/libethereum/Block.cpp
@@ -104,7 +104,7 @@ void Block::resetCurrent()
 	m_transactionSet.clear();
 	m_currentBlock = BlockInfo();
 	m_currentBlock.setCoinbaseAddress(m_beneficiary);
-	m_currentBlock.setTimestamp(max(m_previousBlock.timestamp() + 1, (u256)time(0)));
+	m_currentBlock.setTimestamp(max(m_previousBlock.timestamp() + 1, (u256)getNowUTC()));
 	m_currentBlock.populateFromParent(m_previousBlock);
 
 	// TODO: check.

--- a/libethereum/BlockChain.cpp
+++ b/libethereum/BlockChain.cpp
@@ -527,9 +527,9 @@ ImportRoute BlockChain::import(VerifiedBlockRef const& _block, OverlayDB const& 
 	}
 
 	// Check it's not crazy
-	if (_block.info.timestamp() > (u256)time(0))
+	if (_block.info.timestamp() > (u256)getNowUTC())
 	{
-		clog(BlockChainChat) << _block.info.hash() << ": Future time " << _block.info.timestamp() << " (now at " << time(0) << ")";
+		clog(BlockChainChat) << _block.info.hash() << ": Future time " << _block.info.timestamp() << " (now at " << getNowUTC() << ")";
 		// Block has a timestamp in the future. This is no good.
 		BOOST_THROW_EXCEPTION(FutureTime());
 	}

--- a/libethereum/BlockChain.cpp
+++ b/libethereum/BlockChain.cpp
@@ -527,9 +527,9 @@ ImportRoute BlockChain::import(VerifiedBlockRef const& _block, OverlayDB const& 
 	}
 
 	// Check it's not crazy
-	if (_block.info.timestamp() > (u256)getNowUTC())
+	if (_block.info.timestamp() > (u256)utcTime())
 	{
-		clog(BlockChainChat) << _block.info.hash() << ": Future time " << _block.info.timestamp() << " (now at " << getNowUTC() << ")";
+		clog(BlockChainChat) << _block.info.hash() << ": Future time " << _block.info.timestamp() << " (now at " << utcTime() << ")";
 		// Block has a timestamp in the future. This is no good.
 		BOOST_THROW_EXCEPTION(FutureTime());
 	}

--- a/libethereum/BlockChain.cpp
+++ b/libethereum/BlockChain.cpp
@@ -527,7 +527,7 @@ ImportRoute BlockChain::import(VerifiedBlockRef const& _block, OverlayDB const& 
 	}
 
 	// Check it's not crazy
-	if (_block.info.timestamp() > (u256)utcTime())
+	if (_block.info.timestamp() > utcTime())
 	{
 		clog(BlockChainChat) << _block.info.hash() << ": Future time " << _block.info.timestamp() << " (now at " << utcTime() << ")";
 		// Block has a timestamp in the future. This is no good.

--- a/libethereum/BlockChainSync.cpp
+++ b/libethereum/BlockChainSync.cpp
@@ -114,8 +114,8 @@ void BlockChainSync::onPeerStatus(std::shared_ptr<EthereumPeer> _peer)
 unsigned BlockChainSync::estimatedHashes() const
 {
 	BlockInfo block = host().chain().info();
-	time_t lastBlockTime = (block.hash() == host().chain().genesisHash()) ? 1428192000 : (time_t)block.timestamp();
-	time_t now = utcTime();
+	uint64_t lastBlockTime = (block.hash() == host().chain().genesisHash()) ? 1428192000 : (uint64_t)block.timestamp();
+	uint64_t now = utcTime();
 	unsigned blockCount = c_chainReorgSize;
 	if (lastBlockTime > now)
 		clog(NetWarn) << "Clock skew? Latest block is in the future";

--- a/libethereum/BlockChainSync.cpp
+++ b/libethereum/BlockChainSync.cpp
@@ -115,7 +115,7 @@ unsigned BlockChainSync::estimatedHashes() const
 {
 	BlockInfo block = host().chain().info();
 	time_t lastBlockTime = (block.hash() == host().chain().genesisHash()) ? 1428192000 : (time_t)block.timestamp();
-	time_t now = time(0);
+	time_t now = getNowUTC();
 	unsigned blockCount = c_chainReorgSize;
 	if (lastBlockTime > now)
 		clog(NetWarn) << "Clock skew? Latest block is in the future";

--- a/libethereum/BlockChainSync.cpp
+++ b/libethereum/BlockChainSync.cpp
@@ -115,7 +115,7 @@ unsigned BlockChainSync::estimatedHashes() const
 {
 	BlockInfo block = host().chain().info();
 	time_t lastBlockTime = (block.hash() == host().chain().genesisHash()) ? 1428192000 : (time_t)block.timestamp();
-	time_t now = getNowUTC();
+	time_t now = utcTime();
 	unsigned blockCount = c_chainReorgSize;
 	if (lastBlockTime > now)
 		clog(NetWarn) << "Clock skew? Latest block is in the future";

--- a/libethereum/BlockQueue.cpp
+++ b/libethereum/BlockQueue.cpp
@@ -234,14 +234,14 @@ ImportResult BlockQueue::import(bytesConstRef _block, bool _isOurs)
 
 	// Check it's not in the future
 	(void)_isOurs;
-	if (bi.timestamp() > (u256)time(0)/* && !_isOurs*/)
+	if (bi.timestamp() > (u256)getNowUTC()/* && !_isOurs*/)
 	{
 		m_future.insert(make_pair((unsigned)bi.timestamp(), make_pair(h, _block.toBytes())));
 		char buf[24];
 		time_t bit = (unsigned)bi.timestamp();
 		if (strftime(buf, 24, "%X", localtime(&bit)) == 0)
 			buf[0] = '\0'; // empty if case strftime fails
-		clog(BlockQueueTraceChannel) << "OK - queued for future [" << bi.timestamp() << "vs" << time(0) << "] - will wait until" << buf;
+		clog(BlockQueueTraceChannel) << "OK - queued for future [" << bi.timestamp() << "vs" << getNowUTC() << "] - will wait until" << buf;
 		m_unknownSize += _block.size();
 		m_unknownCount++;
 		m_difficulty += bi.difficulty();
@@ -389,7 +389,7 @@ void BlockQueue::tick()
 
 		cblockq << "Checking past-future blocks...";
 
-		unsigned t = time(0);
+		unsigned t = getNowUTC();
 		if (t <= m_future.begin()->first)
 			return;
 

--- a/libethereum/BlockQueue.cpp
+++ b/libethereum/BlockQueue.cpp
@@ -234,14 +234,14 @@ ImportResult BlockQueue::import(bytesConstRef _block, bool _isOurs)
 
 	// Check it's not in the future
 	(void)_isOurs;
-	if (bi.timestamp() > (u256)getNowUTC()/* && !_isOurs*/)
+	if (bi.timestamp() > (u256)utcTime()/* && !_isOurs*/)
 	{
 		m_future.insert(make_pair((unsigned)bi.timestamp(), make_pair(h, _block.toBytes())));
 		char buf[24];
 		time_t bit = (unsigned)bi.timestamp();
 		if (strftime(buf, 24, "%X", localtime(&bit)) == 0)
 			buf[0] = '\0'; // empty if case strftime fails
-		clog(BlockQueueTraceChannel) << "OK - queued for future [" << bi.timestamp() << "vs" << getNowUTC() << "] - will wait until" << buf;
+		clog(BlockQueueTraceChannel) << "OK - queued for future [" << bi.timestamp() << "vs" << utcTime() << "] - will wait until" << buf;
 		m_unknownSize += _block.size();
 		m_unknownCount++;
 		m_difficulty += bi.difficulty();
@@ -389,7 +389,7 @@ void BlockQueue::tick()
 
 		cblockq << "Checking past-future blocks...";
 
-		unsigned t = getNowUTC();
+		unsigned t = utcTime();
 		if (t <= m_future.begin()->first)
 			return;
 

--- a/libethereum/BlockQueue.cpp
+++ b/libethereum/BlockQueue.cpp
@@ -234,7 +234,7 @@ ImportResult BlockQueue::import(bytesConstRef _block, bool _isOurs)
 
 	// Check it's not in the future
 	(void)_isOurs;
-	if (bi.timestamp() > (u256)utcTime()/* && !_isOurs*/)
+	if (bi.timestamp() > utcTime()/* && !_isOurs*/)
 	{
 		m_future.insert(make_pair((unsigned)bi.timestamp(), make_pair(h, _block.toBytes())));
 		char buf[24];
@@ -389,7 +389,7 @@ void BlockQueue::tick()
 
 		cblockq << "Checking past-future blocks...";
 
-		unsigned t = utcTime();
+		uint64_t t = utcTime();
 		if (t <= m_future.begin()->first)
 			return;
 

--- a/libtestutils/Common.cpp
+++ b/libtestutils/Common.cpp
@@ -50,7 +50,7 @@ std::string dev::test::getTestPath()
 
 int dev::test::randomNumber()
 {
-	static std::mt19937 randomGenerator(getNowUTC());
+	static std::mt19937 randomGenerator(utcTime());
 	randomGenerator.seed(std::random_device()());
 	return std::uniform_int_distribution<int>(1)(randomGenerator);
 }

--- a/libtestutils/Common.cpp
+++ b/libtestutils/Common.cpp
@@ -50,7 +50,7 @@ std::string dev::test::getTestPath()
 
 int dev::test::randomNumber()
 {
-	static std::mt19937 randomGenerator(time(0));
+	static std::mt19937 randomGenerator(getNowUTC());
 	randomGenerator.seed(std::random_device()());
 	return std::uniform_int_distribution<int>(1)(randomGenerator);
 }

--- a/test/libethereum/blockchain.cpp
+++ b/test/libethereum/blockchain.cpp
@@ -560,7 +560,7 @@ mArray importUncles(mObject const& _blObj, vector<BlockHeader>& _vBiUncles, vect
 		BlockHeader uncleBlockFromFields = constructBlock(uncleHeaderObj);
 
 		// make uncle header valid
-		uncleBlockFromFields.setTimestamp((u256)utcTime());
+		uncleBlockFromFields.setTimestamp(utcTime());
 		if (_vBiBlocks.size() > 2)
 		{
 			if (uncleBlockFromFields.number() - 1 < _vBiBlocks.size())

--- a/test/libethereum/blockchain.cpp
+++ b/test/libethereum/blockchain.cpp
@@ -560,7 +560,7 @@ mArray importUncles(mObject const& _blObj, vector<BlockHeader>& _vBiUncles, vect
 		BlockHeader uncleBlockFromFields = constructBlock(uncleHeaderObj);
 
 		// make uncle header valid
-		uncleBlockFromFields.setTimestamp((u256)getNowUTC());
+		uncleBlockFromFields.setTimestamp((u256)utcTime());
 		if (_vBiBlocks.size() > 2)
 		{
 			if (uncleBlockFromFields.number() - 1 < _vBiBlocks.size())

--- a/test/libethereum/blockchain.cpp
+++ b/test/libethereum/blockchain.cpp
@@ -560,7 +560,7 @@ mArray importUncles(mObject const& _blObj, vector<BlockHeader>& _vBiUncles, vect
 		BlockHeader uncleBlockFromFields = constructBlock(uncleHeaderObj);
 
 		// make uncle header valid
-		uncleBlockFromFields.setTimestamp((u256)time(0));
+		uncleBlockFromFields.setTimestamp((u256)getNowUTC());
 		if (_vBiBlocks.size() > 2)
 		{
 			if (uncleBlockFromFields.number() - 1 < _vBiBlocks.size())


### PR DESCRIPTION
Replacing all relevant invocations of time(0) by a function that is
guaranteed to produce a UTC timestamp according to the standard and no
longer depends on the implementation.

According to [time() documentation](http://www.cplusplus.com/reference/ctime/time/):
>The value returned generally represents the number of seconds since 00:00 hours, Jan 1, 1970 UTC (i.e., the current unix timestamp). Although libraries may use a different representation of time: Portable programs should not use the value returned by this function directly, but always rely on calls to other elements of the standard library to translate them to portable types (such as localtime, gmtime or difftime).

So we have to assume that depending on the implementation `time()` may not return the UTC timestamp and as such we may get the wrong time.

Usage of `gmtime()` in our own function should amend that.