### PR TITLE
Update LLL code in tests to avoid using define-on-use variables

### DIFF
--- a/test/libethereum/StateTestsFiller/EIP150/Homestead/stQuadraticComplexityTestFiller.json
+++ b/test/libethereum/StateTestsFiller/EIP150/Homestead/stQuadraticComplexityTestFiller.json
@@ -84,7 +84,7 @@
 
             "bbbf5374fce5edbc8e2a8697c15331677e6ebf0b" : {
                 "balance" : "0xfffffffffffff",
-                "code" : "{ (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALL 1600 0xaaaf5374fce5edbc8e2a8697c15331677e6ebf0b 1 0 50000 0 0) ) [[ 1 ]] @i}",
+                "code" : "{ (def 'i 0x80) (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALL 1600 0xaaaf5374fce5edbc8e2a8697c15331677e6ebf0b 1 0 50000 0 0) ) [[ 1 ]] @i}",
                 "nonce" : "0",
                 "storage" : {
                 }
@@ -132,7 +132,7 @@
 
             "bbbf5374fce5edbc8e2a8697c15331677e6ebf0b" : {
                 "balance" : "0xfffffffffffff",
-                "code" : "{ (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALLCODE 1600 0xaaaf5374fce5edbc8e2a8697c15331677e6ebf0b 1 0 50000 0 0) ) [[ 1 ]] @i}",
+                "code" : "{ (def 'i 0x80) (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALLCODE 1600 0xaaaf5374fce5edbc8e2a8697c15331677e6ebf0b 1 0 50000 0 0) ) [[ 1 ]] @i}",
                 "nonce" : "0",
                 "storage" : {
                 }
@@ -172,7 +172,7 @@
 
             "bbbf5374fce5edbc8e2a8697c15331677e6ebf0b" : {
                 "balance" : "0xfffffffffffff",
-                "code" : "{ (for {} (< @i 1000) [i](+ @i 1) [[ 0 ]] (CREATE 1 0 50000) ) [[ 1 ]] @i}",
+                "code" : "{ (def 'i 0x80) (for {} (< @i 1000) [i](+ @i 1) [[ 0 ]] (CREATE 1 0 50000) ) [[ 1 ]] @i}",
                 "nonce" : "0",
                 "storage" : {
                 }
@@ -212,7 +212,7 @@
 
             "bbbf5374fce5edbc8e2a8697c15331677e6ebf0b" : {
                 "balance" : "0xffffffffffffffffffffffffffffffff",
-                "code" : "{ (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALL 500 1 1 0 50000 0 0) ) [[ 1 ]] @i}",
+                "code" : "{ (def 'i 0x80) (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALL 500 1 1 0 50000 0 0) ) [[ 1 ]] @i}",
                 "nonce" : "0",
                 "storage" : {
                 }
@@ -252,7 +252,7 @@
 
             "bbbf5374fce5edbc8e2a8697c15331677e6ebf0b" : {
                 "balance" : "0xfffffffffffff",
-                "code" : "{ (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALL 78200 2 1 0 50000 0 0) ) [[ 1 ]] @i}",
+                "code" : "{ (def 'i 0x80) (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALL 78200 2 1 0 50000 0 0) ) [[ 1 ]] @i}",
                 "nonce" : "0",
                 "storage" : {
                 }
@@ -292,7 +292,7 @@
 
             "bbbf5374fce5edbc8e2a8697c15331677e6ebf0b" : {
                 "balance" : "0xfffffffffffff",
-                "code" : "{ (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALL 78200 3 1 0 50000 0 0) ) [[ 1 ]] @i}",
+                "code" : "{ (def 'i 0x80) (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALL 78200 3 1 0 50000 0 0) ) [[ 1 ]] @i}",
                 "nonce" : "0",
                 "storage" : {
                 }
@@ -332,7 +332,7 @@
 
             "bbbf5374fce5edbc8e2a8697c15331677e6ebf0b" : {
                 "balance" : "0xfffffffffffff",
-                "code" : "{ (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALL 1564 4 1 0 50000 0 0) ) [[ 1 ]] @i}",
+                "code" : "{ (def 'i 0x80) (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALL 1564 4 1 0 50000 0 0) ) [[ 1 ]] @i}",
                 "nonce" : "0",
                 "storage" : {
                 }
@@ -372,7 +372,7 @@
 
             "bbbf5374fce5edbc8e2a8697c15331677e6ebf0b" : {
                 "balance" : "0xfffffffffffff",
-                "code" : "{ [ 1 ] 42 (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALL 1564 4 1 0 50000 1 50000) ) [[ 1 ]] @i [[ 2 ]] @1 }",
+                "code" : "{ [ 1 ] 42 (def 'i 0x80) (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALL 1564 4 1 0 50000 1 50000) ) [[ 1 ]] @i [[ 2 ]] @1 }",
                 "nonce" : "0",
                 "storage" : {
                 }
@@ -411,7 +411,7 @@
 
             "bbbf5374fce5edbc8e2a8697c15331677e6ebf0b" : {
                 "balance" : "0xfffffffffffff",
-                "code" : "{ (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALL 1564 0xaaaf5374fce5edbc8e2a8697c15331677e6ebf0b 0 0 50000 0 0) ) [[ 1 ]] @i }",
+                "code" : "{ (def 'i 0x80) (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALL 1564 0xaaaf5374fce5edbc8e2a8697c15331677e6ebf0b 0 0 50000 0 0) ) [[ 1 ]] @i }",
                 "nonce" : "0",
                 "storage" : {
                 }
@@ -459,7 +459,7 @@
 
             "bbbf5374fce5edbc8e2a8697c15331677e6ebf0b" : {
                 "balance" : "0xfffffffffffff",
-                "code" : "{ (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALL 1564 0xaaaf5374fce5edbc8e2a8697c15331677e6ebf0b 0 0 50000 0 0) ) [[ 1 ]] @i }",
+                "code" : "{ (def 'i 0x80) (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALL 1564 0xaaaf5374fce5edbc8e2a8697c15331677e6ebf0b 0 0 50000 0 0) ) [[ 1 ]] @i }",
                 "nonce" : "0",
                 "storage" : {
                 }
@@ -509,7 +509,7 @@
 
             "bbbf5374fce5edbc8e2a8697c15331677e6ebf0b" : {
                 "balance" : "0xfffffffffffff",
-                "code" : "{ (for {} (< @i 50) [i](+ @i 1) [[ 0 ]] (CALL 88250000000 0xaaa50000fce5edbc8e2a8697c15331677e6ebf0b 0 0 0 0 0) ) [[ 1 ]] @i }",
+                "code" : "{ (def 'i 0x80) (for {} (< @i 50) [i](+ @i 1) [[ 0 ]] (CALL 88250000000 0xaaa50000fce5edbc8e2a8697c15331677e6ebf0b 0 0 0 0 0) ) [[ 1 ]] @i }",
                 "nonce" : "0",
                 "storage" : {
                 }
@@ -557,7 +557,7 @@
 
             "bbbf5374fce5edbc8e2a8697c15331677e6ebf0b" : {
                 "balance" : "0xfffffffffffff",
-                "code" : "{ (for {} (< @i 50) [i](+ @i 1) [[ 0 ]] (CALL 88250000000 0xaaa50000fce5edbc8e2a8697c15331677e6ebf0b 0 0 0 0 0) ) [[ 1 ]] @i }",
+                "code" : "{ (def 'i 0x80) (for {} (< @i 50) [i](+ @i 1) [[ 0 ]] (CALL 88250000000 0xaaa50000fce5edbc8e2a8697c15331677e6ebf0b 0 0 0 0 0) ) [[ 1 ]] @i }",
                 "nonce" : "0",
                 "storage" : {
                 }
@@ -605,7 +605,7 @@
 
             "bbbf5374fce5edbc8e2a8697c15331677e6ebf0b" : {
                 "balance" : "0xfffffffffffff",
-                "code" : "{ (for {} (< @i 50) [i](+ @i 1) [[ 0 ]] (CALL 88250000000 0xaaa50000fce5edbc8e2a8697c15331677e6ebf0b 0 0 0 0 0) ) [[ 1 ]] @i }",
+                "code" : "{ (def 'i 0x80) (for {} (< @i 50) [i](+ @i 1) [[ 0 ]] (CALL 88250000000 0xaaa50000fce5edbc8e2a8697c15331677e6ebf0b 0 0 0 0 0) ) [[ 1 ]] @i }",
                 "nonce" : "0",
                 "storage" : {
                 }

--- a/test/libethereum/StateTestsFiller/EIP150/Homestead/stSystemOperationsTestFiller.json
+++ b/test/libethereum/StateTestsFiller/EIP150/Homestead/stSystemOperationsTestFiller.json
@@ -2820,7 +2820,7 @@
 
             "bbbf5374fce5edbc8e2a8697c15331677e6ebf0b" : {
                 "balance" : "1000",
-                "code" : "{ (for {} (< @i 10) [i](+ @i 1) [[ 0 ]](CALL 0xfffffffffff 0xaaaf5374fce5edbc8e2a8697c15331677e6ebf0b 1 0 50000 0 0) ) [[ 1 ]] @i}",
+                "code" : "{ (def 'i 0x80) (for {} (< @i 10) [i](+ @i 1) [[ 0 ]](CALL 0xfffffffffff 0xaaaf5374fce5edbc8e2a8697c15331677e6ebf0b 1 0 50000 0 0) ) [[ 1 ]] @i}",
                 "nonce" : "0",
                 "storage" : {
                 }

--- a/test/libethereum/StateTestsFiller/EIP158/Homestead/stQuadraticComplexityTestFiller.json
+++ b/test/libethereum/StateTestsFiller/EIP158/Homestead/stQuadraticComplexityTestFiller.json
@@ -84,7 +84,7 @@
 
             "bbbf5374fce5edbc8e2a8697c15331677e6ebf0b" : {
                 "balance" : "0xfffffffffffff",
-                "code" : "{ (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALL 1600 0xaaaf5374fce5edbc8e2a8697c15331677e6ebf0b 1 0 50000 0 0) ) [[ 1 ]] @i}",
+                "code" : "{ (def 'i 0x80) (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALL 1600 0xaaaf5374fce5edbc8e2a8697c15331677e6ebf0b 1 0 50000 0 0) ) [[ 1 ]] @i}",
                 "nonce" : "0",
                 "storage" : {
                 }
@@ -132,7 +132,7 @@
 
             "bbbf5374fce5edbc8e2a8697c15331677e6ebf0b" : {
                 "balance" : "0xfffffffffffff",
-                "code" : "{ (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALLCODE 1600 0xaaaf5374fce5edbc8e2a8697c15331677e6ebf0b 1 0 50000 0 0) ) [[ 1 ]] @i}",
+                "code" : "{ (def 'i 0x80) (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALLCODE 1600 0xaaaf5374fce5edbc8e2a8697c15331677e6ebf0b 1 0 50000 0 0) ) [[ 1 ]] @i}",
                 "nonce" : "0",
                 "storage" : {
                 }
@@ -172,7 +172,7 @@
 
             "bbbf5374fce5edbc8e2a8697c15331677e6ebf0b" : {
                 "balance" : "0xfffffffffffff",
-                "code" : "{ (for {} (< @i 1000) [i](+ @i 1) [[ 0 ]] (CREATE 1 0 50000) ) [[ 1 ]] @i}",
+                "code" : "{ (def 'i 0x80) (for {} (< @i 1000) [i](+ @i 1) [[ 0 ]] (CREATE 1 0 50000) ) [[ 1 ]] @i}",
                 "nonce" : "0",
                 "storage" : {
                 }
@@ -212,7 +212,7 @@
 
             "bbbf5374fce5edbc8e2a8697c15331677e6ebf0b" : {
                 "balance" : "0xffffffffffffffffffffffffffffffff",
-                "code" : "{ (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALL 500 1 1 0 50000 0 0) ) [[ 1 ]] @i}",
+                "code" : "{ (def 'i 0x80) (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALL 500 1 1 0 50000 0 0) ) [[ 1 ]] @i}",
                 "nonce" : "0",
                 "storage" : {
                 }
@@ -252,7 +252,7 @@
 
             "bbbf5374fce5edbc8e2a8697c15331677e6ebf0b" : {
                 "balance" : "0xfffffffffffff",
-                "code" : "{ (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALL 78200 2 1 0 50000 0 0) ) [[ 1 ]] @i}",
+                "code" : "{ (def 'i 0x80) (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALL 78200 2 1 0 50000 0 0) ) [[ 1 ]] @i}",
                 "nonce" : "0",
                 "storage" : {
                 }
@@ -292,7 +292,7 @@
 
             "bbbf5374fce5edbc8e2a8697c15331677e6ebf0b" : {
                 "balance" : "0xfffffffffffff",
-                "code" : "{ (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALL 78200 3 1 0 50000 0 0) ) [[ 1 ]] @i}",
+                "code" : "{ (def 'i 0x80) (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALL 78200 3 1 0 50000 0 0) ) [[ 1 ]] @i}",
                 "nonce" : "0",
                 "storage" : {
                 }
@@ -332,7 +332,7 @@
 
             "bbbf5374fce5edbc8e2a8697c15331677e6ebf0b" : {
                 "balance" : "0xfffffffffffff",
-                "code" : "{ (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALL 1564 4 1 0 50000 0 0) ) [[ 1 ]] @i}",
+                "code" : "{ (def 'i 0x80) (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALL 1564 4 1 0 50000 0 0) ) [[ 1 ]] @i}",
                 "nonce" : "0",
                 "storage" : {
                 }
@@ -372,7 +372,7 @@
 
             "bbbf5374fce5edbc8e2a8697c15331677e6ebf0b" : {
                 "balance" : "0xfffffffffffff",
-                "code" : "{ [ 1 ] 42 (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALL 1564 4 1 0 50000 1 50000) ) [[ 1 ]] @i [[ 2 ]] @1 }",
+                "code" : "{ [ 1 ] 42 (def 'i 0x80) (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALL 1564 4 1 0 50000 1 50000) ) [[ 1 ]] @i [[ 2 ]] @1 }",
                 "nonce" : "0",
                 "storage" : {
                 }
@@ -411,7 +411,7 @@
 
             "bbbf5374fce5edbc8e2a8697c15331677e6ebf0b" : {
                 "balance" : "0xfffffffffffff",
-                "code" : "{ (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALL 1564 0xaaaf5374fce5edbc8e2a8697c15331677e6ebf0b 0 0 50000 0 0) ) [[ 1 ]] @i }",
+                "code" : "{ (def 'i 0x80) (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALL 1564 0xaaaf5374fce5edbc8e2a8697c15331677e6ebf0b 0 0 50000 0 0) ) [[ 1 ]] @i }",
                 "nonce" : "0",
                 "storage" : {
                 }
@@ -459,7 +459,7 @@
 
             "bbbf5374fce5edbc8e2a8697c15331677e6ebf0b" : {
                 "balance" : "0xfffffffffffff",
-                "code" : "{ (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALL 1564 0xaaaf5374fce5edbc8e2a8697c15331677e6ebf0b 0 0 50000 0 0) ) [[ 1 ]] @i }",
+                "code" : "{ (def 'i 0x80) (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALL 1564 0xaaaf5374fce5edbc8e2a8697c15331677e6ebf0b 0 0 50000 0 0) ) [[ 1 ]] @i }",
                 "nonce" : "0",
                 "storage" : {
                 }
@@ -509,7 +509,7 @@
 
             "bbbf5374fce5edbc8e2a8697c15331677e6ebf0b" : {
                 "balance" : "0xfffffffffffff",
-                "code" : "{ (for {} (< @i 50) [i](+ @i 1) [[ 0 ]] (CALL 88250000000 0xaaa50000fce5edbc8e2a8697c15331677e6ebf0b 0 0 0 0 0) ) [[ 1 ]] @i }",
+                "code" : "{ (def 'i 0x80) (for {} (< @i 50) [i](+ @i 1) [[ 0 ]] (CALL 88250000000 0xaaa50000fce5edbc8e2a8697c15331677e6ebf0b 0 0 0 0 0) ) [[ 1 ]] @i }",
                 "nonce" : "0",
                 "storage" : {
                 }
@@ -557,7 +557,7 @@
 
             "bbbf5374fce5edbc8e2a8697c15331677e6ebf0b" : {
                 "balance" : "0xfffffffffffff",
-                "code" : "{ (for {} (< @i 50) [i](+ @i 1) [[ 0 ]] (CALL 88250000000 0xaaa50000fce5edbc8e2a8697c15331677e6ebf0b 0 0 0 0 0) ) [[ 1 ]] @i }",
+                "code" : "{ (def 'i 0x80) (for {} (< @i 50) [i](+ @i 1) [[ 0 ]] (CALL 88250000000 0xaaa50000fce5edbc8e2a8697c15331677e6ebf0b 0 0 0 0 0) ) [[ 1 ]] @i }",
                 "nonce" : "0",
                 "storage" : {
                 }
@@ -605,7 +605,7 @@
 
             "bbbf5374fce5edbc8e2a8697c15331677e6ebf0b" : {
                 "balance" : "0xfffffffffffff",
-                "code" : "{ (for {} (< @i 50) [i](+ @i 1) [[ 0 ]] (CALL 88250000000 0xaaa50000fce5edbc8e2a8697c15331677e6ebf0b 0 0 0 0 0) ) [[ 1 ]] @i }",
+                "code" : "{ (def 'i 0x80) (for {} (< @i 50) [i](+ @i 1) [[ 0 ]] (CALL 88250000000 0xaaa50000fce5edbc8e2a8697c15331677e6ebf0b 0 0 0 0 0) ) [[ 1 ]] @i }",
                 "nonce" : "0",
                 "storage" : {
                 }

--- a/test/libethereum/StateTestsFiller/EIP158/Homestead/stSystemOperationsTestFiller.json
+++ b/test/libethereum/StateTestsFiller/EIP158/Homestead/stSystemOperationsTestFiller.json
@@ -2820,7 +2820,7 @@
 
             "bbbf5374fce5edbc8e2a8697c15331677e6ebf0b" : {
                 "balance" : "1000",
-                "code" : "{ (for {} (< @i 10) [i](+ @i 1) [[ 0 ]](CALL 0xfffffffffff 0xaaaf5374fce5edbc8e2a8697c15331677e6ebf0b 1 0 50000 0 0) ) [[ 1 ]] @i}",
+                "code" : "{ (def 'i 0x80) (for {} (< @i 10) [i](+ @i 1) [[ 0 ]](CALL 0xfffffffffff 0xaaaf5374fce5edbc8e2a8697c15331677e6ebf0b 1 0 50000 0 0) ) [[ 1 ]] @i}",
                 "nonce" : "0",
                 "storage" : {
                 }

--- a/test/libethereum/StateTestsFiller/Homestead/stQuadraticComplexityTestFiller.json
+++ b/test/libethereum/StateTestsFiller/Homestead/stQuadraticComplexityTestFiller.json
@@ -84,7 +84,7 @@
 
             "bbbf5374fce5edbc8e2a8697c15331677e6ebf0b" : {
                 "balance" : "0xfffffffffffff",
-                "code" : "{ (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALL 1600 0xaaaf5374fce5edbc8e2a8697c15331677e6ebf0b 1 0 50000 0 0) ) [[ 1 ]] @i}",
+                "code" : "{ (def 'i 0x80) (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALL 1600 0xaaaf5374fce5edbc8e2a8697c15331677e6ebf0b 1 0 50000 0 0) ) [[ 1 ]] @i}",
                 "nonce" : "0",
                 "storage" : {
                 }
@@ -132,7 +132,7 @@
 
             "bbbf5374fce5edbc8e2a8697c15331677e6ebf0b" : {
                 "balance" : "0xfffffffffffff",
-                "code" : "{ (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALLCODE 1600 0xaaaf5374fce5edbc8e2a8697c15331677e6ebf0b 1 0 50000 0 0) ) [[ 1 ]] @i}",
+                "code" : "{ (def 'i 0x80) (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALLCODE 1600 0xaaaf5374fce5edbc8e2a8697c15331677e6ebf0b 1 0 50000 0 0) ) [[ 1 ]] @i}",
                 "nonce" : "0",
                 "storage" : {
                 }
@@ -172,7 +172,7 @@
 
             "bbbf5374fce5edbc8e2a8697c15331677e6ebf0b" : {
                 "balance" : "0xfffffffffffff",
-                "code" : "{ (for {} (< @i 1000) [i](+ @i 1) [[ 0 ]] (CREATE 1 0 50000) ) [[ 1 ]] @i}",
+                "code" : "{ (def 'i 0x80) (for {} (< @i 1000) [i](+ @i 1) [[ 0 ]] (CREATE 1 0 50000) ) [[ 1 ]] @i}",
                 "nonce" : "0",
                 "storage" : {
                 }
@@ -212,7 +212,7 @@
 
             "bbbf5374fce5edbc8e2a8697c15331677e6ebf0b" : {
                 "balance" : "0xffffffffffffffffffffffffffffffff",
-                "code" : "{ (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALL 500 1 1 0 50000 0 0) ) [[ 1 ]] @i}",
+                "code" : "{ (def 'i 0x80) (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALL 500 1 1 0 50000 0 0) ) [[ 1 ]] @i}",
                 "nonce" : "0",
                 "storage" : {
                 }
@@ -252,7 +252,7 @@
 
             "bbbf5374fce5edbc8e2a8697c15331677e6ebf0b" : {
                 "balance" : "0xfffffffffffff",
-                "code" : "{ (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALL 78200 2 1 0 50000 0 0) ) [[ 1 ]] @i}",
+                "code" : "{ (def 'i 0x80) (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALL 78200 2 1 0 50000 0 0) ) [[ 1 ]] @i}",
                 "nonce" : "0",
                 "storage" : {
                 }
@@ -292,7 +292,7 @@
 
             "bbbf5374fce5edbc8e2a8697c15331677e6ebf0b" : {
                 "balance" : "0xfffffffffffff",
-                "code" : "{ (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALL 78200 3 1 0 50000 0 0) ) [[ 1 ]] @i}",
+                "code" : "{ (def 'i 0x80) (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALL 78200 3 1 0 50000 0 0) ) [[ 1 ]] @i}",
                 "nonce" : "0",
                 "storage" : {
                 }
@@ -332,7 +332,7 @@
 
             "bbbf5374fce5edbc8e2a8697c15331677e6ebf0b" : {
                 "balance" : "0xfffffffffffff",
-                "code" : "{ (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALL 1564 4 1 0 50000 0 0) ) [[ 1 ]] @i}",
+                "code" : "{ (def 'i 0x80) (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALL 1564 4 1 0 50000 0 0) ) [[ 1 ]] @i}",
                 "nonce" : "0",
                 "storage" : {
                 }
@@ -372,7 +372,7 @@
 
             "bbbf5374fce5edbc8e2a8697c15331677e6ebf0b" : {
                 "balance" : "0xfffffffffffff",
-                "code" : "{ [ 1 ] 42 (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALL 1564 4 1 0 50000 1 50000) ) [[ 1 ]] @i [[ 2 ]] @1 }",
+                "code" : "{ [ 1 ] 42 (def 'i 0x80) (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALL 1564 4 1 0 50000 1 50000) ) [[ 1 ]] @i [[ 2 ]] @1 }",
                 "nonce" : "0",
                 "storage" : {
                 }
@@ -411,7 +411,7 @@
 
             "bbbf5374fce5edbc8e2a8697c15331677e6ebf0b" : {
                 "balance" : "0xfffffffffffff",
-                "code" : "{ (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALL 1564 0xaaaf5374fce5edbc8e2a8697c15331677e6ebf0b 0 0 50000 0 0) ) [[ 1 ]] @i }",
+                "code" : "{ (def 'i 0x80) (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALL 1564 0xaaaf5374fce5edbc8e2a8697c15331677e6ebf0b 0 0 50000 0 0) ) [[ 1 ]] @i }",
                 "nonce" : "0",
                 "storage" : {
                 }
@@ -459,7 +459,7 @@
 
             "bbbf5374fce5edbc8e2a8697c15331677e6ebf0b" : {
                 "balance" : "0xfffffffffffff",
-                "code" : "{ (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALL 1564 0xaaaf5374fce5edbc8e2a8697c15331677e6ebf0b 0 0 50000 0 0) ) [[ 1 ]] @i }",
+                "code" : "{ (def 'i 0x80) (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALL 1564 0xaaaf5374fce5edbc8e2a8697c15331677e6ebf0b 0 0 50000 0 0) ) [[ 1 ]] @i }",
                 "nonce" : "0",
                 "storage" : {
                 }
@@ -509,7 +509,7 @@
 
             "bbbf5374fce5edbc8e2a8697c15331677e6ebf0b" : {
                 "balance" : "0xfffffffffffff",
-                "code" : "{ (for {} (< @i 50) [i](+ @i 1) [[ 0 ]] (CALL 88250000000 0xaaa50000fce5edbc8e2a8697c15331677e6ebf0b 0 0 0 0 0) ) [[ 1 ]] @i }",
+                "code" : "{ (def 'i 0x80) (for {} (< @i 50) [i](+ @i 1) [[ 0 ]] (CALL 88250000000 0xaaa50000fce5edbc8e2a8697c15331677e6ebf0b 0 0 0 0 0) ) [[ 1 ]] @i }",
                 "nonce" : "0",
                 "storage" : {
                 }
@@ -557,7 +557,7 @@
 
             "bbbf5374fce5edbc8e2a8697c15331677e6ebf0b" : {
                 "balance" : "0xfffffffffffff",
-                "code" : "{ (for {} (< @i 50) [i](+ @i 1) [[ 0 ]] (CALL 88250000000 0xaaa50000fce5edbc8e2a8697c15331677e6ebf0b 0 0 0 0 0) ) [[ 1 ]] @i }",
+                "code" : "{ (def 'i 0x80) (for {} (< @i 50) [i](+ @i 1) [[ 0 ]] (CALL 88250000000 0xaaa50000fce5edbc8e2a8697c15331677e6ebf0b 0 0 0 0 0) ) [[ 1 ]] @i }",
                 "nonce" : "0",
                 "storage" : {
                 }
@@ -605,7 +605,7 @@
 
             "bbbf5374fce5edbc8e2a8697c15331677e6ebf0b" : {
                 "balance" : "0xfffffffffffff",
-                "code" : "{ (for {} (< @i 50) [i](+ @i 1) [[ 0 ]] (CALL 88250000000 0xaaa50000fce5edbc8e2a8697c15331677e6ebf0b 0 0 0 0 0) ) [[ 1 ]] @i }",
+                "code" : "{ (def 'i 0x80) (for {} (< @i 50) [i](+ @i 1) [[ 0 ]] (CALL 88250000000 0xaaa50000fce5edbc8e2a8697c15331677e6ebf0b 0 0 0 0 0) ) [[ 1 ]] @i }",
                 "nonce" : "0",
                 "storage" : {
                 }

--- a/test/libethereum/StateTestsFiller/Homestead/stSystemOperationsTestFiller.json
+++ b/test/libethereum/StateTestsFiller/Homestead/stSystemOperationsTestFiller.json
@@ -2819,7 +2819,7 @@
 
             "bbbf5374fce5edbc8e2a8697c15331677e6ebf0b" : {
                 "balance" : "1000",
-                "code" : "{ (for {} (< @i 10) [i](+ @i 1) [[ 0 ]](CALL 0xfffffffffff 0xaaaf5374fce5edbc8e2a8697c15331677e6ebf0b 1 0 50000 0 0) ) [[ 1 ]] @i}",
+                "code" : "{ (def 'i 0x80) (for {} (< @i 10) [i](+ @i 1) [[ 0 ]](CALL 0xfffffffffff 0xaaaf5374fce5edbc8e2a8697c15331677e6ebf0b 1 0 50000 0 0) ) [[ 1 ]] @i}",
                 "nonce" : "0",
                 "storage" : {
                 }

--- a/test/libethereum/StateTestsFiller/stQuadraticComplexityTestFiller.json
+++ b/test/libethereum/StateTestsFiller/stQuadraticComplexityTestFiller.json
@@ -84,7 +84,7 @@
 
             "bbbf5374fce5edbc8e2a8697c15331677e6ebf0b" : {
                 "balance" : "0xfffffffffffff",
-                "code" : "{ (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALL 1600 0xaaaf5374fce5edbc8e2a8697c15331677e6ebf0b 1 0 50000 0 0) ) [[ 1 ]] @i}",
+                "code" : "{ (def 'i 0x80) (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALL 1600 0xaaaf5374fce5edbc8e2a8697c15331677e6ebf0b 1 0 50000 0 0) ) [[ 1 ]] @i}",
                 "nonce" : "0",
                 "storage" : {
                 }
@@ -132,7 +132,7 @@
 
             "bbbf5374fce5edbc8e2a8697c15331677e6ebf0b" : {
                 "balance" : "0xfffffffffffff",
-                "code" : "{ (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALLCODE 1600 0xaaaf5374fce5edbc8e2a8697c15331677e6ebf0b 1 0 50000 0 0) ) [[ 1 ]] @i}",
+                "code" : "{ (def 'i 0x80) (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALLCODE 1600 0xaaaf5374fce5edbc8e2a8697c15331677e6ebf0b 1 0 50000 0 0) ) [[ 1 ]] @i}",
                 "nonce" : "0",
                 "storage" : {
                 }
@@ -172,7 +172,7 @@
 
             "bbbf5374fce5edbc8e2a8697c15331677e6ebf0b" : {
                 "balance" : "0xfffffffffffff",
-                "code" : "{ (for {} (< @i 1000) [i](+ @i 1) [[ 0 ]] (CREATE 1 0 50000) ) [[ 1 ]] @i}",
+                "code" : "{ (def 'i 0x80) (for {} (< @i 1000) [i](+ @i 1) [[ 0 ]] (CREATE 1 0 50000) ) [[ 1 ]] @i}",
                 "nonce" : "0",
                 "storage" : {
                 }
@@ -212,7 +212,7 @@
 
             "bbbf5374fce5edbc8e2a8697c15331677e6ebf0b" : {
                 "balance" : "0xffffffffffffffffffffffffffffffff",
-                "code" : "{ (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALL 500 1 1 0 50000 0 0) ) [[ 1 ]] @i}",
+                "code" : "{ (def 'i 0x80) (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALL 500 1 1 0 50000 0 0) ) [[ 1 ]] @i}",
                 "nonce" : "0",
                 "storage" : {
                 }
@@ -252,7 +252,7 @@
 
             "bbbf5374fce5edbc8e2a8697c15331677e6ebf0b" : {
                 "balance" : "0xfffffffffffff",
-                "code" : "{ (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALL 78200 2 1 0 50000 0 0) ) [[ 1 ]] @i}",
+                "code" : "{ (def 'i 0x80) (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALL 78200 2 1 0 50000 0 0) ) [[ 1 ]] @i}",
                 "nonce" : "0",
                 "storage" : {
                 }
@@ -292,7 +292,7 @@
 
             "bbbf5374fce5edbc8e2a8697c15331677e6ebf0b" : {
                 "balance" : "0xfffffffffffff",
-                "code" : "{ (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALL 78200 3 1 0 50000 0 0) ) [[ 1 ]] @i}",
+                "code" : "{ (def 'i 0x80) (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALL 78200 3 1 0 50000 0 0) ) [[ 1 ]] @i}",
                 "nonce" : "0",
                 "storage" : {
                 }
@@ -332,7 +332,7 @@
 
             "bbbf5374fce5edbc8e2a8697c15331677e6ebf0b" : {
                 "balance" : "0xfffffffffffff",
-                "code" : "{ (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALL 1564 4 1 0 50000 0 0) ) [[ 1 ]] @i}",
+                "code" : "{ (def 'i 0x80) (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALL 1564 4 1 0 50000 0 0) ) [[ 1 ]] @i}",
                 "nonce" : "0",
                 "storage" : {
                 }
@@ -372,7 +372,7 @@
 
             "bbbf5374fce5edbc8e2a8697c15331677e6ebf0b" : {
                 "balance" : "0xfffffffffffff",
-                "code" : "{ [ 1 ] 42 (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALL 1564 4 1 0 50000 1 50000) ) [[ 1 ]] @i [[ 2 ]] @1 }",
+                "code" : "{ [ 1 ] 42 (def 'i 0x80) (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALL 1564 4 1 0 50000 1 50000) ) [[ 1 ]] @i [[ 2 ]] @1 }",
                 "nonce" : "0",
                 "storage" : {
                 }
@@ -411,7 +411,7 @@
 
             "bbbf5374fce5edbc8e2a8697c15331677e6ebf0b" : {
                 "balance" : "0xfffffffffffff",
-                "code" : "{ (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALL 1564 0xaaaf5374fce5edbc8e2a8697c15331677e6ebf0b 0 0 50000 0 0) ) [[ 1 ]] @i }",
+                "code" : "{ (def 'i 0x80) (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALL 1564 0xaaaf5374fce5edbc8e2a8697c15331677e6ebf0b 0 0 50000 0 0) ) [[ 1 ]] @i }",
                 "nonce" : "0",
                 "storage" : {
                 }
@@ -459,7 +459,7 @@
 
             "bbbf5374fce5edbc8e2a8697c15331677e6ebf0b" : {
                 "balance" : "0xfffffffffffff",
-                "code" : "{ (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALL 1564 0xaaaf5374fce5edbc8e2a8697c15331677e6ebf0b 0 0 50000 0 0) ) [[ 1 ]] @i }",
+                "code" : "{ (def 'i 0x80) (for {} (< @i 50000) [i](+ @i 1) [[ 0 ]] (CALL 1564 0xaaaf5374fce5edbc8e2a8697c15331677e6ebf0b 0 0 50000 0 0) ) [[ 1 ]] @i }",
                 "nonce" : "0",
                 "storage" : {
                 }
@@ -509,7 +509,7 @@
 
             "bbbf5374fce5edbc8e2a8697c15331677e6ebf0b" : {
                 "balance" : "0xfffffffffffff",
-                "code" : "{ (for {} (< @i 50) [i](+ @i 1) [[ 0 ]] (CALL 88250000000 0xaaa50000fce5edbc8e2a8697c15331677e6ebf0b 0 0 0 0 0) ) [[ 1 ]] @i }",
+                "code" : "{ (def 'i 0x80) (for {} (< @i 50) [i](+ @i 1) [[ 0 ]] (CALL 88250000000 0xaaa50000fce5edbc8e2a8697c15331677e6ebf0b 0 0 0 0 0) ) [[ 1 ]] @i }",
                 "nonce" : "0",
                 "storage" : {
                 }
@@ -557,7 +557,7 @@
 
             "bbbf5374fce5edbc8e2a8697c15331677e6ebf0b" : {
                 "balance" : "0xfffffffffffff",
-                "code" : "{ (for {} (< @i 50) [i](+ @i 1) [[ 0 ]] (CALL 88250000000 0xaaa50000fce5edbc8e2a8697c15331677e6ebf0b 0 0 0 0 0) ) [[ 1 ]] @i }",
+                "code" : "{ (def 'i 0x80) (for {} (< @i 50) [i](+ @i 1) [[ 0 ]] (CALL 88250000000 0xaaa50000fce5edbc8e2a8697c15331677e6ebf0b 0 0 0 0 0) ) [[ 1 ]] @i }",
                 "nonce" : "0",
                 "storage" : {
                 }
@@ -605,7 +605,7 @@
 
             "bbbf5374fce5edbc8e2a8697c15331677e6ebf0b" : {
                 "balance" : "0xfffffffffffff",
-                "code" : "{ (for {} (< @i 50) [i](+ @i 1) [[ 0 ]] (CALL 88250000000 0xaaa50000fce5edbc8e2a8697c15331677e6ebf0b 0 0 0 0 0) ) [[ 1 ]] @i }",
+                "code" : "{ (def 'i 0x80) (for {} (< @i 50) [i](+ @i 1) [[ 0 ]] (CALL 88250000000 0xaaa50000fce5edbc8e2a8697c15331677e6ebf0b 0 0 0 0 0) ) [[ 1 ]] @i }",
                 "nonce" : "0",
                 "storage" : {
                 }

--- a/test/libethereum/StateTestsFiller/stSystemOperationsTestFiller.json
+++ b/test/libethereum/StateTestsFiller/stSystemOperationsTestFiller.json
@@ -2821,7 +2821,7 @@
 
             "bbbf5374fce5edbc8e2a8697c15331677e6ebf0b" : {
                 "balance" : "1000",
-                "code" : "{ (for {} (< @i 10) [i](+ @i 1) [[ 0 ]](CALL 0xfffffffffff 0xaaaf5374fce5edbc8e2a8697c15331677e6ebf0b 1 0 50000 0 0) ) [[ 1 ]] @i}",
+                "code" : "{ (def 'i 0x80) (for {} (< @i 10) [i](+ @i 1) [[ 0 ]](CALL 0xfffffffffff 0xaaaf5374fce5edbc8e2a8697c15331677e6ebf0b 1 0 50000 0 0) ) [[ 1 ]] @i}",
                 "nonce" : "0",
                 "storage" : {
                 }

--- a/test/libevm/VMTestsFiller/vmIOandFlowOperationsTestFiller.json
+++ b/test/libevm/VMTestsFiller/vmIOandFlowOperationsTestFiller.json
@@ -4126,7 +4126,7 @@
         "0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6" : {
             "balance" : "100000000000000000000000",
             "nonce" : "0",
-            "code" : "{ [i] 1 ( if (> @i 0) { (return 39) [i] 2 } (return 1) ) }",
+            "code" : "{ (def 'i 0x80) [i] 1 ( if (> @i 0) { (return 39) [i] 2 } (return 1) ) }",
             "storage": {}
         }
         },
@@ -4189,7 +4189,7 @@
         "0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6" : {
             "balance" : "100000000000000000000000",
             "nonce" : "0",
-            "code" : "{    [[69]] (caller)   (return 0 (lll     (when (= (caller) @@69)       (for {} (< @i (calldatasize)) [i](+ @i 64)         [[ (calldataload @i) ]] (calldataload (+ @i 32))       )     )   0))}",
+            "code" : "{    [[69]] (caller)   (return 0 (lll     (when (= (caller) @@69)       (def 'i 0x80)       (for {} (< @i (calldatasize)) [i](+ @i 64)         [[ (calldataload @i) ]] (calldataload (+ @i 32))       )     )   0))}",
             "storage": {}
         }
         },
@@ -4302,7 +4302,7 @@
         "0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6" : {
             "balance" : "100000000000000000000000",
             "nonce" : "0",
-            "code" : "(for [i]:10 (> @i 0) [i](- @i 1) [j](+ @i @j))",
+            "code" : "{ (def 'i 0x80) (def 'j 0xA0) (for [i]:10 (> @i 0) [i](- @i 1) [j](+ @i @j)) }",
             "storage": {}
         }
         },
@@ -4330,7 +4330,7 @@
         "0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6" : {
             "balance" : "100000000000000000000000",
             "nonce" : "0",
-            "code" : "(for [i]:0 (< @i 10) [i](+ @i 1) [j](+ @i @j))",
+            "code" : "{ (def 'i 0x80) (def 'j 0xA0) (for [i]:0 (< @i 10) [i](+ @i 1) [j](+ @i @j)) }",
             "storage": {}
         }
         },
@@ -4498,7 +4498,7 @@
         "0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6" : {
             "balance" : "100000000000000000000000",
             "nonce" : "0",
-            "code" : "(when (> 1 0) [i] 13)",
+            "code" : "{ (def 'i 0x80) (when (> 1 0) [i] 13) }",
             "storage": {}
         }
         },


### PR DESCRIPTION
This change should generate the exact same bytecode as before.

Fixes #3387.