### PR TITLE
Returndatacopy throws when offset+size is bigger than the size of returndata buffer

### DIFF
--- a/libevm/VM.cpp
+++ b/libevm/VM.cpp
@@ -763,6 +763,9 @@ void VM::interpretCases()
 		{
 			if (!m_schedule->haveReturnData)
 				throwBadInstruction();
+			bigint const endOfAccess{bigint(m_SP[1]) + bigint(m_SP[2])};
+			if (m_returnData.size() < endOfAccess)
+				throwBufferOverrun(endOfAccess);
 
 			m_copyMemSize = toInt63(m_SP[2]);
 			updateMem(memNeed(m_SP[0], m_SP[2]));

--- a/libevm/VM.cpp
+++ b/libevm/VM.cpp
@@ -763,7 +763,7 @@ void VM::interpretCases()
 		{
 			if (!m_schedule->haveReturnData)
 				throwBadInstruction();
-			bigint const endOfAccess{bigint(m_SP[1]) + bigint(m_SP[2])};
+			bigint const endOfAccess = bigint(m_SP[1]) + bigint(m_SP[2]);
 			if (m_returnData.size() < endOfAccess)
 				throwBufferOverrun(endOfAccess);
 

--- a/libevm/VM.h
+++ b/libevm/VM.h
@@ -158,6 +158,7 @@ private:
 	void throwBadStack(unsigned _removed, unsigned _added);
 	void throwRevertInstruction(owning_bytes_ref&& _output);
 	void throwDisallowedStateChange();
+	void throwBufferOverrun(bigint const& _enfOfAccess);
 
 	void reportStackUse();
 

--- a/libevm/VMCalls.cpp
+++ b/libevm/VMCalls.cpp
@@ -94,6 +94,13 @@ void VM::throwRevertInstruction(owning_bytes_ref&& _output)
 	throw RevertInstruction(move(_output));
 }
 
+void VM::throwBufferOverrun(bigint const& _endOfAccess)
+{
+	if (m_onFail)
+		(this->*m_onFail)();
+	BOOST_THROW_EXCEPTION(BufferOverrun() << RequirementError(_endOfAccess, bigint(m_returnData.size())));
+}
+
 int64_t VM::verifyJumpDest(u256 const& _dest, bool _throw)
 {
 	// check for overflow

--- a/libevm/VMFace.h
+++ b/libevm/VMFace.h
@@ -33,6 +33,7 @@ ETH_SIMPLE_EXCEPTION_VM(OutOfGas);
 ETH_SIMPLE_EXCEPTION_VM(OutOfStack);
 ETH_SIMPLE_EXCEPTION_VM(StackUnderflow);
 ETH_SIMPLE_EXCEPTION_VM(DisallowedStateChange);
+ETH_SIMPLE_EXCEPTION_VM(BufferOverrun);
 
 struct RevertInstruction: VMException
 {

--- a/test/tools/jsontests/StateTests.cpp
+++ b/test/tools/jsontests/StateTests.cpp
@@ -182,6 +182,7 @@ BOOST_AUTO_TEST_CASE(stRevertTest){}
 //Metropolis Tests
 BOOST_AUTO_TEST_CASE(stStackTests){}
 BOOST_AUTO_TEST_CASE(stStaticCall){}
+BOOST_AUTO_TEST_CASE(stReturnDataTest){}
 
 //Stress Tests
 BOOST_AUTO_TEST_CASE(stAttackTest){}


### PR DESCRIPTION
This follows the [change in the EIP](https://github.com/ethereum/EIPs/pull/211/commits/28f1709777cbd99dc96dcdbbef8c532674bfbc86#diff-fd8c393953fe66162d8bb518d87bfb57R43).