### PR TITLE
Fix network listener and modify first test to use random ports.

### DIFF
--- a/libp2p/Host.h
+++ b/libp2p/Host.h
@@ -184,10 +184,10 @@ public:
 	size_t peerCount() const;
 
 	/// Get the address we're listening on currently.
-	std::string listenAddress() const { return m_netPrefs.listenIPAddress.empty() ? "0.0.0.0" : m_netPrefs.listenIPAddress; }
+	std::string listenAddress() const { return m_tcpPublic.address().is_unspecified() ? "0.0.0.0" : m_tcpPublic.address().to_string(); }
 
 	/// Get the port we're listening on currently.
-	unsigned short listenPort() const { return m_netPrefs.listenPort; }
+	unsigned short listenPort() const { return std::max(0, m_listenPort); }
 
 	/// Serialise the set of known peers.
 	bytes saveNetwork() const;

--- a/test/libp2p/peer.cpp
+++ b/test/libp2p/peer.cpp
@@ -45,12 +45,18 @@ BOOST_AUTO_TEST_CASE(host)
 
 	VerbosityHolder setTemporaryLevel(10);
 
-	NetworkPreferences host1prefs("127.0.0.1", 30321, false);
-	NetworkPreferences host2prefs("127.0.0.1", 30322, false);
-	Host host1("Test", host1prefs);
-	Host host2("Test", host2prefs);
+	Host host1("Test", NetworkPreferences("127.0.0.1", 0, false));
 	host1.start();
+	auto host1port = host1.listenPort();
+	BOOST_REQUIRE(host1port);
+
+	Host host2("Test", NetworkPreferences("127.0.0.1", 0, false));
 	host2.start();
+	auto host2port = host2.listenPort();
+	BOOST_REQUIRE(host2port);
+	
+	BOOST_REQUIRE_NE(host1port, host2port);
+	
 	auto node2 = host2.id();
 	int const step = 10;
 
@@ -63,7 +69,7 @@ BOOST_AUTO_TEST_CASE(host)
 		this_thread::sleep_for(chrono::milliseconds(step));
 
 	BOOST_REQUIRE(host1.haveNetwork() && host2.haveNetwork());
-	host1.addNode(node2, NodeIPEndpoint(bi::address::from_string("127.0.0.1"), host2prefs.listenPort, host2prefs.listenPort));
+	host1.addNode(node2, NodeIPEndpoint(bi::address::from_string("127.0.0.1"), host2port, host2port));
 
 	for (int i = 0; i < 3000 && (!host1.peerCount() || !host2.peerCount()); i += step)
 		this_thread::sleep_for(chrono::milliseconds(step));


### PR DESCRIPTION
In cases where a user lets the client pick the default port we were improperly advertising the wrong port and setting port to 0 (so tests can choose random port) causes problems due to return of an unsigned from signed. listenAddress() and listenPort() were also return 'preferred' ports and not what the host is actually listening to. 