### PR TITLE
Fix assert in BlockChainSync

### DIFF
--- a/libethereum/BlockChainSync.cpp
+++ b/libethereum/BlockChainSync.cpp
@@ -554,6 +554,11 @@ void BlockChainSync::onPeerBlockBodies(std::shared_ptr<EthereumPeer> _peer, RLP 
 			continue;
 		}
 		unsigned blockNumber = iter->second;
+		if (haveItem(m_bodies, blockNumber))
+		{
+			clog(NetMessageSummary) << "Skipping already downloaded block body " << blockNumber;
+			continue;
+		}
 		m_headerIdToNumber.erase(id);
 		mergeInto(m_bodies, blockNumber, body.data().toBytes());
 	}


### PR DESCRIPTION
I think assert failure in https://github.com/ethereum/cpp-ethereum/issues/3392 happens when the peer sends us the block body we didn't request (and already downloaded earlier)

This fix adds the check for ignoring such bodies.
`onPeerBlockHeaders` has the similar check for skipping already downloaded headers.