### PR TITLE
Fix utcTime() function

### DIFF
--- a/libdevcore/Common.cpp
+++ b/libdevcore/Common.cpp
@@ -57,12 +57,17 @@ TimerHelper::~TimerHelper()
 		clog(TimerChannel) << m_id << chrono::duration_cast<chrono::milliseconds>(e).count() << "ms";
 }
 
+#ifdef _WIN32 // the windows version of timegm
+#define timegm _mkgmtime
+#endif
+
 uint64_t utcTime()
 {
-	// TODO: Fix if possible to not use time(0) and merge only after testing in all platforms
-	// time_t t = time(0);
-	// return mktime(gmtime(&t));
-	return time(0);
+	time_t t = time(0);
+	// as per http://stackoverflow.com/questions/283166/easy-way-to-convert-a-struct-tm-expressed-in-utc-to-time-t-type
+	// to convert a struct tm to time_t again you need to use timegm and not mktime. The latter would convert it
+	// into local time
+	return timegm(gmtime(&t));
 }
 
 }


### PR DESCRIPTION
This PR is for implementing a `utcTime()` function that does not just use time(0) to return the current UTC timestamp. The reasoning behind this is that according to the [documentation](http://www.cplusplus.com/reference/ctime/time/) 

> The value returned generally represents the number of seconds since 00:00 hours, Jan 1, 1970 UTC (i.e., the current unix timestamp). Although libraries may use a different representation of time: Portable programs should not use the value returned by this function directly, but always rely on calls to other elements of the standard library to translate them to portable types (such as localtime, gmtime or difftime).

the `time(0)` function is not guaranteed to return a UTC timestamp, even though in most implementations, as we have seen, it will. Only way to do that seems to be to combine it with gmtime() as we do in this PR.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ethereum/cpp-ethereum/2936)
<!-- Reviewable:end -->
