### PR TITLE
EIP166 - replay protection via high-order bits of nonce

### DIFF
--- a/libethashseal/Ethash.cpp
+++ b/libethashseal/Ethash.cpp
@@ -158,9 +158,18 @@ void Ethash::verifyTransaction(ImportRequirements::value _ir, TransactionBase co
 		else
 			_t.checkChainId(-4);
 	}
-	// Unneeded as it's checked again in Executive. Keep it here since tests assume it's checked.
-	if (_ir & ImportRequirements::TransactionBasic && _t.baseGasRequired(evmSchedule(EnvInfo(_bi))) > _t.gas())
-		BOOST_THROW_EXCEPTION(OutOfGasIntrinsic());
+	if (_ir & ImportRequirements::TransactionBasic)
+	{
+		if (_bi.number() >= chainParams().u256Param("metropolisForkBlock"))
+		{
+			unsigned const nonceChainId(chainParams().u256Param("nonceChainID"));
+			_t.checkNonceChainId(nonceChainId);
+		}
+
+		// Unneeded as it's checked again in Executive. Keep it here since tests assume it's checked.
+		if (_t.baseGasRequired(evmSchedule(EnvInfo(_bi))) > _t.gas())
+			BOOST_THROW_EXCEPTION(OutOfGasIntrinsic());
+	}
 }
 
 u256 Ethash::childGasLimit(BlockHeader const& _bi, u256 const& _gasFloorTarget) const

--- a/libethashseal/Ethash.cpp
+++ b/libethashseal/Ethash.cpp
@@ -166,7 +166,7 @@ void Ethash::verifyTransaction(ImportRequirements::value _ir, TransactionBase co
 			_t.checkNonceChainId(nonceChainId);
 		}
 
-		// Unneeded as it's checked again in Executive. Keep it here since tests assume it's checked.
+		// TODO: Unneeded as it's checked again in Executive. Keep it here since tests assume it's checked.
 		if (_t.baseGasRequired(evmSchedule(EnvInfo(_bi))) > _t.gas())
 			BOOST_THROW_EXCEPTION(OutOfGasIntrinsic());
 	}

--- a/libethashseal/genesis/eip150Test.cpp
+++ b/libethashseal/genesis/eip150Test.cpp
@@ -31,6 +31,7 @@ R"E(
 		"metropolisForkBlock": "0xfffffffffffffff",
 		"networkID" : "0x01",
 		"chainID": "0x01",
+		"nonceChainID": "0x12",
 		"minGasLimit": "0x1388",
 		"maxGasLimit": "7fffffffffffffff",
 		"tieBreakingGas": false,

--- a/libethashseal/genesis/eip158Test.cpp
+++ b/libethashseal/genesis/eip158Test.cpp
@@ -38,7 +38,8 @@ R"E(
 		"durationLimit": "0x0d",
 		"blockReward": "0x4563918244F40000",
 		"registrar" : "0xc6d9d2cd449a754c494264e1809c50e34d64562b",
-		"networkID" : "0x1"
+		"networkID" : "0x1",
+		"nonceChainID": "0x12"
 	},
 	"genesis": {
 		"nonce": "0x0000000000000042",

--- a/libethashseal/genesis/frontierTest.cpp
+++ b/libethashseal/genesis/frontierTest.cpp
@@ -31,6 +31,7 @@ R"E(
 		"metropolisForkBlock": "0xfffffffffffffff",
 		"networkID" : "0x01",
 		"chainID": "0x01",
+		"nonceChainID": "0x12",
 		"maximumExtraDataSize": "0x20",
 		"tieBreakingGas": false,
 		"minGasLimit": "0x1388",

--- a/libethashseal/genesis/homesteadTest.cpp
+++ b/libethashseal/genesis/homesteadTest.cpp
@@ -32,6 +32,7 @@ R"E(
 		"metropolisForkBlock": "0xfffffffffffffff",
 		"networkID" : "0x01",
 		"chainID": "0x01",
+		"nonceChainID": "0x12",
 		"minGasLimit": "0x1388",
 		"maxGasLimit": "7fffffffffffffff",
 		"tieBreakingGas": false,

--- a/libethashseal/genesis/mainNetwork.cpp
+++ b/libethashseal/genesis/mainNetwork.cpp
@@ -30,6 +30,7 @@ R"E(
 		"metropolisForkBlock": "0xffffffffffffffffff",
 		"networkID" : "0x01",
 		"chainID": "0x01",
+		"nonceChainID": "0x12",
 		"maximumExtraDataSize": "0x20",
 		"tieBreakingGas": false,
 		"minGasLimit": "0x1388",

--- a/libethashseal/genesis/mainNetworkTest.cpp
+++ b/libethashseal/genesis/mainNetworkTest.cpp
@@ -30,6 +30,7 @@ R"E(
 		"metropolisForkBlock": "0xfffffffffffffff",
 		"networkID" : "0x01",
 		"chainID": "0x01",
+		"nonceChainID": "0x12",
 		"maximumExtraDataSize": "0x20",
 		"tieBreakingGas": false,
 		"minGasLimit": "0x1388",

--- a/libethashseal/genesis/metropolisTest.cpp
+++ b/libethashseal/genesis/metropolisTest.cpp
@@ -38,7 +38,8 @@ R"E(
 		"durationLimit": "0x0d",
 		"blockReward": "0x4563918244F40000",
 		"registrar" : "0xc6d9d2cd449a754c494264e1809c50e34d64562b",
-		"networkID" : "0x1"
+		"networkID" : "0x1",
+		"nonceChainID": "0x12"
 	},
 	"genesis": {
 		"nonce": "0x0000000000000042",

--- a/libethashseal/genesis/ropsten.cpp
+++ b/libethashseal/genesis/ropsten.cpp
@@ -38,7 +38,8 @@ R"E(
 		"durationLimit": "0x0d",
 		"blockReward": "0x4563918244F40000",
 		"registrar": "",
-		"networkID" : "0x03"
+		"networkID" : "0x03",
+		"nonceChainID": "0x1c"
 	},
 	"genesis": {
 		"nonce": "0x0000000000000042",

--- a/libethashseal/genesis/transitionnetTest.cpp
+++ b/libethashseal/genesis/transitionnetTest.cpp
@@ -30,6 +30,7 @@ R"E(
 		"metropolisForkBlock": "0xfffffffffffffff",
 		"networkID" : "0x01",
 		"chainID": "0x01",
+		"nonceChainID": "0x12",
 		"maximumExtraDataSize": "0x20",
 		"tieBreakingGas": false,
 		"minGasLimit": "0x1388",

--- a/libethcore/Exceptions.h
+++ b/libethcore/Exceptions.h
@@ -52,6 +52,7 @@ DEV_SIMPLE_EXCEPTION(TooMuchGasUsed);
 DEV_SIMPLE_EXCEPTION(ExtraDataTooBig);
 DEV_SIMPLE_EXCEPTION(ExtraDataIncorrect);
 DEV_SIMPLE_EXCEPTION(InvalidSignature);
+DEV_SIMPLE_EXCEPTION(InvalidChainIdInNonce);
 DEV_SIMPLE_EXCEPTION(InvalidTransactionFormat);
 DEV_SIMPLE_EXCEPTION(InvalidBlockFormat);
 DEV_SIMPLE_EXCEPTION(InvalidUnclesHash);

--- a/libethcore/Transaction.cpp
+++ b/libethcore/Transaction.cpp
@@ -31,6 +31,11 @@ using namespace std;
 using namespace dev;
 using namespace dev::eth;
 
+namespace
+{
+int const c_chainIdInNonceBits = 64;
+}
+
 TransactionBase::TransactionBase(TransactionSkeleton const& _ts, Secret const& _s):
 	m_type(_ts.creation ? ContractCreation : MessageCall),
 	m_nonce(_ts.nonce),
@@ -172,6 +177,13 @@ void TransactionBase::checkChainId(int chainId) const
 {
 	if (m_chainId != chainId && m_chainId != -4)
 		BOOST_THROW_EXCEPTION(InvalidSignature());
+}
+
+void TransactionBase::checkNonceChainId(unsigned _chainId) const
+{
+	unsigned const nonceChainId = static_cast<unsigned>(m_nonce >> c_chainIdInNonceBits);
+	if (nonceChainId != _chainId && nonceChainId != 0)
+		BOOST_THROW_EXCEPTION(InvalidChainIdInNonce());
 }
 
 int64_t TransactionBase::baseGasRequired(bool _contractCreation, bytesConstRef _data, EVMSchedule const& _es)

--- a/libethcore/Transaction.cpp
+++ b/libethcore/Transaction.cpp
@@ -34,6 +34,7 @@ using namespace dev::eth;
 namespace
 {
 int const c_chainIdInNonceBits = 64;
+u256 const c_nonceLowMask = 0xffffffffffffffff;
 }
 
 TransactionBase::TransactionBase(TransactionSkeleton const& _ts, Secret const& _s):
@@ -133,6 +134,11 @@ Address const& TransactionBase::sender() const
 		}
 	}
 	return m_sender;
+}
+
+u256 TransactionBase::nonceLow() const
+{
+	return m_nonce & c_nonceLowMask;
 }
 
 void TransactionBase::sign(Secret const& _priv)

--- a/libethcore/Transaction.cpp
+++ b/libethcore/Transaction.cpp
@@ -34,7 +34,7 @@ using namespace dev::eth;
 namespace
 {
 int const c_chainIdInNonceBits = 64;
-u256 const c_nonceLowMask = 0xffffffffffffffff;
+uint64_t const c_nonceLowMask = 0xffffffffffffffff;
 }
 
 TransactionBase::TransactionBase(TransactionSkeleton const& _ts, Secret const& _s):

--- a/libethcore/Transaction.h
+++ b/libethcore/Transaction.h
@@ -86,13 +86,17 @@ public:
 	/// Force the sender to a particular value. This will result in an invalid transaction RLP.
 	void forceSender(Address const& _a) { m_sender = _a; }
 
-	/// @throws InvalidSValue if the signature has an invalid S value.
+	/// @throws InvalidSignature if the signature has an invalid S value.
 	void checkLowS() const;
 
-	/// @throws InvalidSValue if the chain id is neither -4 nor equal to @a chainId
+	/// @throws InvalidSignature if the chain id is neither -4 nor equal to @a chainId
 	/// Note that "-4" is the chain ID of the pre-155 rules, which should also be considered valid
 	/// after EIP155
 	void checkChainId(int chainId = -4) const;
+
+	/// @throws InvalidChainIdInNonce if the chain id encoded in high-order bits of nonce is neither 0 nor equal to @a _chainId
+	/// 0 is the chain ID of the pre-EIP166 rules, which should also be considered valid after EIP166
+	void checkNonceChainId(unsigned _chainId) const;
 
 	/// @returns true if transaction is non-null.
 	explicit operator bool() const { return m_type != NullTransaction; }

--- a/libethcore/Transaction.h
+++ b/libethcore/Transaction.h
@@ -137,6 +137,9 @@ public:
 	/// @returns the transaction-count of the sender.
 	u256 nonce() const { return m_nonce; }
 
+	/// @returns low-order of bits of nonce that should be used to check against sender nonce according to EIP-166
+	u256 nonceLow() const;
+
 	/// Sets the nonce to the given value. Clears any signature.
 	void setNonce(u256 const& _n) { clearSignature(); m_nonce = _n; }
 

--- a/libethereum/ClientBase.cpp
+++ b/libethereum/ClientBase.cpp
@@ -48,9 +48,7 @@ pair<h256, Address> ClientBase::submitTransaction(TransactionSkeleton const& _t,
 	{
 		ts.nonce = max<u256>(postSeal().transactionsFrom(ts.from), m_tq.maxNonce(ts.from));
 		if (postSeal().info().number() >= bc().chainParams().u256Param("metropolisForkBlock"))
-		{
 			ts.nonce &= (bc().chainParams().u256Param("nonceChainID") << c_chainIdInNonceShift);
-		}
 	}
 	if (ts.gasPrice == Invalid256)
 		ts.gasPrice = gasBidPrice();

--- a/libethereum/Executive.cpp
+++ b/libethereum/Executive.cpp
@@ -180,6 +180,22 @@ void Executive::initialize(Transaction const& _transaction)
 {
 	m_t = _transaction;
 
+	if (m_envInfo.number() >= m_sealEngine.chainParams().u256Param("metropolisForkBlock"))
+	{
+		try
+		{
+			unsigned const nonceChainId(m_sealEngine.chainParams().u256Param("nonceChainID"));
+			m_t.checkNonceChainId(nonceChainId);
+		}
+		catch (InvalidChainIdInNonce const&)
+		{
+			unsigned const nonceChainId(m_sealEngine.chainParams().u256Param("nonceChainID"));
+			clog(ExecutiveWarnChannel) << "Invalid ChainID in tx nonce" << ": Require <" << nonceChainId << " Got" << (m_t.nonce() >> 64);
+			m_excepted = TransactionException::InvalidChainIdInNonce;
+			BOOST_THROW_EXCEPTION(InvalidChainIdInNonce());
+		}
+	}
+
 	// Avoid transactions that would take us beyond the block gas limit.
 	u256 startGasUsed = m_envInfo.gasUsed();
 	if (startGasUsed + (bigint)m_t.gas() > m_envInfo.gasLimit())

--- a/libethereum/Executive.cpp
+++ b/libethereum/Executive.cpp
@@ -228,11 +228,13 @@ void Executive::initialize(Transaction const& _transaction)
 			m_excepted = TransactionException::InvalidSignature;
 			throw;
 		}
-		if (m_t.nonce() != nonceReq)
+
+		u256 const nonceTx = m_envInfo.number() >= m_sealEngine.chainParams().u256Param("metropolisForkBlock") ? m_t.nonceLow() : m_t.nonce();
+		if (nonceTx != nonceReq)
 		{
 			clog(ExecutiveWarnChannel) << "Invalid Nonce: Require" << nonceReq << " Got" << m_t.nonce();
 			m_excepted = TransactionException::InvalidNonce;
-			BOOST_THROW_EXCEPTION(InvalidNonce() << RequirementError((bigint)nonceReq, (bigint)m_t.nonce()));
+			BOOST_THROW_EXCEPTION(InvalidNonce() << RequirementError((bigint)nonceReq, (bigint)nonceTx));
 		}
 	}
 

--- a/libethereum/Transaction.h
+++ b/libethereum/Transaction.h
@@ -41,6 +41,7 @@ enum class TransactionException
 	OutOfGasIntrinsic,		///< Too little gas to pay for the base transaction cost.
 	InvalidSignature,
 	InvalidNonce,
+	InvalidChainIdInNonce,
 	NotEnoughCash,
 	OutOfGasBase,			///< Too little gas to pay for the base transaction cost.
 	BlockGasLimitReached,

--- a/test/unittests/libethashseal/EthashTest.cpp
+++ b/test/unittests/libethashseal/EthashTest.cpp
@@ -1,0 +1,55 @@
+/*
+	This file is part of cpp-ethereum.
+
+	cpp-ethereum is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	cpp-ethereum is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/** @file ethash.cpp
+ * Ethash class testing.
+ */
+
+#include <boost/test/unit_test.hpp>
+#include <test/libtesteth/TestHelper.h>
+#include <libethashseal/Ethash.h>
+
+using namespace std;
+using namespace dev;
+using namespace dev::eth;
+using namespace dev::test;
+
+BOOST_FIXTURE_TEST_SUITE(EthashTests, TestOutputHelper)
+
+BOOST_AUTO_TEST_CASE(verifyTransactionChecksNonceChainId)
+{
+	ChainOperationParams params;
+	params.otherParams["metropolisForkBlock"] = "0x1000";
+	params.otherParams["nonceChainID"] = "18";
+
+	Ethash ethash;
+	ethash.setChainParams(params);
+
+	BlockHeader header;
+	header.setNumber(0x2000);
+
+	u256 invalidNonce = (u256(28) << 64) + 123;
+	Transaction invalidTx(1, 1, 100000, Address(), bytes(), invalidNonce);
+
+	BOOST_CHECK_THROW(ethash.verifyTransaction(ImportRequirements::Everything, invalidTx, header), InvalidChainIdInNonce);
+
+	u256 validNonce = (u256(0x18) << 64) + 123;
+	Transaction validTx(1, 1, 100000, Address(), bytes(), validNonce);
+
+	ethash.verifyTransaction(ImportRequirements::Everything, validTx, header);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/unittests/libethashseal/EthashTest.cpp
+++ b/test/unittests/libethashseal/EthashTest.cpp
@@ -19,7 +19,7 @@
  */
 
 #include <boost/test/unit_test.hpp>
-#include <test/libtesteth/TestHelper.h>
+#include <test/tools/libtesteth/TestHelper.h>
 #include <libethashseal/Ethash.h>
 
 using namespace std;

--- a/test/unittests/libethereum/Transaction.cpp
+++ b/test/unittests/libethereum/Transaction.cpp
@@ -147,4 +147,25 @@ BOOST_AUTO_TEST_CASE(toTransactionExceptionConvert)
 	BOOST_CHECK_MESSAGE(toTransactionException(notEx) == TransactionException::Unknown, "Unexpected should be TransactionException::Unknown");
 }
 
+BOOST_AUTO_TEST_CASE(NonceChainIdZeroAllowed)
+{
+	u256 nonce = 123;
+	Transaction tr(1, 1, 1, Address(), bytes(), nonce);
+	tr.checkNonceChainId(456); // check that it doesn't throw
+}
+
+BOOST_AUTO_TEST_CASE(RequiredChainIdAllowed)
+{
+	u256 nonce = (u256(28) << 64) + 123;
+	Transaction tr(1, 1, 1, Address(), bytes(), nonce);
+	tr.checkNonceChainId(28); // check that it doesn't throw
+}
+
+BOOST_AUTO_TEST_CASE(IncorrectChainIdNotAllowed)
+{
+	u256 nonce = (u256(28) << 64) + 123;
+	Transaction tr(1, 1, 1, Address(), bytes(), nonce);
+	BOOST_CHECK_THROW(tr.checkNonceChainId(18), InvalidChainIdInNonce);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/unittests/libethereum/Transaction.cpp
+++ b/test/unittests/libethereum/Transaction.cpp
@@ -168,4 +168,11 @@ BOOST_AUTO_TEST_CASE(IncorrectChainIdNotAllowed)
 	BOOST_CHECK_THROW(tr.checkNonceChainId(18), InvalidChainIdInNonce);
 }
 
+BOOST_AUTO_TEST_CASE(TransactionNonceLow)
+{
+	u256 nonce = (u256(28) << 64) + 123;
+	Transaction tr(1, 1, 1, Address(), bytes(), nonce);
+	BOOST_CHECK_EQUAL(tr.nonceLow(), 123);
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
https://github.com/ethereum/cpp-ethereum/issues/3617
https://github.com/ethereum/EIPs/issues/166

- [x] Add check for CHAIN_ID in transaction validation for transactions in the block
- [x] Add the check for pending transactions
- [x] When checking against sender nonce, use only lower 64 bits of tx nonce
- [x] Creating nonce for `eth.sendTransaction` RPC call