### PR TITLE
Updated PhoneHome.h header file

### DIFF
--- a/ethminer/PhoneHome.h
+++ b/ethminer/PhoneHome.h
@@ -18,7 +18,7 @@ class PhoneHome : public jsonrpc::Client
             p.append(param1);
             p.append(param2);
             Json::Value result = this->CallMethod("report_benchmark",p);
-            if (result.isInt())
+            if (result.isIntegral())
                 return result.asInt();
             else
                 throw jsonrpc::JsonRpcException(jsonrpc::Errors::ERROR_CLIENT_INVALID_RESPONSE, result.toStyledString());


### PR DESCRIPTION
Fixes https://github.com/ethereum/cpp-ethereum/issues/3234

This file is generated by the stub generator for json-rpc-cpp.
Home-brew recently updated to the very latest 0.7.0 release (https://github.com/cinemast/libjson-rpc-cpp/releases/tag/v0.7.0)
It appears that this code generation step now generates slightly different code.
We have this file committed to Github, despite the fact it is generated, presumably because it is being generated directly into the source tree directory.
We could add a .gitignore setting instead, but I don't know that would really make things much better.
At least we noticed the code change with this setup!

This appears to be the relevant change which altered the generated code.

https://github.com/cinemast/libjson-rpc-cpp/commit/4066b2b376826ca16aad7e2b6d2ee457ed406869