### PR TITLE
A leftover o.clear() from #4114

### DIFF
--- a/test/tools/jsontests/StateTests.cpp
+++ b/test/tools/jsontests/StateTests.cpp
@@ -47,7 +47,10 @@ void doStateTests(json_spirit::mValue& _v, bool _fillin)
 		json_spirit::mObject& o = i.second.get_obj();
 
 		if (!TestOutputHelper::passTest(testname))
+		{
+			o.clear();
 			continue;
+		}
 
 		//For 100% at the log output when making blockchain tests out of state tests
 		if (_fillin == false && Options::get().fillchain)


### PR DESCRIPTION
This fixes #4148.