### PR TITLE
reverse stack direction, simplify stack logic

### DIFF
--- a/libevm/VM.h
+++ b/libevm/VM.h
@@ -146,7 +146,7 @@ private:
 	bool caseCallSetup(CallParameters*, bytesRef& o_output);
 	void caseCall();
 
-	void copyDataToMemory(bytesConstRef _data, u256* m_SP);
+	void copyDataToMemory(bytesConstRef _data, u256* _SP);
 	uint64_t memNeed(u256 _offset, u256 _size);
 
 	void throwOutOfGas();

--- a/libevm/VM.h
+++ b/libevm/VM.h
@@ -65,7 +65,7 @@ public:
 #if EVM_JUMPS_AND_SUBS
 	// invalid code will throw an exeption
 	void validate(ExtVMFace& _ext);
-	void validateSubroutine(uint64_t _PC, uint64_t* _RP, u256* _SP);
+	void validateSubroutine(uint64_t _PC, uint64_t* _rp, u256* _sp);
 #endif
 
 	bytes const& memory() const { return m_mem; }
@@ -146,7 +146,7 @@ private:
 	bool caseCallSetup(CallParameters*, bytesRef& o_output);
 	void caseCall();
 
-	void copyDataToMemory(bytesConstRef _data, u256* _SP);
+	void copyDataToMemory(bytesConstRef _data, u256*_sp);
 	uint64_t memNeed(u256 _offset, u256 _size);
 
 	void throwOutOfGas();

--- a/libevm/VMCalls.cpp
+++ b/libevm/VMCalls.cpp
@@ -25,12 +25,12 @@ using namespace dev::eth;
 
 
 
-void VM::copyDataToMemory(bytesConstRef _data, u256* _SP)
+void VM::copyDataToMemory(bytesConstRef _data, u256*_sp)
 {
-	auto offset = static_cast<size_t>(_SP[0]);
-	s512 bigIndex = _SP[1];
+	auto offset = static_cast<size_t>(_sp[0]);
+	s512 bigIndex = _sp[1];
 	auto index = static_cast<size_t>(bigIndex);
-	auto size = static_cast<size_t>(_SP[2]);
+	auto size = static_cast<size_t>(_sp[2]);
 
 	size_t sizeToBeCopied = bigIndex + size > _data.size() ? _data.size() < bigIndex ? 0 : _data.size() - index : size;
 

--- a/libevm/VMConfig.h
+++ b/libevm/VMConfig.h
@@ -35,7 +35,7 @@ namespace eth
 
 #ifndef EVM_JUMP_DISPATCH
 	#ifdef __GNUC__
-		#define EVM_JUMP_DISPATCH true
+		#define EVM_JUMP_DISPATCH false
 	#else
 		#define EVM_JUMP_DISPATCH false
 	#endif
@@ -49,10 +49,10 @@ namespace eth
 #endif
 
 #ifndef EVM_OPTIMIZE
-	#define EVM_OPTIMIZE true
+	#define EVM_OPTIMIZE false
 #endif
 #if EVM_OPTIMIZE
-	#define EVM_REPLACE_CONST_JUMP true
+	#define EVM_REPLACE_CONST_JUMP false
 	#define EVM_USE_CONSTANT_POOL false
 	#define EVM_DO_FIRST_PASS_OPTIMIZATION ( \
 				EVM_REPLACE_CONST_JUMP || \

--- a/libevm/VMConfig.h
+++ b/libevm/VMConfig.h
@@ -35,7 +35,7 @@ namespace eth
 
 #ifndef EVM_JUMP_DISPATCH
 	#ifdef __GNUC__
-		#define EVM_JUMP_DISPATCH false
+		#define EVM_JUMP_DISPATCH true
 	#else
 		#define EVM_JUMP_DISPATCH false
 	#endif
@@ -49,10 +49,10 @@ namespace eth
 #endif
 
 #ifndef EVM_OPTIMIZE
-	#define EVM_OPTIMIZE false
+	#define EVM_OPTIMIZE true
 #endif
 #if EVM_OPTIMIZE
-	#define EVM_REPLACE_CONST_JUMP false
+	#define EVM_REPLACE_CONST_JUMP true
 	#define EVM_USE_CONSTANT_POOL false
 	#define EVM_DO_FIRST_PASS_OPTIMIZATION ( \
 				EVM_REPLACE_CONST_JUMP || \

--- a/libevm/VMOpt.cpp
+++ b/libevm/VMOpt.cpp
@@ -55,10 +55,9 @@ void VM::copyCode(int _extraBytes)
 	// _extraBytes zero bytes to allow reading virtual data at the end
 	// of the code without bounds checks.
 	auto extendedSize = m_ext->code.size() + _extraBytes;
-	m_codeSpace.reserve(extendedSize);
-	m_codeSpace = m_ext->code;
-	m_codeSpace.resize(extendedSize);
-	m_code = m_codeSpace.data();
+	m_code.reserve(extendedSize);
+	m_code = m_ext->code;
+	m_code.resize(extendedSize);
 }
 
 void VM::optimize()
@@ -239,7 +238,7 @@ void VM::optimize()
 				if (0 <= verifyJumpDest(val, false))
 					m_code[i] = byte(op = Instruction::JUMPCI);
 				
-				TRACE_POST_OPT(1, ii, op);
+				TRACE_POST_OPT(1, i, op);
 			}
 		#endif
 

--- a/libevm/VMValidate.cpp
+++ b/libevm/VMValidate.cpp
@@ -60,10 +60,10 @@ void VM::validate(ExtVMFace& _ext)
 // - PC is the offset in the code to start validating at
 // - RP is the top PC on return stack that RETURNSUB returns to
 // - SP = FP at the top level, so the stack size is also the frame size
-void VM::validateSubroutine(uint64_t _PC, uint64_t* _RP, u256* _SP)
+void VM::validateSubroutine(uint64_t _pc, uint64_t* _rp, u256* _sp)
 {
 	// set current interpreter state
-	m_PC = _PC, m_RP = _RP, m_SP = _SP;
+	m_PC = _pc, m_RP = _rp, m_SP = _sp;
 	
 	INIT_CASES
 	DO_CASES
@@ -98,9 +98,9 @@ void VM::validateSubroutine(uint64_t _PC, uint64_t* _RP, u256* _SP)
 		{
 			// recurse to validate code to jump to, saving and restoring
 			// interpreter state around call
-			_PC = m_PC, _RP = m_RP, _SP = m_SP;
-			validateSubroutine(decodeJumpvDest(m_code, m_PC, m_SP), _RP, _SP);
-			m_PC = _PC, m_RP = _RP, m_SP = _SP;
+			_pc = m_PC, _rp = m_RP, _sp = m_SP;
+			validateSubroutine(decodeJumpvDest(m_code, m_PC, m_SP), _rp, _sp);
+			m_PC = _pc, m_RP = _rp, m_SP = _sp;
 			++m_PC;
 		}
 		NEXT
@@ -112,9 +112,9 @@ void VM::validateSubroutine(uint64_t _PC, uint64_t* _RP, u256* _SP)
 			{
 				// recurse to validate code to jump to, saving and 
 				// restoring interpreter state around call
-				_PC = m_PC, _RP = m_RP, _SP = m_SP;
-				validateSubroutine(decodeJumpDest(m_code, m_PC), _RP, _SP);
-				m_PC = _PC, m_RP = _RP, m_SP = _SP;
+				_pc = m_PC, _rp = m_RP, _sp = m_SP;
+				validateSubroutine(decodeJumpDest(m_code, m_PC), _rp, _sp);
+				m_PC = _pc, m_RP = _rp, m_SP = _sp;
 			}
 		}
 		RETURN
@@ -132,18 +132,18 @@ void VM::validateSubroutine(uint64_t _PC, uint64_t* _RP, u256* _SP)
 		CASE(JUMPSUBV)
 		{
 			// for every subroutine in jump vector
-			_PC = m_PC;
+			_pc = m_PC;
 			for (size_t sub = 0, nSubs = m_code[m_PC+1]; sub < nSubs; ++sub)
 			{
 				// check for enough arguments on stack
 				u256 slot = sub;
-				_SP = &slot;
-				size_t destPC = decodeJumpvDest(m_code, _PC, _SP);
+				_sp = &slot;
+				size_t destPC = decodeJumpvDest(m_code, _pc, _sp);
 				byte nArgs = m_code[destPC+1];
 				if (stackSize() < nArgs) 
 					throwBadStack(stackSize(), nArgs, 0);
 			}
-			m_PC = _PC;
+			m_PC = _pc;
 		}
 		NEXT
 


### PR DESCRIPTION
Many little changes here, mostly in service of having the stack grow down rather than up and moving the adjustment and checking of the stack pointer into the CASE macro.  So instead of this for ADD
```
*(m_SP - 1) += *m_SP;
--m_SP;
```
we get this
```
m_SPP[0] = m_SP[0] + m_SP[1];
```
which is easier to read and corresponds to the yellow paper notation, where SP is the current stack pointer, and SP' is the next one.  It gets much easier to read in some of the more complex operations.  In the old days the array notation might have cost a little performance, but compilers are too smart for that now, especially when the indexes are all small constants.