### PR TITLE
testeth errors when a general state test filler contains more than one test.

### DIFF
--- a/test/tools/jsontests/StateTests.cpp
+++ b/test/tools/jsontests/StateTests.cpp
@@ -41,6 +41,9 @@ namespace dev {  namespace test {
 
 void doStateTests(json_spirit::mValue& _v, bool _fillin)
 {
+	BOOST_REQUIRE_MESSAGE(!_fillin || _v.get_obj().size() == 1,
+		TestOutputHelper::testFileName() + " A GeneralStateTest filler should contain only one test.");
+
 	for (auto& i: _v.get_obj())
 	{
 		string testname = i.first;
@@ -122,7 +125,10 @@ public:
 		test::TestOutputHelper::initTest(fileCount);
 
 		for (auto const& file: files)
+		{
+			test::TestOutputHelper::setCurrentTestFileName(file.filename().string());
 			test::executeTests(file.filename().string(), "/GeneralStateTests/"+_folder, "/GeneralStateTestsFiller/"+_folder, dev::test::doStateTests);
+		}
 
 		test::TestOutputHelper::finishTest();
 	}


### PR DESCRIPTION
Fixes #4092.