### PR TITLE
probabilistic bugfix

### DIFF
--- a/libp2p/NodeTable.cpp
+++ b/libp2p/NodeTable.cpp
@@ -580,7 +580,7 @@ void NodeTable::doCheckEvictions()
 	m_timers.schedule(c_evictionCheckInterval.count(), [this](boost::system::error_code const& _ec)
 	{
 		if (_ec)
-			clog(NodeTableMessageDetail) << "Discovery timer was probably cancelled: " << _ec.value() << _ec.message();
+			clog(NodeTableMessageDetail) << "Check Evictions timer was probably cancelled: " << _ec.value() << _ec.message();
 
 		if (_ec.value() == boost::asio::error::operation_aborted || m_timers.isStopped())
 			return;

--- a/libp2p/NodeTable.cpp
+++ b/libp2p/NodeTable.cpp
@@ -579,7 +579,7 @@ void NodeTable::doCheckEvictions()
 {
 	m_timers.schedule(c_evictionCheckInterval.count(), [this](boost::system::error_code const& _ec)
 	{
-		if (_ec)
+		if (_ec || m_timers.isStopped())
 			return;
 		
 		bool evictionsRemain = false;
@@ -607,7 +607,7 @@ void NodeTable::doDiscovery()
 {
 	m_timers.schedule(c_bucketRefresh.count(), [this](boost::system::error_code const& ec)
 	{
-		if (ec)
+		if (ec || m_timers.isStopped())
 			return;
 		
 		clog(NodeTableEvent) << "performing random discovery";

--- a/libp2p/NodeTable.cpp
+++ b/libp2p/NodeTable.cpp
@@ -199,7 +199,7 @@ void NodeTable::doDiscover(NodeID _node, unsigned _round, shared_ptr<set<shared_
 	m_timers.schedule(c_reqTimeout.count() * 2, [this, _node, _round, _tried](boost::system::error_code const& _ec)
 	{
 		if (_ec)
-			clog(NodeTableMessageDetail) << "Discovery timer canceled: " << _ec.value() << _ec.message();
+			clog(NodeTableMessageDetail) << "Discovery timer was probably cancelled: " << _ec.value() << _ec.message();
 
 		if (_ec.value() == boost::asio::error::operation_aborted || m_timers.isStopped())
 			return;
@@ -579,7 +579,10 @@ void NodeTable::doCheckEvictions()
 {
 	m_timers.schedule(c_evictionCheckInterval.count(), [this](boost::system::error_code const& _ec)
 	{
-		if (_ec || m_timers.isStopped())
+		if (_ec)
+			clog(NodeTableMessageDetail) << "Discovery timer was probably cancelled: " << _ec.value() << _ec.message();
+
+		if (_ec.value() == boost::asio::error::operation_aborted || m_timers.isStopped())
 			return;
 		
 		bool evictionsRemain = false;
@@ -605,9 +608,12 @@ void NodeTable::doCheckEvictions()
 
 void NodeTable::doDiscovery()
 {
-	m_timers.schedule(c_bucketRefresh.count(), [this](boost::system::error_code const& ec)
+	m_timers.schedule(c_bucketRefresh.count(), [this](boost::system::error_code const& _ec)
 	{
-		if (ec || m_timers.isStopped())
+		if (_ec)
+			clog(NodeTableMessageDetail) << "Discovery timer was probably cancelled: " << _ec.value() << _ec.message();
+
+		if (_ec.value() == boost::asio::error::operation_aborted || m_timers.isStopped())
 			return;
 		
 		clog(NodeTableEvent) << "performing random discovery";


### PR DESCRIPTION
Similar to my old PR: https://github.com/ethereum/cpp-ethereum/pull/2784

I can not reproduce the bug anymore, therefore I call this PR "probabilistic bugfix".
However, the following scenario is possible: m_timers.stop() is called, the corresponding variable is set immediately, but the timers are not yet stopped, because it requires to lock the mutex (it might require some time and could trigger the thread switch). Therefore, _ec variable is zero, but destructor of host object has already been called. At this point we should not continue with descovery (or whatever else), and must instead return from the corresponding function.