### PR TITLE
Overwriting a contract results in nonce 1 (after EIP 158) or 0 (before EIP 158)

### DIFF
--- a/libethereum/Executive.cpp
+++ b/libethereum/Executive.cpp
@@ -347,8 +347,10 @@ bool Executive::executeCreate(Address const& _sender, u256 const& _endowment, u2
 	// account if it does not exist yet.
 	m_s.transferBalance(_sender, m_newAddress, _endowment);
 
+	u256 newNonce = m_s.requireAccountStartNonce();
 	if (m_envInfo.number() >= m_sealEngine.chainParams().u256Param("EIP158ForkBlock"))
-		m_s.incNonce(m_newAddress);
+		newNonce += 1;
+	m_s.setNonce(m_newAddress, newNonce);
 
 	// Schedule _init execution if not empty.
 	if (!_init.empty())

--- a/libethereum/State.cpp
+++ b/libethereum/State.cpp
@@ -286,12 +286,26 @@ void State::incNonce(Address const& _addr)
 {
 	if (Account* a = account(_addr))
 	{
+		auto oldNonce = a->nonce();
 		a->incNonce();
-		m_changeLog.emplace_back(Change::Nonce, _addr);
+		m_changeLog.emplace_back(_addr, oldNonce);
 	}
 	else
 		// This is possible if a transaction has gas price 0.
 		createAccount(_addr, Account(requireAccountStartNonce() + 1, 0));
+}
+
+void State::setNonce(Address const& _addr, u256 const& _newNonce)
+{
+	if (Account* a = account(_addr))
+	{
+		auto oldNonce = a->nonce();
+		a->setNonce(_newNonce);
+		m_changeLog.emplace_back(_addr, oldNonce);
+	}
+	else
+		// This is possible when a contract is being created.
+		createAccount(_addr, Account(_newNonce, 0));
 }
 
 void State::addBalance(Address const& _id, u256 const& _amount)
@@ -506,7 +520,7 @@ void State::rollback(size_t _savepoint)
 			account.addBalance(0 - change.value);
 			break;
 		case Change::Nonce:
-			account.setNonce(account.nonce() - 1);
+			account.setNonce(change.value);
 			break;
 		case Change::Create:
 			m_cache.erase(change.address);

--- a/libethereum/State.h
+++ b/libethereum/State.h
@@ -111,7 +111,7 @@ struct Change
 		/// Change::value the storage value.
 		Storage,
 
-		/// Account nonce was increased by 1.
+		/// Account nonce was changed.
 		Nonce,
 
 		/// Account was created (it was not existing before).
@@ -126,7 +126,7 @@ struct Change
 
 	Kind kind;        ///< The kind of the change.
 	Address address;  ///< Changed account address.
-	u256 value;       ///< Change value, e.g. balance, storage.
+	u256 value;       ///< Change value, e.g. balance, storage and nonce.
 	u256 key;         ///< Storage key. Last because used only in one case.
 	bytes oldCode;    ///< Code overwritten by CREATE, empty except in case of address collision.
 
@@ -140,6 +140,11 @@ struct Change
 	/// Helper constructor especially for storage change log.
 	Change(Address const& _addr, u256 const& _key, u256 const& _value):
 			kind(Storage), address(_addr), value(_value), key(_key)
+	{}
+
+	/// Helper constructor for nonce change log.
+	Change(Address const& _addr, u256 const& _value):
+			kind(Nonce), address(_addr), value(_value)
 	{}
 
 	/// Helper constructor especially for new code change log.
@@ -287,6 +292,9 @@ public:
 
 	/// Increament the account nonce.
 	void incNonce(Address const& _id);
+
+	/// Set the account nonce.
+	void setNonce(Address const& _addr, u256 const& _newNonce);
 
 	/// Get the account nonce -- the number of transactions it has sent.
 	/// @returns 0 if the address has never been used.


### PR DESCRIPTION
Fixes #4225 .