### PR TITLE
to many --> too many in two locations

### DIFF
--- a/libdevcore/Common.h
+++ b/libdevcore/Common.h
@@ -23,7 +23,7 @@
 
 #pragma once
 
-// way to many unsigned to size_t warnings in 32 bit build
+// way too many unsigned to size_t warnings in 32 bit build
 #ifdef _M_IX86
 #pragma warning(disable:4244)
 #endif

--- a/libethcore/Transaction.cpp
+++ b/libethcore/Transaction.cpp
@@ -92,7 +92,7 @@ TransactionBase::TransactionBase(bytesConstRef _rlpData, CheckTransaction _check
 			m_sender = sender();
 
 		if (rlp.itemCount() > 9)
-			BOOST_THROW_EXCEPTION(InvalidTransactionFormat() << errinfo_comment("to many fields in the transaction RLP"));
+			BOOST_THROW_EXCEPTION(InvalidTransactionFormat() << errinfo_comment("too many fields in the transaction RLP"));
 	}
 	catch (Exception& _e)
 	{


### PR DESCRIPTION
I was reviewing EIP-86 related PRs and found a "to many".  So I grepped for it.