### PR TITLE
Configure General State Tests

### DIFF
--- a/libethashseal/GenesisInfo.cpp
+++ b/libethashseal/GenesisInfo.cpp
@@ -24,6 +24,7 @@ using namespace dev;
 #include "genesis/ropsten.cpp"
 
 //Test configurations
+#include "genesis/mainNetworkTest.cpp"
 #include "genesis/frontierTest.cpp"
 #include "genesis/homesteadTest.cpp"
 #include "genesis/eip150Test.cpp"
@@ -34,7 +35,8 @@ std::string const& dev::eth::genesisInfo(Network _n)
 {
 	switch (_n)
 	{
-	case Network::MainNetwork: return c_genesisInfoFrontier;
+	case Network::MainNetwork: return c_genesisInfoMainNetwork;
+	case Network::MainNetworkTest: return c_genesisInfoMainNetworkTest;
 	case Network::Ropsten: return c_genesisInfoRopsten;
 	case Network::TransitionnetTest: return c_genesisInfoTest;
 	case Network::FrontierTest: return c_genesisInfoFrontierTest;
@@ -50,8 +52,9 @@ h256 const& dev::eth::genesisStateRoot(Network _n)
 {
 	switch (_n)
 	{
-	case Network::MainNetwork: return c_genesisStateRootFrontier;
+	case Network::MainNetwork: return c_genesisStateRootMainNetwork;
 	case Network::Ropsten: return c_genesisStateRootRopsten;
+	case Network::MainNetworkTest: return c_genesisStateRootMainNetworkTest;
 	case Network::TransitionnetTest: return c_genesisStateRootTest;
 	case Network::FrontierTest: return c_genesisStateRootFrontierTest;
 	case Network::HomesteadTest: return c_genesisStateRootHomesteadTest;

--- a/libethashseal/GenesisInfo.h
+++ b/libethashseal/GenesisInfo.h
@@ -37,6 +37,7 @@ enum class Network
 	MainNetwork = 1,		///< Normal Frontier/Homestead/DAO/EIP150/EIP158 chain.
 	//Morden = 2,			///< Normal Morden chain.
 	Ropsten = 3,			///< New Ropsten Test Network
+	MainNetworkTest = 69,	///< MainNetwork rules but without genesis accounts (for transaction tests).
 	TransitionnetTest = 70,	///< Normal Frontier/Homestead/DAO/EIP150/EIP158 chain without all the premine.
 	FrontierTest = 71,		///< Just test the Frontier-era characteristics "forever" (no Homestead portion).
 	HomesteadTest = 72,		///< Just test the Homestead-era characteristics "forever" (no Frontier portion).

--- a/libethashseal/genesis/frontier.cpp
+++ b/libethashseal/genesis/frontier.cpp
@@ -16,8 +16,8 @@
 */
 #include "../GenesisInfo.h"
 
-static dev::h256 const c_genesisStateRootFrontier("d7f8974fb5ac78d9ac099b9ad5018bedc2ce0a72dad1827a1709da30580f0544");
-static std::string const c_genesisInfoFrontier = std::string() +
+static dev::h256 const c_genesisStateRootMainNetwork("d7f8974fb5ac78d9ac099b9ad5018bedc2ce0a72dad1827a1709da30580f0544");
+static std::string const c_genesisInfoMainNetwork = std::string() +
 R"E(
 {
 	"sealEngine": "Ethash",

--- a/libethashseal/genesis/mainNetworkTest.cpp
+++ b/libethashseal/genesis/mainNetworkTest.cpp
@@ -1,0 +1,60 @@
+/*
+		This file is part of cpp-ethereum.
+
+		cpp-ethereum is free software: you can redistribute it and/or modify
+		it under the terms of the GNU General Public License as published by
+		the Free Software Foundation, either version 3 of the License, or
+		(at your option) any later version.
+
+		cpp-ethereum is distributed in the hope that it will be useful,
+		but WITHOUT ANY WARRANTY; without even the implied warranty of
+		MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+		GNU General Public License for more details.
+
+		You should have received a copy of the GNU General Public License
+		along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "../GenesisInfo.h"
+
+static dev::h256 const c_genesisStateRootMainNetworkTest;
+static std::string const c_genesisInfoMainNetworkTest = std::string() +
+R"E(
+{
+	"sealEngine": "Ethash",
+	"params": {
+		"accountStartNonce": "0x00",
+		"homsteadForkBlock": "0x118c30",
+		"daoHardforkBlock": "0x1d4c00",
+		"EIP150ForkBlock": "0x259518",
+		"EIP158ForkBlock": "0x28d138",
+		"networkID" : "0x01",
+		"chainID": "0x01",
+		"maximumExtraDataSize": "0x20",
+		"tieBreakingGas": false,
+		"minGasLimit": "0x1388",
+		"maxGasLimit": "7fffffffffffffff",
+		"gasLimitBoundDivisor": "0x0400",
+		"minimumDifficulty": "0x020000",
+		"difficultyBoundDivisor": "0x0800",
+		"durationLimit": "0x0d",
+		"blockReward": "0x4563918244F40000",
+		"registrar" : "0xc6d9d2cd449a754c494264e1809c50e34d64562b"
+	},
+	"genesis": {
+		"nonce": "0x0000000000000042",
+		"difficulty": "0x400000000",
+		"mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+		"author": "0x0000000000000000000000000000000000000000",
+		"timestamp": "0x00",
+		"parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+		"extraData": "0x11bbe8db4e347b4e8c937c1c8370e4b5ed33adb3db69cbdb7a38e1e50b1b82fa",
+		"gasLimit": "0x1388"
+	},
+	"accounts": {
+		"0000000000000000000000000000000000000001": { "precompiled": { "name": "ecrecover", "linear": { "base": 3000, "word": 0 } } },
+		"0000000000000000000000000000000000000002": { "precompiled": { "name": "sha256", "linear": { "base": 60, "word": 12 } } },
+		"0000000000000000000000000000000000000003": { "precompiled": { "name": "ripemd160", "linear": { "base": 600, "word": 120 } } },
+		"0000000000000000000000000000000000000004": { "precompiled": { "name": "identity", "linear": { "base": 15, "word": 3 } } }
+	}
+}
+)E";

--- a/test/libethereum/State.cpp
+++ b/test/libethereum/State.cpp
@@ -93,6 +93,8 @@ void doStateTests(json_spirit::mValue& _v, bool _fillin)
 }
 } }// Namespace Close
 
+//Disable OLD StateTests. Use GeneralStateTests at StateTests.cpp instead
+/*
 BOOST_AUTO_TEST_SUITE(StateTestsEIP158)
 BOOST_AUTO_TEST_CASE(stZeroCallsRevertTestEIP158)
 {
@@ -595,4 +597,4 @@ BOOST_AUTO_TEST_CASE(userDefinedFileState)
 }
 
 BOOST_AUTO_TEST_SUITE_END()
-
+*/

--- a/test/libethereum/State.cpp
+++ b/test/libethereum/State.cpp
@@ -93,508 +93,505 @@ void doStateTests(json_spirit::mValue& _v, bool _fillin)
 }
 } }// Namespace Close
 
-//Disable OLD StateTests. Use GeneralStateTests at StateTests.cpp instead
-/*
-BOOST_AUTO_TEST_SUITE(StateTestsEIP158)
-BOOST_AUTO_TEST_CASE(stZeroCallsRevertTestEIP158)
-{
-	dev::test::executeTests("stZeroCallsRevertTest", "/StateTests/EIP158", "/StateTestsFiller/EIP158", dev::test::doStateTests);
-}
-BOOST_AUTO_TEST_CASE(stCodeSizeLimitEIP158)
-{
-	dev::test::executeTests("stCodeSizeLimit", "/StateTests/EIP158", "/StateTestsFiller/EIP158", dev::test::doStateTests);
-}
-BOOST_AUTO_TEST_CASE(stCreateTestEIP158)
-{
-	dev::test::executeTests("stCreateTest", "/StateTests/EIP158", "/StateTestsFiller/EIP158", dev::test::doStateTests);
-}
-BOOST_AUTO_TEST_CASE(stEIP158SpecificTest)
-{
-	dev::test::executeTests("stEIP158SpecificTest", "/StateTests/EIP158", "/StateTestsFiller/EIP158", dev::test::doStateTests);
-}
-BOOST_AUTO_TEST_CASE(stNonZeroCallsTest)
-{
-	dev::test::executeTests("stNonZeroCallsTest", "/StateTests/EIP158", "/StateTestsFiller/EIP158", dev::test::doStateTests);
-}
-BOOST_AUTO_TEST_CASE(stZeroCallsTest)
-{
-	dev::test::executeTests("stZeroCallsTest", "/StateTests/EIP158", "/StateTestsFiller/EIP158", dev::test::doStateTests);
-}
-BOOST_AUTO_TEST_CASE(stChangedTestsEIP150)
-{
-	dev::test::executeTests("stChangedTests", "/StateTests/EIP158/EIP150", "/StateTestsFiller/EIP158/EIP150", dev::test::doStateTests);
-}
-BOOST_AUTO_TEST_CASE(stEIPsingleCodeGasPricesEIP150)
-{
-	dev::test::executeTests("stEIPsingleCodeGasPrices", "/StateTests/EIP158/EIP150", "/StateTestsFiller/EIP158/EIP150", dev::test::doStateTests);
-}
-BOOST_AUTO_TEST_CASE(stEIPSpecificTestEIP150)
-{
-	dev::test::executeTests("stEIPSpecificTest", "/StateTests/EIP158/EIP150", "/StateTestsFiller/EIP158/EIP150", dev::test::doStateTests);
-}
-BOOST_AUTO_TEST_CASE(stMemExpandingEIPCallsEIP150)
-{
-	dev::test::executeTests("stMemExpandingEIPCalls", "/StateTests/EIP158/EIP150", "/StateTestsFiller/EIP158/EIP150", dev::test::doStateTests);
-}
-BOOST_AUTO_TEST_CASE(stBoundsTestEIP)
-{
-	dev::test::executeTests("stBoundsTest", "/StateTests/EIP158/Homestead", "/StateTestsFiller/EIP158/Homestead", dev::test::doStateTests);
-}
-BOOST_AUTO_TEST_CASE(stHomeSteadSpecificEIP)
-{
-	dev::test::executeTests("stHomeSteadSpecific", "/StateTests/EIP158/Homestead", "/StateTestsFiller/EIP158/Homestead", dev::test::doStateTests);
-}
-BOOST_AUTO_TEST_CASE(stCallDelegateCodesCallCodeEIP)
-{
-	dev::test::executeTests("stCallDelegateCodesCallCode", "/StateTests/EIP158/Homestead", "/StateTestsFiller/EIP158/Homestead", dev::test::doStateTests);
-}
-BOOST_AUTO_TEST_CASE(stCallDelegateCodesEIP)
-{
-	dev::test::executeTests("stCallDelegateCodes", "/StateTests/EIP158/Homestead", "/StateTestsFiller/EIP158/Homestead", dev::test::doStateTests);
-}
-BOOST_AUTO_TEST_CASE(stDelegatecallTestEIP)
-{
-	dev::test::executeTests("stDelegatecallTest", "/StateTests/EIP158/Homestead", "/StateTestsFiller/EIP158/Homestead", dev::test::doStateTests);
-}
-BOOST_AUTO_TEST_CASE(stCallCodesEIP)
-{
-	dev::test::executeTests("stCallCodes", "/StateTests/EIP158/Homestead", "/StateTestsFiller/EIP158/Homestead", dev::test::doStateTests);
-}
-BOOST_AUTO_TEST_CASE(stSystemOperationsTestEIP)
-{
-	dev::test::executeTests("stSystemOperationsTest", "/StateTests/EIP158/Homestead", "/StateTestsFiller/EIP158/Homestead", dev::test::doStateTests);
-}
-BOOST_AUTO_TEST_CASE(stCallCreateCallCodeTestEIP)
-{
-	dev::test::executeTests("stCallCreateCallCodeTest", "/StateTests/EIP158/Homestead", "/StateTestsFiller/EIP158/Homestead", dev::test::doStateTests);
-}
-BOOST_AUTO_TEST_CASE(stPreCompiledContractsEIP)
-{
-	dev::test::executeTests("stPreCompiledContracts", "/StateTests/EIP158/Homestead", "/StateTestsFiller/EIP158/Homestead", dev::test::doStateTests);
-}
-BOOST_AUTO_TEST_CASE(stLogTestsEIP)
-{
-	dev::test::executeTests("stLogTests", "/StateTests/EIP158/Homestead", "/StateTestsFiller/EIP158/Homestead", dev::test::doStateTests);
-}
-BOOST_AUTO_TEST_CASE(stRecursiveCreateEIP)
-{
-	dev::test::executeTests("stRecursiveCreate", "/StateTests/EIP158/Homestead", "/StateTestsFiller/EIP158/Homestead", dev::test::doStateTests);
-}
-BOOST_AUTO_TEST_CASE(stInitCodeTestEIP)
-{
-	dev::test::executeTests("stInitCodeTest", "/StateTests/EIP158/Homestead", "/StateTestsFiller/EIP158/Homestead", dev::test::doStateTests);
-}
-BOOST_AUTO_TEST_CASE(stTransactionTestEIP)
-{
-	dev::test::executeTests("stTransactionTest", "/StateTests/EIP158/Homestead", "/StateTestsFiller/EIP158/Homestead", dev::test::doStateTests);
-}
-BOOST_AUTO_TEST_CASE(stSpecialTestEIP)
-{
-	dev::test::executeTests("stSpecialTest", "/StateTests/EIP158/Homestead", "/StateTestsFiller/EIP158/Homestead", dev::test::doStateTests);
-}
-BOOST_AUTO_TEST_CASE(stRefundTestEIP)
-{
-	dev::test::executeTests("stRefundTest", "/StateTests/EIP158/Homestead", "/StateTestsFiller/EIP158/Homestead", dev::test::doStateTests);
-}
-BOOST_AUTO_TEST_CASE(stQuadraticComplexityTestEIP)
-{
-	if (test::Options::get().quadratic)
-		dev::test::executeTests("stQuadraticComplexityTest", "/StateTests/EIP158/Homestead", "/StateTestsFiller/EIP158/Homestead", dev::test::doStateTests);
-}
-BOOST_AUTO_TEST_CASE(stMemoryStressTestEIP)
-{
-	if (test::Options::get().memory)
-		dev::test::executeTests("stMemoryStressTest", "/StateTests/EIP158/Homestead", "/StateTestsFiller/EIP158/Homestead", dev::test::doStateTests);
-}
-BOOST_AUTO_TEST_CASE(stMemoryTestEIP)
-{
-	dev::test::executeTests("stMemoryTest", "/StateTests/EIP158/Homestead", "/StateTestsFiller/EIP158/Homestead", dev::test::doStateTests);
-}
-BOOST_AUTO_TEST_CASE(stWalletTestEIP)
-{
-	dev::test::executeTests("stWalletTest", "/StateTests/EIP158/Homestead", "/StateTestsFiller/EIP158/Homestead", dev::test::doStateTests);
-}
-BOOST_AUTO_TEST_SUITE_END()
+//BOOST_AUTO_TEST_SUITE(StateTestsEIP158)
+//BOOST_AUTO_TEST_CASE(stZeroCallsRevertTestEIP158)
+//{
+//	dev::test::executeTests("stZeroCallsRevertTest", "/StateTests/EIP158", "/StateTestsFiller/EIP158", dev::test::doStateTests);
+//}
+//BOOST_AUTO_TEST_CASE(stCodeSizeLimitEIP158)
+//{
+//	dev::test::executeTests("stCodeSizeLimit", "/StateTests/EIP158", "/StateTestsFiller/EIP158", dev::test::doStateTests);
+//}
+//BOOST_AUTO_TEST_CASE(stCreateTestEIP158)
+//{
+//	dev::test::executeTests("stCreateTest", "/StateTests/EIP158", "/StateTestsFiller/EIP158", dev::test::doStateTests);
+//}
+//BOOST_AUTO_TEST_CASE(stEIP158SpecificTest)
+//{
+//	dev::test::executeTests("stEIP158SpecificTest", "/StateTests/EIP158", "/StateTestsFiller/EIP158", dev::test::doStateTests);
+//}
+//BOOST_AUTO_TEST_CASE(stNonZeroCallsTest)
+//{
+//	dev::test::executeTests("stNonZeroCallsTest", "/StateTests/EIP158", "/StateTestsFiller/EIP158", dev::test::doStateTests);
+//}
+//BOOST_AUTO_TEST_CASE(stZeroCallsTest)
+//{
+//	dev::test::executeTests("stZeroCallsTest", "/StateTests/EIP158", "/StateTestsFiller/EIP158", dev::test::doStateTests);
+//}
+//BOOST_AUTO_TEST_CASE(stChangedTestsEIP150)
+//{
+//	dev::test::executeTests("stChangedTests", "/StateTests/EIP158/EIP150", "/StateTestsFiller/EIP158/EIP150", dev::test::doStateTests);
+//}
+//BOOST_AUTO_TEST_CASE(stEIPsingleCodeGasPricesEIP150)
+//{
+//	dev::test::executeTests("stEIPsingleCodeGasPrices", "/StateTests/EIP158/EIP150", "/StateTestsFiller/EIP158/EIP150", dev::test::doStateTests);
+//}
+//BOOST_AUTO_TEST_CASE(stEIPSpecificTestEIP150)
+//{
+//	dev::test::executeTests("stEIPSpecificTest", "/StateTests/EIP158/EIP150", "/StateTestsFiller/EIP158/EIP150", dev::test::doStateTests);
+//}
+//BOOST_AUTO_TEST_CASE(stMemExpandingEIPCallsEIP150)
+//{
+//	dev::test::executeTests("stMemExpandingEIPCalls", "/StateTests/EIP158/EIP150", "/StateTestsFiller/EIP158/EIP150", dev::test::doStateTests);
+//}
+//BOOST_AUTO_TEST_CASE(stBoundsTestEIP)
+//{
+//	dev::test::executeTests("stBoundsTest", "/StateTests/EIP158/Homestead", "/StateTestsFiller/EIP158/Homestead", dev::test::doStateTests);
+//}
+//BOOST_AUTO_TEST_CASE(stHomeSteadSpecificEIP)
+//{
+//	dev::test::executeTests("stHomeSteadSpecific", "/StateTests/EIP158/Homestead", "/StateTestsFiller/EIP158/Homestead", dev::test::doStateTests);
+//}
+//BOOST_AUTO_TEST_CASE(stCallDelegateCodesCallCodeEIP)
+//{
+//	dev::test::executeTests("stCallDelegateCodesCallCode", "/StateTests/EIP158/Homestead", "/StateTestsFiller/EIP158/Homestead", dev::test::doStateTests);
+//}
+//BOOST_AUTO_TEST_CASE(stCallDelegateCodesEIP)
+//{
+//	dev::test::executeTests("stCallDelegateCodes", "/StateTests/EIP158/Homestead", "/StateTestsFiller/EIP158/Homestead", dev::test::doStateTests);
+//}
+//BOOST_AUTO_TEST_CASE(stDelegatecallTestEIP)
+//{
+//	dev::test::executeTests("stDelegatecallTest", "/StateTests/EIP158/Homestead", "/StateTestsFiller/EIP158/Homestead", dev::test::doStateTests);
+//}
+//BOOST_AUTO_TEST_CASE(stCallCodesEIP)
+//{
+//	dev::test::executeTests("stCallCodes", "/StateTests/EIP158/Homestead", "/StateTestsFiller/EIP158/Homestead", dev::test::doStateTests);
+//}
+//BOOST_AUTO_TEST_CASE(stSystemOperationsTestEIP)
+//{
+//	dev::test::executeTests("stSystemOperationsTest", "/StateTests/EIP158/Homestead", "/StateTestsFiller/EIP158/Homestead", dev::test::doStateTests);
+//}
+//BOOST_AUTO_TEST_CASE(stCallCreateCallCodeTestEIP)
+//{
+//	dev::test::executeTests("stCallCreateCallCodeTest", "/StateTests/EIP158/Homestead", "/StateTestsFiller/EIP158/Homestead", dev::test::doStateTests);
+//}
+//BOOST_AUTO_TEST_CASE(stPreCompiledContractsEIP)
+//{
+//	dev::test::executeTests("stPreCompiledContracts", "/StateTests/EIP158/Homestead", "/StateTestsFiller/EIP158/Homestead", dev::test::doStateTests);
+//}
+//BOOST_AUTO_TEST_CASE(stLogTestsEIP)
+//{
+//	dev::test::executeTests("stLogTests", "/StateTests/EIP158/Homestead", "/StateTestsFiller/EIP158/Homestead", dev::test::doStateTests);
+//}
+//BOOST_AUTO_TEST_CASE(stRecursiveCreateEIP)
+//{
+//	dev::test::executeTests("stRecursiveCreate", "/StateTests/EIP158/Homestead", "/StateTestsFiller/EIP158/Homestead", dev::test::doStateTests);
+//}
+//BOOST_AUTO_TEST_CASE(stInitCodeTestEIP)
+//{
+//	dev::test::executeTests("stInitCodeTest", "/StateTests/EIP158/Homestead", "/StateTestsFiller/EIP158/Homestead", dev::test::doStateTests);
+//}
+//BOOST_AUTO_TEST_CASE(stTransactionTestEIP)
+//{
+//	dev::test::executeTests("stTransactionTest", "/StateTests/EIP158/Homestead", "/StateTestsFiller/EIP158/Homestead", dev::test::doStateTests);
+//}
+//BOOST_AUTO_TEST_CASE(stSpecialTestEIP)
+//{
+//	dev::test::executeTests("stSpecialTest", "/StateTests/EIP158/Homestead", "/StateTestsFiller/EIP158/Homestead", dev::test::doStateTests);
+//}
+//BOOST_AUTO_TEST_CASE(stRefundTestEIP)
+//{
+//	dev::test::executeTests("stRefundTest", "/StateTests/EIP158/Homestead", "/StateTestsFiller/EIP158/Homestead", dev::test::doStateTests);
+//}
+//BOOST_AUTO_TEST_CASE(stQuadraticComplexityTestEIP)
+//{
+//	if (test::Options::get().quadratic)
+//		dev::test::executeTests("stQuadraticComplexityTest", "/StateTests/EIP158/Homestead", "/StateTestsFiller/EIP158/Homestead", dev::test::doStateTests);
+//}
+//BOOST_AUTO_TEST_CASE(stMemoryStressTestEIP)
+//{
+//	if (test::Options::get().memory)
+//		dev::test::executeTests("stMemoryStressTest", "/StateTests/EIP158/Homestead", "/StateTestsFiller/EIP158/Homestead", dev::test::doStateTests);
+//}
+//BOOST_AUTO_TEST_CASE(stMemoryTestEIP)
+//{
+//	dev::test::executeTests("stMemoryTest", "/StateTests/EIP158/Homestead", "/StateTestsFiller/EIP158/Homestead", dev::test::doStateTests);
+//}
+//BOOST_AUTO_TEST_CASE(stWalletTestEIP)
+//{
+//	dev::test::executeTests("stWalletTest", "/StateTests/EIP158/Homestead", "/StateTestsFiller/EIP158/Homestead", dev::test::doStateTests);
+//}
+//BOOST_AUTO_TEST_SUITE_END()
 
-BOOST_AUTO_TEST_SUITE(StateTestsEIP)
-BOOST_AUTO_TEST_CASE(stChangedOnEIPTest)
-{
-	dev::test::executeTests("stChangedTests", "/StateTests/EIP150", "/StateTestsFiller/EIP150", dev::test::doStateTests);
-}
-BOOST_AUTO_TEST_CASE(stEIPSpecificTest)
-{
-	dev::test::executeTests("stEIPSpecificTest", "/StateTests/EIP150", "/StateTestsFiller/EIP150", dev::test::doStateTests);
-}
-BOOST_AUTO_TEST_CASE(stEIPsingleCodeGasPrices)
-{
-	dev::test::executeTests("stEIPsingleCodeGasPrices", "/StateTests/EIP150", "/StateTestsFiller/EIP150", dev::test::doStateTests);
-}
-BOOST_AUTO_TEST_CASE(stMemExpandingEIPCalls)
-{
-	dev::test::executeTests("stMemExpandingEIPCalls", "/StateTests/EIP150", "/StateTestsFiller/EIP150", dev::test::doStateTests);
-}
-BOOST_AUTO_TEST_CASE(stBoundsTestEIP)
-{
-	dev::test::executeTests("stBoundsTest", "/StateTests/EIP150/Homestead", "/StateTestsFiller/EIP150/Homestead", dev::test::doStateTests);
-}
-BOOST_AUTO_TEST_CASE(stHomeSteadSpecificEIP)
-{
-	dev::test::executeTests("stHomeSteadSpecific", "/StateTests/EIP150/Homestead", "/StateTestsFiller/EIP150/Homestead", dev::test::doStateTests);
-}
-BOOST_AUTO_TEST_CASE(stCallDelegateCodesCallCodeEIP)
-{
-	dev::test::executeTests("stCallDelegateCodesCallCode", "/StateTests/EIP150/Homestead", "/StateTestsFiller/EIP150/Homestead", dev::test::doStateTests);
-}
-BOOST_AUTO_TEST_CASE(stCallDelegateCodesEIP)
-{
-	dev::test::executeTests("stCallDelegateCodes", "/StateTests/EIP150/Homestead", "/StateTestsFiller/EIP150/Homestead", dev::test::doStateTests);
-}
-BOOST_AUTO_TEST_CASE(stDelegatecallTestEIP)
-{
-	dev::test::executeTests("stDelegatecallTest", "/StateTests/EIP150/Homestead", "/StateTestsFiller/EIP150/Homestead", dev::test::doStateTests);
-}
-BOOST_AUTO_TEST_CASE(stCallCodesEIP)
-{
-	dev::test::executeTests("stCallCodes", "/StateTests/EIP150/Homestead", "/StateTestsFiller/EIP150/Homestead", dev::test::doStateTests);
-}
-BOOST_AUTO_TEST_CASE(stSystemOperationsTestEIP)
-{
-	dev::test::executeTests("stSystemOperationsTest", "/StateTests/EIP150/Homestead", "/StateTestsFiller/EIP150/Homestead", dev::test::doStateTests);
-}
-BOOST_AUTO_TEST_CASE(stCallCreateCallCodeTestEIP)
-{
-	dev::test::executeTests("stCallCreateCallCodeTest", "/StateTests/EIP150/Homestead", "/StateTestsFiller/EIP150/Homestead", dev::test::doStateTests);
-}
-BOOST_AUTO_TEST_CASE(stPreCompiledContractsEIP)
-{
-	dev::test::executeTests("stPreCompiledContracts", "/StateTests/EIP150/Homestead", "/StateTestsFiller/EIP150/Homestead", dev::test::doStateTests);
-}
-BOOST_AUTO_TEST_CASE(stLogTestsEIP)
-{
-	dev::test::executeTests("stLogTests", "/StateTests/EIP150/Homestead", "/StateTestsFiller/EIP150/Homestead", dev::test::doStateTests);
-}
-BOOST_AUTO_TEST_CASE(stRecursiveCreateEIP)
-{
-	dev::test::executeTests("stRecursiveCreate", "/StateTests/EIP150/Homestead", "/StateTestsFiller/EIP150/Homestead", dev::test::doStateTests);
-}
-BOOST_AUTO_TEST_CASE(stInitCodeTestEIP)
-{
-	dev::test::executeTests("stInitCodeTest", "/StateTests/EIP150/Homestead", "/StateTestsFiller/EIP150/Homestead", dev::test::doStateTests);
-}
-BOOST_AUTO_TEST_CASE(stTransactionTestEIP)
-{
-	dev::test::executeTests("stTransactionTest", "/StateTests/EIP150/Homestead", "/StateTestsFiller/EIP150/Homestead", dev::test::doStateTests);
-}
-BOOST_AUTO_TEST_CASE(stSpecialTestEIP)
-{
-	dev::test::executeTests("stSpecialTest", "/StateTests/EIP150/Homestead", "/StateTestsFiller/EIP150/Homestead", dev::test::doStateTests);
-}
-BOOST_AUTO_TEST_CASE(stRefundTestEIP)
-{
-	dev::test::executeTests("stRefundTest", "/StateTests/EIP150/Homestead", "/StateTestsFiller/EIP150/Homestead", dev::test::doStateTests);
-}
-BOOST_AUTO_TEST_CASE(stQuadraticComplexityTestEIP)
-{
-	if (test::Options::get().quadratic)
-		dev::test::executeTests("stQuadraticComplexityTest", "/StateTests/EIP150/Homestead", "/StateTestsFiller/EIP150/Homestead", dev::test::doStateTests);
-}
-BOOST_AUTO_TEST_CASE(stMemoryStressTestEIP)
-{
-	if (test::Options::get().memory)
-		dev::test::executeTests("stMemoryStressTest", "/StateTests/EIP150/Homestead", "/StateTestsFiller/EIP150/Homestead", dev::test::doStateTests);
-}
-BOOST_AUTO_TEST_CASE(stMemoryTestEIP)
-{
-	dev::test::executeTests("stMemoryTest", "/StateTests/EIP150/Homestead", "/StateTestsFiller/EIP150/Homestead", dev::test::doStateTests);
-}
-BOOST_AUTO_TEST_CASE(stWalletTestEIP)
-{
-	dev::test::executeTests("stWalletTest", "/StateTests/EIP150/Homestead", "/StateTestsFiller/EIP150/Homestead", dev::test::doStateTests);
-}
-BOOST_AUTO_TEST_SUITE_END()
+//BOOST_AUTO_TEST_SUITE(StateTestsEIP)
+//BOOST_AUTO_TEST_CASE(stChangedOnEIPTest)
+//{
+//	dev::test::executeTests("stChangedTests", "/StateTests/EIP150", "/StateTestsFiller/EIP150", dev::test::doStateTests);
+//}
+//BOOST_AUTO_TEST_CASE(stEIPSpecificTest)
+//{
+//	dev::test::executeTests("stEIPSpecificTest", "/StateTests/EIP150", "/StateTestsFiller/EIP150", dev::test::doStateTests);
+//}
+//BOOST_AUTO_TEST_CASE(stEIPsingleCodeGasPrices)
+//{
+//	dev::test::executeTests("stEIPsingleCodeGasPrices", "/StateTests/EIP150", "/StateTestsFiller/EIP150", dev::test::doStateTests);
+//}
+//BOOST_AUTO_TEST_CASE(stMemExpandingEIPCalls)
+//{
+//	dev::test::executeTests("stMemExpandingEIPCalls", "/StateTests/EIP150", "/StateTestsFiller/EIP150", dev::test::doStateTests);
+//}
+//BOOST_AUTO_TEST_CASE(stBoundsTestEIP)
+//{
+//	dev::test::executeTests("stBoundsTest", "/StateTests/EIP150/Homestead", "/StateTestsFiller/EIP150/Homestead", dev::test::doStateTests);
+//}
+//BOOST_AUTO_TEST_CASE(stHomeSteadSpecificEIP)
+//{
+//	dev::test::executeTests("stHomeSteadSpecific", "/StateTests/EIP150/Homestead", "/StateTestsFiller/EIP150/Homestead", dev::test::doStateTests);
+//}
+//BOOST_AUTO_TEST_CASE(stCallDelegateCodesCallCodeEIP)
+//{
+//	dev::test::executeTests("stCallDelegateCodesCallCode", "/StateTests/EIP150/Homestead", "/StateTestsFiller/EIP150/Homestead", dev::test::doStateTests);
+//}
+//BOOST_AUTO_TEST_CASE(stCallDelegateCodesEIP)
+//{
+//	dev::test::executeTests("stCallDelegateCodes", "/StateTests/EIP150/Homestead", "/StateTestsFiller/EIP150/Homestead", dev::test::doStateTests);
+//}
+//BOOST_AUTO_TEST_CASE(stDelegatecallTestEIP)
+//{
+//	dev::test::executeTests("stDelegatecallTest", "/StateTests/EIP150/Homestead", "/StateTestsFiller/EIP150/Homestead", dev::test::doStateTests);
+//}
+//BOOST_AUTO_TEST_CASE(stCallCodesEIP)
+//{
+//	dev::test::executeTests("stCallCodes", "/StateTests/EIP150/Homestead", "/StateTestsFiller/EIP150/Homestead", dev::test::doStateTests);
+//}
+//BOOST_AUTO_TEST_CASE(stSystemOperationsTestEIP)
+//{
+//	dev::test::executeTests("stSystemOperationsTest", "/StateTests/EIP150/Homestead", "/StateTestsFiller/EIP150/Homestead", dev::test::doStateTests);
+//}
+//BOOST_AUTO_TEST_CASE(stCallCreateCallCodeTestEIP)
+//{
+//	dev::test::executeTests("stCallCreateCallCodeTest", "/StateTests/EIP150/Homestead", "/StateTestsFiller/EIP150/Homestead", dev::test::doStateTests);
+//}
+//BOOST_AUTO_TEST_CASE(stPreCompiledContractsEIP)
+//{
+//	dev::test::executeTests("stPreCompiledContracts", "/StateTests/EIP150/Homestead", "/StateTestsFiller/EIP150/Homestead", dev::test::doStateTests);
+//}
+//BOOST_AUTO_TEST_CASE(stLogTestsEIP)
+//{
+//	dev::test::executeTests("stLogTests", "/StateTests/EIP150/Homestead", "/StateTestsFiller/EIP150/Homestead", dev::test::doStateTests);
+//}
+//BOOST_AUTO_TEST_CASE(stRecursiveCreateEIP)
+//{
+//	dev::test::executeTests("stRecursiveCreate", "/StateTests/EIP150/Homestead", "/StateTestsFiller/EIP150/Homestead", dev::test::doStateTests);
+//}
+//BOOST_AUTO_TEST_CASE(stInitCodeTestEIP)
+//{
+//	dev::test::executeTests("stInitCodeTest", "/StateTests/EIP150/Homestead", "/StateTestsFiller/EIP150/Homestead", dev::test::doStateTests);
+//}
+//BOOST_AUTO_TEST_CASE(stTransactionTestEIP)
+//{
+//	dev::test::executeTests("stTransactionTest", "/StateTests/EIP150/Homestead", "/StateTestsFiller/EIP150/Homestead", dev::test::doStateTests);
+//}
+//BOOST_AUTO_TEST_CASE(stSpecialTestEIP)
+//{
+//	dev::test::executeTests("stSpecialTest", "/StateTests/EIP150/Homestead", "/StateTestsFiller/EIP150/Homestead", dev::test::doStateTests);
+//}
+//BOOST_AUTO_TEST_CASE(stRefundTestEIP)
+//{
+//	dev::test::executeTests("stRefundTest", "/StateTests/EIP150/Homestead", "/StateTestsFiller/EIP150/Homestead", dev::test::doStateTests);
+//}
+//BOOST_AUTO_TEST_CASE(stQuadraticComplexityTestEIP)
+//{
+//	if (test::Options::get().quadratic)
+//		dev::test::executeTests("stQuadraticComplexityTest", "/StateTests/EIP150/Homestead", "/StateTestsFiller/EIP150/Homestead", dev::test::doStateTests);
+//}
+//BOOST_AUTO_TEST_CASE(stMemoryStressTestEIP)
+//{
+//	if (test::Options::get().memory)
+//		dev::test::executeTests("stMemoryStressTest", "/StateTests/EIP150/Homestead", "/StateTestsFiller/EIP150/Homestead", dev::test::doStateTests);
+//}
+//BOOST_AUTO_TEST_CASE(stMemoryTestEIP)
+//{
+//	dev::test::executeTests("stMemoryTest", "/StateTests/EIP150/Homestead", "/StateTestsFiller/EIP150/Homestead", dev::test::doStateTests);
+//}
+//BOOST_AUTO_TEST_CASE(stWalletTestEIP)
+//{
+//	dev::test::executeTests("stWalletTest", "/StateTests/EIP150/Homestead", "/StateTestsFiller/EIP150/Homestead", dev::test::doStateTests);
+//}
+//BOOST_AUTO_TEST_SUITE_END()
 
-BOOST_AUTO_TEST_SUITE(StateTestsHomestead)
-BOOST_AUTO_TEST_CASE(stZeroCallsRevertTest)
-{
-	dev::test::executeTests("stZeroCallsRevertTest", "/StateTests/Homestead", "/StateTestsFiller/Homestead", dev::test::doStateTests);
-}
-BOOST_AUTO_TEST_CASE(stBoundsTestHomestead)
-{
-	dev::test::executeTests("stBoundsTest", "/StateTests/Homestead", "/StateTestsFiller/Homestead", dev::test::doStateTests);
-}
+//BOOST_AUTO_TEST_SUITE(StateTestsHomestead)
+//BOOST_AUTO_TEST_CASE(stZeroCallsRevertTest)
+//{
+//	dev::test::executeTests("stZeroCallsRevertTest", "/StateTests/Homestead", "/StateTestsFiller/Homestead", dev::test::doStateTests);
+//}
+//BOOST_AUTO_TEST_CASE(stBoundsTestHomestead)
+//{
+//	dev::test::executeTests("stBoundsTest", "/StateTests/Homestead", "/StateTestsFiller/Homestead", dev::test::doStateTests);
+//}
 
-BOOST_AUTO_TEST_CASE(stHomeSteadSpecific)
-{
-	dev::test::executeTests("stHomeSteadSpecific", "/StateTests/Homestead", "/StateTestsFiller/Homestead", dev::test::doStateTests);
-}
+//BOOST_AUTO_TEST_CASE(stHomeSteadSpecific)
+//{
+//	dev::test::executeTests("stHomeSteadSpecific", "/StateTests/Homestead", "/StateTestsFiller/Homestead", dev::test::doStateTests);
+//}
 
-BOOST_AUTO_TEST_CASE(stCallDelegateCodesCallCodeHomestead)
-{
-	dev::test::executeTests("stCallDelegateCodesCallCode", "/StateTests/Homestead", "/StateTestsFiller/Homestead", dev::test::doStateTests);
-}
+//BOOST_AUTO_TEST_CASE(stCallDelegateCodesCallCodeHomestead)
+//{
+//	dev::test::executeTests("stCallDelegateCodesCallCode", "/StateTests/Homestead", "/StateTestsFiller/Homestead", dev::test::doStateTests);
+//}
 
-BOOST_AUTO_TEST_CASE(stCallDelegateCodesHomestead)
-{
-	dev::test::executeTests("stCallDelegateCodes", "/StateTests/Homestead", "/StateTestsFiller/Homestead", dev::test::doStateTests);
-}
+//BOOST_AUTO_TEST_CASE(stCallDelegateCodesHomestead)
+//{
+//	dev::test::executeTests("stCallDelegateCodes", "/StateTests/Homestead", "/StateTestsFiller/Homestead", dev::test::doStateTests);
+//}
 
-BOOST_AUTO_TEST_CASE(stDelegatecallTestHomestead)
-{
-	dev::test::executeTests("stDelegatecallTest", "/StateTests/Homestead", "/StateTestsFiller/Homestead", dev::test::doStateTests);
-}
+//BOOST_AUTO_TEST_CASE(stDelegatecallTestHomestead)
+//{
+//	dev::test::executeTests("stDelegatecallTest", "/StateTests/Homestead", "/StateTestsFiller/Homestead", dev::test::doStateTests);
+//}
 
-BOOST_AUTO_TEST_CASE(stCallCodesHomestead)
-{
-	dev::test::executeTests("stCallCodes", "/StateTests/Homestead", "/StateTestsFiller/Homestead", dev::test::doStateTests);
-}
+//BOOST_AUTO_TEST_CASE(stCallCodesHomestead)
+//{
+//	dev::test::executeTests("stCallCodes", "/StateTests/Homestead", "/StateTestsFiller/Homestead", dev::test::doStateTests);
+//}
 
-BOOST_AUTO_TEST_CASE(stSystemOperationsTestHomestead)
-{
-	dev::test::executeTests("stSystemOperationsTest", "/StateTests/Homestead", "/StateTestsFiller/Homestead", dev::test::doStateTests);
-}
+//BOOST_AUTO_TEST_CASE(stSystemOperationsTestHomestead)
+//{
+//	dev::test::executeTests("stSystemOperationsTest", "/StateTests/Homestead", "/StateTestsFiller/Homestead", dev::test::doStateTests);
+//}
 
-BOOST_AUTO_TEST_CASE(stCallCreateCallCodeTestHomestead)
-{
-	dev::test::executeTests("stCallCreateCallCodeTest", "/StateTests/Homestead", "/StateTestsFiller/Homestead", dev::test::doStateTests);
-}
+//BOOST_AUTO_TEST_CASE(stCallCreateCallCodeTestHomestead)
+//{
+//	dev::test::executeTests("stCallCreateCallCodeTest", "/StateTests/Homestead", "/StateTestsFiller/Homestead", dev::test::doStateTests);
+//}
 
-BOOST_AUTO_TEST_CASE(stPreCompiledContractsHomestead)
-{
-	dev::test::executeTests("stPreCompiledContracts", "/StateTests/Homestead", "/StateTestsFiller/Homestead", dev::test::doStateTests);
-}
+//BOOST_AUTO_TEST_CASE(stPreCompiledContractsHomestead)
+//{
+//	dev::test::executeTests("stPreCompiledContracts", "/StateTests/Homestead", "/StateTestsFiller/Homestead", dev::test::doStateTests);
+//}
 
-BOOST_AUTO_TEST_CASE(stLogTestsHomestead)
-{
-	dev::test::executeTests("stLogTests", "/StateTests/Homestead", "/StateTestsFiller/Homestead", dev::test::doStateTests);
-}
+//BOOST_AUTO_TEST_CASE(stLogTestsHomestead)
+//{
+//	dev::test::executeTests("stLogTests", "/StateTests/Homestead", "/StateTestsFiller/Homestead", dev::test::doStateTests);
+//}
 
-BOOST_AUTO_TEST_CASE(stRecursiveCreateHomestead)
-{
-	dev::test::executeTests("stRecursiveCreate", "/StateTests/Homestead", "/StateTestsFiller/Homestead", dev::test::doStateTests);
-}
+//BOOST_AUTO_TEST_CASE(stRecursiveCreateHomestead)
+//{
+//	dev::test::executeTests("stRecursiveCreate", "/StateTests/Homestead", "/StateTestsFiller/Homestead", dev::test::doStateTests);
+//}
 
-BOOST_AUTO_TEST_CASE(stInitCodeTestHomestead)
-{
-	dev::test::executeTests("stInitCodeTest", "/StateTests/Homestead", "/StateTestsFiller/Homestead", dev::test::doStateTests);
-}
+//BOOST_AUTO_TEST_CASE(stInitCodeTestHomestead)
+//{
+//	dev::test::executeTests("stInitCodeTest", "/StateTests/Homestead", "/StateTestsFiller/Homestead", dev::test::doStateTests);
+//}
 
-BOOST_AUTO_TEST_CASE(stTransactionTestHomestead)
-{
-	dev::test::executeTests("stTransactionTest", "/StateTests/Homestead", "/StateTestsFiller/Homestead", dev::test::doStateTests);
-}
+//BOOST_AUTO_TEST_CASE(stTransactionTestHomestead)
+//{
+//	dev::test::executeTests("stTransactionTest", "/StateTests/Homestead", "/StateTestsFiller/Homestead", dev::test::doStateTests);
+//}
 
-BOOST_AUTO_TEST_CASE(stSpecialTestHomestead)
-{
-	dev::test::executeTests("stSpecialTest", "/StateTests/Homestead", "/StateTestsFiller/Homestead", dev::test::doStateTests);
-}
+//BOOST_AUTO_TEST_CASE(stSpecialTestHomestead)
+//{
+//	dev::test::executeTests("stSpecialTest", "/StateTests/Homestead", "/StateTestsFiller/Homestead", dev::test::doStateTests);
+//}
 
-BOOST_AUTO_TEST_CASE(stRefundTestHomestead)
-{
-	dev::test::executeTests("stRefundTest", "/StateTests/Homestead", "/StateTestsFiller/Homestead", dev::test::doStateTests);
-}
+//BOOST_AUTO_TEST_CASE(stRefundTestHomestead)
+//{
+//	dev::test::executeTests("stRefundTest", "/StateTests/Homestead", "/StateTestsFiller/Homestead", dev::test::doStateTests);
+//}
 
-BOOST_AUTO_TEST_CASE(stQuadraticComplexityTestHomestead)
-{
-	if (test::Options::get().quadratic)
-		dev::test::executeTests("stQuadraticComplexityTest", "/StateTests/Homestead", "/StateTestsFiller/Homestead", dev::test::doStateTests);
-}
+//BOOST_AUTO_TEST_CASE(stQuadraticComplexityTestHomestead)
+//{
+//	if (test::Options::get().quadratic)
+//		dev::test::executeTests("stQuadraticComplexityTest", "/StateTests/Homestead", "/StateTestsFiller/Homestead", dev::test::doStateTests);
+//}
 
-BOOST_AUTO_TEST_CASE(stMemoryStressTestHomestead)
-{
-	if (test::Options::get().memory)
-		dev::test::executeTests("stMemoryStressTest", "/StateTests/Homestead", "/StateTestsFiller/Homestead", dev::test::doStateTests);
-}
+//BOOST_AUTO_TEST_CASE(stMemoryStressTestHomestead)
+//{
+//	if (test::Options::get().memory)
+//		dev::test::executeTests("stMemoryStressTest", "/StateTests/Homestead", "/StateTestsFiller/Homestead", dev::test::doStateTests);
+//}
 
-BOOST_AUTO_TEST_CASE(stMemoryTestHomestead)
-{
-	dev::test::executeTests("stMemoryTest", "/StateTests/Homestead", "/StateTestsFiller/Homestead", dev::test::doStateTests);
-}
+//BOOST_AUTO_TEST_CASE(stMemoryTestHomestead)
+//{
+//	dev::test::executeTests("stMemoryTest", "/StateTests/Homestead", "/StateTestsFiller/Homestead", dev::test::doStateTests);
+//}
 
-BOOST_AUTO_TEST_CASE(stWalletTestHomestead)
-{
-	dev::test::executeTests("stWalletTest", "/StateTests/Homestead", "/StateTestsFiller/Homestead", dev::test::doStateTests);
-}
+//BOOST_AUTO_TEST_CASE(stWalletTestHomestead)
+//{
+//	dev::test::executeTests("stWalletTest", "/StateTests/Homestead", "/StateTestsFiller/Homestead", dev::test::doStateTests);
+//}
 
-BOOST_AUTO_TEST_SUITE_END()
+//BOOST_AUTO_TEST_SUITE_END()
 
 
-BOOST_AUTO_TEST_SUITE(StateTests)
-BOOST_AUTO_TEST_CASE(stCallCodes)
-{
-	dev::test::executeTests("stCallCodes", "/StateTests", "/StateTestsFiller", dev::test::doStateTests);
-}
+//BOOST_AUTO_TEST_SUITE(StateTests)
+//BOOST_AUTO_TEST_CASE(stCallCodes)
+//{
+//	dev::test::executeTests("stCallCodes", "/StateTests", "/StateTestsFiller", dev::test::doStateTests);
+//}
 
-BOOST_AUTO_TEST_CASE(stExample)
-{
-	dev::test::executeTests("stExample", "/StateTests", "/StateTestsFiller", dev::test::doStateTests);
-}
+//BOOST_AUTO_TEST_CASE(stExample)
+//{
+//	dev::test::executeTests("stExample", "/StateTests", "/StateTestsFiller", dev::test::doStateTests);
+//}
 
-BOOST_AUTO_TEST_CASE(stSystemOperationsTest)
-{
-	dev::test::executeTests("stSystemOperationsTest", "/StateTests", "/StateTestsFiller", dev::test::doStateTests);
-}
+//BOOST_AUTO_TEST_CASE(stSystemOperationsTest)
+//{
+//	dev::test::executeTests("stSystemOperationsTest", "/StateTests", "/StateTestsFiller", dev::test::doStateTests);
+//}
 
-BOOST_AUTO_TEST_CASE(stCallCreateCallCodeTest)
-{
-	dev::test::executeTests("stCallCreateCallCodeTest", "/StateTests", "/StateTestsFiller", dev::test::doStateTests);
-}
+//BOOST_AUTO_TEST_CASE(stCallCreateCallCodeTest)
+//{
+//	dev::test::executeTests("stCallCreateCallCodeTest", "/StateTests", "/StateTestsFiller", dev::test::doStateTests);
+//}
 
-BOOST_AUTO_TEST_CASE(stPreCompiledContracts)
-{
-	dev::test::executeTests("stPreCompiledContracts", "/StateTests", "/StateTestsFiller", dev::test::doStateTests);
-}
+//BOOST_AUTO_TEST_CASE(stPreCompiledContracts)
+//{
+//	dev::test::executeTests("stPreCompiledContracts", "/StateTests", "/StateTestsFiller", dev::test::doStateTests);
+//}
 
-BOOST_AUTO_TEST_CASE(stLogTests)
-{
-	dev::test::executeTests("stLogTests", "/StateTests", "/StateTestsFiller", dev::test::doStateTests);
-}
+//BOOST_AUTO_TEST_CASE(stLogTests)
+//{
+//	dev::test::executeTests("stLogTests", "/StateTests", "/StateTestsFiller", dev::test::doStateTests);
+//}
 
-BOOST_AUTO_TEST_CASE(stRecursiveCreate)
-{
-	dev::test::executeTests("stRecursiveCreate", "/StateTests", "/StateTestsFiller", dev::test::doStateTests);
-}
+//BOOST_AUTO_TEST_CASE(stRecursiveCreate)
+//{
+//	dev::test::executeTests("stRecursiveCreate", "/StateTests", "/StateTestsFiller", dev::test::doStateTests);
+//}
 
-BOOST_AUTO_TEST_CASE(stInitCodeTest)
-{
-	dev::test::executeTests("stInitCodeTest", "/StateTests", "/StateTestsFiller", dev::test::doStateTests);
-}
+//BOOST_AUTO_TEST_CASE(stInitCodeTest)
+//{
+//	dev::test::executeTests("stInitCodeTest", "/StateTests", "/StateTestsFiller", dev::test::doStateTests);
+//}
 
-BOOST_AUTO_TEST_CASE(stTransactionTest)
-{
-	dev::test::executeTests("stTransactionTest", "/StateTests", "/StateTestsFiller", dev::test::doStateTests);
-}
+//BOOST_AUTO_TEST_CASE(stTransactionTest)
+//{
+//	dev::test::executeTests("stTransactionTest", "/StateTests", "/StateTestsFiller", dev::test::doStateTests);
+//}
 
-BOOST_AUTO_TEST_CASE(stSpecialTest)
-{
-	dev::test::executeTests("stSpecialTest", "/StateTests", "/StateTestsFiller", dev::test::doStateTests);
-}
+//BOOST_AUTO_TEST_CASE(stSpecialTest)
+//{
+//	dev::test::executeTests("stSpecialTest", "/StateTests", "/StateTestsFiller", dev::test::doStateTests);
+//}
 
-BOOST_AUTO_TEST_CASE(stRefundTest)
-{
-	dev::test::executeTests("stRefundTest", "/StateTests", "/StateTestsFiller", dev::test::doStateTests);
-}
+//BOOST_AUTO_TEST_CASE(stRefundTest)
+//{
+//	dev::test::executeTests("stRefundTest", "/StateTests", "/StateTestsFiller", dev::test::doStateTests);
+//}
 
-BOOST_AUTO_TEST_CASE(stBlockHashTest)
-{
-	dev::test::executeTests("stBlockHashTest", "/StateTests", "/StateTestsFiller", dev::test::doStateTests);
-}
+//BOOST_AUTO_TEST_CASE(stBlockHashTest)
+//{
+//	dev::test::executeTests("stBlockHashTest", "/StateTests", "/StateTestsFiller", dev::test::doStateTests);
+//}
 
-BOOST_AUTO_TEST_CASE(stQuadraticComplexityTest)
-{
-	if (test::Options::get().quadratic)
-		dev::test::executeTests("stQuadraticComplexityTest", "/StateTests", "/StateTestsFiller", dev::test::doStateTests);
-}
+//BOOST_AUTO_TEST_CASE(stQuadraticComplexityTest)
+//{
+//	if (test::Options::get().quadratic)
+//		dev::test::executeTests("stQuadraticComplexityTest", "/StateTests", "/StateTestsFiller", dev::test::doStateTests);
+//}
 
-BOOST_AUTO_TEST_CASE(stMemoryStressTest)
-{
-	if (test::Options::get().memory)
-		dev::test::executeTests("stMemoryStressTest", "/StateTests", "/StateTestsFiller", dev::test::doStateTests);
-}
+//BOOST_AUTO_TEST_CASE(stMemoryStressTest)
+//{
+//	if (test::Options::get().memory)
+//		dev::test::executeTests("stMemoryStressTest", "/StateTests", "/StateTestsFiller", dev::test::doStateTests);
+//}
 
-BOOST_AUTO_TEST_CASE(stSolidityTest)
-{
-	dev::test::executeTests("stSolidityTest", "/StateTests", "/StateTestsFiller", dev::test::doStateTests);
-}
+//BOOST_AUTO_TEST_CASE(stSolidityTest)
+//{
+//	dev::test::executeTests("stSolidityTest", "/StateTests", "/StateTestsFiller", dev::test::doStateTests);
+//}
 
-BOOST_AUTO_TEST_CASE(stMemoryTest)
-{
-	dev::test::executeTests("stMemoryTest", "/StateTests", "/StateTestsFiller", dev::test::doStateTests);
-}
+//BOOST_AUTO_TEST_CASE(stMemoryTest)
+//{
+//	dev::test::executeTests("stMemoryTest", "/StateTests", "/StateTestsFiller", dev::test::doStateTests);
+//}
 
-BOOST_AUTO_TEST_CASE(stWalletTest)
-{
-	dev::test::executeTests("stWalletTest", "/StateTests", "/StateTestsFiller", dev::test::doStateTests);
-}
+//BOOST_AUTO_TEST_CASE(stWalletTest)
+//{
+//	dev::test::executeTests("stWalletTest", "/StateTests", "/StateTestsFiller", dev::test::doStateTests);
+//}
 
-BOOST_AUTO_TEST_CASE(stTransitionTest)
-{
-	dev::test::executeTests("stTransitionTest", "/StateTests", "/StateTestsFiller", dev::test::doStateTests);
-}
+//BOOST_AUTO_TEST_CASE(stTransitionTest)
+//{
+//	dev::test::executeTests("stTransitionTest", "/StateTests", "/StateTestsFiller", dev::test::doStateTests);
+//}
 
-//todo: Force stRandom to be tested on Homestead Seal Engine ?
-BOOST_AUTO_TEST_CASE(stRandom)
-{
-	test::Options::get(); // parse command line options, e.g. to enable JIT
-	string testPath = dev::test::getTestPath() + "/StateTests/RandomTests";
-	string fillersPath = dev::test::getTestPath() + "/src/StateTestsFiller/RandomTests";
+////todo: Force stRandom to be tested on Homestead Seal Engine ?
+//BOOST_AUTO_TEST_CASE(stRandom)
+//{
+//	test::Options::get(); // parse command line options, e.g. to enable JIT
+//	string testPath = dev::test::getTestPath() + "/StateTests/RandomTests";
+//	string fillersPath = dev::test::getTestPath() + "/src/StateTestsFiller/RandomTests";
 
-	if (dev::test::Options::get().fillTests)
-	{
-		test::TestOutputHelper::initTest();
-		vector<boost::filesystem::path> testFiles;
-		boost::filesystem::directory_iterator iterator(fillersPath);
-		for(; iterator != boost::filesystem::directory_iterator(); ++iterator)
-			if (boost::filesystem::is_regular_file(iterator->path()) && iterator->path().extension() == ".json")
-			{
-				if (test::Options::get().singleTest)
-				{
-					string fileboost = iterator->path().filename().string();
-					string filesingletest = test::Options::get().singleTestName; //parse singletest as a filename of random test
-					if (fileboost == filesingletest || fileboost.substr(0, fileboost.length()-5) == filesingletest)
-						testFiles.push_back(iterator->path());
-				}
-				else
-					testFiles.push_back(iterator->path());
-			}
+//	if (dev::test::Options::get().fillTests)
+//	{
+//		test::TestOutputHelper::initTest();
+//		vector<boost::filesystem::path> testFiles;
+//		boost::filesystem::directory_iterator iterator(fillersPath);
+//		for(; iterator != boost::filesystem::directory_iterator(); ++iterator)
+//			if (boost::filesystem::is_regular_file(iterator->path()) && iterator->path().extension() == ".json")
+//			{
+//				if (test::Options::get().singleTest)
+//				{
+//					string fileboost = iterator->path().filename().string();
+//					string filesingletest = test::Options::get().singleTestName; //parse singletest as a filename of random test
+//					if (fileboost == filesingletest || fileboost.substr(0, fileboost.length()-5) == filesingletest)
+//						testFiles.push_back(iterator->path());
+//				}
+//				else
+//					testFiles.push_back(iterator->path());
+//			}
 
-		test::TestOutputHelper::setMaxTests(testFiles.size() * 2);
-		for (auto& path: testFiles)
-		{
-			std::string filename = path.filename().string();
-			test::TestOutputHelper::setCurrentTestFileName(filename);
-			filename = filename.substr(0, filename.length() - 5); //without .json
-			dev::test::executeTests(filename, "/StateTests/RandomTests", "/StateTestsFiller/RandomTests", dev::test::doStateTests, false);
-		}
-		return; //executeTests has already run test after filling
-	}
+//		test::TestOutputHelper::setMaxTests(testFiles.size() * 2);
+//		for (auto& path: testFiles)
+//		{
+//			std::string filename = path.filename().string();
+//			test::TestOutputHelper::setCurrentTestFileName(filename);
+//			filename = filename.substr(0, filename.length() - 5); //without .json
+//			dev::test::executeTests(filename, "/StateTests/RandomTests", "/StateTestsFiller/RandomTests", dev::test::doStateTests, false);
+//		}
+//		return; //executeTests has already run test after filling
+//	}
 
-	vector<boost::filesystem::path> testFiles;
-	boost::filesystem::directory_iterator iterator(testPath);
-	for(; iterator != boost::filesystem::directory_iterator(); ++iterator)
-		if (boost::filesystem::is_regular_file(iterator->path()) && iterator->path().extension() == ".json")
-		{
-			if (test::Options::get().singleTest)
-			{
-				string fileboost = iterator->path().filename().string();
-				string filesingletest = test::Options::get().singleTestName; //parse singletest as a filename of random test
-				if (fileboost == filesingletest || fileboost.substr(0, fileboost.length()-5) == filesingletest)
-					testFiles.push_back(iterator->path());
-			}
-			else
-				testFiles.push_back(iterator->path());
-		}
+//	vector<boost::filesystem::path> testFiles;
+//	boost::filesystem::directory_iterator iterator(testPath);
+//	for(; iterator != boost::filesystem::directory_iterator(); ++iterator)
+//		if (boost::filesystem::is_regular_file(iterator->path()) && iterator->path().extension() == ".json")
+//		{
+//			if (test::Options::get().singleTest)
+//			{
+//				string fileboost = iterator->path().filename().string();
+//				string filesingletest = test::Options::get().singleTestName; //parse singletest as a filename of random test
+//				if (fileboost == filesingletest || fileboost.substr(0, fileboost.length()-5) == filesingletest)
+//					testFiles.push_back(iterator->path());
+//			}
+//			else
+//				testFiles.push_back(iterator->path());
+//		}
 
-	test::TestOutputHelper::initTest();
-	test::TestOutputHelper::setMaxTests(testFiles.size());
+//	test::TestOutputHelper::initTest();
+//	test::TestOutputHelper::setMaxTests(testFiles.size());
 
-	for (auto& path: testFiles)
-	{
-		try
-		{
-			cnote << "Testing ..." << path.filename();
-			test::TestOutputHelper::setCurrentTestFileName(path.filename().string());
-			json_spirit::mValue v;
-			string s = asString(dev::contents(path.string()));
-			BOOST_REQUIRE_MESSAGE(s.length() > 0, "Content of " + path.string() + " is empty. Have you cloned the 'tests' repo branch develop and set ETHEREUM_TEST_PATH to its path?");
-			json_spirit::read_string(s, v);
-			test::Listener::notifySuiteStarted(path.filename().string());
-			dev::test::doStateTests(v, false);
-		}
-		catch (Exception const& _e)
-		{
-			BOOST_ERROR(path.filename().string() + "Failed test with Exception: " << diagnostic_information(_e));
-		}
-		catch (std::exception const& _e)
-		{
-			BOOST_ERROR(path.filename().string() + "Failed test with Exception: " << _e.what());
-		}
-	}
-}
+//	for (auto& path: testFiles)
+//	{
+//		try
+//		{
+//			cnote << "Testing ..." << path.filename();
+//			test::TestOutputHelper::setCurrentTestFileName(path.filename().string());
+//			json_spirit::mValue v;
+//			string s = asString(dev::contents(path.string()));
+//			BOOST_REQUIRE_MESSAGE(s.length() > 0, "Content of " + path.string() + " is empty. Have you cloned the 'tests' repo branch develop and set ETHEREUM_TEST_PATH to its path?");
+//			json_spirit::read_string(s, v);
+//			test::Listener::notifySuiteStarted(path.filename().string());
+//			dev::test::doStateTests(v, false);
+//		}
+//		catch (Exception const& _e)
+//		{
+//			BOOST_ERROR(path.filename().string() + "Failed test with Exception: " << diagnostic_information(_e));
+//		}
+//		catch (std::exception const& _e)
+//		{
+//			BOOST_ERROR(path.filename().string() + "Failed test with Exception: " << _e.what());
+//		}
+//	}
+//}
 
-BOOST_AUTO_TEST_CASE(userDefinedFileState)
-{
-	dev::test::userDefinedTest(dev::test::doStateTests);
-}
+//BOOST_AUTO_TEST_CASE(userDefinedFileState)
+//{
+//	dev::test::userDefinedTest(dev::test::doStateTests);
+//}
 
-BOOST_AUTO_TEST_SUITE_END()
-*/
+//BOOST_AUTO_TEST_SUITE_END()

--- a/test/libethereum/StateTests.cpp
+++ b/test/libethereum/StateTests.cpp
@@ -127,11 +127,7 @@ public:
 
 BOOST_FIXTURE_TEST_SUITE(StateTestsGeneral, generaltestfixture)
 
-BOOST_AUTO_TEST_CASE(stHomesteadSpecific){}
-BOOST_AUTO_TEST_CASE(stCallDelegateCodesCallCodeHomestead){}
-BOOST_AUTO_TEST_CASE(stCallDelegateCodesHomestead){}
-BOOST_AUTO_TEST_CASE(stDelegatecallTestHomestead){}
-
+//Frontier Tests
 BOOST_AUTO_TEST_CASE(stBlockHashTest){}
 BOOST_AUTO_TEST_CASE(stBoundsTest){}
 BOOST_AUTO_TEST_CASE(stCallCodes){}
@@ -151,8 +147,28 @@ BOOST_AUTO_TEST_CASE(stTransactionTest){}
 BOOST_AUTO_TEST_CASE(stTransitionTest){}
 BOOST_AUTO_TEST_CASE(stWalletTest){}
 
-BOOST_AUTO_TEST_CASE(stCodeSizeLimit){}
+//Homestead Tests
+BOOST_AUTO_TEST_CASE(stCallDelegateCodesCallCodeHomestead){}
+BOOST_AUTO_TEST_CASE(stCallDelegateCodesHomestead){}
+BOOST_AUTO_TEST_CASE(stHomesteadSpecific){}
+BOOST_AUTO_TEST_CASE(stDelegatecallTestHomestead){}
 
+//EIP150 Tests
+BOOST_AUTO_TEST_CASE(stChangedEIP150){}
+BOOST_AUTO_TEST_CASE(stEIP150singleCodeGasPrices){}
+BOOST_AUTO_TEST_CASE(stMemExpandingEIP150Calls){}
+BOOST_AUTO_TEST_CASE(stEIP150Specific){}
+
+//EIP158 Tests
+BOOST_AUTO_TEST_CASE(stEIP158Specific){}
+BOOST_AUTO_TEST_CASE(stNonZeroCallsTest){}
+BOOST_AUTO_TEST_CASE(stZeroCallsTest){}
+BOOST_AUTO_TEST_CASE(stZeroCallsRevert){}
+BOOST_AUTO_TEST_CASE(stCodeSizeLimit){}
+BOOST_AUTO_TEST_CASE(stCreateTest){}
+BOOST_AUTO_TEST_CASE(stRevertTest){}
+
+//Stress Tests
 BOOST_AUTO_TEST_CASE(stMemoryStressTest){}
 BOOST_AUTO_TEST_CASE(stQuadraticComplexityTest){}
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/libethereum/TransactionTests.cpp
+++ b/test/libethereum/TransactionTests.cpp
@@ -37,6 +37,7 @@ namespace dev {  namespace test {
 void doTransactionTests(json_spirit::mValue& _v, bool _fillin)
 {
 	TestOutputHelper::initTest(_v);
+	unique_ptr<SealEngineFace> se(ChainParams(genesisInfo(eth::Network::MainNetworkTest)).createSealEngine());
 	for (auto& i: _v.get_obj())
 	{
 		string testname = i.first;
@@ -45,12 +46,8 @@ void doTransactionTests(json_spirit::mValue& _v, bool _fillin)
 		if (!TestOutputHelper::passTest(o, testname))
 			continue;
 
-		eth::Network sealEngineNet;
 		BOOST_REQUIRE(o.count("blocknumber") > 0);
 		u256 transactionBlock = toInt(o["blocknumber"].get_str());
-		sealEngineNet = eth::Network::MainNetwork;
-
-		unique_ptr<SealEngineFace> se(ChainParams(genesisInfo(sealEngineNet)).createSealEngine());
 		BlockHeader bh;
 		bh.setNumber(transactionBlock);
 
@@ -157,6 +154,7 @@ void doTransactionTests(json_spirit::mValue& _v, bool _fillin)
 			BOOST_CHECK_MESSAGE(txFromFields.sender() == addressReaded || txFromRlp.sender() == addressReaded, testname + "Signature address of sender does not match given sender address!");
 		}
 	}//for
+
 }//doTransactionTests
 
 } }// Namespace Close


### PR DESCRIPTION
From this point we could remove old StateTests and switch to new GeneralStateTests
Fix transaction test time execution by defining mainnetwork test genesis
