### PR TITLE
Testeth errors out on unknown options

### DIFF
--- a/test/tools/libtesteth/Options.cpp
+++ b/test/tools/libtesteth/Options.cpp
@@ -108,7 +108,7 @@ Options::Options(int argc, char** argv)
 		else if (arg == "--stats" && i + 1 < argc)
 		{
 			stats = true;
-			statsOutFile = argv[i + 1];
+			statsOutFile = argv[++i];
 		}
 		else if (arg == "--exectimelog")
 			exectimelog = true;
@@ -138,10 +138,10 @@ Options::Options(int argc, char** argv)
 		else if (arg == "--singletest" && i + 1 < argc)
 		{
 			singleTest = true;
-			auto name1 = std::string{argv[i + 1]};
-			if (i + 2 < argc) // two params
+			auto name1 = std::string{argv[++i]};
+			if (i + 1 < argc) // two params
 			{
-				auto name2 = std::string{argv[i + 2]};
+				auto name2 = std::string{argv[++i]};
 				if (name2[0] == '-') // not param, another option
 					singleTestName = std::move(name1);
 				else
@@ -154,13 +154,13 @@ Options::Options(int argc, char** argv)
 				singleTestName = std::move(name1);
 		}
 		else if (arg == "--singlenet" && i + 1 < argc)
-			singleTestNet = std::string{argv[i + 1]};
+			singleTestNet = std::string{argv[++i]};
 		else if (arg == "--fulloutput")
 			fulloutput = true;
 		else if (arg == "--verbosity" && i + 1 < argc)
 		{
 			static std::ostringstream strCout; //static string to redirect logs to
-			std::string indentLevel = std::string{argv[i + 1]};
+			std::string indentLevel = std::string{argv[++i]};
 			if (indentLevel == "0")
 			{
 				logVerbosity = Verbosity::None;
@@ -172,14 +172,14 @@ Options::Options(int argc, char** argv)
 			else
 				logVerbosity = Verbosity::Full;
 
-			int indentLevelInt = atoi(argv[i + 1]);
+			int indentLevelInt = atoi(argv[i]);
 			if (indentLevelInt > g_logVerbosity)
 				g_logVerbosity = indentLevelInt;
 		}
 		else if (arg == "--createRandomTest")
 			createRandomTest = true;
 		else if (arg == "-t" && i + 1 < argc)
-			rCurrentTestSuite = std::string{argv[i + 1]};
+			rCurrentTestSuite = std::string{argv[++i]};
 		else if (arg == "--checktest" || arg == "--filltest")
 		{
 			//read all line to the end
@@ -190,13 +190,13 @@ Options::Options(int argc, char** argv)
 		else if (arg == "--nonetwork")
 			nonetwork = true;
 		else if (arg == "-d" && i + 1 < argc)
-			trDataIndex = atoi(argv[i + 1]);
+			trDataIndex = atoi(argv[++i]);
 		else if (arg == "-g" && i + 1 < argc)
 			trGasIndex = atoi(argv[i + 1]);
 		else if (arg == "-v" && i + 1 < argc)
-			trValueIndex = atoi(argv[i + 1]);
+			trValueIndex = atoi(argv[++i]);
 		else if (arg == "--testpath" && i + 1 < argc)
-			testpath = std::string{argv[i + 1]};
+			testpath = std::string{argv[++i]};
 		else if (arg == "--statediff")
 			statediff = true;
 	}

--- a/test/tools/libtesteth/Options.cpp
+++ b/test/tools/libtesteth/Options.cpp
@@ -77,6 +77,11 @@ Options::Options(int argc, char** argv)
 	for (auto i = 0; i < argc; ++i)
 	{
 		auto arg = std::string{argv[i]};
+		auto throwIfNoArgumentFollows = [&i, &argc, &arg]()
+		{
+			if (i + 1 >= argc)
+				BOOST_THROW_EXCEPTION(InvalidOption(arg + " option is missing an argument."));
+		};
 		if (arg == "--")
 		{
 			if (seenSeparator)
@@ -90,8 +95,9 @@ Options::Options(int argc, char** argv)
 			exit(0);
 		}
 		else
-		if (arg == "--vm" && i + 1 < argc)
+		if (arg == "--vm")
 		{
+			throwIfNoArgumentFollows();
 			string vmKind = argv[++i];
 			if (vmKind == "interpreter")
 				VMFactory::setKind(VMKind::Interpreter);
@@ -113,8 +119,9 @@ Options::Options(int argc, char** argv)
 			filltests = true;
 		else if (arg == "--fillchain")
 			fillchain = true;
-		else if (arg == "--stats" && i + 1 < argc)
+		else if (arg == "--stats")
 		{
+			throwIfNoArgumentFollows();
 			stats = true;
 			statsOutFile = argv[++i];
 		}
@@ -143,8 +150,9 @@ Options::Options(int argc, char** argv)
 			bigData = true;
 			wallet = true;
 		}
-		else if (arg == "--singletest" && i + 1 < argc)
+		else if (arg == "--singletest")
 		{
+			throwIfNoArgumentFollows();
 			singleTest = true;
 			auto name1 = std::string{argv[++i]};
 			if (i + 1 < argc) // two params
@@ -161,12 +169,16 @@ Options::Options(int argc, char** argv)
 			else
 				singleTestName = std::move(name1);
 		}
-		else if (arg == "--singlenet" && i + 1 < argc)
+		else if (arg == "--singlenet")
+		{
+			throwIfNoArgumentFollows();
 			singleTestNet = std::string{argv[++i]};
+		}
 		else if (arg == "--fulloutput")
 			fulloutput = true;
-		else if (arg == "--verbosity" && i + 1 < argc)
+		else if (arg == "--verbosity")
 		{
+			throwIfNoArgumentFollows();
 			static std::ostringstream strCout; //static string to redirect logs to
 			std::string indentLevel = std::string{argv[++i]};
 			if (indentLevel == "0")
@@ -186,8 +198,11 @@ Options::Options(int argc, char** argv)
 		}
 		else if (arg == "--createRandomTest")
 			createRandomTest = true;
-		else if (arg == "-t" && i + 1 < argc)
+		else if (arg == "-t")
+		{
+			throwIfNoArgumentFollows();
 			rCurrentTestSuite = std::string{argv[++i]};
+		}
 		else if (arg == "--checktest" || arg == "--filltest")
 		{
 			//read all line to the end
@@ -197,14 +212,26 @@ Options::Options(int argc, char** argv)
 		}
 		else if (arg == "--nonetwork")
 			nonetwork = true;
-		else if (arg == "-d" && i + 1 < argc)
+		else if (arg == "-d")
+		{
+			throwIfNoArgumentFollows();
 			trDataIndex = atoi(argv[++i]);
-		else if (arg == "-g" && i + 1 < argc)
+		}
+		else if (arg == "-g")
+		{
+			throwIfNoArgumentFollows();
 			trGasIndex = atoi(argv[i + 1]);
-		else if (arg == "-v" && i + 1 < argc)
+		}
+		else if (arg == "-v")
+		{
+			throwIfNoArgumentFollows();
 			trValueIndex = atoi(argv[++i]);
-		else if (arg == "--testpath" && i + 1 < argc)
+		}
+		else if (arg == "--testpath")
+		{
+			throwIfNoArgumentFollows();
 			testpath = std::string{argv[++i]};
+		}
 		else if (arg == "--statediff")
 			statediff = true;
 		else if (seenSeparator)

--- a/test/tools/libtesteth/Options.cpp
+++ b/test/tools/libtesteth/Options.cpp
@@ -159,7 +159,10 @@ Options::Options(int argc, char** argv)
 			{
 				auto name2 = std::string{argv[++i]};
 				if (name2[0] == '-') // not param, another option
+				{
 					singleTestName = std::move(name1);
+					i--;
+				}
 				else
 				{
 					singleTestFile = std::move(name1);

--- a/test/tools/libtesteth/Options.cpp
+++ b/test/tools/libtesteth/Options.cpp
@@ -73,9 +73,17 @@ Options::Options(int argc, char** argv)
 	trDataIndex = -1;
 	trGasIndex = -1;
 	trValueIndex = -1;
+	bool seenSeparator = false; // true if "--" has been seen.
 	for (auto i = 0; i < argc; ++i)
 	{
 		auto arg = std::string{argv[i]};
+		if (arg == "--")
+		{
+			if (seenSeparator)
+				BOOST_THROW_EXCEPTION(InvalidOption("The separator -- appears more than once in the command line."));
+			seenSeparator = true;
+			continue;
+		}
 		if (arg == "--help")
 		{
 			printHelp();
@@ -199,6 +207,8 @@ Options::Options(int argc, char** argv)
 			testpath = std::string{argv[++i]};
 		else if (arg == "--statediff")
 			statediff = true;
+		else if (seenSeparator)
+			BOOST_THROW_EXCEPTION(InvalidOption("Unknown option: " + arg));
 	}
 
 	//Default option

--- a/test/tools/libtesteth/Options.h
+++ b/test/tools/libtesteth/Options.h
@@ -21,6 +21,7 @@
 #pragma once
 #include <test/tools/libtestutils/Common.h>
 #include <test/tools/libtesteth/JsonSpiritHeaders.h>
+#include <libdevcore/Exceptions.h>
 
 namespace dev
 {
@@ -37,6 +38,11 @@ enum class Verbosity
 class Options
 {
 public:
+	struct InvalidOption: public Exception
+	{
+		InvalidOption(std::string _message = std::string()): Exception(_message) {}
+	};
+
 	bool vmtrace = false;	///< Create EVM execution tracer
 	bool filltests = false; ///< Create JSON test files from execution results
 	bool fillchain = false; ///< Fill tests as a blockchain tests if possible


### PR DESCRIPTION
This PR makes `testeth` throw an error when it sees an unknown option.  Before the PR, `testeth` silently ignores unknown options.

Fixes #4091 .