### PR TITLE
Drop support for builds without JSON RPC

### DIFF
--- a/eth/CMakeLists.txt
+++ b/eth/CMakeLists.txt
@@ -12,8 +12,6 @@ target_link_libraries(eth ${Eth_EVM_LIBRARIES})
 target_link_libraries(eth ${Web3_WEB3JSONRPC_LIBRARIES})
 target_link_libraries(eth ${Web3_WEBTHREE_LIBRARIES})
 target_link_libraries(eth jsonrpc::client)
-# TODO: Remove.
-target_compile_definitions(eth PRIVATE ETH_JSONRPC)
 
 if (EVMJIT)
 	# Do we need include paths here?

--- a/eth/main.cpp
+++ b/eth/main.cpp
@@ -45,7 +45,6 @@
 #include <libethashseal/GenesisInfo.h>
 #include <libwebthree/WebThree.h>
 
-#if ETH_JSONRPC
 #include <libweb3jsonrpc/AccountHolder.h>
 #include <libweb3jsonrpc/Eth.h>
 #include <libweb3jsonrpc/SafeHttpServer.h>
@@ -64,7 +63,6 @@
 #include <libweb3jsonrpc/Debug.h>
 #include <libweb3jsonrpc/Test.h>
 #include "Farm.h"
-#endif // ETH_JSONRPC
 
 #include <ethminer/MinerAux.h>
 #include "AccountManager.h"
@@ -98,7 +96,6 @@ void help()
 		<< endl
 		<< "    -o,--mode <full/peer>  Start a full node or a peer node (default: full)." << endl
 		<< endl
-#if ETH_JSONRPC
 		<< "    -j,--json-rpc  Enable JSON-RPC server (default: off)." << endl
 		<< "    --ipc  Enable IPC server (default: on)." << endl
 		<< "    --ipcpath Set .ipc socket path (default: data directory)" << endl
@@ -107,7 +104,6 @@ void help()
 		<< "    --json-rpc-port <n>  Specify JSON-RPC server port (implies '-j', default: " << SensibleHttpPort << ")." << endl
 		<< "    --rpccorsdomain <domain>  Domain on which to send Access-Control-Allow-Origin header." << endl
 		<< "    --admin <password>  Specify admin session key for JSON-RPC (default: auto-generated and printed at start-up)." << endl
-#endif // ETH_JSONRPC
 		<< "    -K,--kill  Kill the blockchain first." << endl
 		<< "    -R,--rebuild  Rebuild the blockchain from the existing database." << endl
 		<< "    --rescue  Attempt to rescue a corrupt database." << endl
@@ -341,12 +337,10 @@ int main(int argc, char** argv)
 	NodeMode nodeMode = NodeMode::Full;
 	bool interactive = false;
 
-#if ETH_JSONRPC
 	int jsonRPCURL = -1;
 	bool adminViaHttp = false;
 	bool ipc = true;
 	std::string rpcCorsDomain = "";
-#endif // ETH_JSONRPC
 
 	string jsonAdmin;
 	ChainParams chainParams(genesisInfo(eth::Network::MainNetwork), genesisStateRoot(eth::Network::MainNetwork));
@@ -755,7 +749,6 @@ int main(int argc, char** argv)
 		else if (arg == "--old-interactive")
 			interactive = true;
 
-#if ETH_JSONRPC
 		else if ((arg == "-j" || arg == "--json-rpc"))
 			jsonRPCURL = jsonRPCURL == -1 ? SensibleHttpPort : jsonRPCURL;
 		else if (arg == "--admin-via-http")
@@ -770,7 +763,6 @@ int main(int argc, char** argv)
 			ipc = true;
 		else if (arg == "--no-ipc")
 			ipc = false;
-#endif // ETH_JSONRPC
 
 		else if ((arg == "-v" || arg == "--verbosity") && i + 1 < argc)
 			g_logVerbosity = atoi(argv[++i]);
@@ -1195,7 +1187,6 @@ int main(int argc, char** argv)
 	else
 		cout << "Networking disabled. To start, use netstart or pass --bootstrap or a remote host." << endl;
 
-#if ETH_JSONRPC
 	unique_ptr<ModularServer<>> jsonrpcHttpServer;
 	unique_ptr<ModularServer<>> jsonrpcIpcServer;
 	unique_ptr<rpc::SessionManager> sessionManager;
@@ -1296,7 +1287,6 @@ int main(int argc, char** argv)
 		writeFile(getDataDir("web3") + "/session.key", jsonAdmin);
 		writeFile(getDataDir("web3") + "/session.url", "http://localhost:" + toString(jsonRPCURL));
 	}
-#endif // ETH_JSONRPC
 
 	for (auto const& p: preferredNodes)
 		if (p.second.second)
@@ -1327,12 +1317,10 @@ int main(int argc, char** argv)
 		while (!exitHandler.shouldExit())
 			this_thread::sleep_for(chrono::milliseconds(1000));
 
-#if ETH_JSONRPC
 	if (jsonrpcHttpServer.get())
 		jsonrpcHttpServer->StopListening();
 	if (jsonrpcIpcServer.get())
 		jsonrpcIpcServer->StopListening();
-#endif
 
 	auto netData = web3.saveNetwork();
 	if (!netData.empty())

--- a/ethminer/CMakeLists.txt
+++ b/ethminer/CMakeLists.txt
@@ -10,8 +10,6 @@ find_package(Eth)
 
 target_include_directories(ethminer PRIVATE ..)
 target_link_libraries(ethminer ${Eth_ETHASHSEAL_LIBRARIES} jsonrpc::client)
-# TODO: Remove.
-target_compile_definitions(ethminer PRIVATE ETH_JSONRPC)
 
 if (MSVC)
 	find_package(Boost QUIET REQUIRED COMPONENTS chrono date_time)

--- a/ethminer/MinerAux.h
+++ b/ethminer/MinerAux.h
@@ -243,12 +243,10 @@ public:
 	static void streamHelp(ostream& _out)
 	{
 		_out
-#if ETH_JSONRPC
 			<< "Work farming mode:" << endl
 			<< "    -F,--farm <url>  Put into mining farm mode with the work server at URL (default: http://127.0.0.1:8545)" << endl
 			<< "    --farm-recheck <n>  Leave n ms between checks for changed work (default: 500)." << endl
 			<< "    --no-precompute  Don't precompute the next epoch's DAG." << endl
-#endif // ETH_JSONRPC
 			<< "Ethash verify mode:" << endl
 			<< "    -w,--check-pow <headerHash> <seedHash> <difficulty> <nonce>  Check PoW credentials for validity." << endl
 			<< endl
@@ -341,7 +339,6 @@ private:
 		(void)_m;
 		(void)_remote;
 		(void)_recheckPeriod;
-#if ETH_JSONRPC
 		jsonrpc::HttpClient client(_remote);
 
 		h256 id = h256::random();
@@ -440,8 +437,6 @@ private:
 			{
 				this_thread::sleep_for(chrono::milliseconds(100));
 			}
-
-#endif // ETH_JSONRPC
 		exit(0);
 	}
 

--- a/ethminer/MinerAux.h
+++ b/ethminer/MinerAux.h
@@ -27,12 +27,8 @@
 #include <libethcore/BasicAuthority.h>
 #include <libethcore/Exceptions.h>
 #include <libethashseal/EthashCPUMiner.h>
-
-#if ETH_JSONRPC
-	#include <jsonrpccpp/client/connectors/httpclient.h>
-	#include "FarmClient.h"
-#endif // ETH_JSONRPC
-
+#include <jsonrpccpp/client/connectors/httpclient.h>
+#include "FarmClient.h"
 #include "cpp-ethereum/BuildInfo.h"
 
 // TODO - having using derivatives in header files is very poor style, and we need to fix these up.


### PR DESCRIPTION
With reference to #3350 

- [x] Remove` -DJSONRPC` CMake option. See EthOptions.cmake file. **(Seems to be done already)**
- [x] Do not set `-DETH_JSONRPC` compilation flag.
- [x] Remove all `#if ETH_JSONRPC` preprocessor conditionals assuming it is always enabled.