### PR TITLE
libtesteth: fix filling of logs in general state tests

### DIFF
--- a/test/tools/libtesteth/ImportTest.cpp
+++ b/test/tools/libtesteth/ImportTest.cpp
@@ -732,9 +732,6 @@ int ImportTest::exportTest(bytes const& _output)
 			m_testObject.erase(m_testObject.find("expectOut"));
 		}
 
-		// export logs
-		m_testObject["logs"] = exportLog(m_logs);
-
 		// compare expected state with post state
 		if (m_testObject.count("expect") > 0)
 		{

--- a/test/tools/libtesteth/ImportTest.cpp
+++ b/test/tools/libtesteth/ImportTest.cpp
@@ -80,7 +80,7 @@ bytes ImportTest::executeTest()
 				if(opt.trValueIndex != -1 && opt.trValueIndex != tr.valInd)
 					continue;
 
-				std::tie(tr.postState, std::ignore, tr.changeLog) =
+				std::tie(tr.postState, tr.output, tr.changeLog) =
 					executeTransaction(net, *m_envInfo, m_statePre, tr.transaction);
 				tr.netId = net;
 				transactionResults.push_back(tr);
@@ -209,7 +209,7 @@ std::tuple<eth::State, ImportTest::ExecOutput, eth::ChangeLog> ImportTest::execu
 	try
 	{
 		unique_ptr<SealEngineFace> se(ChainParams(genesisInfo(_sealEngineNetwork)).createSealEngine());
-		ImportTest::ExecOutput out = initialState.execute(_env, *se.get(), _tr, Permanence::Uncommitted);
+		ExecOutput out = initialState.execute(_env, *se.get(), _tr, Permanence::Uncommitted);
 		eth::ChangeLog changeLog = initialState.changeLog();
 
 		//Finalize the state manually (clear logs)
@@ -227,10 +227,8 @@ std::tuple<eth::State, ImportTest::ExecOutput, eth::ChangeLog> ImportTest::execu
 	}
 
 	initialState.commit(State::CommitBehaviour::KeepEmptyAccounts);
-	LogEntries emptyLogs;
-	ExecutionResult emptyRes;
-	ImportTest::ExecOutput out = make_pair(emptyRes, TransactionReceipt(h256(), u256(), emptyLogs));
-	return std::make_tuple(initialState, out, initialState.changeLog());
+	ExecOutput emptyOutput(std::make_pair(eth::ExecutionResult(), eth::TransactionReceipt(h256(), u256(), eth::LogEntries())));
+	return std::make_tuple(initialState, emptyOutput, initialState.changeLog());
 }
 
 json_spirit::mObject& ImportTest::makeAllFieldsHex(json_spirit::mObject& _o, bool _isHeader)
@@ -689,6 +687,7 @@ int ImportTest::exportTest(bytes const& _output)
 			obj["value"] = tr.valInd;
 			obj2["indexes"] = obj;
 			obj2["hash"] = toHex(tr.postState.rootHash().asBytes(), 2, HexPrefix::Add);
+			obj2["logs"] = exportLog(tr.output.second.log());
 
 			//Print the post state if transaction has failed on expect section
 			if (Options::get().checkstate)

--- a/test/tools/libtesteth/ImportTest.h
+++ b/test/tools/libtesteth/ImportTest.h
@@ -61,8 +61,6 @@ public:
 
 	eth::State m_statePre;
 	eth::State m_statePost;
-	eth::LogEntries m_logs;
-	eth::LogEntries m_logsExpected;
 
 private:
 	using ExecOutput = std::pair<eth::ExecutionResult, eth::TransactionReceipt>;

--- a/test/tools/libtesteth/ImportTest.h
+++ b/test/tools/libtesteth/ImportTest.h
@@ -74,7 +74,8 @@ private:
 	struct transactionToExecute
 	{
 		transactionToExecute(int d, int g, int v, eth::Transaction const& t):
-			dataInd(d), gasInd(g), valInd(v), transaction(t), postState(0), netId(eth::Network::MainNetwork) {}
+			dataInd(d), gasInd(g), valInd(v), transaction(t), postState(0), netId(eth::Network::MainNetwork),
+			output(std::make_pair(eth::ExecutionResult(), eth::TransactionReceipt(h256(), u256(), eth::LogEntries()))) {}
 		int dataInd;
 		int gasInd;
 		int valInd;
@@ -82,6 +83,7 @@ private:
 		eth::State postState;
 		eth::ChangeLog changeLog;
 		eth::Network netId;
+		ExecOutput output;
 	};
 	std::vector<transactionToExecute> m_transactions;
 	using StateAndMap = std::pair<eth::State, eth::AccountMaskMap>;


### PR DESCRIPTION
This PR adds "logs" to each post state.

See #4234 