### PR TITLE
Add a llvm repository when installing dependencies on Ubuntu xenial

### DIFF
--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -420,6 +420,8 @@ case $(uname -s) in
                     xenial)
                         #xenial
                         echo "Installing cpp-ethereum dependencies on Ubuntu Xenial Xerus (16.04)."
+                        echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-3.9 main" \
+                        | sudo tee -a /etc/apt/sources.list > /dev/null
                         ;;
                     yakkety)
                         #yakkety


### PR DESCRIPTION
Before this commit, on an Ubuntu xenial environment, `./script/install_deps.sh` caused error messages:
```
E: Unable to locate package llvm-3.9-dev
E: Couldn't find any package by glob 'llvm-3.9-dev'
E: Couldn't find any package by regex 'llvm-3.9-dev'
```

After this commit, the error messages disappear, the script finishes successfully,
and the rest of the build goes through.