### PR TITLE
Add the packaging metadata to build the cpp-ethereum snap

### DIFF
--- a/dist/snap/snapcraft.yaml
+++ b/dist/snap/snapcraft.yaml
@@ -20,7 +20,7 @@ apps:
 
 parts:
   cpp-ethereum:
-    source: .
+    source: ../..
     plugin: cmake
     build-packages:
       - build-essential

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -7,8 +7,6 @@ grade: devel
 confinement: devmode
 
 apps:
-  bench:
-    command: bench
   eth:
     command: eth
   ethkey:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,34 @@
+name: cpp-ethereum
+version: master
+summary: blockchain app platform
+description: Ethereum C++ project
+
+grade: devel
+confinement: devmode
+
+apps:
+  bench:
+    command: bench
+  eth:
+    command: eth
+  ethkey:
+    command: ethkey
+  ethminer:
+    command: ethminer
+  ethvm:
+    command: ethvm
+  rlp:
+    command: rlp
+
+parts:
+  cpp-ethereum:
+    source: .
+    plugin: cmake
+    build-packages:
+      - build-essential
+      - libboost-all-dev
+      - libcurl4-openssl-dev
+      - libgmp-dev
+      - libleveldb-dev
+      - libmicrohttpd-dev
+      - libminiupnpc-dev


### PR DESCRIPTION
This is a package for the secure installation of apps that works in most Linux distributions.
Landing it upstream will enable builds that then can be distributed to many users through the Ubuntu store.