### PR TITLE
Fix failing to create DAG file larger than 2 Gb

### DIFF
--- a/libethash/io.c
+++ b/libethash/io.c
@@ -91,7 +91,7 @@ enum ethash_io_rc ethash_io_prepare(
 		goto free_memo;
 	}
 	// make sure it's of the proper size
-	if (fseek(f, (long int)(file_size + ETHASH_DAG_MAGIC_NUM_SIZE - 1), SEEK_SET) != 0) {
+	if (ethash_fseek(f, file_size + ETHASH_DAG_MAGIC_NUM_SIZE - 1, SEEK_SET) != 0) {
 		fclose(f);
 		ETHASH_CRITICAL("Could not seek to the end of DAG file: \"%s\". Insufficient space?", tmpfile);
 		goto free_memo;

--- a/libethash/io.h
+++ b/libethash/io.h
@@ -114,6 +114,16 @@ enum ethash_io_rc ethash_io_prepare(
 FILE* ethash_fopen(char const* file_name, char const* mode);
 
 /**
+ * An fseek wrapper for crossplatform 64-bit seek.
+ *
+ * @param f            The file stream whose fd to get
+ * @param offset       Number of bytes from @a origin
+ * @param origin       Initial position
+ * @return             Current offset or -1 to indicate an error
+ */
+int ethash_fseek(FILE* f, size_t offset, int origin);
+
+/**
  * An strncat wrapper for no-warnings crossplatform strncat.
  *
  * Msvc compiler considers strncat to be insecure and suggests to use their

--- a/libethash/io_posix.c
+++ b/libethash/io_posix.c
@@ -34,6 +34,11 @@ FILE* ethash_fopen(char const* file_name, char const* mode)
 	return fopen(file_name, mode);
 }
 
+int ethash_fseek(FILE* f, size_t offset, int origin)
+{
+	return fseeko(f, offset, origin);
+}
+
 char* ethash_strncat(char* dest, size_t dest_size, char const* src, size_t count)
 {
 	return strlen(dest) + count + 1 <= dest_size ? strncat(dest, src, count) : NULL;

--- a/libethash/io_win32.c
+++ b/libethash/io_win32.c
@@ -26,11 +26,17 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <shlobj.h>
+#include <io.h>
 
 FILE* ethash_fopen(char const* file_name, char const* mode)
 {
 	FILE* f;
 	return fopen_s(&f, file_name, mode) == 0 ? f : NULL;
+}
+
+int ethash_fseek(FILE* f, size_t offset, int origin)
+{
+	return _fseeki64(f, offset, origin);
 }
 
 char* ethash_strncat(char* dest, size_t dest_size, char const* src, size_t count)


### PR DESCRIPTION
Fixes https://github.com/ethereum/cpp-ethereum/issues/4021

`fseek` has 32-bit offset parameter, and there's no fully-portable way in C to do 64-bit seek, so we resort to different version for Windows & POSIX.