### PR TITLE
Fix data race in concurrent queues

### DIFF
--- a/libethereum/BlockQueue.h
+++ b/libethereum/BlockQueue.h
@@ -164,7 +164,7 @@ private:
 	std::deque<UnverifiedBlock> m_unverified;							///< List of <block hash, parent hash, block data> in correct order, ready for verification.
 
 	std::vector<std::thread> m_verifiers;								///< Threads who only verify.
-	bool m_deleting = false;											///< Exit condition for verifiers.
+	std::atomic<bool> m_deleting = {false};								///< Exit condition for verifiers.
 
 	std::function<void(Exception&)> m_onBad;							///< Called if we have a block that doesn't verify.
 	std::atomic<size_t> m_unknownSize;									///< Tracks total size in bytes of all unknown blocks

--- a/libethereum/TransactionQueue.h
+++ b/libethereum/TransactionQueue.h
@@ -211,7 +211,7 @@ private:
 	std::vector<std::thread> m_verifiers;
 	std::deque<UnverifiedTransaction> m_unverified;								///< Pending verification queue
 	mutable Mutex x_queue;														///< Verification queue mutex
-	bool m_aborting = false;													///< Exit condition for verifier.
+	std::atomic<bool> m_aborting = {false};										///< Exit condition for verifier.
 };
 
 }


### PR DESCRIPTION
These concurrent queues could have been better implemented (keeping the both conditions under single lock), but I don't have time to that right now.

Fixes https://github.com/ethereum/cpp-ethereum/issues/3182.