### PR TITLE
LastHashes refactoring

### DIFF
--- a/libdevcore/vector_ref.h
+++ b/libdevcore/vector_ref.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "db.h"
+
 #include <cstring>
 #include <cassert>
 #include <type_traits>

--- a/libethashseal/Ethash.h
+++ b/libethashseal/Ethash.h
@@ -45,7 +45,7 @@ public:
 
 	StringHashMap jsInfo(BlockHeader const& _bi) const override;
 	void verify(Strictness _s, BlockHeader const& _bi, BlockHeader const& _parent, bytesConstRef _block) const override;
-	void verifyTransaction(ImportRequirements::value _ir, TransactionBase const& _t, EnvInfo const& _env) const override;
+	void verifyTransaction(ImportRequirements::value _ir, TransactionBase const& _t, BlockHeader const& _header, u256 const& _startGasUsed) const override;
 	void populateFromParent(BlockHeader& _bi, BlockHeader const& _parent) const override;
 
 	strings sealers() const override;

--- a/libethcore/SealEngine.h
+++ b/libethcore/SealEngine.h
@@ -56,7 +56,7 @@ public:
 	/// Don't forget to call Super::verify when subclassing & overriding.
 	virtual void verify(Strictness _s, BlockHeader const& _bi, BlockHeader const& _parent = BlockHeader(), bytesConstRef _block = bytesConstRef()) const;
 	/// Additional verification for transactions in blocks.
-	virtual void verifyTransaction(ImportRequirements::value _ir, TransactionBase const& _t, EnvInfo const& _env) const;
+	virtual void verifyTransaction(ImportRequirements::value _ir, TransactionBase const& _t, BlockHeader const& _header, u256 const& _startGasUsed) const;
 	/// Don't forget to call Super::populateFromParent when subclassing & overriding.
 	virtual void populateFromParent(BlockHeader& _bi, BlockHeader const& _parent) const;
 
@@ -75,7 +75,7 @@ public:
 	ChainOperationParams const& chainParams() const { return m_params; }
 	void setChainParams(ChainOperationParams const& _params) { m_params = _params; }
 	SealEngineFace* withChainParams(ChainOperationParams const& _params) { setChainParams(_params); return this; }
-	virtual EVMSchedule const& evmSchedule(EnvInfo const&) const = 0;
+	virtual EVMSchedule const& evmSchedule(u256 const& _blockNumber) const = 0;
 
 	virtual bool isPrecompiled(Address const& _a, u256 const& _blockNumber) const
 	{
@@ -105,7 +105,7 @@ public:
 			m_onSealGenerated(ret.out());
 	}
 	void onSealGenerated(std::function<void(bytes const&)> const& _f) override { m_onSealGenerated = _f; }
-	EVMSchedule const& evmSchedule(EnvInfo const&) const override;
+	EVMSchedule const& evmSchedule(u256 const& _blockNumber) const override;
 
 protected:
 	std::function<void(bytes const& s)> m_onSealGenerated;

--- a/libethereum/Block.h
+++ b/libethereum/Block.h
@@ -50,6 +50,7 @@ class BlockChain;
 class State;
 class TransactionQueue;
 struct VerifiedBlockRef;
+class LastBlockHashesFace;
 
 struct BlockChat: public LogChannel { static const char* name(); static const int verbosity = 4; };
 struct BlockTrace: public LogChannel { static const char* name(); static const int verbosity = 5; };
@@ -215,7 +216,7 @@ public:
 
 	/// Execute a given transaction.
 	/// This will append @a _t to the transaction list and change the state accordingly.
-	ExecutionResult execute(LastHashes const& _lh, Transaction const& _t, Permanence _p = Permanence::Committed, OnOpFunc const& _onOp = OnOpFunc());
+	ExecutionResult execute(LastBlockHashesFace const& _lh, Transaction const& _t, Permanence _p = Permanence::Committed, OnOpFunc const& _onOp = OnOpFunc());
 
 	/// Sync our transactions, killing those from the queue that we have and assimilating those that we don't.
 	/// @returns a list of receipts one for each transaction placed from the queue into the state and bool, true iff there are more transactions to be processed.

--- a/libethereum/BlockChain.h
+++ b/libethereum/BlockChain.h
@@ -21,25 +21,26 @@
 
 #pragma once
 
-#include <deque>
-#include <chrono>
-#include <unordered_map>
-#include <unordered_set>
+#include "Account.h"
+#include "BlockDetails.h"
+#include "BlockQueue.h"
+#include "ChainParams.h"
+#include "LastBlockHashesFace.h"
+#include "State.h"
+#include "Transaction.h"
+#include "VerifiedBlock.h"
 #include <libdevcore/db.h>
-#include <libdevcore/Log.h>
 #include <libdevcore/Exceptions.h>
+#include <libdevcore/Log.h>
 #include <libdevcore/Guards.h>
-#include <libethcore/Common.h>
 #include <libethcore/BlockHeader.h>
+#include <libethcore/Common.h>
 #include <libethcore/SealEngine.h>
 #include <libevm/ExtVMFace.h>
-#include "BlockDetails.h"
-#include "Account.h"
-#include "Transaction.h"
-#include "BlockQueue.h"
-#include "VerifiedBlock.h"
-#include "ChainParams.h"
-#include "State.h"
+#include <chrono>
+#include <deque>
+#include <unordered_map>
+#include <unordered_set>
 
 namespace std
 {
@@ -182,9 +183,7 @@ public:
 	/// Get the hash for a given block's number.
 	h256 numberHash(unsigned _i) const { if (!_i) return genesisHash(); return queryExtras<BlockHash, uint64_t, ExtraBlockHash>(_i, m_blockHashes, x_blockHashes, NullBlockHash).value; }
 
-	/// Get the last N hashes for a given block. (N is determined by the LastHashes type.)
-	LastHashes lastHashes() const { return lastHashes(m_lastBlockHash); }
-	LastHashes lastHashes(h256 const& _mostRecentHash) const;
+	LastBlockHashesFace const& lastBlockHashes() const { return *m_lastBlockHashes;  }
 
 	/** Get the block blooms for a number of blocks. Thread-safe.
 	 * @returns the object pertaining to the blocks:
@@ -379,9 +378,8 @@ private:
 	void noteUsed(uint64_t const& _h, unsigned _extra = (unsigned)-1) const { (void)_h; (void)_extra; } // don't note non-hash types
 	std::chrono::system_clock::time_point m_lastCollection;
 
-	void noteCanonChanged() const { Guard l(x_lastLastHashes); m_lastLastHashes.clear(); }
-	mutable Mutex x_lastLastHashes;
-	mutable LastHashes m_lastLastHashes;
+	void noteCanonChanged() const { m_lastBlockHashes->clear(); }
+	std::unique_ptr<LastBlockHashesFace> m_lastBlockHashes;
 
 	void updateStats() const;
 	mutable Statistics m_lastStats;

--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -366,29 +366,6 @@ void Client::appendFromBlock(h256 const& _block, BlockPolarity _polarity, h256Ha
 	}
 }
 
-ExecutionResult Client::call(Address _dest, bytes const& _data, u256 _gas, u256 _value, u256 _gasPrice, Address const& _from)
-{
-	ExecutionResult ret;
-	try
-	{
-		Block temp(chainParams().accountStartNonce);
-		clog(ClientDetail) << "Nonce at " << _dest << " pre:" << m_preSeal.transactionsFrom(_dest) << " post:" << m_postSeal.transactionsFrom(_dest);
-		DEV_READ_GUARDED(x_postSeal)
-			temp = m_postSeal;
-		temp.mutableState().addBalance(_from, _value + _gasPrice * _gas);
-		Executive e(temp);
-		e.setResultRecipient(ret);
-		if (!e.call(_dest, _from, _value, _gasPrice, &_data, _gas))
-			e.go();
-		e.finalize();
-	}
-	catch (...)
-	{
-		cwarn << "Client::call failed: " << boost::current_exception_diagnostic_information();
-	}
-	return ret;
-}
-
 unsigned static const c_syncMin = 1;
 unsigned static const c_syncMax = 1000;
 double static const c_targetDuration = 1;

--- a/libethereum/Client.h
+++ b/libethereum/Client.h
@@ -100,10 +100,6 @@ public:
 	/// Queues a block for import.
 	ImportResult queueBlock(bytes const& _block, bool _isSafe = false);
 
-	using Interface::call; // to remove warning about hiding virtual function
-	/// Makes the given call. Nothing is recorded into the state. This cheats by creating a null address and endowing it with a lot of ETH.
-	ExecutionResult call(Address _dest, bytes const& _data = bytes(), u256 _gas = 125000, u256 _value = 0, u256 _gasPrice = 1 * ether, Address const& _from = Address());
-
 	/// Get the remaining gas limit in this block.
 	virtual u256 gasLimitRemaining() const override { return m_postSeal.gasLimitRemaining(); }
 	/// Get the gas bid price

--- a/libethereum/ClientBase.cpp
+++ b/libethereum/ClientBase.cpp
@@ -70,28 +70,7 @@ ExecutionResult ClientBase::call(Address const& _from, u256 _value, Address _des
 		t.forceSender(_from);
 		if (_ff == FudgeFactor::Lenient)
 			temp.mutableState().addBalance(_from, (u256)(t.gas() * t.gasPrice() + t.value()));
-		ret = temp.execute(bc().lastHashes(), t, Permanence::Reverted);
-	}
-	catch (...)
-	{
-		// TODO: Some sort of notification of failure.
-	}
-	return ret;
-}
-
-ExecutionResult ClientBase::create(Address const& _from, u256 _value, bytes const& _data, u256 _gas, u256 _gasPrice, BlockNumber _blockNumber, FudgeFactor _ff)
-{
-	ExecutionResult ret;
-	try
-	{
-		Block temp = block(_blockNumber);
-		u256 n = temp.transactionsFrom(_from);
-		//	cdebug << "Nonce at " << toAddress(_secret) << " pre:" << m_preSeal.transactionsFrom(toAddress(_secret)) << " post:" << m_postSeal.transactionsFrom(toAddress(_secret));
-		Transaction t(_value, _gasPrice, _gas, _data, n);
-		t.forceSender(_from);
-		if (_ff == FudgeFactor::Lenient)
-			temp.mutableState().addBalance(_from, (u256)(t.gas() * t.gasPrice() + t.value()));
-		ret = temp.execute(bc().lastHashes(), t, Permanence::Reverted);
+		ret = temp.execute(bc().lastBlockHashes(), t, Permanence::Reverted);
 	}
 	catch (...)
 	{
@@ -123,8 +102,7 @@ std::pair<u256, ExecutionResult> ClientBase::estimateGas(Address const& _from, u
 			else
 				t = Transaction(_value, gasPrice, mid, _data, n);
 			t.forceSender(_from);
-			EnvInfo env(bk.info(), bc().lastHashes(), 0);
-			env.setGasLimit(mid);
+			EnvInfo const env(bk.info(), bc().lastBlockHashes(), 0, mid);
 			State tempState(bk.state());
 			tempState.addBalance(_from, (u256)(t.gas() * t.gasPrice() + t.value()));
 			er = tempState.execute(env, *bc().sealEngine(), t, Permanence::Reverted).first;

--- a/libethereum/ClientBase.h
+++ b/libethereum/ClientBase.h
@@ -88,15 +88,10 @@ public:
 	virtual ExecutionResult call(Address const& _secret, u256 _value, Address _dest, bytes const& _data, u256 _gas, u256 _gasPrice, BlockNumber _blockNumber, FudgeFactor _ff = FudgeFactor::Strict) override;
 	using Interface::call;
 
-	/// Makes the given create. Nothing is recorded into the state.
-	virtual ExecutionResult create(Address const& _secret, u256 _value, bytes const& _data, u256 _gas, u256 _gasPrice, BlockNumber _blockNumber, FudgeFactor _ff = FudgeFactor::Strict) override;
-
 	/// Estimate gas usage for call/create.
 	/// @param _maxGas An upper bound value for estimation, if not provided default value of c_maxGasEstimate will be used.
 	/// @param _callback Optional callback function for progress reporting
 	virtual std::pair<u256, ExecutionResult> estimateGas(Address const& _from, u256 _value, Address _dest, bytes const& _data, int64_t _maxGas, u256 _gasPrice, BlockNumber _blockNumber, GasEstimationCallback const& _callback) override;
-
-	using Interface::create;
 
 	using Interface::balanceAt;
 	using Interface::countAt;
@@ -148,7 +143,7 @@ public:
 	virtual BlockHeader pendingInfo() const override;
 	virtual BlockDetails pendingDetails() const override;
 
-	virtual EVMSchedule evmSchedule() const override { return sealEngine()->evmSchedule(EnvInfo(pendingInfo())); }
+	virtual EVMSchedule evmSchedule() const override { return sealEngine()->evmSchedule(pendingInfo().number()); }
 
 	virtual ImportResult injectTransaction(bytes const& _rlp, IfDropped _id = IfDropped::Ignore) override { prepareForTransaction(); return m_tq.import(_rlp, _id); }
 	virtual ImportResult injectBlock(bytes const& _block) override;

--- a/libethereum/ClientTest.cpp
+++ b/libethereum/ClientTest.cpp
@@ -91,7 +91,8 @@ void ClientTest::modifyTimestamp(u256 const& _timestamp)
 	DEV_WRITE_GUARDED(x_preSeal)
 		m_preSeal = block;
 
-	auto lastHashes = bc().lastHashes();
+	auto& lastHashes = bc().lastBlockHashes();
+	assert(bc().currentHash() == block.info().parentHash());
 	for (auto const& t: transactions)
 		block.execute(lastHashes, t);
 

--- a/libethereum/Executive.cpp
+++ b/libethereum/Executive.cpp
@@ -143,15 +143,15 @@ string StandardTrace::json(bool _styled) const
 
 Executive::Executive(Block& _s, BlockChain const& _bc, unsigned _level):
 	m_s(_s.mutableState()),
-	m_envInfo(_s.info(), _bc.lastHashes(_s.info().parentHash())),
+	m_envInfo(_s.info(), _bc.lastBlockHashes(), 0),
 	m_depth(_level),
 	m_sealEngine(*_bc.sealEngine())
 {
 }
 
-Executive::Executive(Block& _s, LastHashes const& _lh, unsigned _level):
+Executive::Executive(Block& _s, LastBlockHashesFace const& _lh, unsigned _level):
 	m_s(_s.mutableState()),
-	m_envInfo(_s.info(), _lh),
+	m_envInfo(_s.info(), _lh, 0),
 	m_depth(_level),
 	m_sealEngine(*_s.sealEngine())
 {
@@ -159,7 +159,7 @@ Executive::Executive(Block& _s, LastHashes const& _lh, unsigned _level):
 
 Executive::Executive(State& io_s, Block const& _block, unsigned _txIndex, BlockChain const& _bc, unsigned _level):
 	m_s(createIntermediateState(io_s, _block, _txIndex, _bc)),
-	m_envInfo(_block.info(), _bc.lastHashes(_block.info().parentHash()), _txIndex ? _block.receipt(_txIndex - 1).gasUsed() : 0),
+	m_envInfo(_block.info(), _bc.lastBlockHashes(), _txIndex ? _block.receipt(_txIndex - 1).gasUsed() : 0),
 	m_depth(_level),
 	m_sealEngine(*_bc.sealEngine())
 {
@@ -179,10 +179,10 @@ void Executive::accrueSubState(SubState& _parentContext)
 void Executive::initialize(Transaction const& _transaction)
 {
 	m_t = _transaction;
-	m_baseGasRequired = m_t.baseGasRequired(m_sealEngine.evmSchedule(m_envInfo));
+	m_baseGasRequired = m_t.baseGasRequired(m_sealEngine.evmSchedule(m_envInfo.number()));
 	try
 	{
-		m_sealEngine.verifyTransaction(ImportRequirements::Everything, m_t, m_envInfo);
+		m_sealEngine.verifyTransaction(ImportRequirements::Everything, m_t, m_envInfo.header(), m_envInfo.gasUsed());
 	}
 	catch (Exception const& ex)
 	{

--- a/libethereum/Executive.h
+++ b/libethereum/Executive.h
@@ -115,7 +115,7 @@ public:
 	 * Creates executive to operate on the state of end of the given block, populating environment
 	 * info accordingly, with last hashes given explicitly.
 	 */
-	Executive(Block& _s, LastHashes const& _lh = LastHashes(), unsigned _level = 0);
+	Executive(Block& _s, LastBlockHashesFace const& _lh, unsigned _level = 0);
 
 	/** Previous-state constructor.
 	 * Creates executive to operate on the state of a particular transaction in the given block,

--- a/libethereum/ExtVM.cpp
+++ b/libethereum/ExtVM.cpp
@@ -20,8 +20,9 @@
  */
 
 #include "ExtVM.h"
-#include <exception>
+#include "LastBlockHashesFace.h"
 #include <boost/thread.hpp>
+#include <exception>
 
 using namespace dev;
 using namespace dev::eth;
@@ -144,8 +145,11 @@ h256 ExtVM::blockHash(u256 _number)
 
 	if (currentNumber < m_sealEngine.chainParams().u256Param("metropolisForkBlock") + 256)
 	{
-		assert(envInfo().lastHashes().size() > (unsigned)(currentNumber - 1 - _number));
-		return envInfo().lastHashes()[(unsigned)(currentNumber - 1 - _number)];
+		h256 const parentHash = envInfo().header().parentHash();
+		h256s const lastHashes = envInfo().lastHashes().precedingHashes(parentHash);
+
+		assert(lastHashes.size() > (unsigned)(currentNumber - 1 - _number));
+		return lastHashes[(unsigned)(currentNumber - 1 - _number)];
 	}
 
 	u256 const nonce = m_s.getNonce(caller);

--- a/libethereum/ExtVM.h
+++ b/libethereum/ExtVM.h
@@ -87,7 +87,7 @@ public:
 	virtual void suicide(Address _a) override final;
 
 	/// Return the EVM gas-price schedule for this execution context.
-	virtual EVMSchedule const& evmSchedule() const override final { return m_sealEngine.evmSchedule(envInfo()); }
+	virtual EVMSchedule const& evmSchedule() const override final { return m_sealEngine.evmSchedule(envInfo().number()); }
 
 	State const& state() const { return m_s; }
 

--- a/libethereum/Interface.h
+++ b/libethereum/Interface.h
@@ -95,13 +95,6 @@ public:
 	ExecutionResult call(Secret const& _secret, u256 _value, Address _dest, bytes const& _data, u256 _gas, u256 _gasPrice, BlockNumber _blockNumber, FudgeFactor _ff = FudgeFactor::Strict) { return call(toAddress(_secret), _value, _dest, _data, _gas, _gasPrice, _blockNumber, _ff); }
 	ExecutionResult call(Secret const& _secret, u256 _value, Address _dest, bytes const& _data, u256 _gas, u256 _gasPrice, FudgeFactor _ff = FudgeFactor::Strict) { return call(toAddress(_secret), _value, _dest, _data, _gas, _gasPrice, _ff); }
 
-	/// Does the given creation. Nothing is recorded into the state.
-	/// @returns the pair of the Address of the created contract together with its code.
-	virtual ExecutionResult create(Address const& _from, u256 _value, bytes const& _data, u256 _gas, u256 _gasPrice, BlockNumber _blockNumber, FudgeFactor _ff = FudgeFactor::Strict) = 0;
-	ExecutionResult create(Address const& _from, u256 _value, bytes const& _data = bytes(), u256 _gas = 1000000, u256 _gasPrice = DefaultGasPrice, FudgeFactor _ff = FudgeFactor::Strict) { return create(_from, _value, _data, _gas, _gasPrice, m_default, _ff); }
-	ExecutionResult create(Secret const& _secret, u256 _value, bytes const& _data, u256 _gas, u256 _gasPrice, BlockNumber _blockNumber, FudgeFactor _ff = FudgeFactor::Strict) { return create(toAddress(_secret), _value, _data, _gas, _gasPrice, _blockNumber, _ff); }
-	ExecutionResult create(Secret const& _secret, u256 _value, bytes const& _data, u256 _gas, u256 _gasPrice, FudgeFactor _ff = FudgeFactor::Strict) { return create(toAddress(_secret), _value, _data, _gas, _gasPrice, _ff); }
-
 	/// Injects the RLP-encoded transaction given by the _rlp into the transaction queue directly.
 	virtual ImportResult injectTransaction(bytes const& _rlp, IfDropped _id = IfDropped::Ignore) = 0;
 

--- a/libethereum/LastBlockHashesFace.h
+++ b/libethereum/LastBlockHashesFace.h
@@ -1,0 +1,49 @@
+/*
+	This file is part of cpp-ethereum.
+
+	cpp-ethereum is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	cpp-ethereum is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/** @file 
+ *  Interface for getting a list of recent block hashes
+ */
+
+#pragma once
+
+
+namespace dev
+{
+
+namespace eth
+{
+
+/**
+* @brief Interface for getting a list of recent block hashes
+* @threadsafe
+*/
+class LastBlockHashesFace
+{
+public:
+	virtual ~LastBlockHashesFace() {}
+
+	/// Get hashes of 256 consecutive blocks preceding and including @a _mostRecentHash
+	/// Hashes are returned in the order of descending height,
+	/// i.e. result[0] is @a _mostRecentHash, result[1] is its parent, result[2] is grandparent etc.
+	virtual h256s precedingHashes(h256 const& _mostRecentHash) const = 0;
+
+	/// Clear any cached result
+	virtual void clear() = 0;
+};
+
+}
+}

--- a/libethereum/State.cpp
+++ b/libethereum/State.cpp
@@ -560,7 +560,7 @@ std::pair<ExecutionResult, TransactionReceipt> State::execute(EnvInfo const& _en
 	return make_pair(res, receipt);
 }
 
-void State::executeBlockTransactions(Block const& _block, unsigned _txCount, LastHashes const& _lastHashes, SealEngineFace const& _sealEngine)
+void State::executeBlockTransactions(Block const& _block, unsigned _txCount, LastBlockHashesFace const& _lastHashes, SealEngineFace const& _sealEngine)
 {
 	u256 gasUsed = 0;
 	for (unsigned i = 0; i < _txCount; ++i)
@@ -659,7 +659,7 @@ State& dev::eth::createIntermediateState(State& o_s, Block const& _block, unsign
 	else
 	{
 		o_s.setRoot(_block.stateRootBeforeTx(0));
-		o_s.executeBlockTransactions(_block, _txIndex, _bc.lastHashes(_block.info().parentHash()), *_bc.sealEngine());
+		o_s.executeBlockTransactions(_block, _txIndex, _bc.lastBlockHashes(), *_bc.sealEngine());
 	}
 	return o_s;
 }

--- a/libethereum/State.h
+++ b/libethereum/State.h
@@ -206,7 +206,7 @@ public:
 
 	/// Execute @a _txCount transactions of a given block.
 	/// This will change the state accordingly.
-	void executeBlockTransactions(Block const& _block, unsigned _txCount, LastHashes const& _lastHashes, SealEngineFace const& _sealEngine);
+	void executeBlockTransactions(Block const& _block, unsigned _txCount, LastBlockHashesFace const& _lastHashes, SealEngineFace const& _sealEngine);
 
 	/// Check if the address is in use.
 	bool addressInUse(Address const& _address) const;

--- a/libevm/ExtVMFace.h
+++ b/libevm/ExtVMFace.h
@@ -193,9 +193,8 @@ struct SubState
 };
 
 class ExtVMFace;
+class LastBlockHashesFace;
 class VM;
-
-using LastHashes = std::vector<h256>;
 
 using OnOpFunc = std::function<void(uint64_t /*steps*/, uint64_t /* PC */, Instruction /*instr*/, bigint /*newMemSize*/, bigint /*gasCost*/, bigint /*gas*/, VM*, ExtVMFace const*)>;
 
@@ -227,31 +226,31 @@ struct CallParameters
 class EnvInfo
 {
 public:
-	EnvInfo() {}
-	EnvInfo(BlockHeader const& _current, LastHashes const& _lh = LastHashes(), u256 const& _gasUsed = u256()):
+	EnvInfo(BlockHeader const& _current, LastBlockHashesFace const& _lh, u256 const& _gasUsed):
 		m_headerInfo(_current),
 		m_lastHashes(_lh),
 		m_gasUsed(_gasUsed)
 	{}
+	// Constructor with custom gasLimit - used in some synthetic scenarios like eth_estimateGas	RPC method
+	EnvInfo(BlockHeader const& _current, LastBlockHashesFace const& _lh, u256 const& _gasUsed, u256 const& _gasLimit):
+		EnvInfo(_current, _lh, _gasUsed)
+	{
+		m_headerInfo.setGasLimit(_gasLimit);
+	}
+
+	BlockHeader const& header() const { return m_headerInfo;  }
 
 	u256 const& number() const { return m_headerInfo.number(); }
 	Address const& author() const { return m_headerInfo.author(); }
 	u256 const& timestamp() const { return m_headerInfo.timestamp(); }
 	u256 const& difficulty() const { return m_headerInfo.difficulty(); }
 	u256 const& gasLimit() const { return m_headerInfo.gasLimit(); }
-	LastHashes const& lastHashes() const { return m_lastHashes; }
+	LastBlockHashesFace const& lastHashes() const { return m_lastHashes; }
 	u256 const& gasUsed() const { return m_gasUsed; }
-
-	void setNumber(u256 const& _v) { m_headerInfo.setNumber(_v); }
-	void setAuthor(Address const& _v) { m_headerInfo.setAuthor(_v); }
-	void setTimestamp(u256 const& _v) { m_headerInfo.setTimestamp(_v); }
-	void setDifficulty(u256 const& _v) { m_headerInfo.setDifficulty(_v); }
-	void setGasLimit(u256 const& _v) { m_headerInfo.setGasLimit(_v); }
-	void setLastHashes(LastHashes&& _lh) { m_lastHashes = _lh; }
 
 private:
 	BlockHeader m_headerInfo;
-	LastHashes m_lastHashes;
+	LastBlockHashesFace const& m_lastHashes;
 	u256 m_gasUsed;
 };
 

--- a/libweb3jsonrpc/Debug.cpp
+++ b/libweb3jsonrpc/Debug.cpp
@@ -70,7 +70,7 @@ Json::Value Debug::traceBlock(Block const& _block, Json::Value const& _json)
 		Transaction t = _block.pending()[k];
 
 		u256 const gasUsed = k ? _block.receipt(k - 1).gasUsed() : 0;
-		EnvInfo envInfo(_block.info(), m_eth.blockChain().lastHashes(_block.info().parentHash()), gasUsed);
+		EnvInfo envInfo(_block.info(), m_eth.blockChain().lastBlockHashes(), gasUsed);
 		Executive e(s, envInfo, *m_eth.blockChain().sealEngine());
 
 		eth::ExecutionResult er;
@@ -199,7 +199,7 @@ Json::Value Debug::debug_traceCall(Json::Value const& _call, std::string const& 
 		Transaction transaction(ts.value, gasPrice, gas, ts.to, ts.data, nonce);
 		transaction.forceSender(ts.from);
 		eth::ExecutionResult er;
-		Executive e(temp);
+		Executive e(temp, m_eth.blockChain().lastBlockHashes());
 		e.setResultRecipient(er);
 		Json::Value trace = traceTransaction(e, transaction, _options);
 		ret["gas"] = toHex(transaction.gas(), HexPrefix::Add);

--- a/test/tools/jsontests/TransactionTests.cpp
+++ b/test/tools/jsontests/TransactionTests.cpp
@@ -73,7 +73,7 @@ void doTransactionTests(json_spirit::mValue& _v, bool _fillin)
 				if (!txFromFields.signature().isValid())
 				if (!onMetropolisAndZeroSig)
 					BOOST_THROW_EXCEPTION(Exception() << errinfo_comment(testname + "transaction from RLP signature is invalid") );
-				se->verifyTransaction(ImportRequirements::Everything, txFromFields, EnvInfo(bh));
+				se->verifyTransaction(ImportRequirements::Everything, txFromFields, bh, 0);
 
 				if (o.count("sender") > 0)
 				{
@@ -125,7 +125,7 @@ void doTransactionTests(json_spirit::mValue& _v, bool _fillin)
 				RLP rlp(stream);
 				txFromRlp = Transaction(rlp.data(), CheckTransaction::Everything);
 				bool onMetropolisAndZeroSig = onMetropolis && txFromRlp.hasZeroSignature();
-				se->verifyTransaction(ImportRequirements::Everything, txFromRlp, EnvInfo(bh));
+				se->verifyTransaction(ImportRequirements::Everything, txFromRlp, bh, 0);
 				if (!txFromRlp.signature().isValid())
 				if (!onMetropolisAndZeroSig)
 					BOOST_THROW_EXCEPTION(Exception() << errinfo_comment(testname + "transaction from RLP signature is invalid") );

--- a/test/tools/jsontests/vm.h
+++ b/test/tools/jsontests/vm.h
@@ -23,13 +23,7 @@ along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 
 #pragma once
 
-#include <fstream>
-#include <cstdint>
-
 #include <test/tools/libtesteth/TestHelper.h>
-#include <boost/test/unit_test.hpp>
-
-#include <json_spirit/json_spirit.h>
 #include <libdevcore/Log.h>
 #include <libdevcore/CommonIO.h>
 #include <libevmcore/Instruction.h>
@@ -39,7 +33,20 @@ along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 #include <libethereum/ExtVM.h>
 #include <libethereum/State.h>
 
-namespace dev { namespace test {
+#include <json_spirit/json_spirit.h>
+#include <boost/test/unit_test.hpp>
+#include <fstream>
+#include <cstdint>
+
+namespace dev
+{
+namespace eth
+{
+class LastBlockHashesFace;
+}
+
+namespace test
+{
 
 class FakeExtVM: public eth::ExtVMFace
 {
@@ -63,7 +70,7 @@ public:
 	void reset(u256 _myBalance, u256 _myNonce, std::map<u256, u256> const& _storage);
 	u256 doPosts();
 	json_spirit::mObject exportEnv();
-	static dev::eth::EnvInfo importEnv(json_spirit::mObject& _o);
+	static dev::eth::EnvInfo importEnv(json_spirit::mObject& _o, eth::LastBlockHashesFace const& _lastBlockHashes);
 	json_spirit::mObject exportState();
 	void importState(json_spirit::mObject& _object);
 	json_spirit::mObject exportExec();

--- a/test/tools/libtesteth/ImportTest.h
+++ b/test/tools/libtesteth/ImportTest.h
@@ -65,7 +65,8 @@ private:
 	using ExecOutput = std::pair<eth::ExecutionResult, eth::TransactionReceipt>;
 	std::tuple<eth::State, ExecOutput, eth::ChangeLog> executeTransaction(eth::Network const _sealEngineNetwork, eth::EnvInfo const& _env, eth::State const& _preState, eth::Transaction const& _tr);
 
-	eth::EnvInfo m_envInfo;
+	std::unique_ptr<eth::LastBlockHashesFace const> m_lastBlockHashes;
+	std::unique_ptr<eth::EnvInfo> m_envInfo;
 	eth::Transaction m_transaction;
 
 	//General State Tests

--- a/test/tools/libtestutils/TestLastBlockHashes.h
+++ b/test/tools/libtestutils/TestLastBlockHashes.h
@@ -1,0 +1,44 @@
+/*
+	This file is part of cpp-ethereum.
+
+	cpp-ethereum is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	cpp-ethereum is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/** @file
+ * Test implementation for LastBlockHahsesFace
+ */
+
+#pragma once
+
+#include <libethereum/LastBlockHashesFace.h>
+
+namespace dev
+{
+namespace test
+{
+
+class TestLastBlockHashes: public eth::LastBlockHashesFace
+{
+public:
+	explicit TestLastBlockHashes(h256s const& _hashes): m_hashes(_hashes) {}
+
+	h256s precedingHashes(h256 const& /* _mostRecentHash */) const override { return m_hashes; }
+	void clear() override {}
+
+private:
+	h256s const m_hashes;
+};
+
+
+}
+}

--- a/test/unittests/libethcore/SealEngineTest.cpp
+++ b/test/unittests/libethcore/SealEngineTest.cpp
@@ -40,10 +40,9 @@ BOOST_AUTO_TEST_CASE(UnsignedTransactionIsValidBeforeMetropolis)
 	BlockHeader header;
 	header.clear();
 	header.setNumber(1);
-	EnvInfo env(header);
 
 	Transaction tx(0, 0, 10000, Address("a94f5374fce5edbc8e2a8697c15331677e6ebf0b"), bytes(), 0);
-	ethash.SealEngineFace::verifyTransaction(ImportRequirements::TransactionSignatures, tx, env); // check that it doesn't throw
+	ethash.SealEngineFace::verifyTransaction(ImportRequirements::TransactionSignatures, tx, header, 0); // check that it doesn't throw
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/unittests/libethereum/BlockChainInsert.cpp
+++ b/test/unittests/libethereum/BlockChainInsert.cpp
@@ -194,7 +194,7 @@ BOOST_AUTO_TEST_CASE(bcBasicInsert)
 	Transaction t(1000, 10000, 100000, me.address(), bytes(), block.transactionsFrom(myMiner.address()), myMiner.secret());
 	assert(t.sender() == myMiner.address());
 	cnote << "Execute transaction";
-	block.execute(tcFull.bc().lastHashes(), t);
+	block.execute(tcFull.bc().lastBlockHashes(), t);
 	cnote << block.state();
 
 	// Seal and import into both.

--- a/test/unittests/libethereum/ExtVMTest.cpp
+++ b/test/unittests/libethereum/ExtVMTest.cpp
@@ -17,8 +17,9 @@
 /** @file ExtVMTest.cpp
  */
 
-#include <test/tools/libtesteth/TestHelper.h>
 #include <test/tools/libtesteth/BlockChainHelper.h>
+#include <test/tools/libtesteth/TestHelper.h>
+#include <test/tools/libtestutils/TestLastBlockHashes.h>
 
 #include <libethereum/Block.h>
 #include <libethereum/ExtVM.h>
@@ -62,7 +63,8 @@ BOOST_AUTO_TEST_CASE(BlockhashOutOfBoundsRetunsZero)
 	Block block = blockchain.genesisBlock(genesisDB);
 	block.sync(blockchain);
 
-	EnvInfo envInfo(block.info(), {}, 0);
+	TestLastBlockHashes lastBlockHashes({});
+	EnvInfo envInfo(block.info(), lastBlockHashes, 0);
 	Address addr("0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b");
 	ExtVM extVM(block.mutableState(), envInfo, *blockchain.sealEngine(), addr, addr, addr, 0, 0, bytesConstRef(), bytesConstRef(), h256());
 
@@ -73,9 +75,10 @@ BOOST_AUTO_TEST_CASE(BlockhashBeforeMetropolisReliesOnLastHashes)
 {
 	Block block = blockchain.genesisBlock(genesisDB);
 	block.sync(blockchain);
-
-	LastHashes lastHashes{ h256("0xaaabbbccc"), h256("0xdddeeefff")};
-	EnvInfo envInfo(block.info(), lastHashes, 0);
+	
+	h256s lastHashes{h256("0xaaabbbccc"), h256("0xdddeeefff")};
+	TestLastBlockHashes lastBlockHashes(lastHashes);
+	EnvInfo envInfo(block.info(), lastBlockHashes, 0);
 	Address addr("0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b");
 	ExtVM extVM(block.mutableState(), envInfo, *blockchain.sealEngine(), addr, addr, addr, 0, 0, bytesConstRef(), bytesConstRef(), h256());
 	h256 hash = extVM.blockHash(1);
@@ -95,8 +98,8 @@ BOOST_AUTO_TEST_CASE(BlockhashDoesntNeedLastHashesInMetropolis)
 	Block block = blockchain.genesisBlock(genesisDB);
 	block.sync(blockchain);
 
-	LastHashes lastHashes{};
-	EnvInfo envInfo(block.info(), lastHashes, 0);
+	TestLastBlockHashes lastBlockHashes({});
+	EnvInfo envInfo(block.info(), lastBlockHashes, 0);
 	Address addr("0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b");
 	ExtVM extVM(block.mutableState(), envInfo, *blockchain.sealEngine(), addr, addr, addr, 0, 0, bytesConstRef(), bytesConstRef(), h256());
 


### PR DESCRIPTION
Follow-up to https://github.com/ethereum/cpp-ethereum/pull/4066
Resolves https://github.com/ethereum/cpp-ethereum/issues/4084

Refactoring basically replaces `LastHashes` vector constructed by `Blockchain` class and passed to `Executive` when we need to execute some VM code with `LastBlockHashesFace` interface provided by `BlockChain` class.
The new interface constructs exactly the same vector, and the behavior before Metropolis is not changed.

After Metropolis BLOCKHASH doesn't access this interface (performs a call to contract instead) and this way we avoid constructing unnecessary hash vector.