### PR TITLE
skip unneeded tests if options are set for a specific test run

### DIFF
--- a/test/tools/libtesteth/ImportTest.cpp
+++ b/test/tools/libtesteth/ImportTest.cpp
@@ -82,6 +82,14 @@ bytes ImportTest::executeTest()
 		{
 			for (size_t i = 0; i < m_transactions.size(); i++)
 			{
+				Options const& opt = Options::get();
+				if(opt.trDataIndex != -1 && opt.trDataIndex != m_transactions[i].dataInd)
+					continue;
+				if(opt.trGasIndex != -1 && opt.trGasIndex != m_transactions[i].gasInd)
+					continue;
+				if(opt.trValueIndex != -1 && opt.trValueIndex != m_transactions[i].valInd)
+					continue;
+
 				eth::Network network = networks[j];
 				std::pair<eth::State, ImportTest::execOutput> out = executeTransaction(network, m_envInfo, m_statePre, m_transactions[i].transaction);
 				m_transactions[i].postState = out.first;
@@ -484,6 +492,14 @@ void ImportTest::checkGeneralTestSectionSearch(json_spirit::mObject const& _expe
 	for(size_t i=0; i<network.size(); i++)
 		BOOST_CHECK_MESSAGE(inArray(allowednetworks, network.at(i)), TestOutputHelper::testName() + "Specified Network not found: " + network.at(i));
 
+	if (!Options::get().singleTestNet.empty())
+	{
+		//skip this check if we execute transactions only on another specified network
+		if (!inArray(network, Options::get().singleTestNet) && !inArray(network, string{"ALL"}))
+			return;
+	}
+
+
 	if (_expects.count("indexes"))
 	{
 		json_spirit::mObject const& indexes = _expects.at("indexes").get_obj();
@@ -491,6 +507,15 @@ void ImportTest::checkGeneralTestSectionSearch(json_spirit::mObject const& _expe
 		parseJsonIntValueIntoVector(indexes.at("gas"), g);
 		parseJsonIntValueIntoVector(indexes.at("value"), v);
 		BOOST_CHECK_MESSAGE(d.size() > 0 && g.size() > 0 && v.size() > 0, TestOutputHelper::testName() + "Indexes arrays not set!");
+
+		//Skip this check if does not fit to options request
+		Options const& opt = Options::get();
+		if (!inArray(d, opt.trDataIndex) && !inArray(d, -1) && opt.trDataIndex != -1)
+			return;
+		if (!inArray(g, opt.trGasIndex) && !inArray(g, -1) && opt.trGasIndex != -1)
+			return;
+		if (!inArray(v, opt.trValueIndex) && !inArray(v, -1) && opt.trValueIndex != -1)
+			return;
 	}
 	else
 		BOOST_ERROR(TestOutputHelper::testName() + "indexes section not set!");
@@ -547,8 +572,8 @@ void ImportTest::checkGeneralTestSectionSearch(json_spirit::mObject const& _expe
 				break;
 		}
 	}
-	if (!_search) //search for a single transaction in one of the expect sections then don't need this output.
-		BOOST_CHECK_MESSAGE(foundResults, TestOutputHelper::testName() + "Expect results was not found in test execution!");
+	if (!_search) //if search for a single transaction in one of the expect sections then don't need this output.
+		BOOST_CHECK_MESSAGE(foundResults, TestOutputHelper::testName() + " Expect results was not found in test execution!");
 }
 
 int ImportTest::exportTest(bytes const& _output)

--- a/test/tools/libtesteth/Options.h
+++ b/test/tools/libtesteth/Options.h
@@ -57,9 +57,9 @@ public:
 	std::string singleTestFile;
 	std::string singleTestName;
 	std::string singleTestNet;
-	int trDataIndex; ///< GeneralState data
-	int trGasIndex; ///< GeneralState gas
-	int trValueIndex; ///< GeneralState value
+	int trDataIndex;	///< GeneralState data
+	int trGasIndex;		///< GeneralState gas
+	int trValueIndex;	///< GeneralState value
 	bool performance = false;
 	bool nonetwork = false;///< For libp2p
 	bool quadratic = false;///< Time consuming tests


### PR DESCRIPTION
minor improvements of `testeth` options 

-d < ind >
-g < ind >
-v < ind >
--singlenet < str >

in combination with 
--filltests 
--fillchain
--checkstate