### PR TITLE
Add a dot graph of all our module dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,5 @@ project.pbxproj
 doc/html
 *.autosave
 node_modules/
+
+dependency_graph.svg

--- a/dependency_graph.dot
+++ b/dependency_graph.dot
@@ -1,0 +1,50 @@
+digraph G {
+	subgraph cluster_libdev {
+		devcore->devcrypto;
+		devcrypto->p2p;
+		label="libdev";
+		graph[style=filled,color=lightgrey];
+	}
+
+	p2p->whisper;
+	subgraph cluster_whisper {
+		whisper->webthree;
+		label = "libwhisper";
+		graph[style=filled,color=lightgrey];
+	}
+
+	ethereum -> webthree;
+
+	subgraph cluster_webthree {
+		webthree->web3jsonrpc;
+		web3jsonrpc->eth;
+		label = "webthree";
+		graph[style=filled,color=lightgrey];
+	}
+
+	subgraph cluster_solidity {
+		 solidity->solc;
+		 solidity->web3jsonrpc;
+		 label = "solidity";
+		graph[style=filled,color=lightgrey];
+	}
+
+	evm->ethereum;
+	lll->ethereum;
+	devcrypto->ethcore;
+	devcore->evmcore;
+	p2p->ethereum;
+	evmcore->evmasm;
+	evmcore->evmjitcpp;
+	evmcore->ethcore;
+	evmjitcpp->evm;
+	ethcore->evm;
+	evmasm->lll;
+	evmasm->solidity;
+
+	subgraph cluster_evmjitcpp {
+		evmjitcpp;
+		graph[style=filled,color=lightgrey];
+	}
+
+}


### PR DESCRIPTION
This graph is based on the one @gavofyork drew to represent how we would like our modules to interconnect. I think having a dot graph is a really good idea since we can all easily edit and visualize it.

To create the graphn in .svg format simply make sure you have
dot/graphviz and issue the folllowing command:

`dot -Tsvg dependency_graph.dot -o dependency_graph.svg`