### PR TITLE
Remove EVMSchedule from Chain Params

### DIFF
--- a/libethcore/ChainOperationParams.h
+++ b/libethcore/ChainOperationParams.h
@@ -62,7 +62,6 @@ struct ChainOperationParams
 	u256 maximumExtraDataSize = 1024;
 	u256 accountStartNonce = 0;
 	bool tieBreakingGas = true;
-	EVMSchedule evmSchedule;
 
 	/// Precompiled contracts as specified in the chain params.
 	std::unordered_map<Address, PrecompiledContract> precompiled;

--- a/libethcore/SealEngine.h
+++ b/libethcore/SealEngine.h
@@ -75,7 +75,7 @@ public:
 	ChainOperationParams const& chainParams() const { return m_params; }
 	void setChainParams(ChainOperationParams const& _params) { m_params = _params; }
 	SealEngineFace* withChainParams(ChainOperationParams const& _params) { setChainParams(_params); return this; }
-	virtual EVMSchedule const& evmSchedule(EnvInfo const&) const { return m_params.evmSchedule; }
+	virtual EVMSchedule const& evmSchedule(EnvInfo const&) const { return DefaultSchedule; }
 
 	virtual bool isPrecompiled(Address const& _a) const { return m_params.precompiled.count(_a); }
 	virtual bigint costOfPrecompiled(Address const& _a, bytesConstRef _in) const { return m_params.precompiled.at(_a).cost(_in); }


### PR DESCRIPTION
Having EVMSchedule is very misleading as it is never initialized other than default constructor and Ethash seal engine never uses it.