### PR TITLE
fix genesis info example output when given a wrong configuration

### DIFF
--- a/eth/main.cpp
+++ b/eth/main.cpp
@@ -895,7 +895,7 @@ int main(int argc, char** argv)
 		catch (...)
 		{
 			cerr << "provided configuration is not well formatted" << endl;
-			cerr << "sample: " << endl << genesisInfo(eth::Network::Ropsten) << endl;
+			cerr << "sample: " << endl << genesisInfo(eth::Network::MainNetworkTest) << endl;
 			return 0;
 		}
 	}


### PR DESCRIPTION
there was an output of genesis with full list of accounts