### PR TITLE
Fix data race in TransactionQueue destructor

### DIFF
--- a/libethereum/TransactionQueue.cpp
+++ b/libethereum/TransactionQueue.cpp
@@ -48,7 +48,8 @@ TransactionQueue::TransactionQueue(unsigned _limit, unsigned _futureLimit):
 
 TransactionQueue::~TransactionQueue()
 {
-	m_aborting = true;
+	DEV_GUARDED(x_queue)
+		m_aborting = true;
 	m_queueReady.notify_all();
 	for (auto& i: m_verifiers)
 		i.join();


### PR DESCRIPTION
Modifying the variable used in condition_variable predicate should be done under the same mutex that `wait()` call uses. Otherwise it's possible that this assignment and `notify_all` are called during predicate testing, i.e. before `wait` resumes waiting; then the thread will miss notification.

This could be the reason of the deadlock with the stack like in https://github.com/ethereum/cpp-ethereum/issues/3182 - there it's waiting in `~TransactionQueue()` on the `join()` call and verifier threads are still waiting on a condition variable; looks like `notify_all()` was missed.

`BlockQueue` desctuctor already does this correctly under guard.