### PR TITLE
Revert bug fix

### DIFF
--- a/ethvm/main.cpp
+++ b/ethvm/main.cpp
@@ -260,7 +260,7 @@ int main(int argc, char** argv)
 	{
 		// Deploy the code on some fake account to be called later.
 		Account account(0, 0);
-		account.setNewCode(bytes{code});
+		account.setCode(bytes{code});
 		std::unordered_map<Address, Account> map;
 		map[contractDestination] = account;
 		state.populateFrom(map);

--- a/libethereum/Account.cpp
+++ b/libethereum/Account.cpp
@@ -28,7 +28,7 @@ using namespace std;
 using namespace dev;
 using namespace dev::eth;
 
-void Account::setNewCode(bytes&& _code)
+void Account::setCode(bytes&& _code)
 {
 	m_codeCache = std::move(_code);
 	m_hasNewCode = true;
@@ -126,7 +126,7 @@ AccountMap dev::eth::jsonToAccountMap(std::string const& _json, u256 const& _def
 					if (o["code"].get_str().find("0x") != 0 && !o["code"].get_str().empty())
 						cerr << "Error importing code of account " << a << "! Code needs to be hex bytecode prefixed by \"0x\".";
 					else
-						ret[a].setNewCode(fromHex(o["code"].get_str()));
+						ret[a].setCode(fromHex(o["code"].get_str()));
 				}
 				else
 					cerr << "Error importing code of account " << a << "! Code field needs to be a string";

--- a/libethereum/Account.h
+++ b/libethereum/Account.h
@@ -143,7 +143,7 @@ public:
 	bool hasNewCode() const { return m_hasNewCode; }
 
 	/// Sets the code of the account. Used by "create" messages.
-	void setNewCode(bytes&& _code);
+	void setCode(bytes&& _code);
 
 	/// Reset the code set by previous CREATE message.
 	void resetCode() { m_codeCache.clear(); m_hasNewCode = false; m_codeHash = EmptySHA3; }

--- a/libethereum/Block.cpp
+++ b/libethereum/Block.cpp
@@ -701,7 +701,7 @@ void Block::updateBlockhashContract()
 	if (blockNumber == metropolisForkBlock)
 	{
 		m_state.createContract(c_blockhashContractAddress);
-		m_state.setNewCode(c_blockhashContractAddress, bytes(c_blockhashContractCode));
+		m_state.setCode(c_blockhashContractAddress, bytes(c_blockhashContractCode));
 		m_state.commit(State::CommitBehaviour::KeepEmptyAccounts);
 	}
 

--- a/libethereum/Executive.cpp
+++ b/libethereum/Executive.cpp
@@ -335,7 +335,7 @@ bool Executive::create(Address _sender, u256 _endowment, u256 _gasPrice, u256 _g
 		// Overwrite with empty code in case the account already has a code
 		// (address collision -- not real life case but we can check it with
 		// synthetic tests).
-		m_s.setNewCode(m_newAddress, {});
+		m_s.setCode(m_newAddress, {});
 
 	return !m_ext;
 }
@@ -400,7 +400,7 @@ bool Executive::go(OnOpFunc const& _onOp)
 				}
 				if (m_res)
 					m_res->output = out.toVector(); // copy output to execution result
-				m_s.setNewCode(m_ext->myAddress, out.toVector());
+				m_s.setCode(m_ext->myAddress, out.toVector());
 			}
 			else
 				m_output = vm->exec(m_gas, *m_ext, _onOp);

--- a/libethereum/State.cpp
+++ b/libethereum/State.cpp
@@ -512,10 +512,7 @@ void State::rollback(size_t _savepoint)
 			m_cache.erase(change.address);
 			break;
 		case Change::NewCode:
-			if (change.oldCode.empty())
-				account.resetCode();
-			else
-				account.setNewCode(std::move(change.oldCode));
+			account.setNewCode(std::move(change.oldCode));
 			break;
 		case Change::Touch:
 			account.untouch();

--- a/libethereum/State.cpp
+++ b/libethereum/State.cpp
@@ -448,10 +448,10 @@ bytes const& State::code(Address const& _addr) const
 	return a->code();
 }
 
-void State::setNewCode(Address const& _address, bytes&& _code)
+void State::setCode(Address const& _address, bytes&& _code)
 {
 	m_changeLog.emplace_back(_address, code(_address));
-	m_cache[_address].setNewCode(std::move(_code));
+	m_cache[_address].setCode(std::move(_code));
 }
 
 h256 State::codeHash(Address const& _a) const
@@ -511,8 +511,8 @@ void State::rollback(size_t _savepoint)
 		case Change::Create:
 			m_cache.erase(change.address);
 			break;
-		case Change::NewCode:
-			account.setNewCode(std::move(change.oldCode));
+		case Change::Code:
+			account.setCode(std::move(change.oldCode));
 			break;
 		case Change::Touch:
 			account.untouch();

--- a/libethereum/State.h
+++ b/libethereum/State.h
@@ -128,15 +128,23 @@ struct Change
 	Address address;  ///< Changed account address.
 	u256 value;       ///< Change value, e.g. balance, storage.
 	u256 key;         ///< Storage key. Last because used only in one case.
+	bytes oldCode;    ///< Code overwritten by CREATE, empty except in case of address collision.
 
 	/// Helper constructor to make change log update more readable.
 	Change(Kind _kind, Address const& _addr, u256 const& _value = 0):
 			kind(_kind), address(_addr), value(_value)
-	{}
+	{
+		assert(_kind != NewCode); // For this the special constructor needs to be used.
+	}
 
 	/// Helper constructor especially for storage change log.
 	Change(Address const& _addr, u256 const& _key, u256 const& _value):
 			kind(Storage), address(_addr), value(_value), key(_key)
+	{}
+
+	/// Helper constructor especially for new code change log.
+	Change(Address const& _addr, bytes const& _oldCode):
+			kind(NewCode), address(_addr), oldCode(_oldCode)
 	{}
 };
 

--- a/libethereum/State.h
+++ b/libethereum/State.h
@@ -118,7 +118,7 @@ struct Change
 		Create,
 
 		/// New code was added to an account (by "create" message execution).
-		NewCode,
+		Code,
 
 		/// Account was touched for the first time.
 		Touch
@@ -134,7 +134,7 @@ struct Change
 	Change(Kind _kind, Address const& _addr, u256 const& _value = 0):
 			kind(_kind), address(_addr), value(_value)
 	{
-		assert(_kind != NewCode); // For this the special constructor needs to be used.
+		assert(_kind != Code); // For this the special constructor needs to be used.
 	}
 
 	/// Helper constructor especially for storage change log.
@@ -144,7 +144,7 @@ struct Change
 
 	/// Helper constructor especially for new code change log.
 	Change(Address const& _addr, bytes const& _oldCode):
-			kind(NewCode), address(_addr), oldCode(_oldCode)
+			kind(Code), address(_addr), oldCode(_oldCode)
 	{}
 };
 
@@ -261,7 +261,7 @@ public:
 	void createContract(Address const& _address);
 
 	/// Sets the code of the account. Must only be called during / after contract creation.
-	void setNewCode(Address const& _address, bytes&& _code);
+	void setCode(Address const& _address, bytes&& _code);
 
 	/// Delete an account (used for processing suicides).
 	void kill(Address _a);

--- a/test/tools/libtesteth/FillJsonFunctions.cpp
+++ b/test/tools/libtesteth/FillJsonFunctions.cpp
@@ -88,7 +88,7 @@ json_spirit::mObject fillJsonWithStateChange(State const& _stateOrig, eth::State
 			eth::Change change = changeLog.at(i);
 			switch (change.kind)
 			{
-				case Change::Kind::NewCode:
+				case Change::Kind::Code:
 					//take the original and final code only
 					before = toHex(_stateOrig.code(change.address), 2, HexPrefix::Add);
 					after = toHex(_statePost.code(change.address), 2, HexPrefix::Add);

--- a/test/unittests/libethereum/StateUnitTests.cpp
+++ b/test/unittests/libethereum/StateUnitTests.cpp
@@ -45,7 +45,7 @@ BOOST_AUTO_TEST_CASE(LoadAccountCode)
 	State s{0};
 	s.createContract(addr);
 	uint8_t codeData[] = {'c', 'o', 'd', 'e'};
-	s.setNewCode(addr, {std::begin(codeData), std::end(codeData)});
+	s.setCode(addr, {std::begin(codeData), std::end(codeData)});
 	s.commit(State::CommitBehaviour::RemoveEmptyAccounts);
 
 	auto& loadedCode = s.code(addr);


### PR DESCRIPTION
This fixes #4130 .

Before Metropolis, when an address collision happens, an existing non-empty code could be overwritten.  The journaling system didn't remember the old code, so it could not recover the old code.  This PR fixes that problem.