### PR TITLE
testeth: Fix a mistake of #4155, enable '-g 0' again

### DIFF
--- a/test/tools/libtesteth/Options.cpp
+++ b/test/tools/libtesteth/Options.cpp
@@ -220,7 +220,7 @@ Options::Options(int argc, char** argv)
 		else if (arg == "-g")
 		{
 			throwIfNoArgumentFollows();
-			trGasIndex = atoi(argv[i + 1]);
+			trGasIndex = atoi(argv[++i]);
 		}
 		else if (arg == "-v")
 		{


### PR DESCRIPTION
This mistake made it impossible to use '-g 0' option of 'testeth'