### PR TITLE
Fix the dangling else in logs for Release build

### DIFF
--- a/libdevcore/Log.h
+++ b/libdevcore/Log.h
@@ -253,14 +253,18 @@ public:
 	template <class T> LogOutputStream& operator<<(T const& _t) { if (Id::verbosity <= g_logVerbosity) { if (_AutoSpacing && m_sstr.str().size() && m_sstr.str().back() != ' ') m_sstr << " "; append(_t); } return *this; }
 };
 
+/// A "hacky" way to make sure the next statement get executed only once without the good old
+/// do { } while(0) macro. We need such a thing due to the dangling else problem and the need
+/// for the logging macros to end with the stream object and not a closing brace '}'
+#define DEV_STATEMENT_ONCE() for (bool i_eth_once_ = true; i_eth_once_; i_eth_once_ = false)
 // Kill all logs when when NLOG is defined.
 #if NLOG
 #define clog(X) nlog(X)
 #define cslog(X) nslog(X)
 #else
 #if NDEBUG
-#define clog(X) if (X::debug) {} else dev::LogOutputStream<X, true>()
-#define cslog(X) if (X::debug) {} else dev::LogOutputStream<X, false>()
+#define clog(X) DEV_STATEMENT_ONCE() if (X::debug) {} else dev::LogOutputStream<X, true>()
+#define cslog(X) DEV_STATEMENT_ONCE() if (X::debug) {} else dev::LogOutputStream<X, false>()
 #else
 #define clog(X) dev::LogOutputStream<X, true>()
 #define cslog(X) dev::LogOutputStream<X, false>()
@@ -274,8 +278,8 @@ public:
 #define cwarn clog(dev::WarnChannel)
 
 // Null stream-like objects.
-#define ndebug if (true) {} else dev::NullOutputStream()
-#define nlog(X) if (true) {} else dev::NullOutputStream()
-#define nslog(X) if (true) {} else dev::NullOutputStream()
+#define ndebug DEV_STATEMENT_ONCE() if (true) {} else dev::NullOutputStream()
+#define nlog(X) DEV_STATEMENT_ONCE() if (true) {} else dev::NullOutputStream()
+#define nslog(X) DEV_STATEMENT_ONCE() if (true) {} else dev::NullOutputStream()
 
 }


### PR DESCRIPTION
In cooperation with @arkpar for fixing the release build in preparation for packaging.

The errors we were getting were like those below and caused by the `NDEBUG` flag being turned on for the release build and having a different logging macro implementation.

```
/home/lefteris/ew/cpp-ethereum/libdevcore/TransientDirectory.cpp: In destructor ‘dev::TransientDirectory::~TransientDirectory()’:
/home/lefteris/ew/cpp-ethereum/libdevcore/TransientDirectory.cpp:62:5: error: suggest explicit braces to avoid ambiguous ‘else’ [-Werror=parentheses]
  if (!ec)
     ^
[ 17%] Building CXX object libjsengine/CMakeFiles/jsengine.dir/JSPrinter.cpp.o
[ 18%] Building CXX object libjsengine/CMakeFiles/jsengine.dir/JSEngine.cpp.o
[ 19%] Building CXX object libdevcore/CMakeFiles/devcore.dir/SHA3.cpp.o
[ 19%] Building CXX object libdevcore/CMakeFiles/devcore.dir/StructuredLogger.cpp.o
[ 20%] Building CXX object libdevcore/CMakeFiles/devcore.dir/Common.cpp.o
[ 20%] Building CXX object libdevcore/CMakeFiles/devcore.dir/CommonData.cpp.o
[ 21%] Building CXX object libdevcore/CMakeFiles/devcore.dir/RangeMask.cpp.o
[ 21%] Building CXX object libdevcore/CMakeFiles/devcore.dir/FixedHash.cpp.o
[ 21%] Building CXX object libdevcore/CMakeFiles/devcore.dir/TrieHash.cpp.o
[ 22%] Linking CXX shared library libethash-cl.so
[ 22%] Built target ethash-cl
cc1plus: all warnings being treated as errors
libdevcore/CMakeFiles/devcore.dir/build.make:62: recipe for target 'libdevcore/CMakeFiles/devcore.dir/TransientDirectory.cpp.o' failed
make[2]: *** [libdevcore/CMakeFiles/devcore.dir/TransientDirectory.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
[ 22%] Linking CXX shared library libjsengine.so
[ 22%] Built target jsengine
/home/lefteris/ew/cpp-ethereum/libdevcore/Common.cpp: In destructor ‘dev::TimerHelper::~TimerHelper()’:
/home/lefteris/ew/cpp-ethereum/libdevcore/Common.cpp:56:5: error: suggest explicit braces to avoid ambiguous ‘else’ [-Werror=parentheses]
  if (!m_ms || e > chrono::milliseconds(m_ms))
```