### PR TITLE
Update install_deps.sh for ArchLinux

### DIFF
--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -151,19 +151,14 @@ case $(uname -s) in
                 libcl \
                 libmicrohttpd \
                 miniupnpc \
-                opencl-headers \
+                opencl-headers
 
-                rm -rf libjson-rpc-cpp
-                git clone git://github.com/cinemast/libjson-rpc-cpp.git
-                cd libjson-rpc-cpp
-                git checkout v0.6.0
-                mkdir build
-                cd build
-                cmake .. -DCOMPILE_TESTS=NO
-                make
-                sudo make install
-                sudo ldconfig
-                cd ../..
+            rm -rf libjson-rpc-cpp-git
+            git clone http://aur.archlinux.org/libjson-rpc-cpp-git.git libjson-rpc-cpp-git
+            cd libjson-rpc-cpp-git
+            makepkg
+            pacman -U libjson-rpc-cpp-git-*.pkg.tar.xz
+            cd ../..
 
         fi
 

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -139,7 +139,10 @@ case $(uname -s) in
             # Arch Linux official repositories.
             # See https://wiki.archlinux.org/index.php/Official_repositories
             pacman -Sy --noconfirm \
-                base-devel \
+                autoconf \
+                automake \
+                gcc \
+                libtool \
                 boost \ 
                 cmake \
                 crypto++ \


### PR DESCRIPTION
- install `autoconf automake gcc libtool` instead of whole `base-devel` group
- use `pacman -U` to install libjson-rpc-cpp instead of `make install` (here: using PKGBUILD from AUR)