### PR TITLE
bugfix in p2p

### DIFF
--- a/libp2p/Host.cpp
+++ b/libp2p/Host.cpp
@@ -236,10 +236,13 @@ void Host::startPeerSession(Public const& _id, RLP const& _rlp, unique_ptr<RLPXF
 		else
 		{
 			// peer doesn't exist, try to get port info from node table
-			if (Node n = m_nodeTable->node(_id))
-				p = make_shared<Peer>(n);
-			else
+			if (m_nodeTable)
+				if (Node n = m_nodeTable->node(_id))
+					p = make_shared<Peer>(n);
+
+			if (!p)
 				p = make_shared<Peer>(Node(_id, UnspecifiedNodeIPEndpoint));
+
 			m_peers[_id] = p;
 		}
 	}

--- a/test/libp2p/peer.cpp
+++ b/test/libp2p/peer.cpp
@@ -118,7 +118,7 @@ BOOST_AUTO_TEST_CASE(saveNodes)
 	for (auto const& h: hosts)
 		host2.addNode(h->id(), NodeIPEndpoint(bi::address::from_string("127.0.0.1"), h->listenPort(), h->listenPort()));
 
-	for (unsigned i = 0; i < c_peers * 1000 && host2.peerCount() < c_peers; i += c_step)
+	for (unsigned i = 0; i < c_peers * 2000 && host2.peerCount() < c_peers; i += c_step)
 		this_thread::sleep_for(chrono::milliseconds(c_step));
 
 	BOOST_CHECK_EQUAL(host.peerCount(), c_peers);


### PR DESCRIPTION
Sometimes the tests crash in my environment (m_nodeTable is null).
Reproduction rate was approx. 20%.