### PR TITLE
Fix locale problems

### DIFF
--- a/bench/main.cpp
+++ b/bench/main.cpp
@@ -56,9 +56,22 @@ void version()
 	exit(0);
 }
 
-void setEnv() 
+/*
+The equivalent of setlocale(LC_ALL, “C”) is called before any user code is run.
+If the user has an invalid environment setting then it is possible for the call
+to set locale to fail, so there are only two possible actions, the first is to
+throw a runtime exception and cause the program to quit (default behaviour),
+or the second is to modify the environment to something sensible (least
+surprising behaviour).
+
+The follow code produces the least surprising behaviour. It will use the user
+specified default locale if it is valid, and if not then it will modify the
+environment the process is running in to use a sensible default. This also means
+that users do not need to install language packs for their OS.
+*/
+void setDefaultOrCLocale()
 {
-#if !defined(WIN32) && !defined(MAC_OSX) && !defined(__FreeBSD__) && !defined(__OpenBSD__)
+#if __unix__
 	if (!std::setlocale(LC_ALL, ""))
 	{
 		setenv("LC_ALL", "C", 1);
@@ -135,7 +148,7 @@ private:
 
 int main(int argc, char** argv)
 {
-	setEnv();
+	setDefaultOrCLocale();
 	Mode mode = Mode::Trie;
 
 	for (int i = 1; i < argc; ++i)

--- a/bench/main.cpp
+++ b/bench/main.cpp
@@ -19,6 +19,7 @@
  * @date 2014
  * RLP tool.
  */
+#include <clocale>
 #include <fstream>
 #include <iostream>
 #include <boost/algorithm/string.hpp>
@@ -53,6 +54,15 @@ void version()
 {
 	cout << "bench part of dev suite version " << dev::Version << endl;
 	exit(0);
+}
+
+void setEnv() {
+	std::setlocale(LC_ALL, "C");
+#if !defined(WIN32) && !defined(MAC_OSX) && !defined(__FreeBSD__) && !defined(__OpenBSD__)
+	if (!std::setlocale(LC_ALL, "")) {
+		setenv("LC_ALL", "C", 1);
+	}
+#endif
 }
 
 enum class Mode {
@@ -124,6 +134,7 @@ private:
 
 int main(int argc, char** argv)
 {
+	setEnv();
 	Mode mode = Mode::Trie;
 
 	for (int i = 1; i < argc; ++i)

--- a/bench/main.cpp
+++ b/bench/main.cpp
@@ -56,10 +56,11 @@ void version()
 	exit(0);
 }
 
-void setEnv() {
-	std::setlocale(LC_ALL, "C");
+void setEnv() 
+{
 #if !defined(WIN32) && !defined(MAC_OSX) && !defined(__FreeBSD__) && !defined(__OpenBSD__)
-	if (!std::setlocale(LC_ALL, "")) {
+	if (!std::setlocale(LC_ALL, ""))
+	{
 		setenv("LC_ALL", "C", 1);
 	}
 #endif

--- a/eth/main.cpp
+++ b/eth/main.cpp
@@ -26,6 +26,7 @@
 #include <chrono>
 #include <fstream>
 #include <iostream>
+#include <clocale>
 #include <signal.h>
 
 #include <boost/algorithm/string.hpp>
@@ -208,6 +209,15 @@ void version()
 	exit(0);
 }
 
+void setEnv() {
+	std::setlocale(LC_ALL, "C");
+#if !defined(WIN32) && !defined(MAC_OSX) && !defined(__FreeBSD__) && !defined(__OpenBSD__)
+	if (!std::setlocale(LC_ALL, "")) {
+		setenv("LC_ALL", "C", 1);
+	}
+#endif
+}
+
 void importPresale(KeyManager& _km, string const& _file, function<string()> _pass)
 {
 	KeyPair k = _km.presaleSecret(contentsString(_file), [&](bool){ return _pass(); });
@@ -293,6 +303,8 @@ bool ExitHandler::s_shouldExit = false;
 
 int main(int argc, char** argv)
 {
+	setEnv();
+
 	// Init defaults
 	Defaults::get();
 	Ethash::init();

--- a/eth/main.cpp
+++ b/eth/main.cpp
@@ -209,9 +209,22 @@ void version()
 	exit(0);
 }
 
-void setEnv()
+/*
+The equivalent of setlocale(LC_ALL, “C”) is called before any user code is run.
+If the user has an invalid environment setting then it is possible for the call
+to set locale to fail, so there are only two possible actions, the first is to
+throw a runtime exception and cause the program to quit (default behaviour),
+or the second is to modify the environment to something sensible (least
+surprising behaviour).
+
+The follow code produces the least surprising behaviour. It will use the user
+specified default locale if it is valid, and if not then it will modify the
+environment the process is running in to use a sensible default. This also means
+that users do not need to install language packs for their OS.
+*/
+void setDefaultOrCLocale()
 {
-#if !defined(WIN32) && !defined(MAC_OSX) && !defined(__FreeBSD__) && !defined(__OpenBSD__)
+#if __unix__
 	if (!std::setlocale(LC_ALL, ""))
 	{
 		setenv("LC_ALL", "C", 1);
@@ -304,7 +317,7 @@ bool ExitHandler::s_shouldExit = false;
 
 int main(int argc, char** argv)
 {
-	setEnv();
+	setDefaultOrCLocale();
 
 	// Init defaults
 	Defaults::get();

--- a/eth/main.cpp
+++ b/eth/main.cpp
@@ -209,10 +209,11 @@ void version()
 	exit(0);
 }
 
-void setEnv() {
-	std::setlocale(LC_ALL, "C");
+void setEnv()
+{
 #if !defined(WIN32) && !defined(MAC_OSX) && !defined(__FreeBSD__) && !defined(__OpenBSD__)
-	if (!std::setlocale(LC_ALL, "")) {
+	if (!std::setlocale(LC_ALL, ""))
+	{
 		setenv("LC_ALL", "C", 1);
 	}
 #endif

--- a/ethkey/main.cpp
+++ b/ethkey/main.cpp
@@ -56,9 +56,22 @@ void version()
 	exit(0);
 }
 
-void setEnv()
+/*
+The equivalent of setlocale(LC_ALL, “C”) is called before any user code is run.
+If the user has an invalid environment setting then it is possible for the call
+to set locale to fail, so there are only two possible actions, the first is to
+throw a runtime exception and cause the program to quit (default behaviour),
+or the second is to modify the environment to something sensible (least
+surprising behaviour).
+
+The follow code produces the least surprising behaviour. It will use the user
+specified default locale if it is valid, and if not then it will modify the
+environment the process is running in to use a sensible default. This also means
+that users do not need to install language packs for their OS.
+*/
+void setDefaultOrCLocale()
 {
-#if !defined(WIN32) && !defined(MAC_OSX) && !defined(__FreeBSD__) && !defined(__OpenBSD__)
+#if __unix__
 	if (!std::setlocale(LC_ALL, ""))
 	{
 		setenv("LC_ALL", "C", 1);
@@ -68,7 +81,7 @@ void setEnv()
 
 int main(int argc, char** argv)
 {
-	setEnv();
+	setDefaultOrCLocale();
 	KeyCLI m(KeyCLI::OperationMode::ListBare);
 	g_logVerbosity = 0;
 

--- a/ethkey/main.cpp
+++ b/ethkey/main.cpp
@@ -22,6 +22,7 @@
 
 #include <thread>
 #include <chrono>
+#include <clocale>
 #include <fstream>
 #include <iostream>
 #include <libdevcore/FileSystem.h>
@@ -55,8 +56,18 @@ void version()
 	exit(0);
 }
 
+void setEnv() {
+	std::setlocale(LC_ALL, "C");
+#if !defined(WIN32) && !defined(MAC_OSX) && !defined(__FreeBSD__) && !defined(__OpenBSD__)
+	if (!std::setlocale(LC_ALL, "")) {
+		setenv("LC_ALL", "C", 1);
+	}
+#endif
+}
+
 int main(int argc, char** argv)
 {
+	setEnv();
 	KeyCLI m(KeyCLI::OperationMode::ListBare);
 	g_logVerbosity = 0;
 

--- a/ethkey/main.cpp
+++ b/ethkey/main.cpp
@@ -56,10 +56,11 @@ void version()
 	exit(0);
 }
 
-void setEnv() {
-	std::setlocale(LC_ALL, "C");
+void setEnv()
+{
 #if !defined(WIN32) && !defined(MAC_OSX) && !defined(__FreeBSD__) && !defined(__OpenBSD__)
-	if (!std::setlocale(LC_ALL, "")) {
+	if (!std::setlocale(LC_ALL, ""))
+	{
 		setenv("LC_ALL", "C", 1);
 	}
 #endif
@@ -92,4 +93,3 @@ int main(int argc, char** argv)
 
 	return 0;
 }
-

--- a/ethminer/main.cpp
+++ b/ethminer/main.cpp
@@ -31,6 +31,7 @@
 	#include <windows.h>
 #endif // defined(_WIN32)
 
+#include <clocale>
 
 #include "MinerAux.h"
 
@@ -63,8 +64,18 @@ void version()
 	exit(0);
 }
 
+void setEnv() {
+	std::setlocale(LC_ALL, "C");
+#if !defined(WIN32) && !defined(MAC_OSX) && !defined(__FreeBSD__) && !defined(__OpenBSD__)
+	if (!std::setlocale(LC_ALL, "")) {
+		setenv("LC_ALL", "C", 1);
+	}
+#endif
+}
+
 int main(int argc, char** argv)
 {
+	setEnv();
 	MinerCLI m(MinerCLI::OperationMode::Farm);
 
 	for (int i = 1; i < argc; ++i)

--- a/ethminer/main.cpp
+++ b/ethminer/main.cpp
@@ -22,11 +22,11 @@
 
 
 
-// Solves the problem of including windows.h before including winsock.h		
-// as detailed here:		
-// http://stackoverflow.com/questions/1372480/c-redefinition-header-files-winsock2-h		
+// Solves the problem of including windows.h before including winsock.h
+// as detailed here:
+// http://stackoverflow.com/questions/1372480/c-redefinition-header-files-winsock2-h
 
-#if defined(_WIN32)	
+#if defined(_WIN32)
 	#define _WINSOCKAPI_
 	#include <windows.h>
 #endif // defined(_WIN32)
@@ -64,10 +64,11 @@ void version()
 	exit(0);
 }
 
-void setEnv() {
-	std::setlocale(LC_ALL, "C");
+void setEnv()
+{
 #if !defined(WIN32) && !defined(MAC_OSX) && !defined(__FreeBSD__) && !defined(__OpenBSD__)
-	if (!std::setlocale(LC_ALL, "")) {
+	if (!std::setlocale(LC_ALL, ""))
+	{
 		setenv("LC_ALL", "C", 1);
 	}
 #endif
@@ -100,4 +101,3 @@ int main(int argc, char** argv)
 
 	return 0;
 }
-

--- a/ethminer/main.cpp
+++ b/ethminer/main.cpp
@@ -64,9 +64,22 @@ void version()
 	exit(0);
 }
 
-void setEnv()
+/*
+The equivalent of setlocale(LC_ALL, “C”) is called before any user code is run.
+If the user has an invalid environment setting then it is possible for the call
+to set locale to fail, so there are only two possible actions, the first is to
+throw a runtime exception and cause the program to quit (default behaviour),
+or the second is to modify the environment to something sensible (least
+surprising behaviour).
+
+The follow code produces the least surprising behaviour. It will use the user
+specified default locale if it is valid, and if not then it will modify the
+environment the process is running in to use a sensible default. This also means
+that users do not need to install language packs for their OS.
+*/
+void setDefaultOrCLocale()
 {
-#if !defined(WIN32) && !defined(MAC_OSX) && !defined(__FreeBSD__) && !defined(__OpenBSD__)
+#if __unix__
 	if (!std::setlocale(LC_ALL, ""))
 	{
 		setenv("LC_ALL", "C", 1);
@@ -76,7 +89,7 @@ void setEnv()
 
 int main(int argc, char** argv)
 {
-	setEnv();
+	setDefaultOrCLocale();
 	MinerCLI m(MinerCLI::OperationMode::Farm);
 
 	for (int i = 1; i < argc; ++i)

--- a/ethvm/main.cpp
+++ b/ethvm/main.cpp
@@ -79,9 +79,22 @@ void version()
 	exit(0);
 }
 
-void setEnv()
+/*
+The equivalent of setlocale(LC_ALL, “C”) is called before any user code is run.
+If the user has an invalid environment setting then it is possible for the call
+to set locale to fail, so there are only two possible actions, the first is to
+throw a runtime exception and cause the program to quit (default behaviour),
+or the second is to modify the environment to something sensible (least
+surprising behaviour).
+
+The follow code produces the least surprising behaviour. It will use the user
+specified default locale if it is valid, and if not then it will modify the
+environment the process is running in to use a sensible default. This also means
+that users do not need to install language packs for their OS.
+*/
+void setDefaultOrCLocale()
 {
-#if !defined(WIN32) && !defined(MAC_OSX) && !defined(__FreeBSD__) && !defined(__OpenBSD__)
+#if __unix__
 	if (!std::setlocale(LC_ALL, ""))
 	{
 		setenv("LC_ALL", "C", 1);
@@ -103,7 +116,7 @@ enum class Mode
 
 int main(int argc, char** argv)
 {
-	setEnv();
+	setDefaultOrCLocale();
 	string inputFile;
 	Mode mode = Mode::Statistics;
 	VMKind vmKind = VMKind::Interpreter;

--- a/ethvm/main.cpp
+++ b/ethvm/main.cpp
@@ -79,6 +79,16 @@ void version()
 	exit(0);
 }
 
+void setEnv()
+{
+#if !defined(WIN32) && !defined(MAC_OSX) && !defined(__FreeBSD__) && !defined(__OpenBSD__)
+	if (!std::setlocale(LC_ALL, ""))
+	{
+		setenv("LC_ALL", "C", 1);
+	}
+#endif
+}
+
 enum class Mode
 {
 	Trace,
@@ -93,6 +103,7 @@ enum class Mode
 
 int main(int argc, char** argv)
 {
+	setEnv();
 	string inputFile;
 	Mode mode = Mode::Statistics;
 	VMKind vmKind = VMKind::Interpreter;
@@ -109,7 +120,7 @@ int main(int argc, char** argv)
 	envInfo.setGasLimit(MaxBlockGasLimit);
 	bytes data;
 	bytes code;
-	
+
 	Ethash::init();
 	NoProof::init();
 

--- a/rlp/main.cpp
+++ b/rlp/main.cpp
@@ -73,9 +73,22 @@ void version()
 	exit(0);
 }
 
-void setEnv()
+/*
+The equivalent of setlocale(LC_ALL, “C”) is called before any user code is run.
+If the user has an invalid environment setting then it is possible for the call
+to set locale to fail, so there are only two possible actions, the first is to
+throw a runtime exception and cause the program to quit (default behaviour),
+or the second is to modify the environment to something sensible (least
+surprising behaviour).
+
+The follow code produces the least surprising behaviour. It will use the user
+specified default locale if it is valid, and if not then it will modify the
+environment the process is running in to use a sensible default. This also means
+that users do not need to install language packs for their OS.
+*/
+void setDefaultOrCLocale()
 {
-#if !defined(WIN32) && !defined(MAC_OSX) && !defined(__FreeBSD__) && !defined(__OpenBSD__)
+#if __unix__
 	if (!std::setlocale(LC_ALL, ""))
 	{
 		setenv("LC_ALL", "C", 1);
@@ -192,6 +205,7 @@ void putOut(bytes _out, Encoding _encoding, bool _encrypt, bool _quiet)
 
 int main(int argc, char** argv)
 {
+	setDefaultOrCLocale();
 	Encoding encoding = Encoding::Auto;
 	Mode mode = Mode::Render;
 	string inputFile;

--- a/rlp/main.cpp
+++ b/rlp/main.cpp
@@ -19,6 +19,7 @@
  * @date 2014
  * RLP tool.
  */
+#include <clocale>
 #include <fstream>
 #include <iostream>
 #include <boost/algorithm/string.hpp>
@@ -70,6 +71,15 @@ void version()
 {
 	cout << "rlp version " << dev::Version << endl;
 	exit(0);
+}
+
+void setEnv() {
+	std::setlocale(LC_ALL, "C");
+#if !defined(WIN32) && !defined(MAC_OSX) && !defined(__FreeBSD__) && !defined(__OpenBSD__)
+	if (!std::setlocale(LC_ALL, "")) {
+		setenv("LC_ALL", "C", 1);
+	}
+#endif
 }
 
 enum class Mode {

--- a/rlp/main.cpp
+++ b/rlp/main.cpp
@@ -73,10 +73,11 @@ void version()
 	exit(0);
 }
 
-void setEnv() {
-	std::setlocale(LC_ALL, "C");
+void setEnv()
+{
 #if !defined(WIN32) && !defined(MAC_OSX) && !defined(__FreeBSD__) && !defined(__OpenBSD__)
-	if (!std::setlocale(LC_ALL, "")) {
+	if (!std::setlocale(LC_ALL, ""))
+	{
 		setenv("LC_ALL", "C", 1);
 	}
 #endif

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -490,16 +490,6 @@ case $(uname -s) in
                 sudo ldconfig
                 cd ../..
 
-                # And install the English language package and reconfigure the locales.
-                # We really shouldn't need to do this, and should instead force our locales to "C"
-                # within our application runtimes, because this issue shows up on multiple Linux distros,
-                # and each will need fixing in the install steps, where we should really just fix it once
-                # in the code.
-                #
-                # See https://github.com/ethereum/webthree-umbrella/issues/169
-                sudo apt-get -y install language-pack-en-base
-                sudo dpkg-reconfigure locales
-
                 ;;
             *)
 

--- a/test/libethereum/test/boostTest.cpp
+++ b/test/libethereum/test/boostTest.cpp
@@ -38,6 +38,7 @@
 
 #pragma GCC diagnostic pop
 
+#include <clocale>
 #include <stdlib.h>
 #include <test/TestHelper.h>
 #include <boost/version.hpp>
@@ -88,9 +89,19 @@ void travisOut()
 	}
 }
 
+void setEnv() {
+	std::setlocale(LC_ALL, "C");
+#if !defined(WIN32) && !defined(MAC_OSX) && !defined(__FreeBSD__) && !defined(__OpenBSD__)
+	if (!std::setlocale(LC_ALL, "")) {
+		setenv("LC_ALL", "C", 1);
+	}
+#endif
+}
+
 //Custom Boost Unit Test Main
 int main( int argc, char* argv[] )
 {
+	setEnv();
 	//Initialize options
 	dev::test::Options const& opt = dev::test::Options::get(argc, argv);
 

--- a/test/libethereum/test/boostTest.cpp
+++ b/test/libethereum/test/boostTest.cpp
@@ -89,10 +89,11 @@ void travisOut()
 	}
 }
 
-void setEnv() {
-	std::setlocale(LC_ALL, "C");
+void setEnv()
+{
 #if !defined(WIN32) && !defined(MAC_OSX) && !defined(__FreeBSD__) && !defined(__OpenBSD__)
-	if (!std::setlocale(LC_ALL, "")) {
+	if (!std::setlocale(LC_ALL, ""))
+	{
 		setenv("LC_ALL", "C", 1);
 	}
 #endif

--- a/test/libethereum/test/boostTest.cpp
+++ b/test/libethereum/test/boostTest.cpp
@@ -89,9 +89,22 @@ void travisOut()
 	}
 }
 
-void setEnv()
+/*
+The equivalent of setlocale(LC_ALL, “C”) is called before any user code is run.
+If the user has an invalid environment setting then it is possible for the call
+to set locale to fail, so there are only two possible actions, the first is to
+throw a runtime exception and cause the program to quit (default behaviour),
+or the second is to modify the environment to something sensible (least
+surprising behaviour).
+
+The follow code produces the least surprising behaviour. It will use the user
+specified default locale if it is valid, and if not then it will modify the
+environment the process is running in to use a sensible default. This also means
+that users do not need to install language packs for their OS.
+*/
+void setDefaultOrCLocale()
 {
-#if !defined(WIN32) && !defined(MAC_OSX) && !defined(__FreeBSD__) && !defined(__OpenBSD__)
+#if __unix__
 	if (!std::setlocale(LC_ALL, ""))
 	{
 		setenv("LC_ALL", "C", 1);
@@ -102,7 +115,7 @@ void setEnv()
 //Custom Boost Unit Test Main
 int main( int argc, char* argv[] )
 {
-	setEnv();
+	setDefaultOrCLocale();
 	//Initialize options
 	dev::test::Options const& opt = dev::test::Options::get(argc, argv);
 

--- a/test/libweb3core/test/test.cpp
+++ b/test/libweb3core/test/test.cpp
@@ -100,9 +100,22 @@ using namespace boost;
 string TestOutputHelper::m_currentTestName = "n/a";
 string TestOutputHelper::m_currentTestCaseName = "n/a";
 
-void setEnv()
+/*
+The equivalent of setlocale(LC_ALL, “C”) is called before any user code is run.
+If the user has an invalid environment setting then it is possible for the call
+to set locale to fail, so there are only two possible actions, the first is to
+throw a runtime exception and cause the program to quit (default behaviour),
+or the second is to modify the environment to something sensible (least
+surprising behaviour).
+
+The follow code produces the least surprising behaviour. It will use the user
+specified default locale if it is valid, and if not then it will modify the
+environment the process is running in to use a sensible default. This also means
+that users do not need to install language packs for their OS.
+*/
+void setDefaultOrCLocale()
 {
-#if !defined(WIN32) && !defined(MAC_OSX) && !defined(__FreeBSD__) && !defined(__OpenBSD__)
+#if __unix__
 	if (!std::setlocale(LC_ALL, ""))
 	{
 		setenv("LC_ALL", "C", 1);
@@ -112,7 +125,7 @@ void setEnv()
 
 void TestOutputHelper::initTest()
 {
-	setEnv();
+	setDefaultOrCLocale();
 	if (Options::get().logVerbosity ==  Options::Verbosity::NiceReport || Options::get().logVerbosity ==  Options::Verbosity::None)
 		g_logVerbosity = -1;
 

--- a/test/libweb3core/test/test.cpp
+++ b/test/libweb3core/test/test.cpp
@@ -30,6 +30,7 @@
 #pragma GCC diagnostic pop
 #include <test/test.h>
 #include <libdevcore/Log.h>
+#include <clocale>
 
 using namespace std;
 
@@ -99,8 +100,18 @@ using namespace boost;
 string TestOutputHelper::m_currentTestName = "n/a";
 string TestOutputHelper::m_currentTestCaseName = "n/a";
 
+void setEnv() {
+	std::setlocale(LC_ALL, "C");
+#if !defined(WIN32) && !defined(MAC_OSX) && !defined(__FreeBSD__) && !defined(__OpenBSD__)
+	if (!std::setlocale(LC_ALL, "")) {
+		setenv("LC_ALL", "C", 1);
+	}
+#endif
+}
+
 void TestOutputHelper::initTest()
 {
+	setEnv();
 	if (Options::get().logVerbosity ==  Options::Verbosity::NiceReport || Options::get().logVerbosity ==  Options::Verbosity::None)
 		g_logVerbosity = -1;
 

--- a/test/libweb3core/test/test.cpp
+++ b/test/libweb3core/test/test.cpp
@@ -100,10 +100,11 @@ using namespace boost;
 string TestOutputHelper::m_currentTestName = "n/a";
 string TestOutputHelper::m_currentTestCaseName = "n/a";
 
-void setEnv() {
-	std::setlocale(LC_ALL, "C");
+void setEnv()
+{
 #if !defined(WIN32) && !defined(MAC_OSX) && !defined(__FreeBSD__) && !defined(__OpenBSD__)
-	if (!std::setlocale(LC_ALL, "")) {
+	if (!std::setlocale(LC_ALL, ""))
+	{
 		setenv("LC_ALL", "C", 1);
 	}
 #endif

--- a/test/webthree/test/test.cpp
+++ b/test/webthree/test/test.cpp
@@ -63,9 +63,22 @@ Options const& Options::get()
 string TestOutputHelper::m_currentTestName = "n/a";
 string TestOutputHelper::m_currentTestCaseName = "n/a";
 
-void setEnv()
+/*
+The equivalent of setlocale(LC_ALL, “C”) is called before any user code is run.
+If the user has an invalid environment setting then it is possible for the call
+to set locale to fail, so there are only two possible actions, the first is to
+throw a runtime exception and cause the program to quit (default behaviour),
+or the second is to modify the environment to something sensible (least
+surprising behaviour).
+
+The follow code produces the least surprising behaviour. It will use the user
+specified default locale if it is valid, and if not then it will modify the
+environment the process is running in to use a sensible default. This also means
+that users do not need to install language packs for their OS.
+*/
+void setDefaultOrCLocale()
 {
-#if !defined(WIN32) && !defined(MAC_OSX) && !defined(__FreeBSD__) && !defined(__OpenBSD__)
+#if __unix__
 	if (!std::setlocale(LC_ALL, ""))
 	{
 		setenv("LC_ALL", "C", 1);
@@ -75,7 +88,7 @@ void setEnv()
 
 void TestOutputHelper::initTest()
 {
-	setEnv();
+	setDefaultOrCLocale();
 	if (Options::get().logVerbosity ==  Options::Verbosity::NiceReport || Options::get().logVerbosity ==  Options::Verbosity::None)
 		g_logVerbosity = -1;
 

--- a/test/webthree/test/test.cpp
+++ b/test/webthree/test/test.cpp
@@ -63,10 +63,11 @@ Options const& Options::get()
 string TestOutputHelper::m_currentTestName = "n/a";
 string TestOutputHelper::m_currentTestCaseName = "n/a";
 
-void setEnv() {
-	std::setlocale(LC_ALL, "C");
+void setEnv()
+{
 #if !defined(WIN32) && !defined(MAC_OSX) && !defined(__FreeBSD__) && !defined(__OpenBSD__)
-	if (!std::setlocale(LC_ALL, "")) {
+	if (!std::setlocale(LC_ALL, ""))
+	{
 		setenv("LC_ALL", "C", 1);
 	}
 #endif

--- a/test/webthree/test/test.cpp
+++ b/test/webthree/test/test.cpp
@@ -12,6 +12,7 @@
 
 #include "test.h"
 #include <libdevcore/Log.h>
+#include <clocale>
 
 using namespace boost;
 using namespace std;
@@ -62,8 +63,18 @@ Options const& Options::get()
 string TestOutputHelper::m_currentTestName = "n/a";
 string TestOutputHelper::m_currentTestCaseName = "n/a";
 
+void setEnv() {
+	std::setlocale(LC_ALL, "C");
+#if !defined(WIN32) && !defined(MAC_OSX) && !defined(__FreeBSD__) && !defined(__OpenBSD__)
+	if (!std::setlocale(LC_ALL, "")) {
+		setenv("LC_ALL", "C", 1);
+	}
+#endif
+}
+
 void TestOutputHelper::initTest()
 {
+	setEnv();
 	if (Options::get().logVerbosity ==  Options::Verbosity::NiceReport || Options::get().logVerbosity ==  Options::Verbosity::None)
 		g_logVerbosity = -1;
 


### PR DESCRIPTION
This pull request fixes #3097. The issue is that it is possible for the POSIX system environment to be invalid when the program starts, causing a runtime exception to be thrown. The solution is to call setlocale to test that setting the user defined default succeeds, only if the call fails then adjust the environment setting to a reasonable default (else the only viable course of action for the program would be to exit).