### PR TITLE
add array filters for expect section in general state tests

### DIFF
--- a/test/TestHelper.cpp
+++ b/test/TestHelper.cpp
@@ -567,6 +567,10 @@ void ImportTest::checkGeneralTestSection(json_spirit::mObject const& _expects, v
 			string trInfo = netIdToString(t.netId) + " data: " + toString(t.dataInd) + " gas: " + toString(t.gasInd) + " val: " + toString(t.valInd);
 			if (_expects.count("result"))
 			{
+				Options const& opt = Options::get();
+				if ((opt.test_d != -1 && opt.test_d != t.dataInd) || (opt.test_g != -1 && opt.test_g != t.gasInd) || (opt.test_v != -1 && opt.test_v != t.valInd))
+					continue;
+
 				State postState = t.postState;
 				eth::AccountMaskMap stateMap;
 				State expectState(0, OverlayDB(), eth::BaseState::Empty);
@@ -587,7 +591,7 @@ void ImportTest::checkGeneralTestSection(json_spirit::mObject const& _expects, v
 
 			//if a single transaction check then stop once found
 			if (network[0] != "ALL" && d[0] != -1 && g[0] != -1 && v[0] != -1)
-			if (d.size() == 1 && g.size() == 1 && v.size() == 1)
+			if (network.size() == 1 && d.size() == 1 && g.size() == 1 && v.size() == 1)
 				break;
 		}
 	}
@@ -1070,6 +1074,9 @@ RLPStream createRLPStreamFromTransactionFields(json_spirit::mObject const& _tObj
 
 Options::Options(int argc, char** argv)
 {
+	test_d = -1;
+	test_g = -1;
+	test_v = -1;
 	for (auto i = 0; i < argc; ++i)
 	{
 		auto arg = std::string{argv[i]};
@@ -1184,6 +1191,12 @@ Options::Options(int argc, char** argv)
 		}
 		else if (arg == "--nonetwork")
 			nonetwork = true;
+		else if (arg == "-d" && i + 1 < argc)
+			test_d = atoi(argv[i + 1]);
+		else if (arg == "-g" && i + 1 < argc)
+			test_g = atoi(argv[i + 1]);
+		else if (arg == "-v" && i + 1 < argc)
+			test_v = atoi(argv[i + 1]);
 	}
 
 	//Default option

--- a/test/TestHelper.cpp
+++ b/test/TestHelper.cpp
@@ -54,6 +54,9 @@ void printHelp()
 	cout << setw(30) << "-t <TestSuite>/<TestCase>" << std::endl;
 
 	cout << std::endl << "Debugging" << std::endl;
+	cout << setw(30) << "-d <index>" << setw(25) << "Set the transaction data array index when running GeneralStateTests" << std::endl;
+	cout << setw(30) << "-g <index>" << setw(25) << "Set the transaction gas array index when running GeneralStateTests" << std::endl;
+	cout << setw(30) << "-v <index>" << setw(25) << "Set the transaction value array index when running GeneralStateTests" << std::endl;
 	cout << setw(30) << "--singletest <TestName>" << setw(25) << "Run on a single test" << std::endl;
 	cout << setw(30) << "--singletest <TestFile> <TestName>" << std::endl;
 	cout << setw(30) << "--verbosity <level>" << setw(25) << "Set logs verbosity. 0 - silent, 1 - only errors, 2 - informative, >2 - detailed" << std::endl;
@@ -568,7 +571,10 @@ void ImportTest::checkGeneralTestSection(json_spirit::mObject const& _expects, v
 			if (_expects.count("result"))
 			{
 				Options const& opt = Options::get();
-				if ((opt.test_d != -1 && opt.test_d != t.dataInd) || (opt.test_g != -1 && opt.test_g != t.gasInd) || (opt.test_v != -1 && opt.test_v != t.valInd))
+				//filter transactions if a specific index set in options
+				if ((opt.trDataIndex != -1 && opt.trDataIndex != t.dataInd) ||
+					(opt.trGasIndex != -1 && opt.trGasIndex != t.gasInd) ||
+					(opt.trValueIndex != -1 && opt.trValueIndex != t.valInd))
 					continue;
 
 				State postState = t.postState;
@@ -1074,9 +1080,9 @@ RLPStream createRLPStreamFromTransactionFields(json_spirit::mObject const& _tObj
 
 Options::Options(int argc, char** argv)
 {
-	test_d = -1;
-	test_g = -1;
-	test_v = -1;
+	trDataIndex = -1;
+	trGasIndex = -1;
+	trValueIndex = -1;
 	for (auto i = 0; i < argc; ++i)
 	{
 		auto arg = std::string{argv[i]};
@@ -1192,11 +1198,11 @@ Options::Options(int argc, char** argv)
 		else if (arg == "--nonetwork")
 			nonetwork = true;
 		else if (arg == "-d" && i + 1 < argc)
-			test_d = atoi(argv[i + 1]);
+			trDataIndex = atoi(argv[i + 1]);
 		else if (arg == "-g" && i + 1 < argc)
-			test_g = atoi(argv[i + 1]);
+			trGasIndex = atoi(argv[i + 1]);
 		else if (arg == "-v" && i + 1 < argc)
-			test_v = atoi(argv[i + 1]);
+			trValueIndex = atoi(argv[i + 1]);
 	}
 
 	//Default option

--- a/test/TestHelper.h
+++ b/test/TestHelper.h
@@ -242,9 +242,9 @@ public:
 	std::string singleTestFile;
 	std::string singleTestName;
 	std::string singleTestNet;
-	int test_d; ///< GeneralState data
-	int test_g; ///< GeneralState gas
-	int test_v; ///< GeneralState value
+	int trDataIndex; ///< GeneralState data
+	int trGasIndex; ///< GeneralState gas
+	int trValueIndex; ///< GeneralState value
 	bool performance = false;
 	bool nonetwork = false;///< For libp2p
 	bool quadratic = false;

--- a/test/TestHelper.h
+++ b/test/TestHelper.h
@@ -242,6 +242,9 @@ public:
 	std::string singleTestFile;
 	std::string singleTestName;
 	std::string singleTestNet;
+	int test_d; ///< GeneralState data
+	int test_g; ///< GeneralState gas
+	int test_v; ///< GeneralState value
 	bool performance = false;
 	bool nonetwork = false;///< For libp2p
 	bool quadratic = false;


### PR DESCRIPTION
this option is used when 
./testeth -t StateTestsGeneral/stTestCase --filltests --checkstate -d 0 -g 0 -v 1

to set specific array values to check in expected results. 
cause in general tests there could be like tens of tests (because of the different transaction fields) and sometime it is needed to produce post state check just for a few of them