### PR TITLE
Fix consensus failure while syncing with the main net after Spurious Dragon

### DIFF
--- a/libethereum/Executive.cpp
+++ b/libethereum/Executive.cpp
@@ -269,6 +269,14 @@ bool Executive::call(CallParameters const& _p, u256 const& _gasPrice, Address co
 		{
 			m_excepted = TransactionException::OutOfGasBase;
 			// Bail from exception.
+			
+			// Empty precompiled contracts need to be deleted even in case of OOG
+			// because the bug in both Geth and Parity led to deleting RIPEMD precompiled in this case
+			// see https://github.com/ethereum/go-ethereum/pull/3341/files#diff-2433aa143ee4772026454b8abd76b9dd
+			// We mark the account as touched here, so that is can be removed among other touched empty accounts (after tx finalization)
+			if (m_envInfo.number() >= m_sealEngine.chainParams().u256Param("EIP158ForkBlock"))
+				m_s.addBalance(_p.codeAddress, 0);
+			
 			return true;	// true actually means "all finished - nothing more to be done regarding go().
 		}
 		else


### PR DESCRIPTION
The account 0x3 (RIPEMD precompile) was deleted in block 2675119 due to incorrect handling at the time of OOG-revertion of empty touched accounts in both Geth and Parity; we need to do the same now.

For all details see 
https://docs.google.com/document/d/1np33QWTKQt8vZcXYEW0jC_cMYqUTqI-LTioYC88RHx8/edit
https://github.com/ethereum/go-ethereum/pull/3341/files#diff-2433aa143ee4772026454b8abd76b9dd
