### PR TITLE
Re-enable OpenCL for both macOS and Ubuntu TravisCI runs

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -27,35 +27,13 @@
 set -e -x
 
 # There is an implicit assumption here that we HAVE to run from repo root
-#
-# NOTE - We are disabling OpenCL here to work around currently unexplained
-# problems which occur when running "testweb3" unit-tests on Ubuntu.
-# The same issue is showing up with the solidity Tests-over-RPC connecting
-# to an `eth` node.
-#
-# Maybe we really need to do something more in our TravisCI configuration which
-# ensures that the VM we have can run with this OpenCL support enabled?  But
-# this simple approach will do for right now.
-#
-# See, for example, https://travis-ci.org/ethereum/cpp-ethereum/jobs/152901242
-#
-# modprobe: ERROR: could not insert 'fglrx': No such device
-# Error: Fail to load fglrx kernel module!
-# Error! Fail to load fglrx kernel module! Maybe you can switch to root user to load kernel module directly
-# modprobe: ERROR: could not insert 'fglrx': No such device
-# Error: Fail to load fglrx kernel module!
-# Error! Fail to load fglrx kernel module! Maybe you can switch to root user to load kernel module directly
-# modprobe: ERROR: could not insert 'fglrx': No such device
-# Error: Fail to load fglrx kernel module!
-# Error! Fail to load fglrx kernel module! Maybe you can switch to root user to load kernel module directly
-# No output has been received in the last 10m0s, this potentially indicates a stalled build or something wrong with the build itself.
 
 mkdir -p build
 cd build
 if [ $(uname -s) == "Linux" ]; then
-    cmake .. -DCMAKE_BUILD_TYPE=$1 -DTESTS=$2 -DETHASHCL=Off -DEVMJIT=On -DLLVM_DIR=/usr/lib/llvm-3.9/lib/cmake/llvm
+    cmake .. -DCMAKE_BUILD_TYPE=$1 -DTESTS=$2 -DEVMJIT=On -DLLVM_DIR=/usr/lib/llvm-3.9/lib/cmake/llvm
 else
-    cmake .. -DCMAKE_BUILD_TYPE=$1 -DTESTS=$2 -DETHASHCL=Off
+    cmake .. -DCMAKE_BUILD_TYPE=$1 -DTESTS=$2
 fi
 
 make -j2


### PR DESCRIPTION
We only disabled it on macOS by mistake as a side-effect of the Ubuntu workaround.
See https://github.com/travis-ci/packer-templates/issues/221.
It looks like the issue in TravisCI has been resolved in the past week or so.

Fixes https://github.com/ethereum/cpp-ethereum/issues/3041