### PR TITLE
Fix arch linux script

### DIFF
--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -169,7 +169,7 @@ case $(uname -s) in
             # The majority of our dependencies can be found in the
             # Arch Linux official repositories.
             # See https://wiki.archlinux.org/index.php/Official_repositories
-            pacman -Sy --noconfirm \
+            sudo pacman -Sy --noconfirm \
                 autoconf \
                 automake \
                 gcc \


### PR DESCRIPTION
Pacman must be run as sudo, makepkg cannot be run as sudo, so running script as sudo doesn't work.

Replaces https://github.com/ethereum/cpp-ethereum/pull/3312