### PR TITLE
Fix eth_call RPC method

### DIFF
--- a/libethcore/Exceptions.h
+++ b/libethcore/Exceptions.h
@@ -51,6 +51,7 @@ DEV_SIMPLE_EXCEPTION(FeeTooSmall);
 DEV_SIMPLE_EXCEPTION(TooMuchGasUsed);
 DEV_SIMPLE_EXCEPTION(ExtraDataTooBig);
 DEV_SIMPLE_EXCEPTION(ExtraDataIncorrect);
+DEV_SIMPLE_EXCEPTION(TransactionIsUnsigned);
 DEV_SIMPLE_EXCEPTION(InvalidSignature);
 DEV_SIMPLE_EXCEPTION(InvalidTransactionFormat);
 DEV_SIMPLE_EXCEPTION(InvalidBlockFormat);

--- a/libethcore/SealEngine.cpp
+++ b/libethcore/SealEngine.cpp
@@ -54,7 +54,7 @@ void SealEngineFace::verifyTransaction(ImportRequirements::value _ir, Transactio
 		(_t.value() != 0 || _t.gasPrice() != 0 || _t.nonce() != 0))
 			BOOST_THROW_EXCEPTION(InvalidZeroSignatureTransaction() << errinfo_got((bigint)_t.gasPrice()) << errinfo_got((bigint)_t.value()) << errinfo_got((bigint)_t.nonce()));
 
-	if (_env.number() >= chainParams().u256Param("homsteadForkBlock") && (_ir & ImportRequirements::TransactionSignatures))
+	if (_env.number() >= chainParams().u256Param("homsteadForkBlock") && (_ir & ImportRequirements::TransactionSignatures) && _t.hasSignature())
 		_t.checkLowS();
 }
 

--- a/libethcore/Transaction.h
+++ b/libethcore/Transaction.h
@@ -82,12 +82,14 @@ public:
 	bool operator!=(TransactionBase const& _c) const { return !operator==(_c); }
 
 	/// @returns sender of the transaction from the signature (and hash).
+	/// @throws TransactionIsUnsigned if signature was not initialized
 	Address const& sender() const;
 	/// Like sender() but will never throw. @returns a null Address if the signature is invalid.
 	Address const& safeSender() const noexcept;
 	/// Force the sender to a particular value. This will result in an invalid transaction RLP.
 	void forceSender(Address const& _a) { m_sender = _a; }
 
+	/// @throws TransactionIsUnsigned if signature was not initialized
 	/// @throws InvalidSValue if the signature has an invalid S value.
 	void checkLowS() const;
 
@@ -103,6 +105,7 @@ public:
 	bool isCreation() const { return m_type == ContractCreation; }
 
 	/// Serialises this transaction to an RLPStream.
+	/// @throws TransactionIsUnsigned if including signature was requested but it was not initialized
 	void streamRLP(RLPStream& _s, IncludeSignature _sig = WithSignature, bool _forEip155hash = false) const;
 
 	/// @returns the RLP serialisation of this transaction.
@@ -144,7 +147,8 @@ public:
 	/// @returns true if the transaction was signed with zero signature
 	bool hasZeroSignature() const { return m_vrs && !m_vrs->s && !m_vrs->r; }
 
-	/// @returns the signature of the transaction. Encodes the sender.
+	/// @returns the signature of the transaction (the signature has the sender encoded in it)
+	/// @throws TransactionIsUnsigned if signature was not initialized
 	SignatureStruct const& signature() const;
 
 	void sign(Secret const& _priv);			///< Sign the transaction.

--- a/test/unittests/libethcore/SealEngineTest.cpp
+++ b/test/unittests/libethcore/SealEngineTest.cpp
@@ -1,0 +1,49 @@
+/*
+	This file is part of cpp-ethereum.
+
+	cpp-ethereum is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	cpp-ethereum is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/** @file SealEngineTest.cpp
+ * SealEngineFace class testing.
+ */
+
+#include <boost/test/unit_test.hpp>
+#include <test/tools/libtesteth/TestHelper.h>
+#include <libethashseal/Ethash.h>
+
+using namespace std;
+using namespace dev;
+using namespace dev::eth;
+using namespace dev::test;
+
+BOOST_FIXTURE_TEST_SUITE(SealEngineTests, TestOutputHelper)
+
+BOOST_AUTO_TEST_CASE(UnsignedTransactionIsValidBeforeMetropolis)
+{
+	ChainOperationParams params;
+	params.otherParams["metropolisForkBlock"] = "0x1000";
+
+	Ethash ethash;
+	ethash.setChainParams(params);
+
+	BlockHeader header;
+	header.clear();
+	header.setNumber(1);
+	EnvInfo env(header);
+
+	Transaction tx(0, 0, 10000, Address("a94f5374fce5edbc8e2a8697c15331677e6ebf0b"), bytes(), 0);
+	ethash.SealEngineFace::verifyTransaction(ImportRequirements::TransactionSignatures, tx, env); // check that it doesn't throw
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/unittests/libethereum/Transaction.cpp
+++ b/test/unittests/libethereum/Transaction.cpp
@@ -166,4 +166,31 @@ BOOST_AUTO_TEST_CASE(blockVerifyZeroTransaction)
 	//BOOST_CHECK_MESSAGE(bc.interface().transactions().size() == 1, "Failed importing zero transaction to block!");
 }
 
+BOOST_AUTO_TEST_CASE(GettingSenderForUnsignedTransactionThrows)
+{
+	Transaction tx(0, 0, 10000, Address("a94f5374fce5edbc8e2a8697c15331677e6ebf0b"), bytes(), 0);
+	BOOST_CHECK(!tx.hasSignature());
+
+	BOOST_REQUIRE_THROW(tx.sender(), TransactionIsUnsigned);
+}
+
+BOOST_AUTO_TEST_CASE(GettingSignatureForUnsignedTransactionThrows)
+{
+	Transaction tx(0, 0, 10000, Address("a94f5374fce5edbc8e2a8697c15331677e6ebf0b"), bytes(), 0);
+	BOOST_REQUIRE_THROW(tx.signature(), TransactionIsUnsigned);
+}
+
+BOOST_AUTO_TEST_CASE(StreamRLPWithSignatureForUnsignedTransactionThrows)
+{
+	Transaction tx(0, 0, 10000, Address("a94f5374fce5edbc8e2a8697c15331677e6ebf0b"), bytes(), 0);
+	RLPStream s;
+	BOOST_REQUIRE_THROW(tx.streamRLP(s, IncludeSignature::WithSignature, false), TransactionIsUnsigned);
+}
+
+BOOST_AUTO_TEST_CASE(CheckLowSForUnsignedTransactionThrows)
+{
+	Transaction tx(0, 0, 10000, Address("a94f5374fce5edbc8e2a8697c15331677e6ebf0b"), bytes(), 0);
+	BOOST_REQUIRE_THROW(tx.checkLowS(), TransactionIsUnsigned);
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This change reflects the fact that we now have both zero signature transactions (eip86, these should be invalid before Metropolis) and actually unsigned transactions created by eth_call. This is expressed by having `boost::optional<SignatureStruct>` member in the `TransactionBase` class