### PR TITLE
Remove unused global variables

### DIFF
--- a/libethereum/GenesisInfo.cpp
+++ b/libethereum/GenesisInfo.cpp
@@ -26,36 +26,6 @@
 using namespace dev;
 using namespace eth;
 
-KeyPair const dev::eth::FluidityTreasure(Secret("a15e7af8ea0a717182d3608e6cdb2bff97ccaad3b6befc8787abe4c937796579"));
-
-std::string const dev::eth::c_genesisInfoFluidity =
-R"ETHEREUM(
-{
-	"sealEngine": "BasicAuthority",
-	"params": {
-		"accountStartNonce": "0x",
-		"maximumExtraDataSize": "0x1000000",
-		"blockReward": "0x",
-		"registrar": "",
-		"networkID" : "0x45"
-	},
-	"genesis": {
-		"author": "0x0000000000000000000000000000000000000000",
-		"timestamp": "0x00",
-		"parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
-		"extraData": "0x",
-		"gasLimit": "0x1000000000000"
-	},
-	"accounts": {
-		"0000000000000000000000000000000000000001": { "wei": "1", "precompiled": { "name": "ecrecover", "linear": { "base": 3000, "word": 0 } } },
-		"0000000000000000000000000000000000000002": { "wei": "1", "precompiled": { "name": "sha256", "linear": { "base": 60, "word": 12 } } },
-		"0000000000000000000000000000000000000003": { "wei": "1", "precompiled": { "name": "ripemd160", "linear": { "base": 600, "word": 120 } } },
-		"0000000000000000000000000000000000000004": { "wei": "1", "precompiled": { "name": "identity", "linear": { "base": 15, "word": 3 } } },
-		"00c9b024c2efc853ecabb8be2fb1d16ce8174ab1": { "wei": "1606938044258990275541962092341162602522202993782792835301376" }
-	}
-}
-)ETHEREUM";
-
 std::string const dev::eth::c_genesisInfoTestBasicAuthority =
 R"E(
 {

--- a/libethereum/GenesisInfo.h
+++ b/libethereum/GenesisInfo.h
@@ -29,9 +29,6 @@ namespace dev
 namespace eth
 {
 
-extern KeyPair const FluidityTreasure;
-
-extern std::string const c_genesisInfoFluidity;
 extern std::string const c_genesisInfoTestBasicAuthority;
 extern dev::Addresses childDaos();
 


### PR DESCRIPTION
Windows build crashed during FluidityTreasure initialization, see https://github.com/ethereum/cpp-ethereum/issues/3490