### PR TITLE
Preventing some undefined behavior reported by Clang Static Analyzer

### DIFF
--- a/libethash/io_posix.c
+++ b/libethash/io_posix.c
@@ -96,6 +96,8 @@ bool ethash_get_default_dirname(char* strbuf, size_t buffsize)
 		struct passwd* pwd = getpwuid(getuid());
 		if (pwd)
 			home_dir = pwd->pw_dir;
+		if (!home_dir)
+			return false;
 	}
 	
 	size_t len = strlen(home_dir);

--- a/libp2p/RLPXFrameWriter.cpp
+++ b/libp2p/RLPXFrameWriter.cpp
@@ -138,7 +138,7 @@ size_t RLPXFrameWriter::mux(RLPXFrameCoder& _coder, unsigned _size, deque<bytes>
 		if (!payload.empty())
 		{
 			if (qs.multiFrame)
-				if (offset == 0)
+				if (offset == 0 && qs.writing)
 					// 1st frame of segmented packet writes total-size of packet
 					_coder.writeFrame(m_protocolId, qs.sequence, qs.writing->size(), &payload, payload);
 				else

--- a/libwebthree/libexecstream/posix/exec-stream-helpers.cpp
+++ b/libwebthree/libexecstream/posix/exec-stream-helpers.cpp
@@ -514,6 +514,7 @@ void thread_buffer_t::get( exec_stream_t::stream_kind_t kind, char * dst, std::s
             }
         }
     }
+    no_more=false;
 }
 
 void thread_buffer_t::put( char * src, std::size_t & size, bool & no_more )
@@ -571,6 +572,7 @@ void thread_buffer_t::put( char * src, std::size_t & size, bool & no_more )
             }
         }
     }
+    no_more=false;
 }
 
 void thread_buffer_t::close_in()


### PR DESCRIPTION
This PR prevents some null pointer dereferences and uninitialized variable access.  These were reported by http://clang-analyzer.llvm.org/