### PR TITLE
Docker update and fixes

### DIFF
--- a/eth/main.cpp
+++ b/eth/main.cpp
@@ -303,6 +303,9 @@ int main(int argc, char** argv)
 {
 	setDefaultOrCLocale();
 
+	// Init secp256k1 context by calling one of the functions.
+	toPublic({});
+
 	// Init defaults
 	Defaults::get();
 	Ethash::init();

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -13,10 +13,6 @@ FROM alpine
 
 RUN apk add --no-cache \
         libstdc++ \
-        boost-filesystem \
-        boost-random \
-        boost-regex \
-        boost-thread \
         gmp \
         libcurl \
         libmicrohttpd \
@@ -26,13 +22,13 @@ RUN apk add --no-cache \
         cmake \
         g++ \
         make \
-        curl-dev boost-dev libmicrohttpd-dev \
+        linux-headers curl-dev libmicrohttpd-dev \
         leveldb-dev --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing/ \
-    && sed -i -E -e 's/include <sys\/poll.h>/include <poll.h>/' /usr/include/boost/asio/detail/socket_types.hpp \
+    && sed -i -E -e 's|#warning|//#warning|' /usr/include/sys/poll.h \
     && git clone --recursive https://github.com/ethereum/cpp-ethereum --branch develop --single-branch --depth 1 \
     && mkdir /build && cd /build \
     && cmake /cpp-ethereum -DCMAKE_BUILD_TYPE=RelWithDebInfo -DTOOLS=Off -DTESTS=Off \
-    && make \
+    && make eth \
     && make install \
     && cd / && rm /build -rf \
     && rm /cpp-ethereum -rf \


### PR DESCRIPTION
This updates the Dockerfile not to install boost and to build only eth.
Also secp256k1 initialization is moved to eth main thread to avoid stack overflow.