### PR TITLE
Change dependancy libcl to ocl-icd for arch linux.

### DIFF
--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -139,7 +139,7 @@ case $(uname -s) in
                 crypto++ \
                 git \
                 leveldb \
-                libcl \
+                ocl-icd \
                 libmicrohttpd \
                 miniupnpc \
                 opencl-headers


### PR DESCRIPTION
ocl-icd is the new maintained dependency that provides libcl for arch linux