### PR TITLE
ipc: Use --ipcpath also on Windows

### DIFF
--- a/libdevcore/FileSystem.cpp
+++ b/libdevcore/FileSystem.cpp
@@ -55,15 +55,8 @@ void dev::setIpcPath(string const& _ipcDir)
 
 string dev::getIpcPath()
 {
-	if (s_ethereumIpcPath.empty())
-		return string(getDataDir());
-	else
-	{
-		size_t socketPos = s_ethereumIpcPath.rfind("geth.ipc");
-		if (socketPos != string::npos)
-			return s_ethereumIpcPath.substr(0, socketPos);
-		return s_ethereumIpcPath;
-	}
+	// Strip "geth.ipc" suffix if provided.
+	return s_ethereumIpcPath.substr(0, s_ethereumIpcPath.rfind("geth.ipc"));
 }
 
 string dev::getDataDir(string _prefix)

--- a/libweb3jsonrpc/WinPipeServer.cpp
+++ b/libweb3jsonrpc/WinPipeServer.cpp
@@ -24,6 +24,7 @@ along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 #include "WinPipeServer.h"
 #include <windows.h>
 #include <libdevcore/Guards.h>
+#include <libdevcore/FileSystem.h>
 
 using namespace std;
 using namespace jsonrpc;
@@ -32,7 +33,7 @@ using namespace dev;
 int const c_bufferSize = 1024;
 
 WindowsPipeServer::WindowsPipeServer(string const& _appId):
-	IpcServerBase("\\\\.\\pipe\\" + _appId + ".ipc")
+	IpcServerBase("\\\\.\\pipe\\" + getIpcPath() + "\\" + _appId + ".ipc")
 {
 }
 


### PR DESCRIPTION
Prepend the named pipe name on Windows with the path provided in --ipcpath argument.

Fixes https://github.com/ethereum/cpp-ethereum/issues/4123.