### PR TITLE
fix out of range call to block's receipts

### DIFF
--- a/libethashseal/Ethash.cpp
+++ b/libethashseal/Ethash.cpp
@@ -162,9 +162,10 @@ void Ethash::verifyTransaction(ImportRequirements::value _ir, TransactionBase co
 		BOOST_THROW_EXCEPTION(OutOfGasIntrinsic());
 
 	// Avoid transactions that would take us beyond the block gas limit.
+	// Should check only actual gas used by transaction
 	u256 startGasUsed = _env.gasUsed();
-	if (startGasUsed + (bigint)_t.gas() > _env.gasLimit())
-		BOOST_THROW_EXCEPTION(BlockGasLimitReached() << RequirementError((bigint)(_env.gasLimit() - startGasUsed), (bigint)_t.gas()));
+	if (startGasUsed + _t.baseGasRequired(evmSchedule(_env)) > _env.gasLimit())
+		BOOST_THROW_EXCEPTION(BlockGasLimitReached() << RequirementError((bigint)(_env.gasLimit() - startGasUsed), (bigint)_t.baseGasRequired(evmSchedule(_env))));
 }
 
 u256 Ethash::childGasLimit(BlockHeader const& _bi, u256 const& _gasFloorTarget) const

--- a/libethashseal/Ethash.cpp
+++ b/libethashseal/Ethash.cpp
@@ -162,10 +162,9 @@ void Ethash::verifyTransaction(ImportRequirements::value _ir, TransactionBase co
 		BOOST_THROW_EXCEPTION(OutOfGasIntrinsic());
 
 	// Avoid transactions that would take us beyond the block gas limit.
-	// Should check only actual gas used by transaction
 	u256 startGasUsed = _env.gasUsed();
-	if (startGasUsed + _t.baseGasRequired(evmSchedule(_env)) > _env.gasLimit())
-		BOOST_THROW_EXCEPTION(BlockGasLimitReached() << RequirementError((bigint)(_env.gasLimit() - startGasUsed), (bigint)_t.baseGasRequired(evmSchedule(_env))));
+	if (startGasUsed + _t.gas() > _env.gasLimit())
+		BOOST_THROW_EXCEPTION(BlockGasLimitReached() << RequirementError((bigint)(_env.gasLimit() - startGasUsed), (bigint)_t.gas()));
 }
 
 u256 Ethash::childGasLimit(BlockHeader const& _bi, u256 const& _gasFloorTarget) const

--- a/libethashseal/Ethash.cpp
+++ b/libethashseal/Ethash.cpp
@@ -163,7 +163,7 @@ void Ethash::verifyTransaction(ImportRequirements::value _ir, TransactionBase co
 
 	// Avoid transactions that would take us beyond the block gas limit.
 	u256 startGasUsed = _env.gasUsed();
-	if (startGasUsed + _t.gas() > _env.gasLimit())
+	if (startGasUsed + (bigint)_t.gas() > _env.gasLimit())
 		BOOST_THROW_EXCEPTION(BlockGasLimitReached() << RequirementError((bigint)(_env.gasLimit() - startGasUsed), (bigint)_t.gas()));
 }
 

--- a/libethereum/Account.cpp
+++ b/libethereum/Account.cpp
@@ -123,10 +123,10 @@ AccountMap dev::eth::jsonToAccountMap(std::string const& _json, u256 const& _def
 				ret[a] = Account(nonce, balance);
 				if (o["code"].type() == json_spirit::str_type)
 				{
-					if (o["code"].get_str().find("0x") != 0)
+					if (o["code"].get_str().find("0x") != 0 && !o["code"].get_str().empty())
 						cerr << "Error importing code of account " << a << "! Code needs to be hex bytecode prefixed by \"0x\".";
 					else
-						ret[a].setNewCode(fromHex(o["code"].get_str().substr(2)));
+						ret[a].setNewCode(fromHex(o["code"].get_str()));
 				}
 				else
 					cerr << "Error importing code of account " << a << "! Code field needs to be a string";

--- a/libethereum/Block.cpp
+++ b/libethereum/Block.cpp
@@ -743,7 +743,7 @@ void Block::commitToSeal(BlockChain const& _bc, bytes const& _extraData)
 		k << i;
 
 		RLPStream receiptrlp;
-		m_receipts[i].streamRLP(receiptrlp);
+		receipt(i).streamRLP(receiptrlp);
 		receiptsMap.insert(std::make_pair(k.out(), receiptrlp.out()));
 
 		RLPStream txrlp;
@@ -836,7 +836,7 @@ State Block::fromPending(unsigned _i) const
 	if (!_i)
 		ret.setRoot(m_previousBlock.stateRoot());
 	else
-		ret.setRoot(m_receipts[_i - 1].stateRoot());
+		ret.setRoot(receipt(_i - 1).stateRoot());
 	return ret;
 }
 

--- a/libethereum/Block.h
+++ b/libethereum/Block.h
@@ -191,16 +191,16 @@ public:
 	h256Hash const& pendingHashes() const { return m_transactionSet; }
 
 	/// Get the transaction receipt for the transaction of the given index.
-	TransactionReceipt const& receipt(unsigned _i) const { return m_receipts[_i]; }
+	TransactionReceipt const& receipt(unsigned _i) const { return m_receipts.at(_i); }
 
 	/// Get the list of pending transactions.
-	LogEntries const& log(unsigned _i) const { return m_receipts[_i].log(); }
+	LogEntries const& log(unsigned _i) const { return receipt(_i).log(); }
 
 	/// Get the bloom filter of all logs that happened in the block.
 	LogBloom logBloom() const;
 
 	/// Get the bloom filter of a particular transaction that happened in the block.
-	LogBloom const& logBloom(unsigned _i) const { return m_receipts[_i].bloom(); }
+	LogBloom const& logBloom(unsigned _i) const { return receipt(_i).bloom(); }
 
 	/// Get the State immediately after the given number of pending transactions have been applied.
 	/// If (_i == 0) returns the initial state of the block.

--- a/test/tools/jsontests/BlockChainTests.cpp
+++ b/test/tools/jsontests/BlockChainTests.cpp
@@ -282,7 +282,7 @@ void doBlockchainTests(json_spirit::mValue& _v, bool _fillin)
 
 			o["blocks"] = blArray;
 			o["postState"] = fillJsonWithState(testChain.topBlock().state());
-			o["lastblockhash"] = toString(testChain.topBlock().blockHeader().hash(WithSeal));
+			o["lastblockhash"] = "0x" + toString(testChain.topBlock().blockHeader().hash(WithSeal));
 
 			//make all values hex in pre section
 			State prestate(State::Null);
@@ -391,7 +391,7 @@ void doBlockchainTests(json_spirit::mValue& _v, bool _fillin)
 
 			//Check lastblock hash
 			BOOST_REQUIRE((o.count("lastblockhash") > 0));
-			string lastTrueBlockHash = toString(testChain.topBlock().blockHeader().hash(WithSeal));
+			string lastTrueBlockHash = "0x" + toString(testChain.topBlock().blockHeader().hash(WithSeal));
 			BOOST_CHECK_MESSAGE(lastTrueBlockHash == o["lastblockhash"].get_str(),
 					testname + "Boost check: lastblockhash does not match " + lastTrueBlockHash + " expected: " + o["lastblockhash"].get_str());
 
@@ -670,10 +670,11 @@ mObject writeBlockHeaderToJson(BlockHeader const& _bi)
 	o["gasLimit"] = toCompactHex(_bi.gasLimit(), HexPrefix::Add, 1);
 	o["gasUsed"] = toCompactHex(_bi.gasUsed(), HexPrefix::Add, 1);
 	o["timestamp"] = toCompactHex(_bi.timestamp(), HexPrefix::Add, 1);
-	o["extraData"] = toHex(_bi.extraData(), 2, HexPrefix::Add);
+	o["extraData"] = (_bi.extraData().size()) ? toHex(_bi.extraData(), 2, HexPrefix::Add) : "";
 	o["mixHash"] = toString(Ethash::mixHash(_bi));
 	o["nonce"] = toString(Ethash::nonce(_bi));
 	o["hash"] = toString(_bi.hash());
+	ImportTest::makeAllFieldsHex(o, true);
 	return o;
 }
 

--- a/test/tools/jsontests/BlockChainTests.cpp
+++ b/test/tools/jsontests/BlockChainTests.cpp
@@ -235,7 +235,7 @@ void doBlockchainTests(json_spirit::mValue& _v, bool _fillin)
 				compareBlocks(block, alterBlock);
 				try
 				{
-					blockchain.addBlock(alterBlock);					
+					blockchain.addBlock(alterBlock);
 					if (testChain.addBlock(alterBlock))
 						cnote << "The most recent best Block now is " <<  importBlockNumber << "in chain" << chainname << "at test " << testname;
 

--- a/test/tools/jsontests/BlockChainTestsBoost.cpp
+++ b/test/tools/jsontests/BlockChainTestsBoost.cpp
@@ -64,8 +64,18 @@ BOOST_AUTO_TEST_CASE(bcWalletTestEIP150)
 	if (test::Options::get().wallet)
 		dev::test::executeTests("bcWalletTest", "/BlockchainTests/EIP150", "/BlockchainTestsFiller/EIP150", dev::test::doBlockchainTests);
 }
+BOOST_AUTO_TEST_CASE(bcInvalidRLPTestEIP150)
+{
+	std::string fillersPath =  dev::test::getTestPath() +  "/src/BlockchainTestsFiller/EIP150";
+	if (!dev::test::Options::get().filltests)
+		dev::test::executeTests("bcInvalidRLPTest", "/BlockchainTests/EIP150", "/BlockchainTestsFiller/EIP150", dev::test::doBlockchainTests);
+	else
+	{
+		dev::test::TestOutputHelper::initTest();
+		dev::test::copyFile(fillersPath + "/bcInvalidRLPTest.json", dev::test::getTestPath() + "/BlockchainTests/EIP150/bcInvalidRLPTest.json");
+	}
+}
 BOOST_AUTO_TEST_SUITE_END()
-
 
 //BlockChainTestsHomestead
 BOOST_FIXTURE_TEST_SUITE(BlockChainTestsHomestead, homesteadFixture)

--- a/test/tools/libtesteth/BlockChainHelper.cpp
+++ b/test/tools/libtesteth/BlockChainHelper.cpp
@@ -196,12 +196,18 @@ void TestBlock::mine(TestBlockChain const& _bc)
 		premineUpdate(blockInfo);
 
 		size_t transactionsOnImport = m_transactionQueue.topTransactions(100).size();
-		block.sync(blockchain, m_transactionQueue, gp); //!!! Invalid transactions are dropped here
-		if (transactionsOnImport >  m_transactionQueue.topTransactions(100).size())
-			cnote << "Dropped invalid Transactions when mining!";
-
+		block.sync(blockchain, m_transactionQueue, gp); //!!! Invalid transactions could be dropped from queue here!!!
+		if (transactionsOnImport >  m_transactionQueue.topTransactions(1000).size())
+			BOOST_ERROR("Dropped invalid Transactions before mining!");
 		dev::eth::mine(block, blockchain, blockchain.sealEngine());
 		blockchain.sealEngine()->verify(JustSeal, block.info());
+		if (transactionsOnImport >  block.pending().size())
+			cnote << "Dropped invalid Transactions when mining!";
+
+		//renew the TestBlock transactions
+		m_transactionQueue.clear();
+		for (size_t i = 0; i <= block.pending().size(); i++)
+			m_transactionQueue.import(block.pending()[i]);
 	}
 	catch (Exception const& _e)
 	{
@@ -214,7 +220,7 @@ void TestBlock::mine(TestBlockChain const& _bc)
 		return;
 	}
 
-	size_t validTransactions = m_transactionQueue.topTransactions(100).size();
+	size_t validTransactions = block.pending().size();
 	m_receipts = RLPStream(validTransactions);
 	for (size_t i = 0; i < validTransactions; i++)
 	{

--- a/test/tools/libtesteth/BlockChainHelper.cpp
+++ b/test/tools/libtesteth/BlockChainHelper.cpp
@@ -197,16 +197,16 @@ void TestBlock::mine(TestBlockChain const& _bc)
 
 		size_t transactionsOnImport = m_transactionQueue.topTransactions(100).size();
 		block.sync(blockchain, m_transactionQueue, gp); //!!! Invalid transactions could be dropped from queue here!!!
-		if (transactionsOnImport >  m_transactionQueue.topTransactions(1000).size())
-			BOOST_ERROR("Dropped invalid Transactions before mining!");
+		//if (transactionsOnImport >  m_transactionQueue.topTransactions(1000).size())
+			//BOOST_ERROR(TestOutputHelper::testName() + " Dropped invalid Transactions before mining!");
 		dev::eth::mine(block, blockchain, blockchain.sealEngine());
 		blockchain.sealEngine()->verify(JustSeal, block.info());
 		if (transactionsOnImport >  block.pending().size())
-			cnote << "Dropped invalid Transactions when mining!";
+			cnote << TestOutputHelper::testName() + " Dropped invalid Transactions when mining!";
 
 		//renew the TestBlock transactions
 		m_transactionQueue.clear();
-		for (size_t i = 0; i <= block.pending().size(); i++)
+		for (size_t i = 0; i < block.pending().size(); i++)
 			m_transactionQueue.import(block.pending()[i]);
 	}
 	catch (Exception const& _e)

--- a/test/tools/libtesteth/ImportTest.cpp
+++ b/test/tools/libtesteth/ImportTest.cpp
@@ -210,21 +210,24 @@ std::pair<eth::State, ImportTest::execOutput> ImportTest::executeTransaction(eth
 	return std::pair<eth::State, ImportTest::execOutput>(initialState, execOut);
 }
 
-json_spirit::mObject& ImportTest::makeAllFieldsHex(json_spirit::mObject& _o)
+json_spirit::mObject& ImportTest::makeAllFieldsHex(json_spirit::mObject& _o, bool _isHeader)
 {
 	static const set<string> hashes {"bloom" , "coinbase", "hash", "mixHash", "parentHash", "receiptTrie",
 									 "stateRoot", "transactionsTrie", "uncleHash", "currentCoinbase",
-									 "previousHash", "to", "address", "caller", "origin", "secretKey", "data"};
+									 "previousHash", "to", "address", "caller", "origin", "secretKey", "data", "extraData"};
 
 	for (auto& i: _o)
 	{
 		bool isHash = false;
 		std::string key = i.first;
 
-		if (key == "data")
+		if (key == "data" || key == "extraData")
 			continue;
 
 		if (hashes.count(key))
+			isHash = true;
+
+		if (_isHeader && key == "nonce")
 			isHash = true;
 
 		std::string str;

--- a/test/tools/libtesteth/ImportTest.h
+++ b/test/tools/libtesteth/ImportTest.h
@@ -48,7 +48,7 @@ public:
 	static void importState(json_spirit::mObject const& _o, eth::State& _state, eth::AccountMaskMap& o_mask);
 	static void importTransaction (json_spirit::mObject const& _o, eth::Transaction& o_tr);
 	void importTransaction(json_spirit::mObject const& _o);
-	static json_spirit::mObject& makeAllFieldsHex(json_spirit::mObject& _o);
+	static json_spirit::mObject& makeAllFieldsHex(json_spirit::mObject& _o, bool _isHeader = false);
 
 	bytes executeTest();
 	int exportTest(bytes const& _output);

--- a/test/tools/libtesteth/TestHelper.cpp
+++ b/test/tools/libtesteth/TestHelper.cpp
@@ -125,7 +125,7 @@ json_spirit::mObject fillJsonWithTransaction(Transaction const& _txn)
 {
 	json_spirit::mObject txObject;
 	txObject["nonce"] = toCompactHex(_txn.nonce(), HexPrefix::Add, 1);
-	txObject["data"] = toHex(_txn.data(), 2, HexPrefix::Add);
+	txObject["data"] = _txn.data().size() ? toHex(_txn.data(), 2, HexPrefix::Add) : "";
 	txObject["gasLimit"] = toCompactHex(_txn.gas(), HexPrefix::Add, 1);
 	txObject["gasPrice"] = toCompactHex(_txn.gasPrice(), HexPrefix::Add, 1);
 	txObject["r"] = toCompactHex(_txn.signature().r, HexPrefix::Add, 1);
@@ -133,6 +133,7 @@ json_spirit::mObject fillJsonWithTransaction(Transaction const& _txn)
 	txObject["v"] = toCompactHex(_txn.signature().v + 27, HexPrefix::Add, 1);
 	txObject["to"] = _txn.isCreation() ? "" : "0x" + toString(_txn.receiveAddress());
 	txObject["value"] = toCompactHex(_txn.value(), HexPrefix::Add, 1);
+	ImportTest::makeAllFieldsHex(txObject);
 	return txObject;
 }
 

--- a/test/unittests/libethereum/Block.cpp
+++ b/test/unittests/libethereum/Block.cpp
@@ -253,4 +253,14 @@ BOOST_AUTO_TEST_CASE(bCopyOperator)
 	}
 }
 
+BOOST_AUTO_TEST_CASE(bGetReceiptOverflow)
+{
+	TestBlockChain bc;
+	TestBlock const& genesisBlock = bc.testGenesis();
+	OverlayDB const& genesisDB = genesisBlock.state().db();
+	BlockChain const& blockchain = bc.interface();
+	Block block = blockchain.genesisBlock(genesisDB);
+	BOOST_CHECK_THROW(block.receipt(123), std::out_of_range);
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
configure blockchain tests mining
make all fields hex and prefixed with 0x

related test update:
https://github.com/ethereum/tests/pull/154 
