### PR TITLE
exportLog() now takes a const reference, yielding some speedup

### DIFF
--- a/test/tools/libtesteth/TestHelper.cpp
+++ b/test/tools/libtesteth/TestHelper.cpp
@@ -150,7 +150,7 @@ std::vector<eth::Network> const& getNetworks()
 	return networks;
 }
 
-json_spirit::mArray exportLog(eth::LogEntries _logs)
+json_spirit::mArray exportLog(eth::LogEntries const& _logs)
 {
 	json_spirit::mArray ret;
 	if (_logs.size() == 0) return ret;

--- a/test/tools/libtesteth/TestHelper.h
+++ b/test/tools/libtesteth/TestHelper.h
@@ -136,7 +136,7 @@ bytes importByteArray(std::string const& _str);
 void checkHexHasEvenLength(std::string const&);
 void copyFile(std::string const& _source, std::string const& _destination);
 eth::LogEntries importLog(json_spirit::mArray& _o);
-json_spirit::mArray exportLog(eth::LogEntries _logs);
+json_spirit::mArray exportLog(eth::LogEntries const& _logs);
 void checkOutput(bytesConstRef _output, json_spirit::mObject& _o);
 void checkStorage(std::map<u256, u256> _expectedStore, std::map<u256, u256> _resultStore, Address _expectedAddr);
 void checkLog(eth::LogEntries _resultLogs, eth::LogEntries _expectedLogs);


### PR DESCRIPTION
Before this change:
```
ETHEREUM_TEST_PATH="../../tests" test/testeth -t "StateTestsGeneral"  86,34s user 1,35s system 74% cpu 1:58,06 total
```
After this change:
```
ETHEREUM_TEST_PATH="../../tests" test/testeth -t "StateTestsGeneral"  67,13s user 1,12s system 98% cpu 1:09,04 total
```