### PR TITLE
Improve ccache usage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -106,17 +106,13 @@ cache:
         # Cache whole deps dir hoping you will not need to download and
         # build external dependencies next build.
         - $TRAVIS_BUILD_DIR/deps
-before_install:
-    # Install ccache on osx
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install ccache; fi
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PATH="/usr/local/opt/ccache/libexec:$PATH"; fi
 install:
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./scripts/install_cmake.sh; fi
     - ./scripts/install_deps.sh
 before_script:
-    - ccache -s
+    - ./scripts/prepare_ccache.sh
     - ./scripts/build.sh $TRAVIS_BUILD_TYPE $TRAVIS_TESTS
-    - ccache -s
+    - ./scripts/cleanup_ccache.sh
 script:
     - cd $TRAVIS_BUILD_DIR/build && ../scripts/tests.sh $TRAVIS_TESTS
 after_success:

--- a/cmake/EthCompilerSettings.cmake
+++ b/cmake/EthCompilerSettings.cmake
@@ -14,13 +14,14 @@
 #
 # These settings then end up spanning all POSIX platforms (Linux, OS X, BSD, etc)
 
-# Use ccache if available
-find_program(CCACHE_FOUND ccache)
-if(CCACHE_FOUND)
+# Setup ccache.
+# ccache is auto-enabled if the tool is found. To disable set -DCCACHE=Off option.
+find_program(CCACHE ccache)
+if(CCACHE)
 	set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
 	set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
-	message("Using ccache")
-endif(CCACHE_FOUND)
+	message(STATUS "ccache enabled (${CCACHE})")
+endif()
 
 if (("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU") OR ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang"))
 	# Enables all the warnings about constructions that some users consider questionable,

--- a/scripts/cleanup_ccache.sh
+++ b/scripts/cleanup_ccache.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+
+set -e
+
+ccache --cleanup
+ccache --show-stats

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -88,6 +88,10 @@ Darwin)
             ;;
     esac
 
+    if [ "$TRAVIS" ]; then
+        TRAVIS_PACKAGES="ccache"
+    fi
+
     # Check for Homebrew install and abort if it is not installed.
     brew -v > /dev/null 2>&1 || { echo >&2 "ERROR - cpp-ethereum requires a Homebrew install.  See http://brew.sh."; exit 1; }
 
@@ -95,7 +99,8 @@ Darwin)
     brew install \
         leveldb \
         libmicrohttpd \
-        miniupnpc
+        miniupnpc \
+        $TRAVIS_PACKAGES
 
     ;;
 

--- a/scripts/prepare_ccache.sh
+++ b/scripts/prepare_ccache.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env sh
+
+set -e
+
+if [ "$TRAVIS_OS_NAME" = "linux" ]; then
+    # In Travis Ubuntu 14.04 ccache is too old and does not support some of
+    # the compiler flags and does not work. Upgrade it to version 3.2.
+    curl -O http://de.archive.ubuntu.com/ubuntu/pool/main/c/ccache/ccache_3.2.4-1_amd64.deb
+    sudo dpkg -i ccache_3.2.4-1_amd64.deb
+fi
+
+ccache --version
+ccache --show-stats
+ccache --zero-stats
+ccache --max-size=1G


### PR DESCRIPTION
On Travis CI limit cache to 1 GB and cleanup after the build. Print better CMake logs and stats.

It turned that this also fixes caching on Travi CI / Linux where ccache was not able to handle `--coverage` flag.