### PR TITLE
Restore OS X Yosemite automation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,19 +60,12 @@ matrix:
         # OS X Yosemite (10.10)
         # https://en.wikipedia.org/wiki/OS_X_Yosemite
         #
-        # TODO - This is currently disabled as a very temporary workaround
-        # for the 'carthage' break.  There is no quick fix for this one, so
-        # let's just side-step it until we have a better understanding of the
-        # root cause.
-        #
-        # See https://github.com/ethereum/solidity/issues/924
-        #
-        #- os: osx
-        #  osx_image: xcode7.1
-        #  env:
-        #      - TRAVIS_BUILD_TYPE=RelWithDebInfo
-        #      - TRAVIS_TESTS=Off
-        #      - ZIP_SUFFIX=osx-yosemite
+        - os: osx
+          osx_image: xcode7.1
+          env:
+              - TRAVIS_BUILD_TYPE=RelWithDebInfo
+              - TRAVIS_TESTS=Off
+              - ZIP_SUFFIX=osx-yosemite
 
         # OS X El Capitan (10.11)
         # https://en.wikipedia.org/wiki/OS_X_El_Capitan

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -91,13 +91,35 @@ case $(uname -s) in
         # Check for Homebrew install and abort if it is not installed.
         brew -v > /dev/null 2>&1 || { echo >&2 "ERROR - cpp-ethereum requires a Homebrew install.  See http://brew.sh."; exit 1; }
 
+        # In August 2016, the 'carthage' package added a requirement for
+        # a full Xcode 7.3 install, not just command-line build tools,
+        # because it needs Swift 2.2.  This requirement is a complete
+        # non-starter for TravisCI, where we have no ability or desire
+        # to do that installation.  We aren't using 'carthage' ourselves,
+        # so we just pin it here prior to 'brew update'.
+        # https://github.com/Homebrew/homebrew-core/issues/3996
+        brew pin carthage
+
+        # Update Homebrew formulas and then upgrade any packages which
+        # we have installed using these updated formulas.  This step is
+        # required even within TravisCI, because the Homebrew formulas
+        # are a constant moving target, and we always need to be chasing
+        # those moving targets.  This is a fundamental design decision
+        # made in 'rolling release' package management systems, and one
+        # which makes our macOS builds fundamentally unstable and
+        # unreliable.  We just had to try to react fast when anything
+        # breaks.
+        #
+        # See https://github.com/ethereum/cpp-ethereum/issues/3089
         brew update
         brew upgrade
 
-        # Bonus fun - TravisCI image for Yosemite includes a gmp version which doesn't
-        # like being updated, so we need to uninstall it first.
+        # Bonus fun - TravisCI image for Yosemite includes a gmp version
+        # which doesn't like being updated, so we need to uninstall it
+        # first, so that the installation step below is a clean install.
         brew uninstall gmp
-
+        
+        # And finally install all the external dependencies.
         brew install \
             boost \
             cmake \


### PR DESCRIPTION
In August 2016, the 'carthage' package added a requirement for a full Xcode 7.3 install, not just command-line build tools, because it needs Swift 2.2. This requirement is a complete non-starter for TravisCI, where we have no ability or desire to do that installation. We aren't using 'carthage' ourselves, so we just pin it here prior to 'brew update'.

https://github.com/Homebrew/homebrew-core/issues/3996