### PR TITLE
Switched miniupnpc to be an optional dependency for libp2p

### DIFF
--- a/libp2p/CMakeLists.txt
+++ b/libp2p/CMakeLists.txt
@@ -6,7 +6,8 @@ file(GLOB HEADERS "*.h")
 
 add_library(p2p ${SRC_LIST} ${HEADERS})
 
-eth_use(p2p REQUIRED Cryptopp Miniupnpc)
+eth_use(p2p REQUIRED Cryptopp)
+eth_use(p2p OPTIONAL Miniupnpc)
 
 find_package(Dev)
 


### PR DESCRIPTION
This should always have been the case.
Looks like this was just a bug in the build files which was always present.