### PR TITLE
Fix checking for requested verification type in BlockChain::verifyBlock()

### DIFF
--- a/libethereum/BlockChain.cpp
+++ b/libethereum/BlockChain.cpp
@@ -1489,7 +1489,7 @@ VerifiedBlockRef BlockChain::verifyBlock(bytesConstRef _block, std::function<voi
 
 	RLP r(_block);
 	unsigned i = 0;
-	if (_ir && !!(ImportRequirements::UncleBasic | ImportRequirements::UncleParent | ImportRequirements::UncleSeals))
+	if (_ir & (ImportRequirements::UncleBasic | ImportRequirements::UncleParent | ImportRequirements::UncleSeals))
 		for (auto const& uncle: r[2])
 		{
 			BlockHeader uh(uncle.data(), HeaderData);
@@ -1522,7 +1522,7 @@ VerifiedBlockRef BlockChain::verifyBlock(bytesConstRef _block, std::function<voi
 			++i;
 		}
 	i = 0;
-	if (_ir && !!(ImportRequirements::TransactionBasic | ImportRequirements::TransactionSignatures))
+	if (_ir & (ImportRequirements::TransactionBasic | ImportRequirements::TransactionSignatures))
 		for (RLP const& tr: r[1])
 		{
 			bytesConstRef d = tr.data();


### PR DESCRIPTION
Fixing the typos in checking the bits set in `ImportRequirements::value`

This probably could lead to unnecessary checks performed when not needed.