### PR TITLE
Fixed Windows testeth.exe command-lines

### DIFF
--- a/scripts/tests.bat
+++ b/scripts/tests.bat
@@ -44,12 +44,12 @@ if "%TESTS%"=="On" (
 
     REM Run the tests for the Interpreter
     echo Testing testeth
-    testeth.exe --verbosity 2
+    testeth.exe
     IF errorlevel 1 GOTO ON-ERROR-CONDITION
 
     REM Run the tests for the JIT
     echo Testing EVMJIT
-    testeth.exe -t VMTests,StateTests --vm jit --verbosity 2
+    testeth.exe -t VMTests,StateTests -- --vm jit
     IF errorlevel 1 GOTO ON-ERROR-CONDITION
     cd ..\..\..
 


### PR DESCRIPTION
These were previously invalid, but the errors were going to STDERR not STDOUT.
So we couldn't see that in the Appveyor logs.