### PR TITLE
testeth (when filling) checks the names of GeneralStateTest cases against the file names

### DIFF
--- a/test/tools/jsontests/StateTests.cpp
+++ b/test/tools/jsontests/StateTests.cpp
@@ -49,6 +49,10 @@ void doStateTests(json_spirit::mValue& _v, bool _fillin)
 		string testname = i.first;
 		json_spirit::mObject& o = i.second.get_obj();
 
+		if (_fillin)
+			BOOST_REQUIRE_MESSAGE(testname + "Filler.json" == TestOutputHelper::testFileName(),
+				TestOutputHelper::testFileName() + " contains a test with a different name '" + testname + "'" );
+
 		if (!TestOutputHelper::passTest(testname))
 			continue;
 


### PR DESCRIPTION
Fixes #4205 