### PR TITLE
VM: Remove unnecessary check for output buffer size

### DIFF
--- a/libevm/JitVM.cpp
+++ b/libevm/JitVM.cpp
@@ -202,9 +202,7 @@ int64_t evm_call(
 	auto output = env.call(params);
 	auto gasLeft = static_cast<int64_t>(params.gas);
 
-	if (output.second)
-		output.second.copyTo({_outputData, _outputSize});
-	
+	output.second.copyTo({_outputData, _outputSize});
 	if (!output.first)
 		// Add failure indicator.
 		gasLeft |= EVM_CALL_FAILURE;

--- a/libevm/VMCalls.cpp
+++ b/libevm/VMCalls.cpp
@@ -144,8 +144,7 @@ void VM::caseCall()
 	if (caseCallSetup(callParams.get(), output))
 	{
 		std::pair<bool, owning_bytes_ref> callResult = m_ext->call(*callParams);
-		if (callResult.second)
-			callResult.second.copyTo(output);
+		callResult.second.copyTo(output);
 
 		m_SPP[0] = callResult.first ? 1 : 0;
 	}


### PR DESCRIPTION
Unless the intention was to check for the bool flag, this check is not needed (copyTo will not copy anything if the output is empty).