### PR TITLE
libethereum: mitigate `testeth` crash in Mac OS

### DIFF
--- a/libethereum/ExtVM.cpp
+++ b/libethereum/ExtVM.cpp
@@ -33,7 +33,7 @@ namespace // anonymous
 static unsigned const c_depthLimit = 1024;
 
 /// Upper bound of stack space needed by single CALL/CREATE execution. Set experimentally.
-static size_t const c_singleExecutionStackSize = 11 * 1024;
+static size_t const c_singleExecutionStackSize = 14 * 1024;
 
 /// Standard thread stack size.
 static size_t const c_defaultStackSize =


### PR DESCRIPTION
This PR tries to solve the test failure in Mac OS X.