### PR TITLE
WIP - Download snapshot through Parity's warp protocol

### DIFF
--- a/eth/main.cpp
+++ b/eth/main.cpp
@@ -147,7 +147,8 @@ void help()
 		<< "    --from <n>  Export only from block n; n may be a decimal, a '0x' prefixed hash, or 'latest'.\n"
 		<< "    --to <n>  Export only to block n (inclusive); n may be a decimal, a '0x' prefixed hash, or 'latest'.\n"
 		<< "    --only <n>  Equivalent to --export-from n --export-to n.\n"
-		<< "    --dont-check  Prevent checking some block aspects. Faster importing, but to apply only when the data is known to be valid.\n\n"
+		<< "    --dont-check  Prevent checking some block aspects. Faster importing, but to apply only when the data is known to be valid.\n"
+		<< "    --download-snapshot <path> Download snapshot data to specified path.\n\n"
 		<< "General Options:\n"
 		<< "    -d,--db-path,--datadir <path>  Load database from path (default: " << getDataDir() << ").\n"
 #if ETH_EVMJIT
@@ -402,6 +403,7 @@ int main(int argc, char** argv)
 	bool listenSet = false;
 	string configJSON;
 	string genesisJSON;
+	string snapshotPath;
 	for (int i = 1; i < argc; ++i)
 	{
 		string arg = argv[i];
@@ -781,6 +783,8 @@ int main(int argc, char** argv)
 			noPinning = true;
 			bootstrap = false;
 		}
+		else if (arg == "--download-snapshot" && i + 1 < argc)
+			snapshotPath = argv[++i];
 		else
 		{
 			cerr << "Invalid argument: " << arg << "\n";
@@ -908,6 +912,7 @@ int main(int argc, char** argv)
 	dev::WebThreeDirect web3(
 		WebThreeDirect::composeClientVersion("eth"),
 		getDataDir(),
+		snapshotPath,
 		chainParams,
 		withExisting,
 		nodeMode == NodeMode::Full ? caps : set<string>(),
@@ -1071,7 +1076,7 @@ int main(int argc, char** argv)
 	if (author)
 		cout << "Mining Beneficiary: " << renderFullAddress(author) << "\n";
 
-	if (bootstrap || !remoteHost.empty() || enableDiscovery || listenSet)
+	if (bootstrap || !remoteHost.empty() || enableDiscovery || listenSet || !preferredNodes.empty())
 	{
 		web3.startNetwork();
 		cout << "Node ID: " << web3.enode() << "\n";

--- a/libethashseal/EthashClient.cpp
+++ b/libethashseal/EthashClient.cpp
@@ -50,10 +50,11 @@ EthashClient::EthashClient(
 	p2p::Host* _host,
 	std::shared_ptr<GasPricer> _gpForAdoption,
 	fs::path const& _dbPath,
+	fs::path const& _snapshotPath,
 	WithExisting _forceAction,
 	TransactionQueue::Limits const& _limits
 ):
-	Client(_params, _networkID, _host, _gpForAdoption, _dbPath, _forceAction, _limits)
+	Client(_params, _networkID, _host, _gpForAdoption, _dbPath, _snapshotPath, _forceAction, _limits)
 {
 	// will throw if we're not an Ethash seal engine.
 	asEthashClient(*this);

--- a/libethashseal/EthashClient.h
+++ b/libethashseal/EthashClient.h
@@ -44,6 +44,7 @@ public:
 		p2p::Host* _host,
 		std::shared_ptr<GasPricer> _gpForAdoption,
 		boost::filesystem::path const& _dbPath = boost::filesystem::path(),
+		boost::filesystem::path const& _snapshotPath = boost::filesystem::path(),
 		WithExisting _forceAction = WithExisting::Trust,
 		TransactionQueue::Limits const& _l = TransactionQueue::Limits{1024, 1024}
 	);

--- a/libethereum/Client.h
+++ b/libethereum/Client.h
@@ -39,6 +39,7 @@
 #include "Block.h"
 #include "CommonNet.h"
 #include "ClientBase.h"
+#include "WarpHostCapability.h"
 
 #include <boost/filesystem/path.hpp>
 
@@ -82,6 +83,7 @@ public:
 		p2p::Host* _host,
 		std::shared_ptr<GasPricer> _gpForAdoption,
 		boost::filesystem::path const& _dbPath = boost::filesystem::path(),
+		boost::filesystem::path const& _snapshotPath = boost::filesystem::path(),
 		WithExisting _forceAction = WithExisting::Trust,
 		TransactionQueue::Limits const& _l = TransactionQueue::Limits{1024, 1024}
 	);
@@ -196,7 +198,7 @@ public:
 protected:
 	/// Perform critical setup functions.
 	/// Must be called in the constructor of the finally derived class.
-	void init(p2p::Host* _extNet, boost::filesystem::path const& _dbPath, WithExisting _forceAction, u256 _networkId);
+	void init(p2p::Host* _extNet, boost::filesystem::path const& _dbPath, boost::filesystem::path const& _snapshotPath, WithExisting _forceAction, u256 _networkId);
 
 	/// InterfaceStub methods
 	BlockChain& bc() override { return m_bc; }
@@ -300,6 +302,7 @@ protected:
 	std::chrono::system_clock::time_point m_lastGetWork;	///< Is there an active and valid remote worker?
 
 	std::weak_ptr<EthereumHost> m_host;		///< Our Ethereum Host. Don't do anything if we can't lock.
+	std::weak_ptr<WarpHostCapability> m_warpHost;
 
 	Handler<> m_tqReady;
 	Handler<h256 const&> m_tqReplaced;

--- a/libethereum/ClientTest.cpp
+++ b/libethereum/ClientTest.cpp
@@ -48,7 +48,7 @@ ClientTest::ClientTest(
 	WithExisting _forceAction,
 	TransactionQueue::Limits const& _limits
 ):
-	Client(_params, _networkID, _host, _gpForAdoption, _dbPath, _forceAction, _limits)
+	Client(_params, _networkID, _host, _gpForAdoption, _dbPath, std::string(), _forceAction, _limits)
 {}
 
 void ClientTest::setChainParams(string const& _genesis)

--- a/libethereum/CommonNet.h
+++ b/libethereum/CommonNet.h
@@ -83,6 +83,8 @@ enum class Asking
 	BlockBodies,
 	NodeData,
 	Receipts,
+	WarpManifest,
+	WarpData,
 	Nothing
 };
 

--- a/libethereum/EthereumPeer.cpp
+++ b/libethereum/EthereumPeer.cpp
@@ -46,6 +46,8 @@ static string toString(Asking _a)
 	case Asking::Receipts: return "Receipts";
 	case Asking::Nothing: return "Nothing";
 	case Asking::State: return "State";
+	case Asking::WarpManifest: return "WarpManifest";
+	case Asking::WarpData: return "WarpData";
 	}
 	return "?";
 }

--- a/libethereum/SnapshotDownloader.cpp
+++ b/libethereum/SnapshotDownloader.cpp
@@ -1,0 +1,141 @@
+/*
+	This file is part of cpp-ethereum.
+
+	cpp-ethereum is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	cpp-ethereum is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/** @file SnapshotDownloader.cpp
+ */
+
+#include "BlockChain.h"
+#include "SnapshotDownloader.h"
+#include "WarpHostCapability.h"
+#include "WarpPeerCapability.h"
+
+#include <libdevcore/CommonIO.h>
+#include <libp2p/Session.h>
+
+#include <boost/filesystem.hpp>
+
+using namespace std;
+using namespace dev;
+using namespace eth;
+using namespace p2p;
+
+struct SnapshotLog: public LogChannel
+{
+	static char const* name() { return "SNAP"; }
+	static int const verbosity = 9;
+};
+
+SnapshotDownloader::SnapshotDownloader(WarpHostCapability& _host, BlockChain const& _blockChain, boost::filesystem::path const& _snapshotPath):
+	m_host(_host), m_blockChain(_blockChain), m_snapshotPath(_snapshotPath)
+{
+}
+
+void SnapshotDownloader::onPeerStatus(shared_ptr<WarpPeerCapability> _peer)
+{
+	if (_peer->validateStatus(m_blockChain.genesisHash(), { m_host.protocolVersion() }, m_host.networkId()))
+		startDownload(_peer);
+}
+
+void SnapshotDownloader::onPeerManifest(shared_ptr<WarpPeerCapability> _peer, RLP const& _r)
+{
+	if (m_downloading)
+		// TODO if this peer has the same snapshot, download from it, too
+		return;
+
+	if (!_r.isList() || _r.itemCount() != 1)
+		return;
+
+	RLP const manifest = _r[0];
+
+	u256 version = manifest[0].toInt<u256>();
+	if (version != 2)
+		return;
+
+	u256 const blockNumber = manifest[4].toInt<u256>();
+	if (blockNumber != m_syncingSnapshotNumber)
+		return;
+
+	h256s const stateHashes = manifest[1].toVector<h256>();
+	h256s const blockHashes = manifest[2].toVector<h256>();
+
+	h256 const stateRoot = manifest[3].toHash<h256>();
+	h256 const blockHash = manifest[5].toHash<h256>();
+
+	clog(SnapshotLog) << "MANIFEST: "
+		<< "version " << version
+		<< "state root " << stateRoot
+		<< "block number " << blockNumber
+		<< "block hash " << blockHash;
+
+	writeFile((m_snapshotPath / "MANIFEST").string(), manifest.data());
+
+	m_stateChunksQueue.assign(stateHashes.begin(), stateHashes.end());
+	m_blockChunksQueue.assign(blockHashes.begin(), blockHashes.end());
+	m_downloading = true;
+	downloadStateChunks(_peer);
+}
+
+void SnapshotDownloader::onPeerData(shared_ptr<WarpPeerCapability> _peer, RLP const& _r)
+{
+	if (!_r.isList() || _r.itemCount() != 1)
+		return;
+
+	// TODO handle timeouts
+
+	RLP const data = _r[0];
+
+	h256 const hash = sha3(data.toBytesConstRef());
+
+	h256 const askedHash = m_stateChunksQueue.empty() ? m_blockChunksQueue.front() : m_stateChunksQueue.front();
+	if (hash == askedHash)
+	{
+
+		// TODO handle writeFile failure
+		writeFile((m_snapshotPath / toHex(hash)).string(), data.toBytesConstRef());
+
+		clog(SnapshotLog) << "Saved chunk" << hash;
+
+		if (m_stateChunksQueue.empty())
+			m_blockChunksQueue.pop_front();
+		else
+			m_stateChunksQueue.pop_front();
+		clog(SnapshotLog) << "State chunks left: " << m_stateChunksQueue.size() << " Block chunks left: " << m_blockChunksQueue.size();
+	}
+
+	downloadStateChunks(_peer);
+}
+
+void SnapshotDownloader::startDownload(shared_ptr<WarpPeerCapability> _peer)
+{
+	m_syncingSnapshotNumber = _peer->snapshotNumber();
+	_peer->requestManifest();
+}
+
+void SnapshotDownloader::downloadStateChunks(shared_ptr<WarpPeerCapability> _peer)
+{
+	if (!m_stateChunksQueue.empty())
+		_peer->requestData(m_stateChunksQueue.front());
+	else
+		downloadBlockChunks(_peer);
+}
+
+void SnapshotDownloader::downloadBlockChunks(shared_ptr<WarpPeerCapability> _peer)
+{
+	if (!m_blockChunksQueue.empty())
+		_peer->requestData(m_blockChunksQueue.front());
+	else
+		clog(SnapshotLog) << "Snapshot download complete!";
+}

--- a/libethereum/SnapshotDownloader.cpp
+++ b/libethereum/SnapshotDownloader.cpp
@@ -36,6 +36,7 @@ struct SnapshotLog: public LogChannel
 {
 	static char const* name() { return "SNAP"; }
 	static int const verbosity = 9;
+	static const bool debug = false;
 };
 
 SnapshotDownloader::SnapshotDownloader(WarpHostCapability& _host, BlockChain const& _blockChain, boost::filesystem::path const& _snapshotPath):

--- a/libethereum/SnapshotDownloader.h
+++ b/libethereum/SnapshotDownloader.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include "CommonNet.h"
+
 #include <memory>
 #include <deque>
 
@@ -42,6 +44,8 @@ public:
 	void onPeerManifest(std::shared_ptr<WarpPeerCapability> _peer, RLP const& _r);
 
 	void onPeerData(std::shared_ptr<WarpPeerCapability> _peer, RLP const& _r);
+
+	void onPeerRequestTimeout(std::shared_ptr<WarpPeerCapability> /*_peer*/, Asking /*_asking*/) {}
 
 private:
 	void startDownload(std::shared_ptr<WarpPeerCapability> _peer);

--- a/libethereum/SnapshotDownloader.h
+++ b/libethereum/SnapshotDownloader.h
@@ -1,0 +1,64 @@
+/*
+	This file is part of cpp-ethereum.
+
+	cpp-ethereum is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	cpp-ethereum is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/** @file SnapshotDownloader.h
+ */
+
+#pragma once
+
+#include <memory>
+#include <deque>
+
+namespace dev
+{
+
+namespace eth
+{
+
+class BlockChain;
+class WarpHostCapability;
+class WarpPeerCapability;
+
+class SnapshotDownloader
+{
+public:
+	SnapshotDownloader(WarpHostCapability& _host, BlockChain const& _blockChain, boost::filesystem::path const& _snapshotPath);
+
+	void onPeerStatus(std::shared_ptr<WarpPeerCapability> _peer);
+
+	void onPeerManifest(std::shared_ptr<WarpPeerCapability> _peer, RLP const& _r);
+
+	void onPeerData(std::shared_ptr<WarpPeerCapability> _peer, RLP const& _r);
+
+private:
+	void startDownload(std::shared_ptr<WarpPeerCapability> _peer);
+	void downloadStateChunks(std::shared_ptr<WarpPeerCapability> _peer);
+	void downloadBlockChunks(std::shared_ptr<WarpPeerCapability> _peer);
+
+	WarpHostCapability& m_host;
+	BlockChain const& m_blockChain;
+
+	u256 m_syncingSnapshotNumber;
+	bool m_downloading = false;
+
+	std::deque<h256> m_stateChunksQueue;
+	std::deque<h256> m_blockChunksQueue;
+
+	boost::filesystem::path const m_snapshotPath;
+};
+
+}
+}

--- a/libethereum/WarpHostCapability.cpp
+++ b/libethereum/WarpHostCapability.cpp
@@ -49,6 +49,11 @@ public:
 		m_downloader.onPeerData(_peer, _r);
 	}
 
+	void onPeerRequestTimeout(std::shared_ptr<WarpPeerCapability> _peer, Asking _asking) override
+	{
+		m_downloader.onPeerRequestTimeout(_peer, _asking);
+	}
+
 private:
 	SnapshotDownloader& m_downloader;
 };
@@ -80,3 +85,9 @@ shared_ptr<Capability> WarpHostCapability::newPeerCapability(shared_ptr<SessionF
 
 	return ret;
 }
+
+void WarpHostCapability::doWork()
+{
+	// TODO call tick() on peers similar to EthereumHost
+}
+

--- a/libethereum/WarpHostCapability.cpp
+++ b/libethereum/WarpHostCapability.cpp
@@ -1,0 +1,82 @@
+/*
+	This file is part of cpp-ethereum.
+
+	cpp-ethereum is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	cpp-ethereum is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/** @file WarpHostCapability.cpp
+ */
+
+#include "WarpHostCapability.h"
+#include "BlockChain.h"
+#include "SnapshotDownloader.h"
+
+using namespace std;
+using namespace dev;
+using namespace dev::eth;
+using namespace p2p;
+
+namespace
+{
+
+class WarpPeerObserver: public WarpPeerObserverFace
+{
+public:
+	explicit WarpPeerObserver(SnapshotDownloader& _downloader): m_downloader(_downloader) {}
+
+	void onPeerStatus(shared_ptr<WarpPeerCapability> _peer) override
+	{
+		m_downloader.onPeerStatus(_peer);
+	}
+
+	void onPeerManifest(shared_ptr<WarpPeerCapability> _peer, RLP const& _r) override
+	{
+		m_downloader.onPeerManifest(_peer, _r);
+	}
+
+	void onPeerData(shared_ptr<WarpPeerCapability> _peer, RLP const& _r) override
+	{
+		m_downloader.onPeerData(_peer, _r);
+	}
+
+private:
+	SnapshotDownloader& m_downloader;
+};
+
+}
+
+WarpHostCapability::WarpHostCapability(BlockChain const& _blockChain, u256 const& _networkId, boost::filesystem::path const& _snapshotPath):
+	m_blockChain(_blockChain),
+	m_networkId(_networkId),
+	m_downloader(new SnapshotDownloader(*this, _blockChain, _snapshotPath)),
+	m_peerObserver(make_shared<WarpPeerObserver>(*m_downloader))
+{
+}
+
+shared_ptr<Capability> WarpHostCapability::newPeerCapability(shared_ptr<SessionFace> const& _s, unsigned _idOffset, p2p::CapDesc const& _cap, uint16_t _capID)
+{
+	auto ret = HostCapability<WarpPeerCapability>::newPeerCapability(_s, _idOffset, _cap, _capID);
+
+	auto cap = capabilityFromSession<WarpPeerCapability>(*_s, _cap.second);
+	assert(cap);
+	cap->init(
+		c_WarpProtocolVersion,
+		m_networkId,
+		m_blockChain.details().totalDifficulty,
+		m_blockChain.currentHash(),
+		m_blockChain.genesisHash(),
+		m_peerObserver
+	);
+
+	return ret;
+}

--- a/libethereum/WarpHostCapability.h
+++ b/libethereum/WarpHostCapability.h
@@ -20,14 +20,13 @@
 #pragma once
 
 #include "WarpPeerCapability.h"
+#include "SnapshotDownloader.h"
 
 namespace dev
 {
 
 namespace eth
 {
-
-class SnapshotDownloader;
 
 class WarpHostCapability: public p2p::HostCapability<WarpPeerCapability>
 {

--- a/libethereum/WarpHostCapability.h
+++ b/libethereum/WarpHostCapability.h
@@ -22,13 +22,15 @@
 #include "WarpPeerCapability.h"
 #include "SnapshotDownloader.h"
 
+#include <libdevcore/Worker.h>
+
 namespace dev
 {
 
 namespace eth
 {
 
-class WarpHostCapability: public p2p::HostCapability<WarpPeerCapability>
+class WarpHostCapability: public p2p::HostCapability<WarpPeerCapability>, Worker
 {
 public:
 	WarpHostCapability(BlockChain const& _blockChain, u256 const& _networkId, boost::filesystem::path const& _snapshotPath);
@@ -40,6 +42,8 @@ protected:
 	std::shared_ptr<p2p::Capability> newPeerCapability(std::shared_ptr<p2p::SessionFace> const& _s, unsigned _idOffset, p2p::CapDesc const& _cap, uint16_t _capID) override;
 
 private:
+	void doWork() override;
+
 	BlockChain const& m_blockChain;
 	u256 const m_networkId;
 

--- a/libethereum/WarpHostCapability.h
+++ b/libethereum/WarpHostCapability.h
@@ -1,0 +1,52 @@
+/*
+	This file is part of cpp-ethereum.
+
+	cpp-ethereum is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	cpp-ethereum is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/** @file WarpHostCapability.h
+ */
+
+#pragma once
+
+#include "WarpPeerCapability.h"
+
+namespace dev
+{
+
+namespace eth
+{
+
+class SnapshotDownloader;
+
+class WarpHostCapability: public p2p::HostCapability<WarpPeerCapability>
+{
+public:
+	WarpHostCapability(BlockChain const& _blockChain, u256 const& _networkId, boost::filesystem::path const& _snapshotPath);
+
+	unsigned protocolVersion() const { return c_WarpProtocolVersion; }
+	u256 networkId() const { return m_networkId; }
+
+protected:
+	std::shared_ptr<p2p::Capability> newPeerCapability(std::shared_ptr<p2p::SessionFace> const& _s, unsigned _idOffset, p2p::CapDesc const& _cap, uint16_t _capID) override;
+
+private:
+	BlockChain const& m_blockChain;
+	u256 const m_networkId;
+
+	std::unique_ptr<SnapshotDownloader> m_downloader;
+	std::shared_ptr<WarpPeerObserverFace> m_peerObserver;
+};
+
+}
+}

--- a/libethereum/WarpPeerCapability.cpp
+++ b/libethereum/WarpPeerCapability.cpp
@@ -45,6 +45,8 @@ bool WarpPeerCapability::interpret(unsigned _id, RLP const& _r)
 		{
 		case WarpStatusPacket:
 		{
+			// TODO check that packet has enough elements
+
 			// Packet layout:
 			// [ version:P, state_hashes : [hash_1:B_32, hash_2 : B_32, ...],  block_hashes : [hash_1:B_32, hash_2 : B_32, ...], 
 			//		state_root : B_32, block_number : P, block_hash : B_32 ]

--- a/libethereum/WarpPeerCapability.cpp
+++ b/libethereum/WarpPeerCapability.cpp
@@ -1,0 +1,175 @@
+/*
+	This file is part of cpp-ethereum.
+
+	cpp-ethereum is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	cpp-ethereum is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/** @file WarpPeerCapability.cpp
+ */
+
+#include "WarpPeerCapability.h"
+
+using namespace std;
+using namespace dev;
+using namespace dev::eth;
+using namespace p2p;
+
+WarpPeerCapability::WarpPeerCapability(std::shared_ptr<SessionFace> _s, HostCapabilityFace* _h, unsigned _i, CapDesc const& _cap, uint16_t _capID):
+	Capability(_s, _h, _i, _capID)
+{
+}
+
+void WarpPeerCapability::init(unsigned _hostProtocolVersion, u256 _hostNetworkId, u256 _chainTotalDifficulty, h256 _chainCurrentHash, h256 _chainGenesisHash, std::shared_ptr<WarpPeerObserverFace> _observer)
+{
+	m_hostProtocolVersion = _hostProtocolVersion;
+	m_observer = _observer;
+	requestStatus(_hostNetworkId, _chainTotalDifficulty, _chainCurrentHash, _chainGenesisHash);
+}
+
+bool WarpPeerCapability::interpret(unsigned _id, RLP const& _r)
+{
+	m_lastAsk = std::chrono::system_clock::to_time_t(chrono::system_clock::now());
+	try
+	{
+		switch (_id)
+		{
+		case WarpStatusPacket:
+		{
+			// Packet layout:
+			// [ version:P, state_hashes : [hash_1:B_32, hash_2 : B_32, ...],  block_hashes : [hash_1:B_32, hash_2 : B_32, ...], 
+			//		state_root : B_32, block_number : P, block_hash : B_32 ]
+			m_protocolVersion = _r[0].toInt<unsigned>();
+			m_networkId = _r[1].toInt<u256>();
+			m_totalDifficulty = _r[2].toInt<u256>();
+			m_latestHash = _r[3].toHash<h256>();
+			m_genesisHash = _r[4].toHash<h256>();
+			m_snapshotHash = _r[5].toHash<h256>();
+			m_snapshotNumber = _r[6].toInt<u256>();
+
+			clog(NetMessageSummary) << "Status: "
+				<< "protocol version " << m_protocolVersion
+				<< "networkId " << m_networkId
+				<< "genesis hash " << m_genesisHash
+				<< "total difficulty " << m_totalDifficulty
+				<< "latest hash" << m_latestHash
+				<< "snapshot hash" << m_snapshotHash
+				<< "snapshot number" << m_snapshotNumber;
+				setIdle();
+			m_observer->onPeerStatus(dynamic_pointer_cast<WarpPeerCapability>(shared_from_this()));
+			break;
+		}
+		case GetBlockHeadersPacket:
+		{
+			RLPStream s;
+			prep(s, BlockHeadersPacket);
+			sealAndSend(s);
+			break;
+		}
+		case SnapshotManifest:
+		{
+			setIdle();
+			m_observer->onPeerManifest((dynamic_pointer_cast<WarpPeerCapability>(shared_from_this())), _r);
+			break;
+		}
+		case SnapshotData:
+		{
+			setIdle();
+			m_observer->onPeerData((dynamic_pointer_cast<WarpPeerCapability>(shared_from_this())), _r);
+			break;
+		}
+		default:
+			return false;
+		}
+	}
+	catch (Exception const&)
+	{
+		clog(NetWarn) << "Warp Peer causing an Exception:" << boost::current_exception_diagnostic_information() << _r;
+	}
+	catch (std::exception const& _e)
+	{
+		clog(NetWarn) << "Warp Peer causing an exception:" << _e.what() << _r;
+	}
+
+	return true;
+}
+
+/// Validates whether peer is able to communicate with the host, disables peer if not
+bool WarpPeerCapability::validateStatus(h256 const& _genesisHash, std::vector<unsigned> const& _protocolVersions, u256 const& _networkId)
+{
+	std::shared_ptr<SessionFace> s = session();
+	if (!s)
+		return false; // Expired
+
+	if (m_genesisHash != _genesisHash)
+	{
+		disable("Invalid genesis hash");
+		return false;
+	}
+	if (find(_protocolVersions.begin(), _protocolVersions.end(), m_protocolVersion) == _protocolVersions.end())
+	{
+		disable("Invalid protocol version.");
+		return false;
+	}
+	if (m_networkId != _networkId)
+	{
+		disable("Invalid network identifier.");
+		return false;
+	}
+	if (m_asking != Asking::State && m_asking != Asking::Nothing)
+	{
+		disable("Peer banned for unexpected status message.");
+		return false;
+	}
+
+	return true;
+}
+
+void WarpPeerCapability::requestStatus(u256 _hostNetworkId, u256 _chainTotalDifficulty, h256 _chainCurrentHash, h256 _chainGenesisHash)
+{
+	assert(m_asking == Asking::Nothing);
+	setAsking(Asking::State);
+	RLPStream s;
+	prep(s, WarpStatusPacket, 7)
+		<< m_hostProtocolVersion
+		<< _hostNetworkId
+		<< _chainTotalDifficulty
+		<< _chainCurrentHash
+		<< _chainGenesisHash
+		<< h256()
+		<< u256();
+	sealAndSend(s);
+}
+
+void WarpPeerCapability::requestManifest()
+{
+	assert(m_asking == Asking::Nothing);
+	setAsking(Asking::WarpManifest);
+	RLPStream s;
+	prep(s, GetSnapshotManifest);
+	sealAndSend(s);
+}
+
+void WarpPeerCapability::requestData(h256 const& _chunkHash)
+{
+	assert(m_asking == Asking::Nothing);
+	setAsking(Asking::WarpData);
+	RLPStream s;
+	prep(s, GetSnapshotData, 1) << _chunkHash;
+	sealAndSend(s);
+}
+
+void WarpPeerCapability::setAsking(Asking _a)
+{
+	m_asking = _a;
+	m_lastAsk = std::chrono::system_clock::to_time_t(chrono::system_clock::now());
+}

--- a/libethereum/WarpPeerCapability.cpp
+++ b/libethereum/WarpPeerCapability.cpp
@@ -24,7 +24,7 @@ using namespace dev;
 using namespace dev::eth;
 using namespace p2p;
 
-WarpPeerCapability::WarpPeerCapability(std::shared_ptr<SessionFace> _s, HostCapabilityFace* _h, unsigned _i, CapDesc const& _cap, uint16_t _capID):
+WarpPeerCapability::WarpPeerCapability(std::shared_ptr<SessionFace> _s, HostCapabilityFace* _h, unsigned _i, CapDesc const& /* _cap */, uint16_t _capID):
 	Capability(_s, _h, _i, _capID)
 {
 }

--- a/libethereum/WarpPeerCapability.h
+++ b/libethereum/WarpPeerCapability.h
@@ -54,6 +54,8 @@ public:
 	virtual void onPeerManifest(std::shared_ptr<WarpPeerCapability> _peer, RLP const& _r) = 0;
 
 	virtual void onPeerData(std::shared_ptr<WarpPeerCapability> _peer, RLP const& _r) = 0;
+
+	virtual void onPeerRequestTimeout(std::shared_ptr<WarpPeerCapability> _peer, Asking _asking) = 0;
 };
 
 

--- a/libethereum/WarpPeerCapability.h
+++ b/libethereum/WarpPeerCapability.h
@@ -1,0 +1,117 @@
+/*
+	This file is part of cpp-ethereum.
+
+	cpp-ethereum is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	cpp-ethereum is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/** @file WarpPeerCapability.h
+ */
+
+#pragma once
+
+#include "CommonNet.h"
+
+#include <libdevcore/Common.h>
+#include <libp2p/Capability.h>
+
+namespace dev
+{
+namespace eth
+{
+
+class WarpPeerCapability;
+
+const unsigned c_WarpProtocolVersion = 1;
+
+enum WarpSubprotocolPacketType: byte
+{
+	WarpStatusPacket = 0x00,
+	GetSnapshotManifest = 0x11,
+	SnapshotManifest = 0x12,
+	GetSnapshotData = 0x13,
+	SnapshotData = 0x14,
+
+	WarpSubprotocolPacketCount
+};
+
+class WarpPeerObserverFace
+{
+public:
+	virtual ~WarpPeerObserverFace() {}
+
+	virtual void onPeerStatus(std::shared_ptr<WarpPeerCapability> _peer) = 0;
+
+	virtual void onPeerManifest(std::shared_ptr<WarpPeerCapability> _peer, RLP const& _r) = 0;
+
+	virtual void onPeerData(std::shared_ptr<WarpPeerCapability> _peer, RLP const& _r) = 0;
+};
+
+
+class WarpPeerCapability: public p2p::Capability
+{
+public:
+	WarpPeerCapability(std::shared_ptr<p2p::SessionFace> _s, p2p::HostCapabilityFace* _h, unsigned _i, p2p::CapDesc const& _cap, uint16_t _capID);
+
+	static std::string name() { return "par"; }
+
+	static u256 version() { return c_WarpProtocolVersion; }
+
+	static unsigned messageCount() { return WarpSubprotocolPacketCount; }
+
+	void init(unsigned _hostProtocolVersion, u256 _hostNetworkId, u256 _chainTotalDifficulty, h256 _chainCurrentHash, h256 _chainGenesisHash, std::shared_ptr<WarpPeerObserverFace> _observer);
+
+	/// Validates whether peer is able to communicate with the host, disables peer if not
+	bool validateStatus(h256 const& _genesisHash, std::vector<unsigned> const& _protocolVersions, u256 const& _networkId);
+
+	void requestStatus(u256 _hostNetworkId, u256 _chainTotalDifficulty, h256 _chainCurrentHash, h256 _chainGenesisHash);
+	void requestManifest();
+	void requestData(h256 const& _chunkHash);
+
+	u256 snapshotNumber() const { return m_snapshotNumber; }
+
+
+private:
+	using p2p::Capability::sealAndSend;
+
+	/// Interpret an incoming message.
+	bool interpret(unsigned _id, RLP const& _r) override;
+
+	void setAsking(Asking _a);
+		
+	void setIdle() { setAsking(Asking::Nothing); }
+
+	unsigned m_hostProtocolVersion = 0;
+
+	/// Peer's protocol version.
+	unsigned m_protocolVersion = 0;
+
+	/// Peer's network id.
+	u256 m_networkId;
+
+	/// What, if anything, we last asked the other peer for.
+	Asking m_asking = Asking::Nothing;
+	/// When we asked for it. Allows a time out.
+	std::atomic<time_t> m_lastAsk;
+
+	/// These are determined through either a Status message.
+	h256 m_latestHash;						///< Peer's latest block's hash.
+	u256 m_totalDifficulty;					///< Peer's latest block's total difficulty.
+	h256 m_genesisHash;						///< Peer's genesis hash
+	h256 m_snapshotHash;
+	u256 m_snapshotNumber;
+
+	std::shared_ptr<WarpPeerObserverFace> m_observer;
+};
+
+}
+}

--- a/libwebthree/WebThree.cpp
+++ b/libwebthree/WebThree.cpp
@@ -39,6 +39,7 @@ static_assert(BOOST_VERSION >= 106400, "Wrong boost headers version");
 WebThreeDirect::WebThreeDirect(
 	std::string const& _clientVersion,
 	boost::filesystem::path const& _dbPath,
+	boost::filesystem::path const& _snapshotPath,
 	eth::ChainParams const& _params,
 	WithExisting _we,
 	std::set<std::string> const& _interfaces,
@@ -56,11 +57,11 @@ WebThreeDirect::WebThreeDirect(
 		Ethash::init();
 		NoProof::init();
 		if (_params.sealEngineName == "Ethash")
-			m_ethereum.reset(new eth::EthashClient(_params, (int)_params.networkID, &m_net, shared_ptr<GasPricer>(), _dbPath, _we));
+			m_ethereum.reset(new eth::EthashClient(_params, (int)_params.networkID, &m_net, shared_ptr<GasPricer>(), _dbPath, _snapshotPath, _we));
 		else if (_params.sealEngineName == "NoProof" && _testing)
 			m_ethereum.reset(new eth::ClientTest(_params, (int)_params.networkID, &m_net, shared_ptr<GasPricer>(), _dbPath, _we));
 		else
-			m_ethereum.reset(new eth::Client(_params, (int)_params.networkID, &m_net, shared_ptr<GasPricer>(), _dbPath, _we));
+			m_ethereum.reset(new eth::Client(_params, (int)_params.networkID, &m_net, shared_ptr<GasPricer>(), _dbPath, _snapshotPath, _we));
 		string bp = DEV_QUOTED(ETH_BUILD_PLATFORM);
 		vector<string> bps;
 		boost::split(bps, bp, boost::is_any_of("/"));

--- a/libwebthree/WebThree.h
+++ b/libwebthree/WebThree.h
@@ -124,6 +124,7 @@ public:
 	WebThreeDirect(
 		std::string const& _clientVersion,
 		boost::filesystem::path const& _dbPath,
+		boost::filesystem::path const& _snapshotPath,
 		eth::ChainParams const& _params,
 		WithExisting _we = WithExisting::Trust,
 		std::set<std::string> const& _interfaces = {"eth", "shh", "bzz"},

--- a/test/unittests/libweb3jsonrpc/Client.cpp
+++ b/test/unittests/libweb3jsonrpc/Client.cpp
@@ -60,6 +60,7 @@ BOOST_AUTO_TEST_CASE(Personal)
 	dev::WebThreeDirect web3(
 		WebThreeDirect::composeClientVersion("eth"),
 		getDataDir(),
+		string(),
 		ChainParams(),
 		WithExisting::Kill,
 		set<string>{"eth"},


### PR DESCRIPTION
This is still in PoC-stage, downloads only from single peer, needs improvements in many minor details and tests.

It's better to start this pinning to one of Parity's boot nodes:
```
./eth --download-snapshot snapshot_dir -v 9 --peerset required:016b20125f447a3b203a3cae953b2ede8ffe51290c071e7599294be84317635730c397b8ff74404d6be412d539ee5bb5c3c700618723d3b53958c92bd33eaa82@159.203.210.80:30303 --pin --no-discovery
```

(other bootnodes for main net are here: https://github.com/paritytech/parity/blob/master/ethcore/res/ethereum/foundation.json#L182 )