### PR TITLE
Install add-apt-repository package.

### DIFF
--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -469,6 +469,9 @@ case $(uname -s) in
                     # On Travis CI llvm package conficts with the new to be installed.
                     sudo apt-get -y remove llvm
                 fi
+                sudo apt-get -y update
+                # this installs the add-apt-repository command
+                sudo apt-get install -y --no-install-recommends software-properties-common
                 sudo add-apt-repository -y ppa:ethereum/ethereum
                 sudo apt-get -y update
                 sudo apt-get install -y --no-install-recommends --allow-unauthenticated \


### PR DESCRIPTION
I noticed that while setting up a docker image for cpp-ethereum - actually we are missing also a package for `sudo` and `lsb_release`. The former does not make much sense and the latter could actually be replaced by accessing `/etc/lsb-release` manually.