### PR TITLE
remove stBounds

### DIFF
--- a/test/tools/jsontests/BlockChainTests.cpp
+++ b/test/tools/jsontests/BlockChainTests.cpp
@@ -115,7 +115,7 @@ void doBlockchainTestNoLog(json_spirit::mValue& _v, bool _fillin)
 		json_spirit::mObject& o = i.second.get_obj();
 
 		//Select test by name if --singletest is set and not filling state tests as blockchain
-		if (!TestOutputHelper::passTest(testname) && !Options::get().fillchain)
+		if (!Options::get().fillchain && !TestOutputHelper::passTest(testname))
 		{
 			o.clear(); //don't add irrelevant tests to the final file when filling
 			continue;

--- a/test/tools/jsontests/StateTests.cpp
+++ b/test/tools/jsontests/StateTests.cpp
@@ -104,8 +104,6 @@ public:
 	generaltestfixture()
 	{
 		string casename = boost::unit_test::framework::current_test_case().p_name;
-		if (casename == "stMemoryStressTest" && !test::Options::get().memory)
-			return;
 		if (casename == "stQuadraticComplexityTest" && !test::Options::get().quadratic)
 			return;
 		fillAllFilesInFolder(casename);

--- a/test/tools/jsontests/StateTests.cpp
+++ b/test/tools/jsontests/StateTests.cpp
@@ -104,8 +104,6 @@ public:
 	generaltestfixture()
 	{
 		string casename = boost::unit_test::framework::current_test_case().p_name;
-		if (casename == "stBoundsTest" && !test::Options::get().memory)
-			return;
 		if (casename == "stMemoryStressTest" && !test::Options::get().memory)
 			return;
 		if (casename == "stQuadraticComplexityTest" && !test::Options::get().quadratic)
@@ -135,7 +133,6 @@ public:
 BOOST_FIXTURE_TEST_SUITE(StateTestsGeneral, generaltestfixture)
 
 //Frontier Tests
-BOOST_AUTO_TEST_CASE(stBoundsTest){}
 BOOST_AUTO_TEST_CASE(stCallCodes){}
 BOOST_AUTO_TEST_CASE(stCallCreateCallCodeTest){}
 BOOST_AUTO_TEST_CASE(stExample){}

--- a/test/tools/libtesteth/ImportTest.cpp
+++ b/test/tools/libtesteth/ImportTest.cpp
@@ -189,7 +189,7 @@ bytes ImportTest::executeTest()
 			string tmpFillerName = getTestPath() + "/src/GenStateTestAsBcTemp/" + TestOutputHelper::caseName() + "/" + TestOutputHelper::testName() + "Filler.json";
 			writeFile(tmpFillerName, asBytes(json_spirit::write_string((json_spirit::mValue)json, true)));
 			dev::test::executeTests(TestOutputHelper::testName(), "/BlockchainTests/GeneralStateTests/" + TestOutputHelper::caseName(),
-																"/GenStateTestAsBcTemp/" + TestOutputHelper::caseName(), dev::test::doBlockchainTests);
+																"/GenStateTestAsBcTemp/" + TestOutputHelper::caseName(), dev::test::doBlockchainTestNoLog);
 		}
 
 		m_transactions.clear();


### PR DESCRIPTION
remove stBounds
disable memory flag when running stMemoryStress tests in GeneralState (update with 250M gas limit)

lets see how travis pass this
tests are pointing to https://github.com/ethereum/tests/pull/191