### PR TITLE
TestHelper.cpp: fix the Windows build, continued

### DIFF
--- a/test/tools/libtesteth/TestHelper.cpp
+++ b/test/tools/libtesteth/TestHelper.cpp
@@ -223,6 +223,7 @@ std::string executeCmd(std::string const& _command)
 {
 #if defined(_WIN32)
 	BOOST_ERROR("executeCmd() has not been implemented for Windows.");
+	return "";
 #else
 	char output[1024];
 	FILE *fp = popen(_command.c_str(), "r");


### PR DESCRIPTION
error C4716: 'dev::test::executeCmd': must return a value [C:\projects\cpp-ethereum\build\test\testeth.vcxproj]