### PR TITLE
Fix VM ignoring virtual push data

### DIFF
--- a/libevm/VM.cpp
+++ b/libevm/VM.cpp
@@ -771,9 +771,12 @@ void VM::interpretCases()
 			onOperation();
 			updateIOGas();
 
-			int i = (int)m_op - (int)Instruction::PUSH1 + 1;
+			int numBytes = (int)m_op - (int)Instruction::PUSH1 + 1;
 			*++m_sp = 0;
-			for (++m_pc; i--; ++m_pc)
+			// Construct a number out of PUSH bytes.
+			// This requires the code has been copied and extended by 32 zero
+			// bytes to handle "out of code" push data here.
+			for (++m_pc; numBytes--; ++m_pc)
 				*m_sp = (*m_sp << 8) | m_code[m_pc];
 		}
 		CASE_END

--- a/libevm/VMOpt.cpp
+++ b/libevm/VMOpt.cpp
@@ -54,7 +54,8 @@ void VM::initEntry()
 {
 	m_bounce = &VM::interpretCases;
 
-	// Copy and extend code by 32 bytes to handle virtual push data.
+	// Copy and extend code by 32 zero bytes to allow reading virtual push data
+	// at the end of the code without bounds checks.
 	auto extendedSize = m_ext->code.size() + 32;
 	m_codeSpace.reserve(extendedSize);
 	m_codeSpace = m_ext->code;

--- a/libevm/VMOpt.cpp
+++ b/libevm/VMOpt.cpp
@@ -49,20 +49,22 @@ void VM::initMetrics()
 	done = true;
 }
 
-//
-// init interpreter on entry
-//
-
+/// Init interpreter on entry.
 void VM::initEntry()
 {
-	m_bounce = &VM::interpretCases;	
+	m_bounce = &VM::interpretCases;
+
+	// Copy and extend code by 32 bytes to handle virtual push data.
+	auto extendedSize = m_ext->code.size() + 32;
+	m_codeSpace.reserve(extendedSize);
 	m_codeSpace = m_ext->code;
+	m_codeSpace.resize(extendedSize);
 	m_code = m_codeSpace.data();
 
 	interpretCases(); // first time initializes
-	
-	initMetrics();	
-	
+
+	initMetrics();
+
 	optimize();
 }
 

--- a/test/libevm/VMTestsFiller/vmPushDupSwapTestFiller.json
+++ b/test/libevm/VMTestsFiller/vmPushDupSwapTestFiller.json
@@ -2502,5 +2502,33 @@
             "gasPrice" : "100000000000000",
             "gas" : "100000"
         }
+    },
+
+    "push32Undefined3": {
+        "env" : {
+            "previousHash" : "5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6",
+            "currentNumber" : "0",
+            "currentGasLimit" : "1000000",
+            "currentDifficulty" : "256",
+            "currentTimestamp" : "1",
+            "currentCoinbase" : "2adc25665018aa1fe0e6bc666dac8fc2697ff9ba"
+        },
+        "pre" : {
+            "0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6" : {
+                "balance" : "100000000000000000000000",
+                "nonce" : "0",
+                "code" : "0x7f",
+                "storage": {}
+            }
+        },
+        "exec" : {
+            "address" : "0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "origin" : "cd1722f3947def4cf144679da39c4c32bdc35681",
+            "caller" : "cd1722f3947def4cf144679da39c4c32bdc35681",
+            "value" : "1000000000000000000",
+            "data" : "",
+            "gasPrice" : "100000000000000",
+            "gas" : "100000"
+        }
     }
 }


### PR DESCRIPTION
Zerod push data might not be physically in the EVM bytecode. E.g. "60" is valid bytecode and it mean PUSH1(0x00) by interpreting the code as "6000000000000000000000000...".

I fixed that by exceeding the copy of the code made by the VM by 32 zerod bytes. But I'm not sure why this copy is made in the first place. @gcolvin?

Fixes #3333.