### PR TITLE
Introduce the code size cache.

### DIFF
--- a/libethereum/BlockChainSync.cpp
+++ b/libethereum/BlockChainSync.cpp
@@ -745,6 +745,7 @@ void BlockChainSync::resetSync()
 
 void BlockChainSync::restartSync()
 {
+	RecursiveGuard l(x_sync);
 	resetSync();
 	m_highestBlock = 0;
 	m_haveCommonHeader = false;

--- a/libethereum/CodeSizeCache.h
+++ b/libethereum/CodeSizeCache.h
@@ -1,0 +1,79 @@
+/*
+	This file is part of cpp-ethereum.
+
+	cpp-ethereum is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	cpp-ethereum is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/** @file CodeSizeCache.h
+ * @date 2016
+ */
+
+#pragma once
+
+#include <map>
+#include <libdevcore/FixedHash.h>
+#include <libdevcore/Guards.h>
+
+namespace dev
+{
+namespace eth
+{
+
+/**
+ * @brief Simple thread-safe cache to store a mapping from code hash to code size.
+ * If the cache is full, a random element is removed.
+ */
+class CodeSizeCache
+{
+public:
+	void store(h256 const& _hash, size_t size)
+	{
+		UniqueGuard g(x_cache);
+		if (m_cache.size() > c_maxSize)
+			removeElement();
+		m_cache[_hash] = size;
+	}
+	bool contains(h256 const& _hash) const
+	{
+		UniqueGuard g(x_cache);
+		return m_cache.count(_hash);
+	}
+	size_t get(h256 const& _hash) const
+	{
+		UniqueGuard g(x_cache);
+		return m_cache.at(_hash);
+	}
+
+	static CodeSizeCache& instance() { static CodeSizeCache cache; return cache; }
+
+private:
+	/// Removes a random element from the cache.
+	void removeElement()
+	{
+		if (!m_cache.empty())
+		{
+			auto it = m_cache.lower_bound(h256::random());
+			if (it == m_cache.end())
+				it = m_cache.begin();
+			m_cache.erase(it);
+		}
+	}
+
+	static const size_t c_maxSize = 50000;
+	mutable Mutex x_cache;
+	std::map<h256, size_t> m_cache;
+};
+
+}
+}
+

--- a/libethereum/CodeSizeCache.h
+++ b/libethereum/CodeSizeCache.h
@@ -39,8 +39,8 @@ public:
 	void store(h256 const& _hash, size_t size)
 	{
 		UniqueGuard g(x_cache);
-		if (m_cache.size() > c_maxSize)
-			removeElement();
+		if (m_cache.size() >= c_maxSize)
+			removeRandomElement();
 		m_cache[_hash] = size;
 	}
 	bool contains(h256 const& _hash) const
@@ -58,7 +58,7 @@ public:
 
 private:
 	/// Removes a random element from the cache.
-	void removeElement()
+	void removeRandomElement()
 	{
 		if (!m_cache.empty())
 		{

--- a/libethereum/Executive.cpp
+++ b/libethereum/Executive.cpp
@@ -304,11 +304,11 @@ bool Executive::create(Address _sender, u256 _endowment, u256 _gasPrice, u256 _g
 	if (!_init.empty())
 		m_ext = make_shared<ExtVM>(m_s, m_envInfo, m_sealEngine, m_newAddress, _sender, _origin, _endowment, _gasPrice, bytesConstRef(), _init, sha3(_init), m_depth);
 
-	m_s.m_cache[m_newAddress] = Account(m_s.requireAccountStartNonce(), m_s.balance(m_newAddress), Account::ContractConception);
+	m_s.createContract(m_newAddress);
 	m_s.transferBalance(_sender, m_newAddress, _endowment);
 
 	if (_init.empty())
-		m_s.m_cache[m_newAddress].setCode({});
+		m_s.setCode(m_newAddress, {});
 
 	return !m_ext;
 }
@@ -371,7 +371,7 @@ bool Executive::go(OnOpFunc const& _onOp)
 				}
 				if (m_res)
 					m_res->output = out; // copy output to execution result
-				m_s.m_cache[m_newAddress].setCode(std::move(out)); // FIXME: Set only if Success?
+				m_s.setCode(m_newAddress, std::move(out));
 			}
 			else
 			{
@@ -439,7 +439,7 @@ void Executive::finalize()
 	// Suicides...
 	if (m_ext)
 		for (auto a: m_ext->sub.suicides)
-			m_s.m_cache[a].kill();
+			m_s.kill(a);
 
 	// Logs..
 	if (m_ext)

--- a/libethereum/ExtVM.cpp
+++ b/libethereum/ExtVM.cpp
@@ -106,6 +106,11 @@ bool ExtVM::call(CallParameters& _p)
 	return !e.excepted();
 }
 
+size_t ExtVM::codeSizeAt(dev::Address _a)
+{
+	return m_s.codeSize(_a);
+}
+
 h160 ExtVM::create(u256 _endowment, u256& io_gas, bytesConstRef _code, OnOpFunc const& _onOp)
 {
 	// Increment associated nonce for sender.

--- a/libethereum/ExtVM.h
+++ b/libethereum/ExtVM.h
@@ -57,6 +57,9 @@ public:
 	/// Read address's code.
 	virtual bytes const& codeAt(Address _a) override final { return m_s.code(_a); }
 
+	/// @returns the size of the code in  bytes at the given address.
+	virtual size_t codeSizeAt(Address _a) override final;
+
 	/// Create a new contract.
 	virtual h160 create(u256 _endowment, u256& io_gas, bytesConstRef _code, OnOpFunc const& _onOp = {}) override final;
 

--- a/libethereum/State.cpp
+++ b/libethereum/State.cpp
@@ -329,21 +329,15 @@ void State::subBalance(Address const& _id, bigint const& _amount)
 		it->second.addBalance(-_amount);
 }
 
-Address State::newContract(u256 const& _balance, bytes const& _code)
+void State::createContract(Address const& _address)
 {
-	auto h = sha3(_code);
-	m_db.insert(h, &_code);
-	while (true)
-	{
-		Address ret = Address::random();
-		ensureCached(ret, false, false);
-		auto it = m_cache.find(ret);
-		if (it == m_cache.end())
-		{
-			m_cache[ret] = Account(requireAccountStartNonce(), _balance, EmptyTrie, h, Account::Changed);
-			return ret;
-		}
-	}
+	m_cache[_address] = Account(requireAccountStartNonce(), balance(_address), Account::ContractConception);
+}
+
+void State::kill(Address _a)
+{
+	// Address is present because it executed previously.
+	m_cache.at(_a).kill();
 }
 
 u256 State::transactionsFrom(Address const& _id) const

--- a/libethereum/State.h
+++ b/libethereum/State.h
@@ -109,7 +109,6 @@ class State
 	friend class ExtVM;
 	friend class dev::test::ImportTest;
 	friend class dev::test::StateLoader;
-	friend class Executive;
 	friend class BlockChain;
 
 public:
@@ -195,8 +194,14 @@ public:
 	/// Set the value of a storage position of an account.
 	void setStorage(Address const& _contract, u256 const& _location, u256 const& _value) { m_cache[_contract].setStorage(_location, _value); }
 
-	/// Create a new contract.
-	Address newContract(u256 const& _balance, bytes const& _code);
+	/// Create a contract at the given address (with unset code and unchanged balance).
+	void createContract(Address const& _address);
+
+	/// Sets the code of the account. Must only be called during / after contract creation.
+	void setCode(Address const& _address, bytes&& _code) { m_cache[_address].setCode(std::move(_code)); }
+
+	/// Delete an account (used for processing suicides).
+	void kill(Address _a);
 
 	/// Get the storage of an account.
 	/// @note This is expensive. Don't use it unless you need to.

--- a/libethereum/State.h
+++ b/libethereum/State.h
@@ -29,6 +29,7 @@
 #include <libdevcore/OverlayDB.h>
 #include <libethcore/Exceptions.h>
 #include <libethcore/BlockHeader.h>
+#include <libethereum/CodeSizeCache.h>
 #include <libethereum/GenericMiner.h>
 #include <libevm/ExtVMFace.h>
 #include "Account.h"
@@ -210,6 +211,10 @@ public:
 	/// @returns EmptySHA3 if no account exists at that address or if there is no code associated with the address.
 	h256 codeHash(Address const& _contract) const;
 
+	/// Get the byte-size of the code of an account.
+	/// @returns code(_contract).size(), but utilizes CodeSizeHash.
+	size_t codeSize(Address const& _contract) const;
+
 	/// Note that the given address is sending a transaction and thus increment the associated ticker.
 	void noteSending(Address const& _id);
 
@@ -300,6 +305,8 @@ AddressHash commit(AccountMap const& _cache, SecureTrieDB<Address, DB>& _state)
 				if (i.second.isFreshCode())
 				{
 					h256 ch = sha3(i.second.code());
+					// Store the size of the code
+					CodeSizeCache::instance().store(ch, i.second.code().size());
 					_state.db()->insert(ch, &i.second.code());
 					s << ch;
 				}

--- a/libethereum/State.h
+++ b/libethereum/State.h
@@ -253,8 +253,8 @@ private:
 	/// exist in the DB.
 	void ensureCached(Address const& _a, bool _requireCode, bool _forceCreate) const;
 
-	/// Retrieve all information about a given address into a cache.
-	void ensureCached(std::unordered_map<Address, Account>& _cache, Address const& _a, bool _requireCode, bool _forceCreate) const;
+	/// Purges non-modified entries in m_cache if it grows too large.
+	void clearCacheIfTooLarge() const;
 
 	/// Debugging only. Good for checking the Trie is in shape.
 	bool isTrieGood(bool _enforceRefs, bool _requireNoLeftOvers) const;
@@ -265,6 +265,7 @@ private:
 	OverlayDB m_db;								///< Our overlay for the state tree.
 	SecureTrieDB<Address, OverlayDB> m_state;	///< Our state tree, as an OverlayDB DB.
 	mutable std::unordered_map<Address, Account> m_cache;	///< Our address cache. This stores the states of each address that has (or at least might have) been changed.
+	mutable std::set<Address> m_unchangedCacheEntries;	///< Tracks entries in m_cache that can potentially be purged if it grows too large.
 	AddressHash m_touched;						///< Tracks all addresses touched so far.
 
 	u256 m_accountStartNonce;

--- a/libevm/ExtVMFace.h
+++ b/libevm/ExtVMFace.h
@@ -250,6 +250,9 @@ public:
 	/// Read address's code.
 	virtual bytes const& codeAt(Address) { return NullBytes; }
 
+	/// @returns the size of the code in bytes at the given address.
+	virtual size_t codeSizeAt(Address) { return 0; }
+
 	/// Subtract amount from account's balance.
 	virtual void subBalance(u256) {}
 

--- a/libevm/VM.cpp
+++ b/libevm/VM.cpp
@@ -618,7 +618,7 @@ void VM::interpretCases()
 			onOperation();
 			updateIOGas();
 
-			*m_sp = m_ext->codeAt(asAddress(*m_sp)).size();
+			*m_sp = m_ext->codeSizeAt(asAddress(*m_sp));
 			++m_pc;
 		CASE_END
 

--- a/test/libevm/vm.h
+++ b/test/libevm/vm.h
@@ -57,6 +57,7 @@ public:
 	virtual u256 txCount(Address _a) override { return std::get<1>(addresses[_a]); }
 	virtual void suicide(Address _a) override { std::get<0>(addresses[_a]) += std::get<0>(addresses[myAddress]); addresses.erase(myAddress); }
 	virtual bytes const& codeAt(Address _a) override { return std::get<3>(addresses[_a]); }
+	virtual size_t codeSizeAt(Address _a) override { return std::get<3>(addresses[_a]).size(); }
 	virtual h160 create(u256 _endowment, u256& io_gas, bytesConstRef _init, eth::OnOpFunc const&) override;
 	virtual bool call(eth::CallParameters&) override;
 	void setTransaction(Address _caller, u256 _value, u256 _gasPrice, bytes const& _data);


### PR DESCRIPTION
This cache stores a mapping from code hash to code size in order
to avoid having to load the full code for extcodesize.

Connects to #3353