### PR TITLE
EIP98 - Remove state root hash from transaction receipt

### DIFF
--- a/libethcore/Exceptions.h
+++ b/libethcore/Exceptions.h
@@ -75,6 +75,7 @@ DEV_SIMPLE_EXCEPTION(InvalidParentHash);
 DEV_SIMPLE_EXCEPTION(InvalidUncleParentHash);
 DEV_SIMPLE_EXCEPTION(InvalidNumber);
 DEV_SIMPLE_EXCEPTION(InvalidZeroSignatureTransaction);
+DEV_SIMPLE_EXCEPTION(InvalidTransactionReceiptFormat);
 DEV_SIMPLE_EXCEPTION(BlockNotFound);
 DEV_SIMPLE_EXCEPTION(UnknownParent);
 

--- a/libethereum/Block.cpp
+++ b/libethereum/Block.cpp
@@ -829,15 +829,10 @@ bool Block::sealBlock(bytesConstRef _header)
 	return true;
 }
 
-State Block::fromPending(unsigned _i) const
+h256 Block::stateRootBeforeTx(unsigned _i) const
 {
-	State ret = m_state;
 	_i = min<unsigned>(_i, m_transactions.size());
-	if (!_i)
-		ret.setRoot(m_previousBlock.stateRoot());
-	else
-		ret.setRoot(receipt(_i - 1).stateRoot());
-	return ret;
+	return (_i > 0 ? receipt(_i - 1).stateRoot() : m_previousBlock.stateRoot());
 }
 
 LogBloom Block::logBloom() const

--- a/libethereum/Block.h
+++ b/libethereum/Block.h
@@ -202,9 +202,10 @@ public:
 	/// Get the bloom filter of a particular transaction that happened in the block.
 	LogBloom const& logBloom(unsigned _i) const { return receipt(_i).bloom(); }
 
-	/// Get the State root hash immediately after the given number of pending transactions have been applied.
+	/// Get the State root hash immediately after all previous transactions before transaction @a _i have been applied.
 	/// If (_i == 0) returns the initial state of the block.
 	/// If (_i == pending().size()) returns the final state of the block, prior to rewards.
+	/// Returns zero hash if intermediate state root is not available in the receipt (the case after EIP98)
 	h256 stateRootBeforeTx(unsigned _i) const;
 
 	// State-change operations

--- a/libethereum/Block.h
+++ b/libethereum/Block.h
@@ -202,10 +202,10 @@ public:
 	/// Get the bloom filter of a particular transaction that happened in the block.
 	LogBloom const& logBloom(unsigned _i) const { return receipt(_i).bloom(); }
 
-	/// Get the State immediately after the given number of pending transactions have been applied.
+	/// Get the State root hash immediately after the given number of pending transactions have been applied.
 	/// If (_i == 0) returns the initial state of the block.
 	/// If (_i == pending().size()) returns the final state of the block, prior to rewards.
-	State fromPending(unsigned _i) const;
+	h256 stateRootBeforeTx(unsigned _i) const;
 
 	// State-change operations
 

--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -775,28 +775,6 @@ Block Client::block(h256 const& _blockHash, PopulationStatistics* o_stats) const
 	}
 }
 
-State Client::state(unsigned _txi, h256 const& _blockHash) const
-{
-	try
-	{
-		return block(_blockHash).fromPending(_txi);
-	}
-	catch (Exception& ex)
-	{
-		ex << errinfo_block(bc().block(_blockHash));
-		onBadBlock(ex);
-		return State(chainParams().accountStartNonce);
-	}
-}
-
-eth::State Client::state(unsigned _txi) const
-{
-	DEV_READ_GUARDED(x_postSeal)
-		return m_postSeal.fromPending(_txi);
-	assert(false);
-	return State(chainParams().accountStartNonce);
-}
-
 void Client::flushTransactions()
 {
 	doWork();

--- a/libethereum/Client.h
+++ b/libethereum/Client.h
@@ -112,12 +112,6 @@ public:
 	// [PRIVATE API - only relevant for base clients, not available in general]
 	/// Get the block.
 	dev::eth::Block block(h256 const& _blockHash, PopulationStatistics* o_stats) const;
-	/// Get the state of the given block part way through execution, immediately before transaction
-	/// index @a _txi.
-	dev::eth::State state(unsigned _txi, h256 const& _block) const;
-	/// Get the state of the currently pending block part way through execution, immediately before
-	/// transaction index @a _txi.
-	dev::eth::State state(unsigned _txi) const;
 
 	/// Get the object representing the current state of Ethereum.
 	dev::eth::Block postState() const { ReadGuard l(x_postSeal); return m_postSeal; }

--- a/libethereum/Executive.cpp
+++ b/libethereum/Executive.cpp
@@ -157,20 +157,12 @@ Executive::Executive(Block& _s, LastHashes const& _lh, unsigned _level):
 {
 }
 
-Executive::Executive(State& _s, Block const& _block, unsigned _txIndex, BlockChain const& _bc, unsigned _level):
-	m_s(_s = _block.state()),
+Executive::Executive(State& io_s, Block const& _block, unsigned _txIndex, BlockChain const& _bc, unsigned _level):
+	m_s(createIntermediateState(io_s, _block, _txIndex, _bc)),
 	m_envInfo(_block.info(), _bc.lastHashes(_block.info().parentHash()), _txIndex ? _block.receipt(_txIndex - 1).gasUsed() : 0),
 	m_depth(_level),
 	m_sealEngine(*_bc.sealEngine())
 {
-	u256 const rootHash = _block.stateRootBeforeTx(_txIndex);
-	if (rootHash)
-		m_s.setRoot(rootHash);
-	else
-	{
-		m_s.setRoot(_block.stateRootBeforeTx(0));
-		m_s.executeBlockTransactions(_block, _txIndex, _bc.lastHashes(_block.info().parentHash()), *_bc.sealEngine());
-	}
 }
 
 u256 Executive::gasUsed() const

--- a/libethereum/Executive.h
+++ b/libethereum/Executive.h
@@ -122,7 +122,7 @@ public:
 	 * populating environment info from the given Block and the LastHashes portion from the BlockChain.
 	 * State is assigned the resultant value, but otherwise unused.
 	 */
-	Executive(State& _s, Block const& _block, unsigned _txIndex, BlockChain const& _bc, unsigned _level = 0);
+	Executive(State& io_s, Block const& _block, unsigned _txIndex, BlockChain const& _bc, unsigned _level = 0);
 
 	Executive(Executive const&) = delete;
 	void operator=(Executive) = delete;

--- a/libethereum/State.cpp
+++ b/libethereum/State.cpp
@@ -539,7 +539,8 @@ std::pair<ExecutionResult, TransactionReceipt> State::execute(EnvInfo const& _en
 		commit(removeEmptyAccounts ? State::CommitBehaviour::RemoveEmptyAccounts : State::CommitBehaviour::KeepEmptyAccounts);
 	}
 
-	return make_pair(res, TransactionReceipt(rootHash(), startGasUsed + e.gasUsed(), e.logs()));
+	h256 const rootState = _envInfo.number() >= _sealEngine.chainParams().u256Param("metropolisForkBlock") ? h256() : rootHash();
+	return make_pair(res, TransactionReceipt(rootState, startGasUsed + e.gasUsed(), e.logs()));
 }
 
 std::ostream& dev::eth::operator<<(std::ostream& _out, State const& _s)

--- a/libethereum/State.cpp
+++ b/libethereum/State.cpp
@@ -540,8 +540,10 @@ std::pair<ExecutionResult, TransactionReceipt> State::execute(EnvInfo const& _en
 		commit(removeEmptyAccounts ? State::CommitBehaviour::RemoveEmptyAccounts : State::CommitBehaviour::KeepEmptyAccounts);
 	}
 
-	h256 const rootState = _envInfo.number() >= _sealEngine.chainParams().u256Param("metropolisForkBlock") ? h256() : rootHash();
-	return make_pair(res, TransactionReceipt(rootState, startGasUsed + e.gasUsed(), e.logs()));
+	TransactionReceipt const receipt = _envInfo.number() >= _sealEngine.chainParams().u256Param("metropolisForkBlock") ?
+		TransactionReceipt(startGasUsed + e.gasUsed(), e.logs()) :
+		TransactionReceipt(rootHash(), startGasUsed + e.gasUsed(), e.logs());
+	return make_pair(res, receipt);
 }
 
 void State::executeBlockTransactions(Block const& _block, unsigned _txCount, LastHashes const& _lastHashes, SealEngineFace const& _sealEngine)

--- a/libethereum/State.cpp
+++ b/libethereum/State.cpp
@@ -36,7 +36,6 @@
 #include "Defaults.h"
 #include "ExtVM.h"
 #include "Executive.h"
-#include "BlockChain.h"
 #include "TransactionQueue.h"
 
 using namespace std;
@@ -49,6 +48,20 @@ const char* StateSafeExceptions::name() { return EthViolet "⚙" EthBlue " ℹ";
 const char* StateDetail::name() { return EthViolet "⚙" EthWhite " ◌"; }
 const char* StateTrace::name() { return EthViolet "⚙" EthGray " ◎"; }
 const char* StateChat::name() { return EthViolet "⚙" EthWhite " ◌"; }
+
+namespace
+{
+
+void executeTransaction(Executive& _e, Transaction const& _t, OnOpFunc const& _onOp)
+{
+	_e.initialize(_t);
+
+	if (!_e.execute())
+		_e.go(_onOp);
+	_e.finalize();
+}
+
+}
 
 State::State(u256 const& _accountStartNonce, OverlayDB const& _db, BaseState _bs):
 	m_db(_db),
@@ -524,13 +537,9 @@ std::pair<ExecutionResult, TransactionReceipt> State::execute(EnvInfo const& _en
 	Executive e(*this, _envInfo, _sealEngine);
 	ExecutionResult res;
 	e.setResultRecipient(res);
-	e.initialize(_t);
 
-	// OK - transaction looks valid - execute.
-	u256 startGasUsed = _envInfo.gasUsed();
-	if (!e.execute())
-		e.go(onOp);
-	e.finalize();
+	u256 const startGasUsed = _envInfo.gasUsed();
+	executeTransaction(e, _t, onOp);
 
 	if (_p == Permanence::Reverted)
 		m_cache.clear();
@@ -554,10 +563,7 @@ void State::executeBlockTransactions(Block const& _block, unsigned _txCount, Las
 		EnvInfo envInfo(_block.info(), _lastHashes, gasUsed);
 
 		Executive e(*this, envInfo, _sealEngine);
-		e.initialize(_block.pending()[i]);
-		if (!e.execute())
-			e.go();
-		e.finalize();
+		executeTransaction(e, _block.pending()[i], OnOpFunc());
 
 		gasUsed += e.gasUsed();
 	}
@@ -637,4 +643,18 @@ std::ostream& dev::eth::operator<<(std::ostream& _out, State const& _s)
 		}
 	}
 	return _out;
+}
+
+State& dev::eth::createIntermediateState(State& o_s, Block const& _block, unsigned _txIndex, BlockChain const& _bc)
+{
+	o_s = _block.state();
+	u256 const rootHash = _block.stateRootBeforeTx(_txIndex);
+	if (rootHash)
+		o_s.setRoot(rootHash);
+	else
+	{
+		o_s.setRoot(_block.stateRootBeforeTx(0));
+		o_s.executeBlockTransactions(_block, _txIndex, _bc.lastHashes(_block.info().parentHash()), *_bc.sealEngine());
+	}
+	return o_s;
 }

--- a/libethereum/State.h
+++ b/libethereum/State.h
@@ -207,6 +207,8 @@ public:
 	/// This will change the state accordingly.
 	std::pair<ExecutionResult, TransactionReceipt> execute(EnvInfo const& _envInfo, SealEngineFace const& _sealEngine, Transaction const& _t, Permanence _p = Permanence::Committed, OnOpFunc const& _onOp = OnOpFunc());
 
+	void executeBlockTransactions(Block const& _block, unsigned _txCount, LastHashes const& _lastHashes, SealEngineFace const& _sealEngine);
+
 	/// Check if the address is in use.
 	bool addressInUse(Address const& _address) const;
 

--- a/libethereum/State.h
+++ b/libethereum/State.h
@@ -95,7 +95,7 @@ DEV_SIMPLE_EXCEPTION(InvalidAccountStartNonceInState);
 DEV_SIMPLE_EXCEPTION(IncorrectAccountStartNonceInState);
 
 class SealEngineFace;
-
+class Executive;
 
 namespace detail
 {
@@ -207,6 +207,8 @@ public:
 	/// This will change the state accordingly.
 	std::pair<ExecutionResult, TransactionReceipt> execute(EnvInfo const& _envInfo, SealEngineFace const& _sealEngine, Transaction const& _t, Permanence _p = Permanence::Committed, OnOpFunc const& _onOp = OnOpFunc());
 
+	/// Execute @a _txCount transactions of a given block.
+	/// This will change the state accordingly.
 	void executeBlockTransactions(Block const& _block, unsigned _txCount, LastHashes const& _lastHashes, SealEngineFace const& _sealEngine);
 
 	/// Check if the address is in use.
@@ -338,6 +340,8 @@ private:
 };
 
 std::ostream& operator<<(std::ostream& _out, State const& _s);
+
+State& createIntermediateState(State& o_s, Block const& _block, unsigned _txIndex, BlockChain const& _bc);
 
 template <class DB>
 AddressHash commit(AccountMap const& _cache, SecureTrieDB<Address, DB>& _state)

--- a/libethereum/TransactionReceipt.h
+++ b/libethereum/TransactionReceipt.h
@@ -32,6 +32,9 @@ namespace dev
 namespace eth
 {
 
+/// Transaction receipt, constructed either from RLP representation or from individual values.
+/// State Root is optional, m_stateRoot is h256() when it is empty (for transactions after Metropolis)
+/// Empty state root is not included into RLP-encoding.
 class TransactionReceipt
 {
 public:

--- a/libethereum/TransactionReceipt.h
+++ b/libethereum/TransactionReceipt.h
@@ -37,6 +37,7 @@ class TransactionReceipt
 public:
 	TransactionReceipt(bytesConstRef _rlp);
 	TransactionReceipt(h256 _root, u256 _gasUsed, LogEntries const& _log);
+	TransactionReceipt(u256 _gasUsed, LogEntries const& _log) : TransactionReceipt(h256(), _gasUsed, _log) {}
 
 	h256 const& stateRoot() const { return m_stateRoot; }
 	u256 const& gasUsed() const { return m_gasUsed; }

--- a/libweb3jsonrpc/Debug.cpp
+++ b/libweb3jsonrpc/Debug.cpp
@@ -142,15 +142,8 @@ Json::Value Debug::debug_storageRangeAt(string const& _blockHashOrNumber, int _t
 		Block block = m_eth.block(blockHash(_blockHashOrNumber));
 
 		unsigned const i = ((unsigned)_txIndex < block.pending().size()) ? (unsigned)_txIndex : block.pending().size();
-		State state(block.state());
-		u256 const rootHash = block.stateRootBeforeTx(_txIndex);
-		if (rootHash)
-			state.setRoot(rootHash);
-		else
-		{
-			state.setRoot(block.stateRootBeforeTx(0));
-			state.executeBlockTransactions(block, i, m_eth.blockChain().lastHashes(block.info().parentHash()), *m_eth.blockChain().sealEngine());
-		}
+		State state(State::Null);
+		createIntermediateState(state, block, i, m_eth.blockChain());
 
 		map<h256, pair<u256, u256>> const storage(state.storage(Address(_address)));
 

--- a/test/tools/libtesteth/BlockChainHelper.cpp
+++ b/test/tools/libtesteth/BlockChainHelper.cpp
@@ -502,7 +502,7 @@ bool TestBlockChain::addBlock(TestBlock const& _block)
 		block.sync(*m_blockChain.get());
 
 		//BOOST_REQUIRE(m_lastBlock.blockHeader().hash() == BlockHeader(block.blockData()).hash());
-		m_lastBlock.setState(block.fromPending(10000));
+		m_lastBlock.setState(/*block.fromPending(10000)*/block.state());
 		return true;
 	}
 

--- a/test/tools/libtesteth/BlockChainHelper.cpp
+++ b/test/tools/libtesteth/BlockChainHelper.cpp
@@ -501,8 +501,9 @@ bool TestBlockChain::addBlock(TestBlock const& _block)
 		Block block = (m_blockChain.get()->genesisBlock(genesisDB));
 		block.sync(*m_blockChain.get());
 
-		//BOOST_REQUIRE(m_lastBlock.blockHeader().hash() == BlockHeader(block.blockData()).hash());
-		m_lastBlock.setState(/*block.fromPending(10000)*/block.state());
+		State st(block.state());
+		st.setRoot(block.info().stateRoot());
+		m_lastBlock.setState(st);
 		return true;
 	}
 

--- a/test/unittests/libethereum/Block.cpp
+++ b/test/unittests/libethereum/Block.cpp
@@ -76,16 +76,17 @@ BOOST_AUTO_TEST_CASE(bStates)
 
 		Block block2 = blockchain.genesisBlock(genesisDB);
 		block2.populateFromChain(blockchain, testBlock.blockHeader().hash());
-		State stateAfterInsert = block2.fromPending(0); //get the state of blockchain on previous block
+/*		State stateAfterInsert = block2.fromPending(0); //get the state of blockchain on previous block
 		BOOST_REQUIRE(ImportTest::compareStates(stateBofore, stateAfterInsert) == 0);
 
+		// TODO remove this
 		State stateAfterInsert1 = block2.fromPending(1); //get the state of blockchain on current block executed
 		BOOST_REQUIRE(ImportTest::compareStates(stateAfterInsert, stateAfterInsert1, eth::AccountMaskMap(), WhenError::DontThrow) == 1);
 
 		State stateAfterInsert2 = block2.fromPending(2); //get the state of blockchain on current block executed
 		BOOST_REQUIRE(ImportTest::compareStates(stateBofore, stateAfterInsert2, eth::AccountMaskMap(), WhenError::DontThrow) == 1);
 		BOOST_REQUIRE(ImportTest::compareStates(stateAfterInsert1, stateAfterInsert2, eth::AccountMaskMap(), WhenError::DontThrow) == 1);
-
+*/
 		//Block2 will start a new block on top of blockchain
 		BOOST_REQUIRE(block1.info() == block2.info());
 		block2.sync(blockchain);

--- a/test/unittests/libethereum/Block.cpp
+++ b/test/unittests/libethereum/Block.cpp
@@ -59,7 +59,7 @@ BOOST_AUTO_TEST_CASE(bStates)
 		OverlayDB const& genesisDB = genesisBlock.state().db();
 		BlockChain const& blockchain = testBlockchain.interface();
 
-		State stateBofore = testBlockchain.topBlock().state();
+		h256 stateBefore = testBlockchain.topBlock().state().rootHash();
 
 		TestBlock testBlock;
 		TestTransaction transaction1 = TestTransaction::defaultTransaction(1);
@@ -76,17 +76,16 @@ BOOST_AUTO_TEST_CASE(bStates)
 
 		Block block2 = blockchain.genesisBlock(genesisDB);
 		block2.populateFromChain(blockchain, testBlock.blockHeader().hash());
-/*		State stateAfterInsert = block2.fromPending(0); //get the state of blockchain on previous block
-		BOOST_REQUIRE(ImportTest::compareStates(stateBofore, stateAfterInsert) == 0);
+		h256 stateAfterInsert = block2.stateRootBeforeTx(0); //get the state of blockchain on previous block
+		BOOST_REQUIRE_EQUAL(stateBefore, stateAfterInsert);
 
-		// TODO remove this
-		State stateAfterInsert1 = block2.fromPending(1); //get the state of blockchain on current block executed
-		BOOST_REQUIRE(ImportTest::compareStates(stateAfterInsert, stateAfterInsert1, eth::AccountMaskMap(), WhenError::DontThrow) == 1);
+		h256 stateAfterInsert1 = block2.stateRootBeforeTx(1); //get the state of blockchain on current block executed
+		BOOST_REQUIRE(stateAfterInsert != stateAfterInsert1);
 
-		State stateAfterInsert2 = block2.fromPending(2); //get the state of blockchain on current block executed
-		BOOST_REQUIRE(ImportTest::compareStates(stateBofore, stateAfterInsert2, eth::AccountMaskMap(), WhenError::DontThrow) == 1);
-		BOOST_REQUIRE(ImportTest::compareStates(stateAfterInsert1, stateAfterInsert2, eth::AccountMaskMap(), WhenError::DontThrow) == 1);
-*/
+		h256 stateAfterInsert2 = block2.stateRootBeforeTx(2); //get the state of blockchain on current block executed
+		BOOST_REQUIRE(stateBefore != stateAfterInsert2);
+		BOOST_REQUIRE(stateAfterInsert1 != stateAfterInsert2);
+
 		//Block2 will start a new block on top of blockchain
 		BOOST_REQUIRE(block1.info() == block2.info());
 		block2.sync(blockchain);

--- a/test/unittests/libethereum/Block.cpp
+++ b/test/unittests/libethereum/Block.cpp
@@ -59,7 +59,7 @@ BOOST_AUTO_TEST_CASE(bStates)
 		OverlayDB const& genesisDB = genesisBlock.state().db();
 		BlockChain const& blockchain = testBlockchain.interface();
 
-		h256 stateBefore = testBlockchain.topBlock().state().rootHash();
+		h256 stateRootBefore = testBlockchain.topBlock().state().rootHash();
 
 		TestBlock testBlock;
 		TestTransaction transaction1 = TestTransaction::defaultTransaction(1);
@@ -76,15 +76,15 @@ BOOST_AUTO_TEST_CASE(bStates)
 
 		Block block2 = blockchain.genesisBlock(genesisDB);
 		block2.populateFromChain(blockchain, testBlock.blockHeader().hash());
-		h256 stateAfterInsert = block2.stateRootBeforeTx(0); //get the state of blockchain on previous block
-		BOOST_REQUIRE_EQUAL(stateBefore, stateAfterInsert);
+		h256 stateRootAfterInsert = block2.stateRootBeforeTx(0); //get the state of blockchain on previous block
+		BOOST_REQUIRE_EQUAL(stateRootBefore, stateRootAfterInsert);
 
-		h256 stateAfterInsert1 = block2.stateRootBeforeTx(1); //get the state of blockchain on current block executed
-		BOOST_REQUIRE(stateAfterInsert != stateAfterInsert1);
+		h256 stateRootAfterInsert1 = block2.stateRootBeforeTx(1); //get the state of blockchain on current block executed
+		BOOST_REQUIRE(stateRootAfterInsert != stateRootAfterInsert1);
 
-		h256 stateAfterInsert2 = block2.stateRootBeforeTx(2); //get the state of blockchain on current block executed
-		BOOST_REQUIRE(stateBefore != stateAfterInsert2);
-		BOOST_REQUIRE(stateAfterInsert1 != stateAfterInsert2);
+		h256 stateRootAfterInsert2 = block2.stateRootBeforeTx(2); //get the state of blockchain on current block executed
+		BOOST_REQUIRE(stateRootBefore != stateRootAfterInsert2);
+		BOOST_REQUIRE(stateRootAfterInsert1 != stateRootAfterInsert2);
 
 		//Block2 will start a new block on top of blockchain
 		BOOST_REQUIRE(block1.info() == block2.info());

--- a/test/unittests/libethereum/Block.cpp
+++ b/test/unittests/libethereum/Block.cpp
@@ -50,8 +50,6 @@ BOOST_AUTO_TEST_CASE(bStructures)
 
 BOOST_AUTO_TEST_CASE(bStates)
 {
-	if (!dev::test::Options::get().quadratic)
-		return;
 	try
 	{
 		TestBlockChain testBlockchain(TestBlockChain::defaultGenesisBlock());


### PR DESCRIPTION
Implementing Option 1 of EIP - removing state root hash from Receipt RLP

https://github.com/ethereum/cpp-ethereum/issues/3613
https://github.com/ethereum/EIPs/issues/98

- [x] Save zero hash instead of root state hash
- [x] Remove root state hash instead of saving zero hash
- [x] Implement debug RPC methods (trace, storageRangeAt) without relying on state root in receipt
- [x] Fix tests relying on state root in receipts