### PR TITLE
Enabled EVMJIT test for Ubuntu.  More comments.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ matrix:
         # some Docker support, which we should probably investigate, at least for
         # Ubuntu 16.04 LTS "Xenial Xerus"
         # See https://en.wikipedia.org/wiki/List_of_Ubuntu_releases#Ubuntu_16.04_LTS_.28Xenial_Xerus.29.
+        # See https://github.com/ethereum/cpp-ethereum/issues/3269
         - os: linux
           dist: trusty
           sudo: required
@@ -80,6 +81,8 @@ matrix:
         # running into the 48min timeout.  We need to make this process
         # quicker.
         #
+        # See https://github.com/ethereum/cpp-ethereum/issues/3267
+        #
         #- os: osx
         #  osx_image: xcode7.3
         #  env:
@@ -90,6 +93,12 @@ matrix:
         # macOS Sierra (10.12)
         # https://en.wikipedia.org/wiki/MacOS_Sierra
         #
+        # TODO - Tests are currently disabled because they are consistently
+        # running into the 48min timeout.  We need to make this process
+        # quicker.
+        #
+        # See https://github.com/ethereum/cpp-ethereum/issues/3268
+
         - os: osx
           osx_image: xcode8
           env:

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -32,9 +32,22 @@ TESTS=$1
 BUILD_ROOT=$(pwd)
 
 if [[ "$TESTS" == "On" ]]; then
+
+    # Clone the end-to-end test repo, and point environment variable at it.
     cd ../..
     git clone https://github.com/ethereum/tests.git
     export ETHEREUM_TEST_PATH=$(pwd)/tests/
+
+    # Run the tests for the Interpreter
     cd cpp-ethereum/build
     $BUILD_ROOT/test/testeth
+
+    # Run the tests for the JIT (but only for Ubuntu, not macOS)
+    # The whole automation process is too slow for macOS, and we don't have
+    # enough time to build LLVM, build EVMJIT and run the tests twice within
+    # the 48 minute absolute maximum run time for TravisCI.
+    if [[ "$OSTYPE" != "darwin"* ]]; then
+        $BUILD_ROOT/test/testeth -t VMTests,StateTests -- --vm jit
+    fi
+
 fi


### PR DESCRIPTION
Enabled EVMJIT unit-tests on Ubuntu (we were building LLVM and EVMJIT, but not testing them).