### PR TITLE
Fix mining in solidity tests using test.mineBlocks

### DIFF
--- a/libethereum/BlockChainSync.h
+++ b/libethereum/BlockChainSync.h
@@ -58,6 +58,10 @@ public:
 	/// Restart sync
 	void restartSync();
 
+	/// Called after all blocks have been downloaded
+	/// Public only for test mode
+	void completeSync();
+
 	/// Called by peer to report status
 	void onPeerStatus(std::shared_ptr<EthereumPeer> _peer);
 
@@ -83,9 +87,6 @@ public:
 private:
 	/// Resume downloading after witing state
 	void continueSync();
-
-	/// Called after all blocks have been donloaded
-	void completeSync();
 
 	/// Enter waiting state
 	void pauseSync();

--- a/libethereum/ClientTest.cpp
+++ b/libethereum/ClientTest.cpp
@@ -116,3 +116,13 @@ void ClientTest::onNewBlocks(h256s const& _blocks, h256Hash& io_changed)
 	if(--m_blocksToMine <= 0)
 		stopSealing();
 }
+
+bool ClientTest::completeSync()
+{
+	auto h = m_host.lock();
+	if (!h)
+		return false;
+
+	h->completeSync();
+	return true;
+}

--- a/libethereum/ClientTest.h
+++ b/libethereum/ClientTest.h
@@ -51,6 +51,7 @@ public:
 	void modifyTimestamp(u256 const& _timestamp);
 	void rewindToBlock(unsigned _number);
 	bool addBlock(std::string const& _rlp);
+	bool completeSync();
 
 protected:
 	unsigned m_blocksToMine;

--- a/libethereum/EthereumHost.cpp
+++ b/libethereum/EthereumHost.cpp
@@ -421,6 +421,12 @@ void EthereumHost::reset()
 	m_transactionsSent.clear();
 }
 
+void EthereumHost::completeSync()
+{
+	RecursiveGuard l(x_sync);
+	m_sync->completeSync();
+}
+
 void EthereumHost::doWork()
 {
 	bool netChange = ensureInitialised();

--- a/libethereum/EthereumHost.h
+++ b/libethereum/EthereumHost.h
@@ -70,6 +70,8 @@ public:
 	void setNetworkId(u256 _n) { m_networkId = _n; }
 
 	void reset();
+	/// Don't sync further - used only in test mode
+	void completeSync();
 
 	bool isSyncing() const;
 	bool isBanned(p2p::NodeID const& _id) const { return !!m_banned.count(_id); }

--- a/libweb3jsonrpc/Test.cpp
+++ b/libweb3jsonrpc/Test.cpp
@@ -94,6 +94,7 @@ bool Test::test_rewindToBlock(int _number)
 	try
 	{
 		m_eth.rewind(_number);
+		asClientTest(m_eth).completeSync();
 	}
 	catch (std::exception const&)
 	{


### PR DESCRIPTION
Mining can start only when sync is complete, i.e. `BlockChainSync::m_state == SynState::Idle`

We need a way for tests to forcibly mark sync as complete.