### PR TITLE
Improve Docker for users

### DIFF
--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -2,14 +2,16 @@ FROM ubuntu:xenial
 MAINTAINER chriseth
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN apt-get -y update
-RUN apt-get upgrade -q -y
-RUN apt-get -q -y install git lsb-release sudo software-properties-common
-RUN git clone https://github.com/ethereum/cpp-ethereum.git
-RUN cpp-ethereum/scripts/install_deps.sh
-RUN mkdir cpp-ethereum/build
-RUN cd cpp-ethereum/build && cmake .. && make install
-RUN ldconfig # should actually be part of make install...
+RUN apt-get update &&\
+    apt-get -q -y install git-core sudo lsb-release software-properties-common &&\
+    git clone https://github.com/ethereum/cpp-ethereum.git &&\
+    cpp-ethereum/scripts/install_deps.sh &&\
+    mkdir cpp-ethereum/build &&\
+    cd cpp-ethereum/build &&\
+    cmake .. && \
+    make install && \
+    ldconfig &&\
+    rm -rf /cpp-ethereum
 
 EXPOSE 8545 30303
 

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -2,8 +2,9 @@
 # https://github.com/ethereum/cpp-ethereum/blob/develop/scripts/docker-eth
 # or call `docker run` like this:
 #
-##    mkdir -p ~/.ethereum ~/.web3 && docker run --rm -it \
-##    --net=host -v ~/.ethereum:/.ethereum -v ~/.web3:/.web3 \
+##    mkdir -p ~/.ethereum ~/.web3
+##    docker run --rm -it --net=host \
+##    -v ~/.ethereum:/.ethereum -v ~/.web3:/.web3 \
 ##    -e HOME=/ --user $(id -u):$(id -g) ethereum/client-cpp
 
 FROM ubuntu:xenial

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,3 +1,11 @@
+# For running this container as non-root user, see
+# https://github.com/ethereum/cpp-ethereum/blob/develop/scripts/docker-eth
+# or call `docker run` like this:
+#
+##    mkdir -p ~/.ethereum ~/.web3 && docker run --rm -it \
+##    --net=host -v ~/.ethereum:/.ethereum -v ~/.web3:/.web3 \
+##    -e HOME=/ --user $(id -u):$(id -g) ethereum/client-cpp
+
 FROM ubuntu:xenial
 MAINTAINER chriseth
 ENV DEBIAN_FRONTEND noninteractive

--- a/scripts/docker-eth
+++ b/scripts/docker-eth
@@ -1,0 +1,14 @@
+#!/usr/bin/env sh
+mkdir -p ~/.ethereum ~/.web3
+
+# check if sudo is necessary
+if ! id -nG $(whoami)|grep -qw "docker"; then SUDO='sudo'; fi
+
+$SUDO docker run --rm -it \
+           --net=host \
+           -v ~/.ethereum:/.ethereum \
+           -v ~/.web3:/.web3 \
+           -e HOME=/ \
+           --user $(id -u):$(id -g) \
+           ethereum/client-cpp $@
+

--- a/scripts/docker-eth
+++ b/scripts/docker-eth
@@ -2,7 +2,7 @@
 mkdir -p ~/.ethereum ~/.web3
 
 # check if sudo is necessary
-if ! id -nG $(whoami)|grep -qw "docker"; then SUDO='sudo'; fi
+if ! id -nG $(whoami)|grep -qw "docker"; then SUDO='sudo'; else SUDO=''; fi
 
 $SUDO docker run --rm -it \
            --net=host \


### PR DESCRIPTION
Tackles #3053

This PR consists of two parts and is my entry to the hacktoberfest

1) Reduce docker image size

Having all commands in one RUN and removing /cpp-ethereum afterwards allows to
reduce the image size from 2.686 GB to 1.252 GB.

Further image size reduction could be possible by removing build dependencies.

2) Document running container as user (non-root) #3053

There is no stable way to define a user of the host-system inside the
Dockerfile. Therefore I describe how to *run* the container as the current
user. I also added a convenience script to `scripts/`, that users can install
in their PATH, that will behave just like a local installation.

The other option (that I did not follow here) would be `--userns-remap`, but
this needs more setup and is only supported in newer docker installations.