### PR TITLE
Fix move assignment operator of UnverifiedTransaction.

### DIFF
--- a/libethereum/TransactionQueue.h
+++ b/libethereum/TransactionQueue.h
@@ -142,12 +142,12 @@ private:
 		Transaction transaction; ///< Transaction data
 	};
 
-	/// Trasnaction pending verification
+	/// Transaction pending verification
 	struct UnverifiedTransaction
 	{
 		UnverifiedTransaction() {}
 		UnverifiedTransaction(bytesConstRef const& _t, h512 const& _nodeId): transaction(_t.toBytes()), nodeId(_nodeId) {}
-		UnverifiedTransaction(UnverifiedTransaction&& _t): transaction(std::move(_t.transaction)) {}
+		UnverifiedTransaction(UnverifiedTransaction&& _t): transaction(std::move(_t.transaction)), nodeId(std::move(_t.nodeId)) {}
 		UnverifiedTransaction& operator=(UnverifiedTransaction&& _other)
 		{
 			assert(&_other != this);


### PR DESCRIPTION
Fixes https://github.com/ethereum/cpp-ethereum/issues/3472
Thanks to @ancjf for finding this!

As far as I can see, the effect of this change is only that information regarding the peer is now updated correctly: We now remember properly which transactions are known to the peer and adjust the rating. This happens in `EthereumHost::onTransactionImported`.