### PR TITLE
make missing test file a warning

### DIFF
--- a/test/libethereum/StateTests.cpp
+++ b/test/libethereum/StateTests.cpp
@@ -179,6 +179,7 @@ BOOST_AUTO_TEST_CASE(stRevertTest){}
 
 //Metropolis Tests
 BOOST_AUTO_TEST_CASE(stStackTests){}
+BOOST_AUTO_TEST_CASE(stZeroKnowledge){}
 
 //Stress Tests
 BOOST_AUTO_TEST_CASE(stAttackTest){}

--- a/test/libtesteth/TestHelper.cpp
+++ b/test/libtesteth/TestHelper.cpp
@@ -474,7 +474,12 @@ void executeTests(const string& _name, const string& _testPathAppendix, const st
 		cnote << "TEST " << name << ":";
 		json_spirit::mValue v;
 		string s = asString(dev::contents(testPath + "/" + name + ".json"));
-		BOOST_REQUIRE_MESSAGE(s.length() > 0, "Contents of " + testPath + "/" + name + ".json is empty. Have you cloned the 'tests' repo branch develop and set ETHEREUM_TEST_PATH to its path?");
+		BOOST_WARN_MESSAGE(s.length() > 0, "Missing test file!");
+		if(s.length() == 0)
+		{
+			TestOutputHelper::printWarn("Contents of " + testPath + "/" + name + ".json is empty. Have you cloned the 'tests' repo branch develop and set ETHEREUM_TEST_PATH to its path?");
+			return;
+		}
 		json_spirit::read_string(s, v);
 		Listener::notifySuiteStarted(name);
 		doTests(v, false);

--- a/test/libtesteth/TestOutputHelper.h
+++ b/test/libtesteth/TestOutputHelper.h
@@ -39,6 +39,7 @@ public:
 	static std::string const& testName() { return m_currentTestName; }
 	static std::string const& caseName() { return m_currentTestCaseName; }
 	static std::string const& testFileName() { return m_currentTestFileName; }
+	static void printWarn(std::string const& _str) {std::cerr << _str << std::endl;}
 	static void finishTest();
 	static void printTestExecStats();
 	~TestOutputHelper() { TestOutputHelper::finishTest(); }


### PR DESCRIPTION
with this PR we could add test fillers before a PR that contains changes is merged into develop
thus just having warning messages instead of errors of missing tests

once new PR is merged we could fill actual tests and get rid of the warnings.

on the other hand if some tests are really missing or smth is screwed with testeth setup 
it would be just warnings for tests with fillers