### PR TITLE
Add gas per second to output in case of slow import

### DIFF
--- a/libethereum/BlockChain.cpp
+++ b/libethereum/BlockChain.cpp
@@ -939,16 +939,19 @@ ImportRoute BlockChain::import(VerifiedBlockRef const& _block, OverlayDB const& 
 	checkBest = t.elapsed();
 	if (total.elapsed() > 0.5)
 	{
-		cnote << "SLOW IMPORT:" << _block.info.hash() << " #" << _block.info.number();
-		cnote << "  Import took:" << total.elapsed();
-		cnote << "  gas per second:" << static_cast<double>(_block.info.gasUsed()) / enactment;
-		cnote << "  preliminaryChecks:" << preliminaryChecks;
-		cnote << "  enactment:" << enactment;
-		cnote << "  collation:" << collation;
-		cnote << "  writing:" << writing;
-		cnote << "  checkBest:" << checkBest;
-		cnote << "  " << _block.transactions.size() << " transactions";
-		cnote << "  " << _block.info.gasUsed() << " gas used";
+		unsigned const gasPerSecond = static_cast<double>(_block.info.gasUsed()) / enactment;
+		cnote << "SLOW IMPORT: " 
+			<< "{ \"blockHash\": \"" << _block.info.hash() << "\", "
+			<< "\"blockNumber\": " << _block.info.number() << ", " 
+			<< "\"importTime\": " << total.elapsed() << ", "
+			<< "\"gasPerSecond\": " << gasPerSecond << ", "
+			<< "\"preliminaryChecks\":" << preliminaryChecks << ", "
+			<< "\"enactment\":" << enactment << ", "
+			<< "\"collation\":" << collation << ", "
+			<< "\"writing\":" << writing << ", "
+			<< "\"checkBest\":" << checkBest << ", "
+			<< "\"transactions\":" << _block.transactions.size() << ", "
+			<< "\"gasUsed\":" << _block.info.gasUsed() << " }";
 	}
 #endif // ETH_TIMED_IMPORTS
 

--- a/libethereum/BlockChain.cpp
+++ b/libethereum/BlockChain.cpp
@@ -941,6 +941,7 @@ ImportRoute BlockChain::import(VerifiedBlockRef const& _block, OverlayDB const& 
 	{
 		cnote << "SLOW IMPORT:" << _block.info.hash() << " #" << _block.info.number();
 		cnote << "  Import took:" << total.elapsed();
+		cnote << "  gas per second:" << static_cast<double>(_block.info.gasUsed()) / enactment;
 		cnote << "  preliminaryChecks:" << preliminaryChecks;
 		cnote << "  enactment:" << enactment;
 		cnote << "  collation:" << collation;


### PR DESCRIPTION
See #3447

This gives the output like:
```
  i  15:49:14.308|eth  SLOW IMPORT: #03724c9bΓÇª  # 756852
  i  15:49:14.310|eth    Import took: 1.37246
  i  15:49:14.311|eth    gas per second: 2.3543e+06
  i  15:49:14.314|eth    preliminaryChecks: 0.00571
  i  15:49:14.316|eth    enactment: 1.35903
  i  15:49:14.319|eth    collation: 1.8e-05
  i  15:49:14.322|eth    writing: 0.001557
  i  15:49:14.324|eth    checkBest: 0.00413
  i  15:49:14.327|eth    54  transactions
  i  15:49:14.329|eth    3199570  gas used
```