### PR TITLE
issues/3332 use-after-free

### DIFF
--- a/libp2p/Host.cpp
+++ b/libp2p/Host.cpp
@@ -658,8 +658,8 @@ void Host::run(boost::system::error_code const&)
 		// and also stops blocking worker thread, allowing worker thread to exit
 		m_ioService.stop();
 
-		// resetting timer signals network that nothing else can be scheduled to run
-		m_timer.reset();
+		// cancel any pending timer
+		m_timer->cancel();
 		return;
 	}
 


### PR DESCRIPTION
calling m_timer.reset() detroys m_ioService which is later used in doneWorking(). 

https://github.com/ethereum/cpp-ethereum/issues/3332