### PR TITLE
Disable failing deadlineTimer test

### DIFF
--- a/test/libweb3core/test/libp2p/net.cpp
+++ b/test/libweb3core/test/libp2p/net.cpp
@@ -323,6 +323,19 @@ BOOST_AUTO_TEST_SUITE_END()
 
 BOOST_AUTO_TEST_SUITE(netTypes)
 
+/*
+
+Test disabled by Bob Summerwill on 1st Sep 2016, because it is
+consistently failing on Ubuntu within TravisCI, and also appears
+to be testing timing-specific behaviour within Boost code which
+we did not author.
+
+See https://github.com/ethereum/cpp-ethereum/issues/3253.
+
+TODO - Work out why this test was written in the first place,
+and why it has started failing.   Re-add it or remove it.
+
+
 BOOST_AUTO_TEST_CASE(deadlineTimer)
 {
 	if (test::Options::get().nonetwork)
@@ -347,6 +360,7 @@ BOOST_AUTO_TEST_CASE(deadlineTimer)
 	io.stop();
 	thread.join();
 }
+*/
 
 BOOST_AUTO_TEST_CASE(unspecifiedNode)
 {


### PR DESCRIPTION
It is consistently failing on Ubuntu within TravisCI, and also appears
to be testing timing-specific behaviour within Boost code which
we did not author.

See https://github.com/ethereum/cpp-ethereum/issues/3253.

TODO - Work out why this test was written in the first place,
and why it has started failing.   Re-add it or remove it.