### PR TITLE
Remove duplicate includes, spurious parentheses and spaces

### DIFF
--- a/libdevcore/RLP.h
+++ b/libdevcore/RLP.h
@@ -209,10 +209,10 @@ public:
 			ret.reserve(itemCount());
 			for (auto const& i: *this)
 				ret.push_back(i.convert<T>(_flags));
-		 }
+		}
 		else if (_flags & ThrowOnFail)
 			BOOST_THROW_EXCEPTION(BadCast());
-		 return ret;
+		return ret;
 	}
 
 	template <class T>

--- a/libethereum/BlockQueue.h
+++ b/libethereum/BlockQueue.h
@@ -29,7 +29,6 @@
 #include <libdevcore/Log.h>
 #include <libethcore/Common.h>
 #include <libdevcore/Guards.h>
-#include <libethcore/Common.h>
 #include <libethcore/BlockHeader.h>
 #include "VerifiedBlock.h"
 

--- a/libethereum/VerifiedBlock.h
+++ b/libethereum/VerifiedBlock.h
@@ -60,8 +60,8 @@ struct VerifiedBlock
 	{
 		assert(&_other != this);
 
-		verified = (std::move(_other.verified));
-		blockData = (std::move(_other.blockData));
+		verified = std::move(_other.verified);
+		blockData = std::move(_other.blockData);
 		return *this;
 	}
 


### PR DESCRIPTION
I noticed the same header was included twice, so I removed one of the includes.  I put some more similar harmless changes together.