### PR TITLE
enable onOp tracing for all users

### DIFF
--- a/libevm/VMConfig.h
+++ b/libevm/VMConfig.h
@@ -58,6 +58,7 @@ namespace eth
 #endif
 
 
+#define ETH_VMTRACE 1 // turn on for now until others catch up
 #if ETH_VMTRACE
 	#define onOperation() doOnOperation()
 #else


### PR DESCRIPTION
VMConfig.h is using ETH_VMTRACE to control whether to enable tracing with a provided onOp() function.  This is set with cmake -DVMTRACE for testeth, but other users of tracing and single stepping don't yet know to build this way.  So enable onOp()  unconditionally until we work this out.