### PR TITLE
Fix EVMJIT call cost bug

### DIFF
--- a/libethereum/ExtVM.cpp
+++ b/libethereum/ExtVM.cpp
@@ -33,7 +33,7 @@ namespace // anonymous
 static unsigned const c_depthLimit = 1024;
 
 /// Upper bound of stack space needed by single CALL/CREATE execution. Set experimentally.
-static size_t const c_singleExecutionStackSize = 6 * 1024;
+static size_t const c_singleExecutionStackSize = 9 * 1024;
 
 /// Standard thread stack size.
 static size_t const c_defaultStackSize =

--- a/libevm/JitVM.cpp
+++ b/libevm/JitVM.cpp
@@ -176,12 +176,11 @@ int64_t evm_call(
 		u256 gas = _gas;
 		auto addr = env.create(value, gas, input, {});
 		auto gasLeft = static_cast<decltype(_gas)>(gas);
-		auto finalCost = _gas - gasLeft;
 		if (addr)
 			std::memcpy(_outputData, addr.data(), 20);
 		else
-			finalCost |= EVM_CALL_FAILURE;
-		return finalCost;
+			gasLeft |= EVM_CALL_FAILURE;
+		return gasLeft;
 	}
 
 	CallParameters params;

--- a/libevm/JitVM.cpp
+++ b/libevm/JitVM.cpp
@@ -112,6 +112,9 @@ evm_variant evm_query(
 		v.int64 = env.exists(addr);
 		break;
 	}
+	case EVM_CALL_DEPTH:
+		v.int64 = env.depth;
+		break;
 	}
 	return v;
 }


### PR DESCRIPTION
I moved gas cost calculations for calls to VM implementation. That fixes EVMJIT integration bug and has better scalability (number of VM implementations should be lower than number of users).

However, I had to increase stack space needed for calls because some of the logic has been moved.