### PR TITLE
Suppressing deprecation warnings for SHA3_256 and SHA3_512 classes in CryptoPP

### DIFF
--- a/libethash/sha3_cryptopp.cpp
+++ b/libethash/sha3_cryptopp.cpp
@@ -20,6 +20,37 @@
 * @date 2015
 */
 #include <stdint.h>
+
+#if defined(__GNUC__)
+    // Do not warn about uses of functions (see Function Attributes), variables
+    // (see Variable Attributes), and types (see Type Attributes) marked as
+    // deprecated by using the deprecated attribute.
+    //
+    // Specifically we are suppressing the warnings from the deprecation
+    // attributes added to the SHA3_256 and SHA3_512 classes in CryptoPP
+    // after the 5.6.3 release.
+    //
+    // From that header file ...
+    //
+    // "The Crypto++ SHA-3 implementation dates back to January 2013 when NIST
+    // selected Keccak as SHA-3. In August 2015 NIST finalized SHA-3, and it
+    // was a modified version of the Keccak selection. Crypto++ 5.6.2 through
+    // 5.6.4 provides the pre-FIPS 202 version of SHA-3; while Crypto++ 5.7
+    // and above provides the FIPS 202 version of SHA-3.
+    //
+    // See also http://en.wikipedia.org/wiki/SHA-3
+    //
+    // This means that we will never be able to move to the CryptoPP-5.7.x
+    // series of releases, because Ethereum requires Keccak, not the final
+    // SHA-3 standard algorithm.   We are planning to migrate cpp-ethereum
+    // off CryptoPP anyway, so this is unlikely to be a long-standing issue.
+    //
+    // https://github.com/ethereum/cpp-ethereum/issues/3088
+    //
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif // defined(__GNUC__)
+
 #include <cryptopp/sha3.h>
 
 extern "C" {
@@ -35,3 +66,7 @@ void SHA3_512(uint8_t* const ret, uint8_t const* data, size_t size)
 	CryptoPP::SHA3_512().CalculateDigest(ret, data, size);
 }
 }
+
+#if defined(__GNUC__)
+  	#pragma GCC diagnostic pop
+#endif // defined(__GNUC__)

--- a/libp2p/RLPXFrameCoder.cpp
+++ b/libp2p/RLPXFrameCoder.cpp
@@ -190,6 +190,36 @@ bool RLPXFrameCoder::authAndDecryptFrame(bytesRef io)
 	return true;
 }
 
+#if defined(__GNUC__)
+    // Do not warn about uses of functions (see Function Attributes), variables
+    // (see Variable Attributes), and types (see Type Attributes) marked as
+    // deprecated by using the deprecated attribute.
+    //
+    // Specifically we are suppressing the warnings from the deprecation
+    // attributes added to the SHA3_256 and SHA3_512 classes in CryptoPP
+    // after the 5.6.3 release.
+    //
+    // From that header file ...
+    //
+    // "The Crypto++ SHA-3 implementation dates back to January 2013 when NIST
+    // selected Keccak as SHA-3. In August 2015 NIST finalized SHA-3, and it
+    // was a modified version of the Keccak selection. Crypto++ 5.6.2 through
+    // 5.6.4 provides the pre-FIPS 202 version of SHA-3; while Crypto++ 5.7
+    // and above provides the FIPS 202 version of SHA-3.
+    //
+    // See also http://en.wikipedia.org/wiki/SHA-3
+    //
+    // This means that we will never be able to move to the CryptoPP-5.7.x
+    // series of releases, because Ethereum requires Keccak, not the final
+    // SHA-3 standard algorithm.   We are planning to migrate cpp-ethereum
+    // off CryptoPP anyway, so this is unlikely to be a long-standing issue.
+    //
+    // https://github.com/ethereum/cpp-ethereum/issues/3088
+    //
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif // defined(__GNUC__)
+
 h128 RLPXFrameCoder::egressDigest()
 {
 	SHA3_256 h(m_egressMac);
@@ -250,3 +280,7 @@ void RLPXFrameCoder::updateMAC(SHA3_256& _mac, bytesConstRef _seed)
 	// update mac for final digest
 	_mac.Update(encDigest.data(), h128::size);
 }
+
+#if defined(__GNUC__)
+  	#pragma GCC diagnostic pop
+#endif // defined(__GNUC__)

--- a/libp2p/RLPXFrameCoder.h
+++ b/libp2p/RLPXFrameCoder.h
@@ -126,6 +126,37 @@ protected:
 	void updateIngressMACWithFrame(bytesConstRef _cipher);
 
 private:
+
+#if defined(__GNUC__)
+    // Do not warn about uses of functions (see Function Attributes), variables
+    // (see Variable Attributes), and types (see Type Attributes) marked as
+    // deprecated by using the deprecated attribute.
+    //
+    // Specifically we are suppressing the warnings from the deprecation
+    // attributes added to the SHA3_256 and SHA3_512 classes in CryptoPP
+    // after the 5.6.3 release.
+    //
+    // From that header file ...
+    //
+    // "The Crypto++ SHA-3 implementation dates back to January 2013 when NIST
+    // selected Keccak as SHA-3. In August 2015 NIST finalized SHA-3, and it
+    // was a modified version of the Keccak selection. Crypto++ 5.6.2 through
+    // 5.6.4 provides the pre-FIPS 202 version of SHA-3; while Crypto++ 5.7
+    // and above provides the FIPS 202 version of SHA-3.
+    //
+    // See also http://en.wikipedia.org/wiki/SHA-3
+    //
+    // This means that we will never be able to move to the CryptoPP-5.7.x
+    // series of releases, because Ethereum requires Keccak, not the final
+    // SHA-3 standard algorithm.   We are planning to migrate cpp-ethereum
+    // off CryptoPP anyway, so this is unlikely to be a long-standing issue.
+    //
+    // https://github.com/ethereum/cpp-ethereum/issues/3088
+    //
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif // defined(__GNUC__)
+
 	/// Update state of _mac.
 	void updateMAC(CryptoPP::SHA3_256& _mac, bytesConstRef _seed = bytesConstRef());
 
@@ -141,6 +172,10 @@ private:
 	
 	CryptoPP::SHA3_256 m_egressMac;			///< State of MAC for egress ciphertext.
 	CryptoPP::SHA3_256 m_ingressMac;			///< State of MAC for ingress ciphertext.
+
+#if defined(__GNUC__)
+  	#pragma GCC diagnostic pop
+#endif // defined(__GNUC__)
 };
 
 }

--- a/test/libweb3core/test/libdevcrypto/crypto.cpp
+++ b/test/libweb3core/test/libdevcrypto/crypto.cpp
@@ -112,6 +112,36 @@ BOOST_AUTO_TEST_CASE(common_encrypt_decrypt)
 	BOOST_REQUIRE(plain == asBytes(message));
 }
 
+#if defined(__GNUC__)
+    // Do not warn about uses of functions (see Function Attributes), variables
+    // (see Variable Attributes), and types (see Type Attributes) marked as
+    // deprecated by using the deprecated attribute.
+    //
+    // Specifically we are suppressing the warnings from the deprecation
+    // attributes added to the SHA3_256 and SHA3_512 classes in CryptoPP
+    // after the 5.6.3 release.
+    //
+    // From that header file ...
+    //
+    // "The Crypto++ SHA-3 implementation dates back to January 2013 when NIST
+    // selected Keccak as SHA-3. In August 2015 NIST finalized SHA-3, and it
+    // was a modified version of the Keccak selection. Crypto++ 5.6.2 through
+    // 5.6.4 provides the pre-FIPS 202 version of SHA-3; while Crypto++ 5.7
+    // and above provides the FIPS 202 version of SHA-3.
+    //
+    // See also http://en.wikipedia.org/wiki/SHA-3
+    //
+    // This means that we will never be able to move to the CryptoPP-5.7.x
+    // series of releases, because Ethereum requires Keccak, not the final
+    // SHA-3 standard algorithm.   We are planning to migrate cpp-ethereum
+    // off CryptoPP anyway, so this is unlikely to be a long-standing issue.
+    //
+    // https://github.com/ethereum/cpp-ethereum/issues/3088
+    //
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif // defined(__GNUC__)
+
 BOOST_AUTO_TEST_CASE(cryptopp_cryptopp_secp256k1libport)
 {
 #if ETH_HAVE_SECP256K1
@@ -838,6 +868,10 @@ BOOST_AUTO_TEST_CASE(recoverVgt3)
 		}
 	}
 }
+
+#if defined(__GNUC__)
+  	#pragma GCC diagnostic pop
+#endif // defined(__GNUC__)
 
 BOOST_AUTO_TEST_SUITE_END()
 

--- a/test/libweb3core/test/libp2p/rlpx.cpp
+++ b/test/libweb3core/test/libp2p/rlpx.cpp
@@ -52,6 +52,36 @@ static CryptoPP::OID s_curveOID(CryptoPP::ASN1::secp256k1());
 static CryptoPP::DL_GroupParameters_EC<CryptoPP::ECP> s_params(s_curveOID);
 static CryptoPP::DL_GroupParameters_EC<CryptoPP::ECP>::EllipticCurve s_curve(s_params.GetCurve());
 
+#if defined(__GNUC__)
+    // Do not warn about uses of functions (see Function Attributes), variables
+    // (see Variable Attributes), and types (see Type Attributes) marked as
+    // deprecated by using the deprecated attribute.
+    //
+    // Specifically we are suppressing the warnings from the deprecation
+    // attributes added to the SHA3_256 and SHA3_512 classes in CryptoPP
+    // after the 5.6.3 release.
+    //
+    // From that header file ...
+    //
+    // "The Crypto++ SHA-3 implementation dates back to January 2013 when NIST
+    // selected Keccak as SHA-3. In August 2015 NIST finalized SHA-3, and it
+    // was a modified version of the Keccak selection. Crypto++ 5.6.2 through
+    // 5.6.4 provides the pre-FIPS 202 version of SHA-3; while Crypto++ 5.7
+    // and above provides the FIPS 202 version of SHA-3.
+    //
+    // See also http://en.wikipedia.org/wiki/SHA-3
+    //
+    // This means that we will never be able to move to the CryptoPP-5.7.x
+    // series of releases, because Ethereum requires Keccak, not the final
+    // SHA-3 standard algorithm.   We are planning to migrate cpp-ethereum
+    // off CryptoPP anyway, so this is unlikely to be a long-standing issue.
+    //
+    // https://github.com/ethereum/cpp-ethereum/issues/3088
+    //
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif // defined(__GNUC__)
+
 BOOST_AUTO_TEST_CASE(test_secrets_cpp_vectors)
 {
 	KeyPair init(Secret(sha3("initiator")));
@@ -372,6 +402,10 @@ BOOST_AUTO_TEST_CASE(test_secrets_from_go)
 	m_frameDec.ProcessData(plaintext.data(), recvHello.data(), h128::size);
 	
 }
+
+#if defined(__GNUC__)
+  	#pragma GCC diagnostic pop
+#endif // defined(__GNUC__)
 
 BOOST_AUTO_TEST_CASE(ecies_interop_test_primitives)
 {


### PR DESCRIPTION
These attributes were added after the 5.6.3 release.

From that header file ...

"The Crypto++ SHA-3 implementation dates back to January 2013 when NIST
selected Keccak as SHA-3. In August 2015 NIST finalized SHA-3, and it
was a modified version of the Keccak selection. Crypto++ 5.6.2 through
5.6.4 provides the pre-FIPS 202 version of SHA-3; while Crypto++ 5.7
and above provides the FIPS 202 version of SHA-3.

See also http://en.wikipedia.org/wiki/SHA-3"

This means that we will never be able to move to the CryptoPP-5.7.x
series of releases, because Ethereum requires Keccak, not the final
SHA-3 standard algorithm.   We are planning to migrate cpp-ethereum
off CryptoPP anyway, so this is unlikely to be a long-standing issue.

See https://github.com/ethereum/cpp-ethereum/issues/3088.