### PR TITLE
Add missing virtual destructor in RLPXDatagramFace

### DIFF
--- a/libp2p/UDP.h
+++ b/libp2p/UDP.h
@@ -70,6 +70,7 @@ struct RLPXDatagramFace: public UDPDatagram
 	static Public authenticate(bytesConstRef _sig, bytesConstRef _rlp);
 
 	RLPXDatagramFace(bi::udp::endpoint const& _ep): UDPDatagram(_ep) {}
+	virtual ~RLPXDatagramFace() = default;
 
 	virtual h256 sign(Secret const& _from);
 	virtual uint8_t packetType() const = 0;


### PR DESCRIPTION
We might consider pushing the destructor to the top of the hierarchy, but this is correct fix for current situation.

Thank you ASan for reporting me this issue.