### PR TITLE
Fix possible exploit related to account cache updating

### DIFF
--- a/libethereum/State.h
+++ b/libethereum/State.h
@@ -286,7 +286,7 @@ private:
 	OverlayDB m_db;								///< Our overlay for the state tree.
 	SecureTrieDB<Address, OverlayDB> m_state;	///< Our state tree, as an OverlayDB DB.
 	mutable std::unordered_map<Address, Account> m_cache;	///< Our address cache. This stores the states of each address that has (or at least might have) been changed.
-	mutable std::set<Address> m_unchangedCacheEntries;	///< Tracks entries in m_cache that can potentially be purged if it grows too large.
+	mutable std::vector<Address> m_unchangedCacheEntries;	///< Tracks entries in m_cache that can potentially be purged if it grows too large.
 	AddressHash m_touched;						///< Tracks all addresses touched so far.
 
 	u256 m_accountStartNonce;


### PR DESCRIPTION
Improve the logic for selecting the random element to remove from cache:
generate random element index instead of generating the random address and
finding the closest one in cache