### PR TITLE
move transaction verification checks to sealEngine

### DIFF
--- a/libethashseal/Ethash.cpp
+++ b/libethashseal/Ethash.cpp
@@ -164,10 +164,7 @@ void Ethash::verifyTransaction(ImportRequirements::value _ir, TransactionBase co
 	// Avoid transactions that would take us beyond the block gas limit.
 	u256 startGasUsed = _env.gasUsed();
 	if (startGasUsed + (bigint)_t.gas() > _env.gasLimit())
-	{
-		//clog(ExecutiveWarnChannel) << "Cannot fit tx in block" << _env.number() << ": Require <" << (_env.gasLimit() - startGasUsed) << " Got" << _t.gas();
 		BOOST_THROW_EXCEPTION(BlockGasLimitReached() << RequirementError((bigint)(_env.gasLimit() - startGasUsed), (bigint)_t.gas()));
-	}
 }
 
 u256 Ethash::childGasLimit(BlockHeader const& _bi, u256 const& _gasFloorTarget) const

--- a/libethashseal/Ethash.cpp
+++ b/libethashseal/Ethash.cpp
@@ -168,14 +168,6 @@ void Ethash::verifyTransaction(ImportRequirements::value _ir, TransactionBase co
 		//clog(ExecutiveWarnChannel) << "Cannot fit tx in block" << _env.number() << ": Require <" << (_env.gasLimit() - startGasUsed) << " Got" << _t.gas();
 		BOOST_THROW_EXCEPTION(BlockGasLimitReached() << RequirementError((bigint)(_env.gasLimit() - startGasUsed), (bigint)_t.gas()));
 	}
-
-	// Check gas cost is enough.
-	int64_t baseGasRequired = _t.baseGasRequired(evmSchedule(_env));
-	if (baseGasRequired > _t.gas())
-	{
-		//clog(ExecutiveWarnChannel) << "Not enough gas to pay for the transaction: Require >" << m_baseGasRequired << " Got" << _t.gas();
-		BOOST_THROW_EXCEPTION(OutOfGasBase() << RequirementError((bigint)baseGasRequired, (bigint)_t.gas()));
-	}
 }
 
 u256 Ethash::childGasLimit(BlockHeader const& _bi, u256 const& _gasFloorTarget) const

--- a/libethereum/Executive.cpp
+++ b/libethereum/Executive.cpp
@@ -178,34 +178,16 @@ void Executive::accrueSubState(SubState& _parentContext)
 
 void Executive::initialize(Transaction const& _transaction)
 {
-	m_t = _transaction;
-
 	try
 	{
-		m_sealEngine.verifyTransaction(ImportRequirements::Everything, _transaction, m_envInfo);
+		m_t = _transaction;
+		m_sealEngine.verifyTransaction(ImportRequirements::Everything, m_t, m_envInfo);
+		m_baseGasRequired = m_t.baseGasRequired(m_sealEngine.evmSchedule(m_envInfo));
 	}
 	catch (Exception const& ex)
 	{
 		m_excepted = toTransactionException(ex);
-		throw;
-	}
-
-	// Avoid transactions that would take us beyond the block gas limit.
-	u256 startGasUsed = m_envInfo.gasUsed();
-	if (startGasUsed + (bigint)m_t.gas() > m_envInfo.gasLimit())
-	{
-		clog(ExecutiveWarnChannel) << "Cannot fit tx in block" << m_envInfo.number() << ": Require <" << (m_envInfo.gasLimit() - startGasUsed) << " Got" << m_t.gas();
-		m_excepted = TransactionException::BlockGasLimitReached;
-		BOOST_THROW_EXCEPTION(BlockGasLimitReached() << RequirementError((bigint)(m_envInfo.gasLimit() - startGasUsed), (bigint)m_t.gas()));
-	}
-
-	// Check gas cost is enough.
-	m_baseGasRequired = m_t.baseGasRequired(m_sealEngine.evmSchedule(m_envInfo));
-	if (m_baseGasRequired > m_t.gas())
-	{
-		clog(ExecutiveWarnChannel) << "Not enough gas to pay for the transaction: Require >" << m_baseGasRequired << " Got" << m_t.gas();
-		m_excepted = TransactionException::OutOfGasBase;
-		BOOST_THROW_EXCEPTION(OutOfGasBase() << RequirementError((bigint)m_baseGasRequired, (bigint)m_t.gas()));
+		BOOST_THROW_EXCEPTION(ex);
 	}
 
 	if (!m_t.hasZeroSignature())

--- a/libethereum/Executive.cpp
+++ b/libethereum/Executive.cpp
@@ -178,11 +178,11 @@ void Executive::accrueSubState(SubState& _parentContext)
 
 void Executive::initialize(Transaction const& _transaction)
 {
+	m_t = _transaction;
+	m_baseGasRequired = m_t.baseGasRequired(m_sealEngine.evmSchedule(m_envInfo));
 	try
 	{
-		m_t = _transaction;
 		m_sealEngine.verifyTransaction(ImportRequirements::Everything, m_t, m_envInfo);
-		m_baseGasRequired = m_t.baseGasRequired(m_sealEngine.evmSchedule(m_envInfo));
 	}
 	catch (Exception const& ex)
 	{

--- a/libethereum/Executive.cpp
+++ b/libethereum/Executive.cpp
@@ -187,7 +187,7 @@ void Executive::initialize(Transaction const& _transaction)
 	catch (Exception const& ex)
 	{
 		m_excepted = toTransactionException(ex);
-		BOOST_THROW_EXCEPTION(ex);
+		throw;
 	}
 
 	if (!m_t.hasZeroSignature())

--- a/libevm/ExtVMFace.h
+++ b/libevm/ExtVMFace.h
@@ -218,7 +218,7 @@ public:
 	Address const& author() const { return m_headerInfo.author(); }
 	u256 const& timestamp() const { return m_headerInfo.timestamp(); }
 	u256 const& difficulty() const { return m_headerInfo.difficulty(); }
-	u256 gasLimit() const { return m_headerInfo.gasLimit(); }
+	u256 const& gasLimit() const { return m_headerInfo.gasLimit(); }
 	LastHashes const& lastHashes() const { return m_lastHashes; }
 	u256 const& gasUsed() const { return m_gasUsed; }
 
@@ -226,7 +226,7 @@ public:
 	void setAuthor(Address const& _v) { m_headerInfo.setAuthor(_v); }
 	void setTimestamp(u256 const& _v) { m_headerInfo.setTimestamp(_v); }
 	void setDifficulty(u256 const& _v) { m_headerInfo.setDifficulty(_v); }
-	void setGasLimit(u256 _v) { m_headerInfo.setGasLimit(_v); }
+	void setGasLimit(u256 const& _v) { m_headerInfo.setGasLimit(_v); }
 	void setLastHashes(LastHashes&& _lh) { m_lastHashes = _lh; }
 
 private:

--- a/libevm/ExtVMFace.h
+++ b/libevm/ExtVMFace.h
@@ -209,52 +209,28 @@ class EnvInfo
 public:
 	EnvInfo() {}
 	EnvInfo(BlockHeader const& _current, LastHashes const& _lh = LastHashes(), u256 const& _gasUsed = u256()):
-		m_number(_current.number()),
-		m_author(_current.author()),
-		m_timestamp(_current.timestamp()),
-		m_difficulty(_current.difficulty()),
-		// Trim gas limit to int64. convert_to used explicitly instead of
-		// static_cast to be noticed when BlockHeader::gasLimit() will be
-		// changed to int64 too.
-		m_gasLimit(_current.gasLimit().convert_to<int64_t>()),
+		m_headerInfo(_current),
 		m_lastHashes(_lh),
 		m_gasUsed(_gasUsed)
 	{}
 
-	EnvInfo(BlockHeader const& _current, LastHashes&& _lh, u256 const& _gasUsed = u256()):
-		m_number(_current.number()),
-		m_author(_current.author()),
-		m_timestamp(_current.timestamp()),
-		m_difficulty(_current.difficulty()),
-		// Trim gas limit to int64. convert_to used explicitly instead of
-		// static_cast to be noticed when BlockHeader::gasLimit() will be
-		// changed to int64 too.
-		m_gasLimit(_current.gasLimit().convert_to<int64_t>()),
-		m_lastHashes(_lh),
-		m_gasUsed(_gasUsed)
-	{}
-
-	u256 const& number() const { return m_number; }
-	Address const& author() const { return m_author; }
-	u256 const& timestamp() const { return m_timestamp; }
-	u256 const& difficulty() const { return m_difficulty; }
-	int64_t gasLimit() const { return m_gasLimit; }
+	u256 const& number() const { return m_headerInfo.number(); }
+	Address const& author() const { return m_headerInfo.author(); }
+	u256 const& timestamp() const { return m_headerInfo.timestamp(); }
+	u256 const& difficulty() const { return m_headerInfo.difficulty(); }
+	u256 gasLimit() const { return m_headerInfo.gasLimit(); }
 	LastHashes const& lastHashes() const { return m_lastHashes; }
 	u256 const& gasUsed() const { return m_gasUsed; }
 
-	void setNumber(u256 const& _v) { m_number = _v; }
-	void setAuthor(Address const& _v) { m_author = _v; }
-	void setTimestamp(u256 const& _v) { m_timestamp = _v; }
-	void setDifficulty(u256 const& _v) { m_difficulty = _v; }
-	void setGasLimit(int64_t _v) { m_gasLimit = _v; }
+	void setNumber(u256 const& _v) { m_headerInfo.setNumber(_v); }
+	void setAuthor(Address const& _v) { m_headerInfo.setAuthor(_v); }
+	void setTimestamp(u256 const& _v) { m_headerInfo.setTimestamp(_v); }
+	void setDifficulty(u256 const& _v) { m_headerInfo.setDifficulty(_v); }
+	void setGasLimit(u256 _v) { m_headerInfo.setGasLimit(_v); }
 	void setLastHashes(LastHashes&& _lh) { m_lastHashes = _lh; }
 
 private:
-	u256 m_number;
-	Address m_author;
-	u256 m_timestamp;
-	u256 m_difficulty;
-	int64_t m_gasLimit;
+	BlockHeader m_headerInfo;
 	LastHashes m_lastHashes;
 	u256 m_gasUsed;
 };

--- a/libevm/JitVM.cpp
+++ b/libevm/JitVM.cpp
@@ -73,7 +73,8 @@ void evm_query(
 		o_result->uint256be = toEvmC(env.envInfo().difficulty());
 		break;
 	case EVM_GAS_LIMIT:
-		o_result->int64 = env.envInfo().gasLimit();
+		// TODO: Handle overflow / exception
+		o_result->int64 = static_cast<int64_t>(env.envInfo().gasLimit());
 		break;
 	case EVM_NUMBER:
 		// TODO: Handle overflow / exception

--- a/test/tools/jsontests/TransactionTests.cpp
+++ b/test/tools/jsontests/TransactionTests.cpp
@@ -50,6 +50,7 @@ void doTransactionTests(json_spirit::mValue& _v, bool _fillin)
 		u256 transactionBlock = toInt(o["blocknumber"].get_str());
 		BlockHeader bh;
 		bh.setNumber(transactionBlock);
+		bh.setGasLimit(u256("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"));
 		bool onMetropolis = (transactionBlock >= se->chainParams().u256Param("metropolisForkBlock"));
 
 		if (_fillin)


### PR DESCRIPTION
connects to #4038 

refactor envInfo 
split LastHashes and envInfo

next step is to replace envInfo with BlockHeader

updated test branch 
https://github.com/ethereum/tests/pull/151

@vbuterin 
all of the state tests that used blockhash are now useless and should be migrated into blockchain tests.