### PR TITLE
Disable brew upgrade in install script for MacOS

### DIFF
--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -91,49 +91,9 @@ case $(uname -s) in
         # Check for Homebrew install and abort if it is not installed.
         brew -v > /dev/null 2>&1 || { echo >&2 "ERROR - cpp-ethereum requires a Homebrew install.  See http://brew.sh."; exit 1; }
 
-        # In August 2016, the 'carthage' package added a requirement for
-        # a full Xcode 7.3 install, not just command-line build tools,
-        # because it needs Swift 2.2.  This requirement is a complete
-        # non-starter for TravisCI, where we have no ability or desire
-        # to do that installation.  We aren't using 'carthage' ourselves,
-        # so we just pin it here prior to 'brew update'.
-        # https://github.com/Homebrew/homebrew-core/issues/3996
-        brew pin carthage
-
-        # A change was committed to 'brew' on 4th September 2016 which
-        # broke various packages, including 'gnupg' and 'nvm.  We can
-        # work around that issue by pinning the Formula for the time being.
-        # The rolling release pattern strikes again.  Live projects
-        # around the world are the test environment.
-        brew pin gnupg
-        brew pin nvm
-
-        # Update Homebrew formulas and then upgrade any packages which
-        # we have installed using these updated formulas.  This step is
-        # required even within TravisCI, because the Homebrew formulas
-        # are a constant moving target, and we always need to be chasing
-        # those moving targets.  This is a fundamental design decision
-        # made in 'rolling release' package management systems, and one
-        # which makes our macOS builds fundamentally unstable and
-        # unreliable.  We just had to try to react fast when anything
-        # breaks.
-        #
-        # See https://github.com/ethereum/cpp-ethereum/issues/3089
-        brew update
-        brew upgrade
-
-        # Bonus fun - TravisCI image for Yosemite includes a gmp version
-        # which doesn't like being updated, so we need to uninstall it
-        # first, so that the installation step below is a clean install.
-        brew uninstall gmp
-
         # And finally install all the external dependencies.
         brew install \
-            boost \
-            ccache \
-            cmake \
             cryptopp \
-            gmp \
             leveldb \
             libmicrohttpd \
             miniupnpc


### PR DESCRIPTION
The idea behind this change is to depend only on homebrew packages provided by default by Travis CI. We will not be able to track changes in homebrew packages, but we cannot afford to have it right now. This also makes the script `install_deps.sh` not useful for MacOS, but it never was. 