### PR TITLE
libdevcore: speed up toHex, remove _w, _prefix parameters

### DIFF
--- a/libdevcore/CommonData.h
+++ b/libdevcore/CommonData.h
@@ -42,44 +42,36 @@ enum class WhenError
 	Throw = 1,
 };
 
-namespace
+template <class Iterator>
+inline std::string toHex(Iterator _it, Iterator _end, std::string _prefix)
 {
+	typedef std::iterator_traits<Iterator> traits;
+	static_assert(sizeof(typename traits::value_type) == 1, "toHex needs byte-sized element type");
 
-const char* hexdigits = "0123456789abcdef";
-
-template <class T>
-inline void writeHex(T const& _data, std::string& o_hex, size_t _off)
-{
-	for (byte i: _data)
+	static char const* hexdigits = "0123456789abcdef";
+	size_t off = _prefix.size();
+	std::string hex(std::distance(_it, _end)*2 + off, '0');
+	hex.replace(0, off, _prefix);
+	for (; _it != _end; _it++)
 	{
-		o_hex[_off++] = hexdigits[i >> 4];
-		o_hex[_off++] = hexdigits[i & 0x0f];
+		hex[off++] = hexdigits[*_it >> 4];
+		hex[off++] = hexdigits[*_it & 0x0f];
 	}
-}
-
+	return hex;
 }
 
 /// Convert a series of bytes to the corresponding hex string.
 /// @example toHex("A\x69") == "4169"
-template <class T>
-std::string toHex(T const& _data)
+template <class T> std::string toHex(T const& _data)
 {
-	static_assert(sizeof(typename T::value_type) == 1, "toHex needs byte-sized element type");
-	std::string hex(_data.size()*2, '0');
-	writeHex(_data, hex, 0);
-	return hex;
+	return toHex(_data.begin(), _data.end(), "");
 }
 
 /// Convert a series of bytes to the corresponding hex string with 0x prefix.
 /// @example toHexPrefix("A\x69") == "0x4169"
-template <class T>
-std::string toHexPrefix(T const& _data)
+template <class T> std::string toHexPrefix(T const& _data)
 {
-	static_assert(sizeof(typename T::value_type) == 1, "toHexPrefix needs byte-sized element type");
-	std::string hex(_data.size()*2 + 2, '0');
-	hex.replace(0, 2, "0x");
-	writeHex(_data, hex, 2);
-	return hex;
+	return toHex(_data.begin(), _data.end(), "0x");
 }
 
 /// Converts a (printable) ASCII hex string into the corresponding byte stream.

--- a/libdevcore/CommonData.h
+++ b/libdevcore/CommonData.h
@@ -68,8 +68,8 @@ template <class T> std::string toHex(T const& _data)
 }
 
 /// Convert a series of bytes to the corresponding hex string with 0x prefix.
-/// @example toHexPrefix("A\x69") == "0x4169"
-template <class T> std::string toHexPrefix(T const& _data)
+/// @example toHexPrefixed("A\x69") == "0x4169"
+template <class T> std::string toHexPrefixed(T const& _data)
 {
 	return toHex(_data.begin(), _data.end(), "0x");
 }
@@ -184,9 +184,9 @@ inline std::string toCompactHex(u256 val, unsigned _min = 0)
 	return toHex(toCompactBigEndian(val, _min));
 }
 
-inline std::string toCompactHexPrefix(u256 val, unsigned _min = 0)
+inline std::string toCompactHexPrefixed(u256 val, unsigned _min = 0)
 {
-	return toHexPrefix(toCompactBigEndian(val, _min));
+	return toHexPrefixed(toCompactBigEndian(val, _min));
 }
 
 // Algorithms for string and string-like collections.

--- a/libdevcore/CommonData.h
+++ b/libdevcore/CommonData.h
@@ -54,7 +54,7 @@ std::string toHex(Iterator _it, Iterator _end, std::string _prefix)
 	hex.replace(0, off, _prefix);
 	for (; _it != _end; _it++)
 	{
-		hex[off++] = hexdigits[*_it >> 4];
+		hex[off++] = hexdigits[(*_it >> 4) & 0x0f];
 		hex[off++] = hexdigits[*_it & 0x0f];
 	}
 	return hex;

--- a/libdevcore/CommonData.h
+++ b/libdevcore/CommonData.h
@@ -44,7 +44,19 @@ enum class WhenError
 
 namespace
 {
-	const char* hexdigits = "0123456789abcdef";
+
+const char* hexdigits = "0123456789abcdef";
+
+template <class T>
+inline void writeHex(T const& _data, std::string& o_hex, size_t _off)
+{
+	for (byte i: _data)
+	{
+		o_hex[_off++] = hexdigits[i>>4];
+		o_hex[_off++] = hexdigits[i&0x0f];
+	}
+}
+
 }
 
 /// Convert a series of bytes to the corresponding string of hex duplets.
@@ -54,12 +66,19 @@ std::string toHex(T const& _data)
 {
 	static_assert(sizeof(typename T::value_type) == 1, "toHex needs byte-sized element type");
 	std::string hex(_data.size()*2, '0');
-	size_t off = 0;
-	for (auto i: _data)
-	{
-		hex[off++] = hexdigits[(byte)(i)>>4];
-		hex[off++] = hexdigits[(byte)(i)&0x0f];
-	}
+	writeHex(_data, hex, 0);
+	return hex;
+}
+
+/// Convert a series of bytes to the corresponding string of hex duplets.
+/// @example toHex("A\x69") == "4169"
+template <class T>
+std::string toHexPrefix(T const& _data)
+{
+	static_assert(sizeof(typename T::value_type) == 1, "toHexPrefix needs byte-sized element type");
+	std::string hex(_data.size()*2 + 2, '0');
+	hex.replace(0, 2, "0x");
+	writeHex(_data, hex, 2);
 	return hex;
 }
 
@@ -168,15 +187,14 @@ inline std::string toCompactBigEndianString(T _val, unsigned _min = 0)
 	return ret;
 }
 
-/// Convenience function for conversion of a u256 to hex
-inline std::string toHex(u256 val)
-{
-	return toHex(toBigEndian(val));
-}
-
 inline std::string toCompactHex(u256 val, unsigned _min = 0)
 {
 	return toHex(toCompactBigEndian(val, _min));
+}
+
+inline std::string toCompactHexPrefix(u256 val, unsigned _min = 0)
+{
+	return toHexPrefix(toCompactBigEndian(val, _min));
 }
 
 // Algorithms for string and string-like collections.

--- a/libdevcore/CommonData.h
+++ b/libdevcore/CommonData.h
@@ -52,8 +52,8 @@ inline void writeHex(T const& _data, std::string& o_hex, size_t _off)
 {
 	for (byte i: _data)
 	{
-		o_hex[_off++] = hexdigits[i>>4];
-		o_hex[_off++] = hexdigits[i&0x0f];
+		o_hex[_off++] = hexdigits[i >> 4];
+		o_hex[_off++] = hexdigits[i & 0x0f];
 	}
 }
 

--- a/libdevcore/CommonData.h
+++ b/libdevcore/CommonData.h
@@ -43,7 +43,7 @@ enum class WhenError
 };
 
 template <class Iterator>
-inline std::string toHex(Iterator _it, Iterator _end, std::string _prefix)
+std::string toHex(Iterator _it, Iterator _end, std::string _prefix)
 {
 	typedef std::iterator_traits<Iterator> traits;
 	static_assert(sizeof(typename traits::value_type) == 1, "toHex needs byte-sized element type");
@@ -179,14 +179,14 @@ inline std::string toCompactBigEndianString(T _val, unsigned _min = 0)
 	return ret;
 }
 
-inline std::string toCompactHex(u256 val, unsigned _min = 0)
+inline std::string toCompactHex(u256 _val, unsigned _min = 0)
 {
-	return toHex(toCompactBigEndian(val, _min));
+	return toHex(toCompactBigEndian(_val, _min));
 }
 
-inline std::string toCompactHexPrefixed(u256 val, unsigned _min = 0)
+inline std::string toCompactHexPrefixed(u256 _val, unsigned _min = 0)
 {
-	return toHexPrefixed(toCompactBigEndian(val, _min));
+	return toHexPrefixed(toCompactBigEndian(_val, _min));
 }
 
 // Algorithms for string and string-like collections.

--- a/libdevcore/CommonData.h
+++ b/libdevcore/CommonData.h
@@ -59,7 +59,7 @@ inline void writeHex(T const& _data, std::string& o_hex, size_t _off)
 
 }
 
-/// Convert a series of bytes to the corresponding string of hex duplets.
+/// Convert a series of bytes to the corresponding hex string.
 /// @example toHex("A\x69") == "4169"
 template <class T>
 std::string toHex(T const& _data)
@@ -70,8 +70,8 @@ std::string toHex(T const& _data)
 	return hex;
 }
 
-/// Convert a series of bytes to the corresponding string of hex duplets.
-/// @example toHex("A\x69") == "4169"
+/// Convert a series of bytes to the corresponding hex string with 0x prefix.
+/// @example toHexPrefix("A\x69") == "0x4169"
 template <class T>
 std::string toHexPrefix(T const& _data)
 {

--- a/libdevcore/CommonData.h
+++ b/libdevcore/CommonData.h
@@ -42,22 +42,25 @@ enum class WhenError
 	Throw = 1,
 };
 
-enum class HexPrefix
+namespace
 {
-	DontAdd = 0,
-	Add = 1,
-};
+	const char* hexdigits = "0123456789abcdef";
+}
+
 /// Convert a series of bytes to the corresponding string of hex duplets.
-/// @param _w specifies the width of the first of the elements. Defaults to two - enough to represent a byte.
 /// @example toHex("A\x69") == "4169"
 template <class T>
-std::string toHex(T const& _data, int _w = 2, HexPrefix _prefix = HexPrefix::DontAdd)
+std::string toHex(T const& _data)
 {
-	std::ostringstream ret;
-	unsigned ii = 0;
+	static_assert(sizeof(typename T::value_type) == 1, "toHex needs byte-sized element type");
+	std::string hex(_data.size()*2, '0');
+	size_t off = 0;
 	for (auto i: _data)
-		ret << std::hex << std::setfill('0') << std::setw(ii++ ? 2 : _w) << (int)(typename std::make_unsigned<decltype(i)>::type)i;
-	return (_prefix == HexPrefix::Add) ? "0x" + ret.str() : ret.str();
+	{
+		hex[off++] = hexdigits[(byte)(i)>>4];
+		hex[off++] = hexdigits[(byte)(i)&0x0f];
+	}
+	return hex;
 }
 
 /// Converts a (printable) ASCII hex string into the corresponding byte stream.
@@ -166,16 +169,14 @@ inline std::string toCompactBigEndianString(T _val, unsigned _min = 0)
 }
 
 /// Convenience function for conversion of a u256 to hex
-inline std::string toHex(u256 val, HexPrefix prefix = HexPrefix::DontAdd)
+inline std::string toHex(u256 val)
 {
-	std::string str = toHex(toBigEndian(val));
-	return (prefix == HexPrefix::Add) ? "0x" + str : str;
+	return toHex(toBigEndian(val));
 }
 
-inline std::string toCompactHex(u256 val, HexPrefix prefix = HexPrefix::DontAdd, unsigned _min = 0)
+inline std::string toCompactHex(u256 val, unsigned _min = 0)
 {
-	std::string str = toHex(toCompactBigEndian(val, _min));
-	return (prefix == HexPrefix::Add) ? "0x" + str : str;
+	return toHex(toCompactBigEndian(val, _min));
 }
 
 // Algorithms for string and string-like collections.

--- a/libdevcore/CommonIO.h
+++ b/libdevcore/CommonIO.h
@@ -77,7 +77,7 @@ std::string memDump(bytes const& _bytes, unsigned _width = 8, bool _html = false
 template <class S, class T> struct StreamOut { static S& bypass(S& _out, T const& _t) { _out << _t; return _out; } };
 template <class S> struct StreamOut<S, uint8_t> { static S& bypass(S& _out, uint8_t const& _t) { _out << (int)_t; return _out; } };
 
-inline std::ostream& operator<<(std::ostream& _out, bytes const& _e) { _out << "0x" + toHex(_e); return _out; }
+inline std::ostream& operator<<(std::ostream& _out, bytes const& _e) { _out << toHexPrefix(_e); return _out; }
 template <class T> inline std::ostream& operator<<(std::ostream& _out, std::vector<T> const& _e);
 template <class T, std::size_t Z> inline std::ostream& operator<<(std::ostream& _out, std::array<T, Z> const& _e);
 template <class T, class U> inline std::ostream& operator<<(std::ostream& _out, std::pair<T, U> const& _e);

--- a/libdevcore/CommonIO.h
+++ b/libdevcore/CommonIO.h
@@ -77,7 +77,7 @@ std::string memDump(bytes const& _bytes, unsigned _width = 8, bool _html = false
 template <class S, class T> struct StreamOut { static S& bypass(S& _out, T const& _t) { _out << _t; return _out; } };
 template <class S> struct StreamOut<S, uint8_t> { static S& bypass(S& _out, uint8_t const& _t) { _out << (int)_t; return _out; } };
 
-inline std::ostream& operator<<(std::ostream& _out, bytes const& _e) { _out << toHexPrefix(_e); return _out; }
+inline std::ostream& operator<<(std::ostream& _out, bytes const& _e) { _out << toHexPrefixed(_e); return _out; }
 template <class T> inline std::ostream& operator<<(std::ostream& _out, std::vector<T> const& _e);
 template <class T, std::size_t Z> inline std::ostream& operator<<(std::ostream& _out, std::array<T, Z> const& _e);
 template <class T, class U> inline std::ostream& operator<<(std::ostream& _out, std::pair<T, U> const& _e);

--- a/libdevcore/CommonIO.h
+++ b/libdevcore/CommonIO.h
@@ -77,7 +77,7 @@ std::string memDump(bytes const& _bytes, unsigned _width = 8, bool _html = false
 template <class S, class T> struct StreamOut { static S& bypass(S& _out, T const& _t) { _out << _t; return _out; } };
 template <class S> struct StreamOut<S, uint8_t> { static S& bypass(S& _out, uint8_t const& _t) { _out << (int)_t; return _out; } };
 
-inline std::ostream& operator<<(std::ostream& _out, bytes const& _e) { _out << toHex(_e, 2, HexPrefix::Add); return _out; }
+inline std::ostream& operator<<(std::ostream& _out, bytes const& _e) { _out << "0x" + toHex(_e); return _out; }
 template <class T> inline std::ostream& operator<<(std::ostream& _out, std::vector<T> const& _e);
 template <class T, std::size_t Z> inline std::ostream& operator<<(std::ostream& _out, std::array<T, Z> const& _e);
 template <class T, class U> inline std::ostream& operator<<(std::ostream& _out, std::pair<T, U> const& _e);

--- a/libdevcore/CommonJS.h
+++ b/libdevcore/CommonJS.h
@@ -33,7 +33,7 @@ namespace dev
 
 template <unsigned S> std::string toJS(FixedHash<S> const& _h)
 {
-	return "0x" + toHex(_h.ref());
+	return toHexPrefix(_h.ref());
 }
 
 template <unsigned N> std::string toJS(boost::multiprecision::number<boost::multiprecision::cpp_int_backend<N, N, boost::multiprecision::unsigned_magnitude, boost::multiprecision::unchecked, void>> const& _n)
@@ -48,7 +48,7 @@ inline std::string toJS(bytes const& _n, std::size_t _padding = 0)
 {
 	bytes n = _n;
 	n.resize(std::max<unsigned>(n.size(), _padding));
-	return "0x" + toHex(n);
+	return toHexPrefix(n);
 }
 
 template<unsigned T> std::string toJS(SecureFixedHash<T> const& _i)

--- a/libdevcore/CommonJS.h
+++ b/libdevcore/CommonJS.h
@@ -33,7 +33,7 @@ namespace dev
 
 template <unsigned S> std::string toJS(FixedHash<S> const& _h)
 {
-	return toHexPrefix(_h.ref());
+	return toHexPrefixed(_h.ref());
 }
 
 template <unsigned N> std::string toJS(boost::multiprecision::number<boost::multiprecision::cpp_int_backend<N, N, boost::multiprecision::unsigned_magnitude, boost::multiprecision::unchecked, void>> const& _n)
@@ -48,7 +48,7 @@ inline std::string toJS(bytes const& _n, std::size_t _padding = 0)
 {
 	bytes n = _n;
 	n.resize(std::max<unsigned>(n.size(), _padding));
-	return toHexPrefix(n);
+	return toHexPrefixed(n);
 }
 
 template<unsigned T> std::string toJS(SecureFixedHash<T> const& _i)

--- a/libdevcore/FixedHash.h
+++ b/libdevcore/FixedHash.h
@@ -323,10 +323,7 @@ template<> inline size_t FixedHash<32>::hash::operator()(FixedHash<32> const& va
 template <unsigned N>
 inline std::ostream& operator<<(std::ostream& _out, FixedHash<N> const& _h)
 {
-	_out << std::noshowbase << std::hex << std::setfill('0');
-	for (unsigned i = 0; i < N; ++i)
-		_out << std::setw(2) << (int)_h[i];
-	_out << std::dec;
+	_out << toHex(_h.ref());
 	return _out;
 }
 

--- a/libdevcore/FixedHash.h
+++ b/libdevcore/FixedHash.h
@@ -323,7 +323,7 @@ template<> inline size_t FixedHash<32>::hash::operator()(FixedHash<32> const& va
 template <unsigned N>
 inline std::ostream& operator<<(std::ostream& _out, FixedHash<N> const& _h)
 {
-	_out << toHex(_h.ref());
+	_out << toHex(_h);
 	return _out;
 }
 

--- a/libethereum/Executive.cpp
+++ b/libethereum/Executive.cpp
@@ -74,7 +74,7 @@ void StandardTrace::operator()(uint64_t _steps, uint64_t PC, Instruction inst, b
 	if (!m_options.disableStack)
 	{
 		for (auto const& i: vm.stack())
-			stack.append("0x" + toHex(toCompactBigEndian(i, 1)));
+			stack.append(toCompactHexPrefix(i, 1));
 		r["stack"] = stack;
 	}
 
@@ -121,7 +121,7 @@ void StandardTrace::operator()(uint64_t _steps, uint64_t PC, Instruction inst, b
 	{
 		Json::Value storage(Json::objectValue);
 		for (auto const& i: ext.state().storage(ext.myAddress))
-			storage["0x" + toCompactHex(i.second.first, 1)] = toCompactHex(i.second.second, 1);
+			storage[toCompactHexPrefix(i.second.first, 1)] = toCompactHexPrefix(i.second.second, 1);
 		r["storage"] = storage;
 	}
 

--- a/libethereum/Executive.cpp
+++ b/libethereum/Executive.cpp
@@ -112,7 +112,7 @@ void StandardTrace::operator()(uint64_t _steps, uint64_t PC, Instruction inst, b
 		for (unsigned i = 0; i < vm.memory().size(); i += 32)
 		{
 			bytesConstRef memRef(vm.memory().data() + i, 32);
-			memJson.append(toHex(memRef, 2, HexPrefix::DontAdd));
+			memJson.append(toHex(memRef));
 		}
 		r["memory"] = memJson;
 	}
@@ -121,7 +121,7 @@ void StandardTrace::operator()(uint64_t _steps, uint64_t PC, Instruction inst, b
 	{
 		Json::Value storage(Json::objectValue);
 		for (auto const& i: ext.state().storage(ext.myAddress))
-			storage[toCompactHex(i.second.first, HexPrefix::Add, 1)] = toCompactHex(i.second.second, HexPrefix::Add, 1);
+			storage["0x" + toCompactHex(i.second.first, 1)] = toCompactHex(i.second.second, 1);
 		r["storage"] = storage;
 	}
 

--- a/libethereum/Executive.cpp
+++ b/libethereum/Executive.cpp
@@ -74,7 +74,7 @@ void StandardTrace::operator()(uint64_t _steps, uint64_t PC, Instruction inst, b
 	if (!m_options.disableStack)
 	{
 		for (auto const& i: vm.stack())
-			stack.append(toCompactHexPrefix(i, 1));
+			stack.append(toCompactHexPrefixed(i, 1));
 		r["stack"] = stack;
 	}
 
@@ -121,7 +121,7 @@ void StandardTrace::operator()(uint64_t _steps, uint64_t PC, Instruction inst, b
 	{
 		Json::Value storage(Json::objectValue);
 		for (auto const& i: ext.state().storage(ext.myAddress))
-			storage[toCompactHexPrefix(i.second.first, 1)] = toCompactHexPrefix(i.second.second, 1);
+			storage[toCompactHexPrefixed(i.second.first, 1)] = toCompactHexPrefixed(i.second.second, 1);
 		r["storage"] = storage;
 	}
 

--- a/libweb3jsonrpc/Debug.cpp
+++ b/libweb3jsonrpc/Debug.cpp
@@ -92,7 +92,7 @@ Json::Value Debug::debug_traceTransaction(string const& _txHash, Json::Value con
 		Executive e(s, block, t.transactionIndex(), m_eth.blockChain());
 		e.setResultRecipient(er);
 		Json::Value trace = traceTransaction(e, t, _json);
-		ret["gas"] = toHex(t.gas(), HexPrefix::Add);
+		ret["gas"] = toJS(t.gas());
 		ret["return"] = toHex(er.output, 2, HexPrefix::Add);
 		ret["structLogs"] = trace;
 	}
@@ -202,7 +202,7 @@ Json::Value Debug::debug_traceCall(Json::Value const& _call, std::string const& 
 		Executive e(temp, m_eth.blockChain().lastBlockHashes());
 		e.setResultRecipient(er);
 		Json::Value trace = traceTransaction(e, transaction, _options);
-		ret["gas"] = toHex(transaction.gas(), HexPrefix::Add);
+		ret["gas"] = toJS(transaction.gas());
 		ret["return"] = toHex(er.output, 2, HexPrefix::Add);
 		ret["structLogs"] = trace;
 	}

--- a/libweb3jsonrpc/Debug.cpp
+++ b/libweb3jsonrpc/Debug.cpp
@@ -93,7 +93,7 @@ Json::Value Debug::debug_traceTransaction(string const& _txHash, Json::Value con
 		e.setResultRecipient(er);
 		Json::Value trace = traceTransaction(e, t, _json);
 		ret["gas"] = toJS(t.gas());
-		ret["return"] = toHex(er.output, 2, HexPrefix::Add);
+		ret["return"] = "0x" + toHex(er.output);
 		ret["structLogs"] = trace;
 	}
 	catch(Exception const& _e)
@@ -153,14 +153,14 @@ Json::Value Debug::debug_storageRangeAt(string const& _blockHashOrNumber, int _t
 		{
 			if (ret["storage"].size() == static_cast<unsigned>(_maxResults))
 			{
-				ret["nextKey"] = toCompactHex(it->first, HexPrefix::Add, 1);
+				ret["nextKey"] = "0x" + toCompactHex(it->first, 1);
 				break;
 			}
 
 			Json::Value keyValue(Json::objectValue);
-			std::string hashedKey = toCompactHex(it->first, HexPrefix::Add, 1);
-			keyValue["key"] = toCompactHex(it->second.first, HexPrefix::Add, 1);
-			keyValue["value"] = toCompactHex(it->second.second, HexPrefix::Add, 1);
+			std::string hashedKey = "0x" + toCompactHex(it->first, 1);
+			keyValue["key"] = "0x" + toCompactHex(it->second.first, 1);
+			keyValue["value"] = "0x" + toCompactHex(it->second.second, 1);
 
 			ret["storage"][hashedKey] = keyValue;
 		}
@@ -179,7 +179,7 @@ std::string Debug::debug_preimage(std::string const& _hashedKey)
 	h256 const hashedKey(h256fromHex(_hashedKey));
 	bytes const key = m_eth.stateDB().lookupAux(hashedKey);
 
-	return key.empty() ? std::string() : toHex(key, 2, HexPrefix::Add);
+	return key.empty() ? std::string() : "0x" + toHex(key);
 }
 
 Json::Value Debug::debug_traceCall(Json::Value const& _call, std::string const& _blockNumber, Json::Value const& _options)
@@ -203,7 +203,7 @@ Json::Value Debug::debug_traceCall(Json::Value const& _call, std::string const& 
 		e.setResultRecipient(er);
 		Json::Value trace = traceTransaction(e, transaction, _options);
 		ret["gas"] = toJS(transaction.gas());
-		ret["return"] = toHex(er.output, 2, HexPrefix::Add);
+		ret["return"] = "0x" + toHex(er.output);
 		ret["structLogs"] = trace;
 	}
 	catch(Exception const& _e)

--- a/libweb3jsonrpc/Debug.cpp
+++ b/libweb3jsonrpc/Debug.cpp
@@ -93,7 +93,7 @@ Json::Value Debug::debug_traceTransaction(string const& _txHash, Json::Value con
 		e.setResultRecipient(er);
 		Json::Value trace = traceTransaction(e, t, _json);
 		ret["gas"] = toJS(t.gas());
-		ret["return"] = toHexPrefix(er.output);
+		ret["return"] = toHexPrefixed(er.output);
 		ret["structLogs"] = trace;
 	}
 	catch(Exception const& _e)
@@ -153,14 +153,14 @@ Json::Value Debug::debug_storageRangeAt(string const& _blockHashOrNumber, int _t
 		{
 			if (ret["storage"].size() == static_cast<unsigned>(_maxResults))
 			{
-				ret["nextKey"] = toCompactHexPrefix(it->first, 1);
+				ret["nextKey"] = toCompactHexPrefixed(it->first, 1);
 				break;
 			}
 
 			Json::Value keyValue(Json::objectValue);
-			std::string hashedKey = toCompactHexPrefix(it->first, 1);
-			keyValue["key"] = toCompactHexPrefix(it->second.first, 1);
-			keyValue["value"] = toCompactHexPrefix(it->second.second, 1);
+			std::string hashedKey = toCompactHexPrefixed(it->first, 1);
+			keyValue["key"] = toCompactHexPrefixed(it->second.first, 1);
+			keyValue["value"] = toCompactHexPrefixed(it->second.second, 1);
 
 			ret["storage"][hashedKey] = keyValue;
 		}
@@ -179,7 +179,7 @@ std::string Debug::debug_preimage(std::string const& _hashedKey)
 	h256 const hashedKey(h256fromHex(_hashedKey));
 	bytes const key = m_eth.stateDB().lookupAux(hashedKey);
 
-	return key.empty() ? std::string() : toHexPrefix(key);
+	return key.empty() ? std::string() : toHexPrefixed(key);
 }
 
 Json::Value Debug::debug_traceCall(Json::Value const& _call, std::string const& _blockNumber, Json::Value const& _options)
@@ -203,7 +203,7 @@ Json::Value Debug::debug_traceCall(Json::Value const& _call, std::string const& 
 		e.setResultRecipient(er);
 		Json::Value trace = traceTransaction(e, transaction, _options);
 		ret["gas"] = toJS(transaction.gas());
-		ret["return"] = toHexPrefix(er.output);
+		ret["return"] = toHexPrefixed(er.output);
 		ret["structLogs"] = trace;
 	}
 	catch(Exception const& _e)

--- a/libweb3jsonrpc/Debug.cpp
+++ b/libweb3jsonrpc/Debug.cpp
@@ -93,7 +93,7 @@ Json::Value Debug::debug_traceTransaction(string const& _txHash, Json::Value con
 		e.setResultRecipient(er);
 		Json::Value trace = traceTransaction(e, t, _json);
 		ret["gas"] = toJS(t.gas());
-		ret["return"] = "0x" + toHex(er.output);
+		ret["return"] = toHexPrefix(er.output);
 		ret["structLogs"] = trace;
 	}
 	catch(Exception const& _e)
@@ -153,14 +153,14 @@ Json::Value Debug::debug_storageRangeAt(string const& _blockHashOrNumber, int _t
 		{
 			if (ret["storage"].size() == static_cast<unsigned>(_maxResults))
 			{
-				ret["nextKey"] = "0x" + toCompactHex(it->first, 1);
+				ret["nextKey"] = toCompactHexPrefix(it->first, 1);
 				break;
 			}
 
 			Json::Value keyValue(Json::objectValue);
-			std::string hashedKey = "0x" + toCompactHex(it->first, 1);
-			keyValue["key"] = "0x" + toCompactHex(it->second.first, 1);
-			keyValue["value"] = "0x" + toCompactHex(it->second.second, 1);
+			std::string hashedKey = toCompactHexPrefix(it->first, 1);
+			keyValue["key"] = toCompactHexPrefix(it->second.first, 1);
+			keyValue["value"] = toCompactHexPrefix(it->second.second, 1);
 
 			ret["storage"][hashedKey] = keyValue;
 		}
@@ -179,7 +179,7 @@ std::string Debug::debug_preimage(std::string const& _hashedKey)
 	h256 const hashedKey(h256fromHex(_hashedKey));
 	bytes const key = m_eth.stateDB().lookupAux(hashedKey);
 
-	return key.empty() ? std::string() : "0x" + toHex(key);
+	return key.empty() ? std::string() : toHexPrefix(key);
 }
 
 Json::Value Debug::debug_traceCall(Json::Value const& _call, std::string const& _blockNumber, Json::Value const& _options)
@@ -203,7 +203,7 @@ Json::Value Debug::debug_traceCall(Json::Value const& _call, std::string const& 
 		e.setResultRecipient(er);
 		Json::Value trace = traceTransaction(e, transaction, _options);
 		ret["gas"] = toJS(transaction.gas());
-		ret["return"] = "0x" + toHex(er.output);
+		ret["return"] = toHexPrefix(er.output);
 		ret["structLogs"] = trace;
 	}
 	catch(Exception const& _e)

--- a/rlp/main.cpp
+++ b/rlp/main.cpp
@@ -132,28 +132,28 @@ public:
 		string indent;
 		bool hexInts = false;
 		bool stringInts = true;
-		bool hexPrefix = true;
 		bool forceString = false;
 		bool escapeAll = false;
 		bool forceHex = true;
 	};
 
-	RLPStreamer(ostream& _out, Prefs _p): m_out(_out), m_prefs(_p) {}
+	RLPStreamer(ostream& _out, Prefs _p): m_out(_out), m_prefs(_p)
+	{
+		if (_p.hexInts)
+			_out << std::hex << std::showbase << std::nouppercase;
+	}
 
 	void output(RLP const& _d, unsigned _level = 0)
 	{
 		if (_d.isNull())
 			m_out << "null";
 		else if (_d.isInt() && !m_prefs.stringInts)
-			if (m_prefs.hexInts)
-				m_out << (m_prefs.hexPrefix ? "0x" : "") << toHex(toCompactBigEndian(_d.toInt<bigint>(RLP::LaissezFaire), 1), 1);
-			else
-				m_out << _d.toInt<bigint>(RLP::LaissezFaire);
+			m_out << _d.toInt<bigint>(RLP::LaissezFaire);
 		else if (_d.isData() || (_d.isInt() && m_prefs.stringInts))
 			if (m_prefs.forceString || (!m_prefs.forceHex && isAscii(_d.toString())))
 				m_out << escaped(_d.toString(), m_prefs.escapeAll);
 			else
-				m_out << "\"" << (m_prefs.hexPrefix ? "0x" : "") << toHex(_d.toBytes()) << "\"";
+				m_out << "\"0x" << toHex(_d.toBytes()) << "\"";
 		else if (_d.isList())
 		{
 			m_out << "[";

--- a/rlp/main.cpp
+++ b/rlp/main.cpp
@@ -153,7 +153,7 @@ public:
 			if (m_prefs.forceString || (!m_prefs.forceHex && isAscii(_d.toString())))
 				m_out << escaped(_d.toString(), m_prefs.escapeAll);
 			else
-				m_out << "\"0x" << toHex(_d.toBytes()) << "\"";
+				m_out << "\"" << toHexPrefixed(_d.toBytes()) << "\"";
 		else if (_d.isList())
 		{
 			m_out << "[";

--- a/test/tools/fuzzTesting/fuzzHelper.cpp
+++ b/test/tools/fuzzTesting/fuzzHelper.cpp
@@ -112,7 +112,7 @@ int RandomCode::recursiveRLP(std::string& _result, int _depth, std::string& _deb
 			}
 			else
 			{
-				std::string hexlength = toCompactHex(length, HexPrefix::DontAdd, 1);
+				std::string hexlength = toCompactHex(length, 1);
 				header = toCompactHex(247 + hexlength.size() / 2) + hexlength;
 				rtype = 4;
 			}
@@ -141,7 +141,7 @@ int RandomCode::recursiveRLP(std::string& _result, int _depth, std::string& _deb
 		case 0:
 		{
 			//single byte [0x00, 0x7f]
-			std::string rlp = emptyZeros + toCompactHex(genbug ? randUniIntGen() % 255 : randUniIntGen() % 128, HexPrefix::DontAdd, 1);
+			std::string rlp = emptyZeros + toCompactHex(genbug ? randUniIntGen() % 255 : randUniIntGen() % 128, 1);
 			_result.insert(0, rlp);
 			_debug.insert(0, "[" + rlp + "]");
 			return 1;
@@ -167,7 +167,7 @@ int RandomCode::recursiveRLP(std::string& _result, int _depth, std::string& _deb
 				len = 56;
 
 			std::string hex = rndByteSequence(len);
-			std::string hexlen = emptyZeros2 + toCompactHex(len, HexPrefix::DontAdd, 1);
+			std::string hexlen = emptyZeros2 + toCompactHex(len, 1);
 			std::string rlpblock = toCompactHex(183 + hexlen.size() / 2) + hexlen + emptyZeros + hex;
 			_debug.insert(0, "[" + toCompactHex(183 + hexlen.size() / 2) + hexlen + "(" + toString(len) + "){2}]" + emptyZeros + hex);
 			_result.insert(0, rlpblock);
@@ -188,7 +188,7 @@ int RandomCode::recursiveRLP(std::string& _result, int _depth, std::string& _deb
 			int len = randUniIntGen() % 100;
 			if (len < 56 && genValidRlp)
 				len = 56;
-			std::string hexlen = emptyZeros2 + toCompactHex(len, HexPrefix::DontAdd, 1);
+			std::string hexlen = emptyZeros2 + toCompactHex(len, 1);
 			std::string rlpblock = toCompactHex(247 + hexlen.size() / 2) + hexlen + emptyZeros + rndByteSequence(len);
 			_debug.insert(0, "[" + toCompactHex(247 + hexlen.size() / 2) + hexlen + "(" + toString(len) + "){4}]" + emptyZeros + rndByteSequence(len));
 			_result.insert(0, rlpblock);
@@ -216,7 +216,7 @@ std::string RandomCode::rndByteSequence(int _length, SizeStrictness _sizeType)
 	for (auto i = 0; i < _length; i++)
 	{
 		uint8_t byte = randOpCodeGen();
-		hash += toCompactHex(byte, HexPrefix::DontAdd, 1);
+		hash += toCompactHex(byte, 1);
 	}
 	return hash;
 }
@@ -245,7 +245,7 @@ std::string RandomCode::generate(int _maxOpNumber, RandomCodeOptions _options)
 			|| std::find(invalidOpcodes.begin(), invalidOpcodes.end(), inst) != invalidOpcodes.end())
 		{
 			if (_options.useUndefinedOpCodes)
-				code += toCompactHex(opcode, HexPrefix::DontAdd, 1);
+				code += toCompactHex(opcode, 1);
 			else
 			{
 				//Byte code is yet not implemented. do not count it.
@@ -263,7 +263,7 @@ std::string RandomCode::generate(int _maxOpNumber, RandomCodeOptions _options)
 			else
 			{
 				code += fillArguments(inst, _options);
-				code += toCompactHex(opcode, HexPrefix::DontAdd, 1);
+				code += toCompactHex(opcode, 1);
 			}
 		}
 	}
@@ -309,7 +309,7 @@ std::string RandomCode::getPushCode(std::string const& _hex)
 
 std::string RandomCode::getPushCode(int _value)
 {
-	std::string hexString = toCompactHex(_value, HexPrefix::DontAdd, 1);
+	std::string hexString = toCompactHex(_value, 1);
 	return getPushCode(hexString);
 }
 

--- a/test/tools/fuzzTesting/fuzzHelper.cpp
+++ b/test/tools/fuzzTesting/fuzzHelper.cpp
@@ -277,8 +277,8 @@ std::string RandomCode::randomUniIntHex(u256 _maxVal)
 	refreshSeed();
 	int rand = randUniIntGen() % 100;
 	if (rand < 50)
-		return toCompactHexPrefix((u256)randUniIntGen() % _maxVal);
-	return toCompactHexPrefix((u256)randUInt64Gen() % _maxVal);
+		return toCompactHexPrefixed((u256)randUniIntGen() % _maxVal);
+	return toCompactHexPrefixed((u256)randUInt64Gen() % _maxVal);
 }
 
 u256 RandomCode::randomUniInt(u256 _maxVal)

--- a/test/tools/fuzzTesting/fuzzHelper.cpp
+++ b/test/tools/fuzzTesting/fuzzHelper.cpp
@@ -277,8 +277,8 @@ std::string RandomCode::randomUniIntHex(u256 _maxVal)
 	refreshSeed();
 	int rand = randUniIntGen() % 100;
 	if (rand < 50)
-		return "0x" + toCompactHex((u256)randUniIntGen() % _maxVal);
-	return "0x" + toCompactHex((u256)randUInt64Gen() % _maxVal);
+		return toCompactHexPrefix((u256)randUniIntGen() % _maxVal);
+	return toCompactHexPrefix((u256)randUInt64Gen() % _maxVal);
 }
 
 u256 RandomCode::randomUniInt(u256 _maxVal)

--- a/test/tools/jsontests/BlockChainTests.cpp
+++ b/test/tools/jsontests/BlockChainTests.cpp
@@ -235,7 +235,7 @@ void fillBCTest(json_spirit::mObject& _o)
 	assert(testChain.interface().isKnown(genesisBlock.blockHeader().hash(WithSeal)));
 
 	_o["genesisBlockHeader"] = writeBlockHeaderToJson(genesisBlock.blockHeader());
-	_o["genesisRLP"] = toHex(genesisBlock.bytes(), 2, HexPrefix::Add);
+	_o["genesisRLP"] = "0x" + toHex(genesisBlock.bytes());
 	BOOST_REQUIRE(_o.count("blocks"));
 
 	mArray blArray;
@@ -326,7 +326,7 @@ void fillBCTest(json_spirit::mObject& _o)
 		if (blObj.count("blockHeader"))
 			overwriteBlockHeaderForTest(blObj.at("blockHeader").get_obj(), alterBlock, *chainMap[chainname]);
 
-		blObj["rlp"] = toHex(alterBlock.bytes(), 2, HexPrefix::Add);
+		blObj["rlp"] = "0x" + toHex(alterBlock.bytes());
 		blObj["blockHeader"] = writeBlockHeaderToJson(alterBlock.blockHeader());
 
 		mArray aUncleList;
@@ -812,12 +812,12 @@ mObject writeBlockHeaderToJson(BlockHeader const& _bi)
 	o["transactionsTrie"] = toString(_bi.transactionsRoot());
 	o["receiptTrie"] = toString(_bi.receiptsRoot());
 	o["bloom"] = toString(_bi.logBloom());
-	o["difficulty"] = toCompactHex(_bi.difficulty(), HexPrefix::Add, 1);
-	o["number"] = toCompactHex(_bi.number(), HexPrefix::Add, 1);
-	o["gasLimit"] = toCompactHex(_bi.gasLimit(), HexPrefix::Add, 1);
-	o["gasUsed"] = toCompactHex(_bi.gasUsed(), HexPrefix::Add, 1);
-	o["timestamp"] = toCompactHex(_bi.timestamp(), HexPrefix::Add, 1);
-	o["extraData"] = (_bi.extraData().size()) ? toHex(_bi.extraData(), 2, HexPrefix::Add) : "";
+	o["difficulty"] = "0x" + toCompactHex(_bi.difficulty(), 1);
+	o["number"] = "0x" + toCompactHex(_bi.number(), 1);
+	o["gasLimit"] = "0x" + toCompactHex(_bi.gasLimit(), 1);
+	o["gasUsed"] = "0x" + toCompactHex(_bi.gasUsed(), 1);
+	o["timestamp"] = "0x" + toCompactHex(_bi.timestamp(), 1);
+	o["extraData"] = (_bi.extraData().size()) ? "0x" + toHex(_bi.extraData()) : "";
 	o["mixHash"] = toString(Ethash::mixHash(_bi));
 	o["nonce"] = toString(Ethash::nonce(_bi));
 	o["hash"] = toString(_bi.hash());

--- a/test/tools/jsontests/BlockChainTests.cpp
+++ b/test/tools/jsontests/BlockChainTests.cpp
@@ -235,7 +235,7 @@ void fillBCTest(json_spirit::mObject& _o)
 	assert(testChain.interface().isKnown(genesisBlock.blockHeader().hash(WithSeal)));
 
 	_o["genesisBlockHeader"] = writeBlockHeaderToJson(genesisBlock.blockHeader());
-	_o["genesisRLP"] = "0x" + toHex(genesisBlock.bytes());
+	_o["genesisRLP"] = toHexPrefix(genesisBlock.bytes());
 	BOOST_REQUIRE(_o.count("blocks"));
 
 	mArray blArray;
@@ -326,7 +326,7 @@ void fillBCTest(json_spirit::mObject& _o)
 		if (blObj.count("blockHeader"))
 			overwriteBlockHeaderForTest(blObj.at("blockHeader").get_obj(), alterBlock, *chainMap[chainname]);
 
-		blObj["rlp"] = "0x" + toHex(alterBlock.bytes());
+		blObj["rlp"] = toHexPrefix(alterBlock.bytes());
 		blObj["blockHeader"] = writeBlockHeaderToJson(alterBlock.blockHeader());
 
 		mArray aUncleList;
@@ -812,12 +812,12 @@ mObject writeBlockHeaderToJson(BlockHeader const& _bi)
 	o["transactionsTrie"] = toString(_bi.transactionsRoot());
 	o["receiptTrie"] = toString(_bi.receiptsRoot());
 	o["bloom"] = toString(_bi.logBloom());
-	o["difficulty"] = "0x" + toCompactHex(_bi.difficulty(), 1);
-	o["number"] = "0x" + toCompactHex(_bi.number(), 1);
-	o["gasLimit"] = "0x" + toCompactHex(_bi.gasLimit(), 1);
-	o["gasUsed"] = "0x" + toCompactHex(_bi.gasUsed(), 1);
-	o["timestamp"] = "0x" + toCompactHex(_bi.timestamp(), 1);
-	o["extraData"] = (_bi.extraData().size()) ? "0x" + toHex(_bi.extraData()) : "";
+	o["difficulty"] = toCompactHexPrefix(_bi.difficulty(), 1);
+	o["number"] = toCompactHexPrefix(_bi.number(), 1);
+	o["gasLimit"] = toCompactHexPrefix(_bi.gasLimit(), 1);
+	o["gasUsed"] = toCompactHexPrefix(_bi.gasUsed(), 1);
+	o["timestamp"] = toCompactHexPrefix(_bi.timestamp(), 1);
+	o["extraData"] = (_bi.extraData().size()) ? toHexPrefix(_bi.extraData()) : "";
 	o["mixHash"] = toString(Ethash::mixHash(_bi));
 	o["nonce"] = toString(Ethash::nonce(_bi));
 	o["hash"] = toString(_bi.hash());

--- a/test/tools/jsontests/BlockChainTests.cpp
+++ b/test/tools/jsontests/BlockChainTests.cpp
@@ -395,7 +395,7 @@ void fillBCTest(json_spirit::mObject& _o)
 
 	_o["blocks"] = blArray;
 	_o["postState"] = fillJsonWithState(testChain.topBlock().state());
-	_o["lastblockhash"] = "0x" + toString(testChain.topBlock().blockHeader().hash(WithSeal));
+	_o["lastblockhash"] = toHexPrefixed(testChain.topBlock().blockHeader().hash(WithSeal));
 
 	//make all values hex in pre section
 	State prestate(State::Null);
@@ -528,7 +528,7 @@ void testBCTest(json_spirit::mObject& _o)
 
 	//Check lastblock hash
 	BOOST_REQUIRE((_o.count("lastblockhash") > 0));
-	string lastTrueBlockHash = "0x" + toString(testChain.topBlock().blockHeader().hash(WithSeal));
+	string lastTrueBlockHash = toHexPrefixed(testChain.topBlock().blockHeader().hash(WithSeal));
 	BOOST_CHECK_MESSAGE(lastTrueBlockHash == _o["lastblockhash"].get_str(),
 			testName + "Boost check: lastblockhash does not match " + lastTrueBlockHash + " expected: " + _o["lastblockhash"].get_str());
 

--- a/test/tools/jsontests/BlockChainTests.cpp
+++ b/test/tools/jsontests/BlockChainTests.cpp
@@ -235,7 +235,7 @@ void fillBCTest(json_spirit::mObject& _o)
 	assert(testChain.interface().isKnown(genesisBlock.blockHeader().hash(WithSeal)));
 
 	_o["genesisBlockHeader"] = writeBlockHeaderToJson(genesisBlock.blockHeader());
-	_o["genesisRLP"] = toHexPrefix(genesisBlock.bytes());
+	_o["genesisRLP"] = toHexPrefixed(genesisBlock.bytes());
 	BOOST_REQUIRE(_o.count("blocks"));
 
 	mArray blArray;
@@ -326,7 +326,7 @@ void fillBCTest(json_spirit::mObject& _o)
 		if (blObj.count("blockHeader"))
 			overwriteBlockHeaderForTest(blObj.at("blockHeader").get_obj(), alterBlock, *chainMap[chainname]);
 
-		blObj["rlp"] = toHexPrefix(alterBlock.bytes());
+		blObj["rlp"] = toHexPrefixed(alterBlock.bytes());
 		blObj["blockHeader"] = writeBlockHeaderToJson(alterBlock.blockHeader());
 
 		mArray aUncleList;
@@ -812,12 +812,12 @@ mObject writeBlockHeaderToJson(BlockHeader const& _bi)
 	o["transactionsTrie"] = toString(_bi.transactionsRoot());
 	o["receiptTrie"] = toString(_bi.receiptsRoot());
 	o["bloom"] = toString(_bi.logBloom());
-	o["difficulty"] = toCompactHexPrefix(_bi.difficulty(), 1);
-	o["number"] = toCompactHexPrefix(_bi.number(), 1);
-	o["gasLimit"] = toCompactHexPrefix(_bi.gasLimit(), 1);
-	o["gasUsed"] = toCompactHexPrefix(_bi.gasUsed(), 1);
-	o["timestamp"] = toCompactHexPrefix(_bi.timestamp(), 1);
-	o["extraData"] = (_bi.extraData().size()) ? toHexPrefix(_bi.extraData()) : "";
+	o["difficulty"] = toCompactHexPrefixed(_bi.difficulty(), 1);
+	o["number"] = toCompactHexPrefixed(_bi.number(), 1);
+	o["gasLimit"] = toCompactHexPrefixed(_bi.gasLimit(), 1);
+	o["gasUsed"] = toCompactHexPrefixed(_bi.gasUsed(), 1);
+	o["timestamp"] = toCompactHexPrefixed(_bi.timestamp(), 1);
+	o["extraData"] = (_bi.extraData().size()) ? toHexPrefixed(_bi.extraData()) : "";
 	o["mixHash"] = toString(Ethash::mixHash(_bi));
 	o["nonce"] = toString(Ethash::nonce(_bi));
 	o["hash"] = toString(_bi.hash());

--- a/test/tools/jsontests/TransactionTests.cpp
+++ b/test/tools/jsontests/TransactionTests.cpp
@@ -63,7 +63,7 @@ void doTransactionTests(json_spirit::mValue& _v, bool _fillin)
 
 			//Construct Rlp of the given transaction
 			RLPStream rlpStream = createRLPStreamFromTransactionFields(tObj);
-			o["rlp"] = toHexPrefix(rlpStream.out());
+			o["rlp"] = toHexPrefixed(rlpStream.out());
 
 			try
 			{

--- a/test/tools/jsontests/TransactionTests.cpp
+++ b/test/tools/jsontests/TransactionTests.cpp
@@ -63,7 +63,7 @@ void doTransactionTests(json_spirit::mValue& _v, bool _fillin)
 
 			//Construct Rlp of the given transaction
 			RLPStream rlpStream = createRLPStreamFromTransactionFields(tObj);
-			o["rlp"] = "0x" + toHex(rlpStream.out());
+			o["rlp"] = toHexPrefix(rlpStream.out());
 
 			try
 			{

--- a/test/tools/jsontests/TransactionTests.cpp
+++ b/test/tools/jsontests/TransactionTests.cpp
@@ -63,7 +63,7 @@ void doTransactionTests(json_spirit::mValue& _v, bool _fillin)
 
 			//Construct Rlp of the given transaction
 			RLPStream rlpStream = createRLPStreamFromTransactionFields(tObj);
-			o["rlp"] = toHex(rlpStream.out(), 2, HexPrefix::Add);
+			o["rlp"] = "0x" + toHex(rlpStream.out());
 
 			try
 			{

--- a/test/tools/jsontests/vm.cpp
+++ b/test/tools/jsontests/vm.cpp
@@ -81,11 +81,11 @@ void FakeExtVM::reset(u256 _myBalance, u256 _myNonce, map<u256, u256> const& _st
 mObject FakeExtVM::exportEnv()
 {
 	mObject ret;
-	ret["currentDifficulty"] = "0x" + toCompactHex(envInfo().difficulty(), 1);
-	ret["currentTimestamp"] =  "0x" + toCompactHex(envInfo().timestamp(), 1);
+	ret["currentDifficulty"] = toCompactHexPrefix(envInfo().difficulty(), 1);
+	ret["currentTimestamp"] =  toCompactHexPrefix(envInfo().timestamp(), 1);
 	ret["currentCoinbase"] = "0x" + toString(envInfo().author());
-	ret["currentNumber"] = "0x" + toCompactHex(envInfo().number(), 1);
-	ret["currentGasLimit"] = "0x" + toCompactHex(envInfo().gasLimit(), 1);
+	ret["currentNumber"] = toCompactHexPrefix(envInfo().number(), 1);
+	ret["currentGasLimit"] = toCompactHexPrefix(envInfo().gasLimit(), 1);
 	return ret;
 }
 
@@ -115,15 +115,15 @@ mObject FakeExtVM::exportState()
 	for (auto const& a: addresses)
 	{
 		mObject o;
-		o["balance"] = "0x" + toCompactHex(get<0>(a.second), 1);
-		o["nonce"] = "0x" + toCompactHex(get<1>(a.second), 1);
+		o["balance"] = toCompactHexPrefix(get<0>(a.second), 1);
+		o["nonce"] = toCompactHexPrefix(get<1>(a.second), 1);
 		{
 			mObject store;
 			for (auto const& s: get<2>(a.second))
-				store["0x" + toCompactHex(s.first, 1)] = toCompactHex(s.second, 1);
+				store[toCompactHexPrefix(s.first, 1)] = toCompactHexPrefix(s.second, 1);
 			o["storage"] = store;
 		}
-		o["code"] = "0x" + toHex(get<3>(a.second));
+		o["code"] = toHexPrefix(get<3>(a.second));
 		ret["0x" + toString(a.first)] = o;
 	}
 	return ret;
@@ -156,11 +156,11 @@ mObject FakeExtVM::exportExec()
 	ret["address"] = "0x" + toString(myAddress);
 	ret["caller"] = "0x" + toString(caller);
 	ret["origin"] = "0x" + toString(origin);
-	ret["value"] = "0x" + toCompactHex(value, 1);
-	ret["gasPrice"] = "0x" + toCompactHex(gasPrice, 1);
-	ret["gas"] = "0x" + toCompactHex(execGas, 1);
-	ret["data"] = "0x" + toHex(data);
-	ret["code"] = "0x" + toHex(code);
+	ret["value"] = toCompactHexPrefix(value, 1);
+	ret["gasPrice"] = toCompactHexPrefix(gasPrice, 1);
+	ret["gas"] = toCompactHexPrefix(execGas, 1);
+	ret["data"] = toHexPrefix(data);
+	ret["code"] = toHexPrefix(code);
 	return ret;
 }
 
@@ -203,9 +203,9 @@ mArray FakeExtVM::exportCallCreates()
 	{
 		mObject o;
 		o["destination"] = tx.isCreation() ? "" : "0x" + toString(tx.receiveAddress());
-		o["gasLimit"] = "0x" + toCompactHex(tx.gas(), 1);
-		o["value"] = "0x" + toCompactHex(tx.value(), 1);
-		o["data"] = "0x" + toHex(tx.data());
+		o["gasLimit"] = toCompactHexPrefix(tx.gas(), 1);
+		o["value"] = toCompactHexPrefix(tx.value(), 1);
+		o["data"] = toHexPrefix(tx.data());
 		ret.push_back(o);
 	}
 	return ret;
@@ -394,7 +394,7 @@ void doVMTests(json_spirit::mValue& _v, bool _fillin)
 				}
 
 				o["callcreates"] = fev.exportCallCreates();
-				o["out"] = output.size() > 4096 ? "#" + toString(output.size()) : "0x" + toHex(output);
+				o["out"] = output.size() > 4096 ? "#" + toString(output.size()) : toHexPrefix(output);
 
 				// compare expected output with post output
 				if (o.count("expectOut") > 0)
@@ -408,7 +408,7 @@ void doVMTests(json_spirit::mValue& _v, bool _fillin)
 					o.erase(o.find("expectOut"));
 				}
 
-				o["gas"] = "0x" + toCompactHex(fev.gas, 1);
+				o["gas"] = toCompactHexPrefix(fev.gas, 1);
 				o["logs"] = exportLog(fev.sub.logs);
 			}
 		}

--- a/test/tools/jsontests/vm.cpp
+++ b/test/tools/jsontests/vm.cpp
@@ -81,11 +81,11 @@ void FakeExtVM::reset(u256 _myBalance, u256 _myNonce, map<u256, u256> const& _st
 mObject FakeExtVM::exportEnv()
 {
 	mObject ret;
-	ret["currentDifficulty"] = toCompactHexPrefix(envInfo().difficulty(), 1);
-	ret["currentTimestamp"] =  toCompactHexPrefix(envInfo().timestamp(), 1);
+	ret["currentDifficulty"] = toCompactHexPrefixed(envInfo().difficulty(), 1);
+	ret["currentTimestamp"] =  toCompactHexPrefixed(envInfo().timestamp(), 1);
 	ret["currentCoinbase"] = "0x" + toString(envInfo().author());
-	ret["currentNumber"] = toCompactHexPrefix(envInfo().number(), 1);
-	ret["currentGasLimit"] = toCompactHexPrefix(envInfo().gasLimit(), 1);
+	ret["currentNumber"] = toCompactHexPrefixed(envInfo().number(), 1);
+	ret["currentGasLimit"] = toCompactHexPrefixed(envInfo().gasLimit(), 1);
 	return ret;
 }
 
@@ -115,15 +115,15 @@ mObject FakeExtVM::exportState()
 	for (auto const& a: addresses)
 	{
 		mObject o;
-		o["balance"] = toCompactHexPrefix(get<0>(a.second), 1);
-		o["nonce"] = toCompactHexPrefix(get<1>(a.second), 1);
+		o["balance"] = toCompactHexPrefixed(get<0>(a.second), 1);
+		o["nonce"] = toCompactHexPrefixed(get<1>(a.second), 1);
 		{
 			mObject store;
 			for (auto const& s: get<2>(a.second))
-				store[toCompactHexPrefix(s.first, 1)] = toCompactHexPrefix(s.second, 1);
+				store[toCompactHexPrefixed(s.first, 1)] = toCompactHexPrefixed(s.second, 1);
 			o["storage"] = store;
 		}
-		o["code"] = toHexPrefix(get<3>(a.second));
+		o["code"] = toHexPrefixed(get<3>(a.second));
 		ret["0x" + toString(a.first)] = o;
 	}
 	return ret;
@@ -156,11 +156,11 @@ mObject FakeExtVM::exportExec()
 	ret["address"] = "0x" + toString(myAddress);
 	ret["caller"] = "0x" + toString(caller);
 	ret["origin"] = "0x" + toString(origin);
-	ret["value"] = toCompactHexPrefix(value, 1);
-	ret["gasPrice"] = toCompactHexPrefix(gasPrice, 1);
-	ret["gas"] = toCompactHexPrefix(execGas, 1);
-	ret["data"] = toHexPrefix(data);
-	ret["code"] = toHexPrefix(code);
+	ret["value"] = toCompactHexPrefixed(value, 1);
+	ret["gasPrice"] = toCompactHexPrefixed(gasPrice, 1);
+	ret["gas"] = toCompactHexPrefixed(execGas, 1);
+	ret["data"] = toHexPrefixed(data);
+	ret["code"] = toHexPrefixed(code);
 	return ret;
 }
 
@@ -203,9 +203,9 @@ mArray FakeExtVM::exportCallCreates()
 	{
 		mObject o;
 		o["destination"] = tx.isCreation() ? "" : "0x" + toString(tx.receiveAddress());
-		o["gasLimit"] = toCompactHexPrefix(tx.gas(), 1);
-		o["value"] = toCompactHexPrefix(tx.value(), 1);
-		o["data"] = toHexPrefix(tx.data());
+		o["gasLimit"] = toCompactHexPrefixed(tx.gas(), 1);
+		o["value"] = toCompactHexPrefixed(tx.value(), 1);
+		o["data"] = toHexPrefixed(tx.data());
 		ret.push_back(o);
 	}
 	return ret;
@@ -394,7 +394,7 @@ void doVMTests(json_spirit::mValue& _v, bool _fillin)
 				}
 
 				o["callcreates"] = fev.exportCallCreates();
-				o["out"] = output.size() > 4096 ? "#" + toString(output.size()) : toHexPrefix(output);
+				o["out"] = output.size() > 4096 ? "#" + toString(output.size()) : toHexPrefixed(output);
 
 				// compare expected output with post output
 				if (o.count("expectOut") > 0)
@@ -408,7 +408,7 @@ void doVMTests(json_spirit::mValue& _v, bool _fillin)
 					o.erase(o.find("expectOut"));
 				}
 
-				o["gas"] = toCompactHexPrefix(fev.gas, 1);
+				o["gas"] = toCompactHexPrefixed(fev.gas, 1);
 				o["logs"] = exportLog(fev.sub.logs);
 			}
 		}

--- a/test/tools/jsontests/vm.cpp
+++ b/test/tools/jsontests/vm.cpp
@@ -81,11 +81,11 @@ void FakeExtVM::reset(u256 _myBalance, u256 _myNonce, map<u256, u256> const& _st
 mObject FakeExtVM::exportEnv()
 {
 	mObject ret;
-	ret["currentDifficulty"] = toCompactHex(envInfo().difficulty(), HexPrefix::Add, 1);
-	ret["currentTimestamp"] =  toCompactHex(envInfo().timestamp(), HexPrefix::Add, 1);
+	ret["currentDifficulty"] = "0x" + toCompactHex(envInfo().difficulty(), 1);
+	ret["currentTimestamp"] =  "0x" + toCompactHex(envInfo().timestamp(), 1);
 	ret["currentCoinbase"] = "0x" + toString(envInfo().author());
-	ret["currentNumber"] = toCompactHex(envInfo().number(), HexPrefix::Add, 1);
-	ret["currentGasLimit"] = toCompactHex(envInfo().gasLimit(), HexPrefix::Add, 1);
+	ret["currentNumber"] = "0x" + toCompactHex(envInfo().number(), 1);
+	ret["currentGasLimit"] = "0x" + toCompactHex(envInfo().gasLimit(), 1);
 	return ret;
 }
 
@@ -115,15 +115,15 @@ mObject FakeExtVM::exportState()
 	for (auto const& a: addresses)
 	{
 		mObject o;
-		o["balance"] = toCompactHex(get<0>(a.second), HexPrefix::Add, 1);
-		o["nonce"] = toCompactHex(get<1>(a.second), HexPrefix::Add, 1);
+		o["balance"] = "0x" + toCompactHex(get<0>(a.second), 1);
+		o["nonce"] = "0x" + toCompactHex(get<1>(a.second), 1);
 		{
 			mObject store;
 			for (auto const& s: get<2>(a.second))
-				store[toCompactHex(s.first, HexPrefix::Add, 1)] = toCompactHex(s.second, HexPrefix::Add, 1);
+				store["0x" + toCompactHex(s.first, 1)] = toCompactHex(s.second, 1);
 			o["storage"] = store;
 		}
-		o["code"] = toHex(get<3>(a.second), 2, HexPrefix::Add);
+		o["code"] = "0x" + toHex(get<3>(a.second));
 		ret["0x" + toString(a.first)] = o;
 	}
 	return ret;
@@ -156,11 +156,11 @@ mObject FakeExtVM::exportExec()
 	ret["address"] = "0x" + toString(myAddress);
 	ret["caller"] = "0x" + toString(caller);
 	ret["origin"] = "0x" + toString(origin);
-	ret["value"] = toCompactHex(value, HexPrefix::Add, 1);
-	ret["gasPrice"] = toCompactHex(gasPrice, HexPrefix::Add, 1);
-	ret["gas"] = toCompactHex(execGas, HexPrefix::Add, 1);
-	ret["data"] = toHex(data, 2, HexPrefix::Add);
-	ret["code"] = toHex(code, 2, HexPrefix::Add);
+	ret["value"] = "0x" + toCompactHex(value, 1);
+	ret["gasPrice"] = "0x" + toCompactHex(gasPrice, 1);
+	ret["gas"] = "0x" + toCompactHex(execGas, 1);
+	ret["data"] = "0x" + toHex(data);
+	ret["code"] = "0x" + toHex(code);
 	return ret;
 }
 
@@ -203,9 +203,9 @@ mArray FakeExtVM::exportCallCreates()
 	{
 		mObject o;
 		o["destination"] = tx.isCreation() ? "" : "0x" + toString(tx.receiveAddress());
-		o["gasLimit"] = toCompactHex(tx.gas(), HexPrefix::Add, 1);
-		o["value"] = toCompactHex(tx.value(), HexPrefix::Add, 1);
-		o["data"] = toHex(tx.data(), 2, HexPrefix::Add);
+		o["gasLimit"] = "0x" + toCompactHex(tx.gas(), 1);
+		o["value"] = "0x" + toCompactHex(tx.value(), 1);
+		o["data"] = "0x" + toHex(tx.data());
 		ret.push_back(o);
 	}
 	return ret;
@@ -394,7 +394,7 @@ void doVMTests(json_spirit::mValue& _v, bool _fillin)
 				}
 
 				o["callcreates"] = fev.exportCallCreates();
-				o["out"] = output.size() > 4096 ? "#" + toString(output.size()) : toHex(output, 2, HexPrefix::Add);
+				o["out"] = output.size() > 4096 ? "#" + toString(output.size()) : "0x" + toHex(output);
 
 				// compare expected output with post output
 				if (o.count("expectOut") > 0)
@@ -408,7 +408,7 @@ void doVMTests(json_spirit::mValue& _v, bool _fillin)
 					o.erase(o.find("expectOut"));
 				}
 
-				o["gas"] = toCompactHex(fev.gas, HexPrefix::Add, 1);
+				o["gas"] = "0x" + toCompactHex(fev.gas, 1);
 				o["logs"] = exportLog(fev.sub.logs);
 			}
 		}

--- a/test/tools/jsontests/vm.cpp
+++ b/test/tools/jsontests/vm.cpp
@@ -83,7 +83,7 @@ mObject FakeExtVM::exportEnv()
 	mObject ret;
 	ret["currentDifficulty"] = toCompactHexPrefixed(envInfo().difficulty(), 1);
 	ret["currentTimestamp"] =  toCompactHexPrefixed(envInfo().timestamp(), 1);
-	ret["currentCoinbase"] = "0x" + toString(envInfo().author());
+	ret["currentCoinbase"] = toHexPrefixed(envInfo().author());
 	ret["currentNumber"] = toCompactHexPrefixed(envInfo().number(), 1);
 	ret["currentGasLimit"] = toCompactHexPrefixed(envInfo().gasLimit(), 1);
 	return ret;
@@ -124,7 +124,7 @@ mObject FakeExtVM::exportState()
 			o["storage"] = store;
 		}
 		o["code"] = toHexPrefixed(get<3>(a.second));
-		ret["0x" + toString(a.first)] = o;
+		ret[toHexPrefixed(a.first)] = o;
 	}
 	return ret;
 }
@@ -153,9 +153,9 @@ void FakeExtVM::importState(mObject& _object)
 mObject FakeExtVM::exportExec()
 {
 	mObject ret;
-	ret["address"] = "0x" + toString(myAddress);
-	ret["caller"] = "0x" + toString(caller);
-	ret["origin"] = "0x" + toString(origin);
+	ret["address"] = toHexPrefixed(myAddress);
+	ret["caller"] = toHexPrefixed(caller);
+	ret["origin"] = toHexPrefixed(origin);
 	ret["value"] = toCompactHexPrefixed(value, 1);
 	ret["gasPrice"] = toCompactHexPrefixed(gasPrice, 1);
 	ret["gas"] = toCompactHexPrefixed(execGas, 1);
@@ -202,7 +202,7 @@ mArray FakeExtVM::exportCallCreates()
 	for (Transaction const& tx: callcreates)
 	{
 		mObject o;
-		o["destination"] = tx.isCreation() ? "" : "0x" + toString(tx.receiveAddress());
+		o["destination"] = tx.isCreation() ? "" : toHexPrefixed(tx.receiveAddress());
 		o["gasLimit"] = toCompactHexPrefixed(tx.gas(), 1);
 		o["value"] = toCompactHexPrefixed(tx.value(), 1);
 		o["data"] = toHexPrefixed(tx.data());

--- a/test/tools/libtesteth/FillJsonFunctions.cpp
+++ b/test/tools/libtesteth/FillJsonFunctions.cpp
@@ -39,15 +39,15 @@ namespace test
 json_spirit::mObject fillJsonWithTransaction(Transaction const& _txn)
 {
 	json_spirit::mObject txObject;
-	txObject["nonce"] = toCompactHexPrefix(_txn.nonce(), 1);
-	txObject["data"] = _txn.data().size() ? toHexPrefix(_txn.data()) : "";
-	txObject["gasLimit"] = toCompactHexPrefix(_txn.gas(), 1);
-	txObject["gasPrice"] = toCompactHexPrefix(_txn.gasPrice(), 1);
-	txObject["r"] = toCompactHexPrefix(_txn.signature().r, 1);
-	txObject["s"] = toCompactHexPrefix(_txn.signature().s, 1);
-	txObject["v"] = toCompactHexPrefix(_txn.signature().v + 27, 1);
+	txObject["nonce"] = toCompactHexPrefixed(_txn.nonce(), 1);
+	txObject["data"] = _txn.data().size() ? toHexPrefixed(_txn.data()) : "";
+	txObject["gasLimit"] = toCompactHexPrefixed(_txn.gas(), 1);
+	txObject["gasPrice"] = toCompactHexPrefixed(_txn.gasPrice(), 1);
+	txObject["r"] = toCompactHexPrefixed(_txn.signature().r, 1);
+	txObject["s"] = toCompactHexPrefixed(_txn.signature().s, 1);
+	txObject["v"] = toCompactHexPrefixed(_txn.signature().v + 27, 1);
 	txObject["to"] = _txn.isCreation() ? "" : "0x" + toString(_txn.receiveAddress());
-	txObject["value"] = toCompactHexPrefix(_txn.value(), 1);
+	txObject["value"] = toCompactHexPrefixed(_txn.value(), 1);
 	ImportTest::makeAllFieldsHex(txObject);
 	return txObject;
 }
@@ -90,8 +90,8 @@ json_spirit::mObject fillJsonWithStateChange(State const& _stateOrig, eth::State
 			{
 				case Change::Kind::Code:
 					//take the original and final code only
-					before = toHexPrefix(_stateOrig.code(change.address));
-					after = toHexPrefix(_statePost.code(change.address));
+					before = toHexPrefixed(_stateOrig.code(change.address));
+					after = toHexPrefixed(_statePost.code(change.address));
 					record.push_back(before);
 					record.push_back("->");
 					record.push_back(after);
@@ -100,8 +100,8 @@ json_spirit::mObject fillJsonWithStateChange(State const& _stateOrig, eth::State
 				break;
 				case Change::Kind::Nonce:
 					//take the original and final nonce only
-					before = toCompactHexPrefix(_stateOrig.getNonce(change.address), 1);
-					after = toCompactHexPrefix(_statePost.getNonce(change.address), 1);
+					before = toCompactHexPrefixed(_stateOrig.getNonce(change.address), 1);
+					after = toCompactHexPrefixed(_statePost.getNonce(change.address), 1);
 					record.push_back(before);
 					record.push_back("->");
 					record.push_back(after);
@@ -109,8 +109,8 @@ json_spirit::mObject fillJsonWithStateChange(State const& _stateOrig, eth::State
 					logInfo["nonce"] << "'nonce' : ['" + before + "', '->', '" + after + "']" << std::endl;
 				break;
 				case Change::Kind::Balance:
-					before = toCompactHexPrefix(tmpBalance, 1);
-					after = toCompactHexPrefix(change.value, 1);
+					before = toCompactHexPrefixed(tmpBalance, 1);
+					after = toCompactHexPrefixed(change.value, 1);
 					record.push_back(before);
 					record.push_back("+=");
 					record.push_back(after);
@@ -124,8 +124,8 @@ json_spirit::mObject fillJsonWithStateChange(State const& _stateOrig, eth::State
 				break;
 				case Change::Kind::Storage:
 					//take the original and final storage only
-					before = toCompactHexPrefix(change.key, 1) + " : " + toCompactHexPrefix(_stateOrig.storage(change.address, change.key), 1);
-					after = toCompactHexPrefix(change.key, 1) + " : " + toCompactHexPrefix(_statePost.storage(change.address, change.key), 1);
+					before = toCompactHexPrefixed(change.key, 1) + " : " + toCompactHexPrefixed(_stateOrig.storage(change.address, change.key), 1);
+					after = toCompactHexPrefixed(change.key, 1) + " : " + toCompactHexPrefixed(_statePost.storage(change.address, change.key), 1);
 					record.push_back(before);
 					record.push_back("->");
 					record.push_back(after);
@@ -149,8 +149,8 @@ json_spirit::mObject fillJsonWithStateChange(State const& _stateOrig, eth::State
 		if (agregatedBalance.size())
 		{
 			json_spirit::mArray record;
-			string before = toCompactHexPrefix(_stateOrig.balance(currentAddress), 1);
-			string after = toCompactHexPrefix(_statePost.balance(currentAddress), 1);
+			string before = toCompactHexPrefixed(_stateOrig.balance(currentAddress), 1);
+			string after = toCompactHexPrefixed(_statePost.balance(currentAddress), 1);
 			record.push_back(before);
 			record.push_back("->");
 			record.push_back(after);
@@ -187,22 +187,22 @@ json_spirit::mObject fillJsonWithState(State const& _state, eth::AccountMaskMap 
 
 		json_spirit::mObject o;
 		if (mapEmpty || _map.at(a.first).hasBalance())
-			o["balance"] = toCompactHexPrefix(_state.balance(a.first), 1);
+			o["balance"] = toCompactHexPrefixed(_state.balance(a.first), 1);
 		if (mapEmpty || _map.at(a.first).hasNonce())
-			o["nonce"] = toCompactHexPrefix(_state.getNonce(a.first), 1);
+			o["nonce"] = toCompactHexPrefixed(_state.getNonce(a.first), 1);
 
 		if (mapEmpty || _map.at(a.first).hasStorage())
 		{
 			json_spirit::mObject store;
 			for (auto const& s: _state.storage(a.first))
-				store[toCompactHexPrefix(s.second.first, 1)] = toCompactHexPrefix(s.second.second, 1);
+				store[toCompactHexPrefixed(s.second.first, 1)] = toCompactHexPrefixed(s.second.second, 1);
 			o["storage"] = store;
 		}
 
 		if (mapEmpty || _map.at(a.first).hasCode())
 		{
 			if (_state.code(a.first).size() > 0)
-				o["code"] = toHexPrefix(_state.code(a.first));
+				o["code"] = toHexPrefixed(_state.code(a.first));
 			else
 				o["code"] = "";
 		}

--- a/test/tools/libtesteth/FillJsonFunctions.cpp
+++ b/test/tools/libtesteth/FillJsonFunctions.cpp
@@ -39,15 +39,15 @@ namespace test
 json_spirit::mObject fillJsonWithTransaction(Transaction const& _txn)
 {
 	json_spirit::mObject txObject;
-	txObject["nonce"] = "0x" + toCompactHex(_txn.nonce(), 1);
-	txObject["data"] = _txn.data().size() ? "0x" + toHex(_txn.data()) : "";
-	txObject["gasLimit"] = "0x" + toCompactHex(_txn.gas(), 1);
-	txObject["gasPrice"] = "0x" + toCompactHex(_txn.gasPrice(), 1);
-	txObject["r"] = "0x" + toCompactHex(_txn.signature().r, 1);
-	txObject["s"] = "0x" + toCompactHex(_txn.signature().s, 1);
-	txObject["v"] = "0x" + toCompactHex(_txn.signature().v + 27, 1);
+	txObject["nonce"] = toCompactHexPrefix(_txn.nonce(), 1);
+	txObject["data"] = _txn.data().size() ? toHexPrefix(_txn.data()) : "";
+	txObject["gasLimit"] = toCompactHexPrefix(_txn.gas(), 1);
+	txObject["gasPrice"] = toCompactHexPrefix(_txn.gasPrice(), 1);
+	txObject["r"] = toCompactHexPrefix(_txn.signature().r, 1);
+	txObject["s"] = toCompactHexPrefix(_txn.signature().s, 1);
+	txObject["v"] = toCompactHexPrefix(_txn.signature().v + 27, 1);
 	txObject["to"] = _txn.isCreation() ? "" : "0x" + toString(_txn.receiveAddress());
-	txObject["value"] = "0x" + toCompactHex(_txn.value(), 1);
+	txObject["value"] = toCompactHexPrefix(_txn.value(), 1);
 	ImportTest::makeAllFieldsHex(txObject);
 	return txObject;
 }
@@ -90,8 +90,8 @@ json_spirit::mObject fillJsonWithStateChange(State const& _stateOrig, eth::State
 			{
 				case Change::Kind::Code:
 					//take the original and final code only
-					before = "0x" + toHex(_stateOrig.code(change.address));
-					after = "0x" + toHex(_statePost.code(change.address));
+					before = toHexPrefix(_stateOrig.code(change.address));
+					after = toHexPrefix(_statePost.code(change.address));
 					record.push_back(before);
 					record.push_back("->");
 					record.push_back(after);
@@ -100,8 +100,8 @@ json_spirit::mObject fillJsonWithStateChange(State const& _stateOrig, eth::State
 				break;
 				case Change::Kind::Nonce:
 					//take the original and final nonce only
-					before = "0x" + toCompactHex(_stateOrig.getNonce(change.address), 1);
-					after = "0x" + toCompactHex(_statePost.getNonce(change.address), 1);
+					before = toCompactHexPrefix(_stateOrig.getNonce(change.address), 1);
+					after = toCompactHexPrefix(_statePost.getNonce(change.address), 1);
 					record.push_back(before);
 					record.push_back("->");
 					record.push_back(after);
@@ -109,8 +109,8 @@ json_spirit::mObject fillJsonWithStateChange(State const& _stateOrig, eth::State
 					logInfo["nonce"] << "'nonce' : ['" + before + "', '->', '" + after + "']" << std::endl;
 				break;
 				case Change::Kind::Balance:
-					before = "0x" + toCompactHex(tmpBalance, 1);
-					after = "0x" + toCompactHex(change.value, 1);
+					before = toCompactHexPrefix(tmpBalance, 1);
+					after = toCompactHexPrefix(change.value, 1);
 					record.push_back(before);
 					record.push_back("+=");
 					record.push_back(after);
@@ -124,8 +124,8 @@ json_spirit::mObject fillJsonWithStateChange(State const& _stateOrig, eth::State
 				break;
 				case Change::Kind::Storage:
 					//take the original and final storage only
-					before = "0x" + toCompactHex(change.key, 1) + " : " + toCompactHex(_stateOrig.storage(change.address, change.key), 1);
-					after = "0x" + toCompactHex(change.key, 1) + " : " + toCompactHex(_statePost.storage(change.address, change.key), 1);
+					before = toCompactHexPrefix(change.key, 1) + " : " + toCompactHexPrefix(_stateOrig.storage(change.address, change.key), 1);
+					after = toCompactHexPrefix(change.key, 1) + " : " + toCompactHexPrefix(_statePost.storage(change.address, change.key), 1);
 					record.push_back(before);
 					record.push_back("->");
 					record.push_back(after);
@@ -149,8 +149,8 @@ json_spirit::mObject fillJsonWithStateChange(State const& _stateOrig, eth::State
 		if (agregatedBalance.size())
 		{
 			json_spirit::mArray record;
-			string before = "0x" + toCompactHex(_stateOrig.balance(currentAddress), 1);
-			string after = "0x" + toCompactHex(_statePost.balance(currentAddress), 1);
+			string before = toCompactHexPrefix(_stateOrig.balance(currentAddress), 1);
+			string after = toCompactHexPrefix(_statePost.balance(currentAddress), 1);
 			record.push_back(before);
 			record.push_back("->");
 			record.push_back(after);
@@ -187,22 +187,22 @@ json_spirit::mObject fillJsonWithState(State const& _state, eth::AccountMaskMap 
 
 		json_spirit::mObject o;
 		if (mapEmpty || _map.at(a.first).hasBalance())
-			o["balance"] = "0x" + toCompactHex(_state.balance(a.first), 1);
+			o["balance"] = toCompactHexPrefix(_state.balance(a.first), 1);
 		if (mapEmpty || _map.at(a.first).hasNonce())
-			o["nonce"] = "0x" + toCompactHex(_state.getNonce(a.first), 1);
+			o["nonce"] = toCompactHexPrefix(_state.getNonce(a.first), 1);
 
 		if (mapEmpty || _map.at(a.first).hasStorage())
 		{
 			json_spirit::mObject store;
 			for (auto const& s: _state.storage(a.first))
-				store["0x" + toCompactHex(s.second.first, 1)] = toCompactHex(s.second.second, 1);
+				store[toCompactHexPrefix(s.second.first, 1)] = toCompactHexPrefix(s.second.second, 1);
 			o["storage"] = store;
 		}
 
 		if (mapEmpty || _map.at(a.first).hasCode())
 		{
 			if (_state.code(a.first).size() > 0)
-				o["code"] = "0x" + toHex(_state.code(a.first));
+				o["code"] = toHexPrefix(_state.code(a.first));
 			else
 				o["code"] = "";
 		}

--- a/test/tools/libtesteth/FillJsonFunctions.cpp
+++ b/test/tools/libtesteth/FillJsonFunctions.cpp
@@ -46,7 +46,7 @@ json_spirit::mObject fillJsonWithTransaction(Transaction const& _txn)
 	txObject["r"] = toCompactHexPrefixed(_txn.signature().r, 1);
 	txObject["s"] = toCompactHexPrefixed(_txn.signature().s, 1);
 	txObject["v"] = toCompactHexPrefixed(_txn.signature().v + 27, 1);
-	txObject["to"] = _txn.isCreation() ? "" : "0x" + toString(_txn.receiveAddress());
+	txObject["to"] = _txn.isCreation() ? "" : toHexPrefixed(_txn.receiveAddress());
 	txObject["value"] = toCompactHexPrefixed(_txn.value(), 1);
 	ImportTest::makeAllFieldsHex(txObject);
 	return txObject;
@@ -160,7 +160,7 @@ json_spirit::mObject fillJsonWithStateChange(State const& _stateOrig, eth::State
 		}
 
 		//commit changes
-		oState["0x" + toString(currentAddress)] = o;
+		oState[toHexPrefixed(currentAddress)] = o;
 		log << endl << currentAddress << endl;
 		for (std::map<string, ostringstream>::iterator it = logInfo.begin(); it != logInfo.end(); it++)
 			log << (*it).second.str();
@@ -206,7 +206,7 @@ json_spirit::mObject fillJsonWithState(State const& _state, eth::AccountMaskMap 
 			else
 				o["code"] = "";
 		}
-		oState["0x" + toString(a.first)] = o;
+		oState[toHexPrefixed(a.first)] = o;
 	}
 	return oState;
 }

--- a/test/tools/libtesteth/FillJsonFunctions.cpp
+++ b/test/tools/libtesteth/FillJsonFunctions.cpp
@@ -39,15 +39,15 @@ namespace test
 json_spirit::mObject fillJsonWithTransaction(Transaction const& _txn)
 {
 	json_spirit::mObject txObject;
-	txObject["nonce"] = toCompactHex(_txn.nonce(), HexPrefix::Add, 1);
-	txObject["data"] = _txn.data().size() ? toHex(_txn.data(), 2, HexPrefix::Add) : "";
-	txObject["gasLimit"] = toCompactHex(_txn.gas(), HexPrefix::Add, 1);
-	txObject["gasPrice"] = toCompactHex(_txn.gasPrice(), HexPrefix::Add, 1);
-	txObject["r"] = toCompactHex(_txn.signature().r, HexPrefix::Add, 1);
-	txObject["s"] = toCompactHex(_txn.signature().s, HexPrefix::Add, 1);
-	txObject["v"] = toCompactHex(_txn.signature().v + 27, HexPrefix::Add, 1);
+	txObject["nonce"] = "0x" + toCompactHex(_txn.nonce(), 1);
+	txObject["data"] = _txn.data().size() ? "0x" + toHex(_txn.data()) : "";
+	txObject["gasLimit"] = "0x" + toCompactHex(_txn.gas(), 1);
+	txObject["gasPrice"] = "0x" + toCompactHex(_txn.gasPrice(), 1);
+	txObject["r"] = "0x" + toCompactHex(_txn.signature().r, 1);
+	txObject["s"] = "0x" + toCompactHex(_txn.signature().s, 1);
+	txObject["v"] = "0x" + toCompactHex(_txn.signature().v + 27, 1);
 	txObject["to"] = _txn.isCreation() ? "" : "0x" + toString(_txn.receiveAddress());
-	txObject["value"] = toCompactHex(_txn.value(), HexPrefix::Add, 1);
+	txObject["value"] = "0x" + toCompactHex(_txn.value(), 1);
 	ImportTest::makeAllFieldsHex(txObject);
 	return txObject;
 }
@@ -90,8 +90,8 @@ json_spirit::mObject fillJsonWithStateChange(State const& _stateOrig, eth::State
 			{
 				case Change::Kind::Code:
 					//take the original and final code only
-					before = toHex(_stateOrig.code(change.address), 2, HexPrefix::Add);
-					after = toHex(_statePost.code(change.address), 2, HexPrefix::Add);
+					before = "0x" + toHex(_stateOrig.code(change.address));
+					after = "0x" + toHex(_statePost.code(change.address));
 					record.push_back(before);
 					record.push_back("->");
 					record.push_back(after);
@@ -100,8 +100,8 @@ json_spirit::mObject fillJsonWithStateChange(State const& _stateOrig, eth::State
 				break;
 				case Change::Kind::Nonce:
 					//take the original and final nonce only
-					before = toCompactHex(_stateOrig.getNonce(change.address), HexPrefix::Add, 1);
-					after = toCompactHex(_statePost.getNonce(change.address), HexPrefix::Add, 1);
+					before = "0x" + toCompactHex(_stateOrig.getNonce(change.address), 1);
+					after = "0x" + toCompactHex(_statePost.getNonce(change.address), 1);
 					record.push_back(before);
 					record.push_back("->");
 					record.push_back(after);
@@ -109,8 +109,8 @@ json_spirit::mObject fillJsonWithStateChange(State const& _stateOrig, eth::State
 					logInfo["nonce"] << "'nonce' : ['" + before + "', '->', '" + after + "']" << std::endl;
 				break;
 				case Change::Kind::Balance:
-					before = toCompactHex(tmpBalance, HexPrefix::Add, 1);
-					after = toCompactHex(change.value, HexPrefix::Add, 1);
+					before = "0x" + toCompactHex(tmpBalance, 1);
+					after = "0x" + toCompactHex(change.value, 1);
 					record.push_back(before);
 					record.push_back("+=");
 					record.push_back(after);
@@ -124,8 +124,8 @@ json_spirit::mObject fillJsonWithStateChange(State const& _stateOrig, eth::State
 				break;
 				case Change::Kind::Storage:
 					//take the original and final storage only
-					before = toCompactHex(change.key, HexPrefix::Add, 1) + " : " + toCompactHex(_stateOrig.storage(change.address, change.key), HexPrefix::Add, 1);
-					after = toCompactHex(change.key, HexPrefix::Add, 1) + " : " + toCompactHex(_statePost.storage(change.address, change.key), HexPrefix::Add, 1);
+					before = "0x" + toCompactHex(change.key, 1) + " : " + toCompactHex(_stateOrig.storage(change.address, change.key), 1);
+					after = "0x" + toCompactHex(change.key, 1) + " : " + toCompactHex(_statePost.storage(change.address, change.key), 1);
 					record.push_back(before);
 					record.push_back("->");
 					record.push_back(after);
@@ -149,8 +149,8 @@ json_spirit::mObject fillJsonWithStateChange(State const& _stateOrig, eth::State
 		if (agregatedBalance.size())
 		{
 			json_spirit::mArray record;
-			string before = toCompactHex(_stateOrig.balance(currentAddress), HexPrefix::Add, 1);
-			string after = toCompactHex(_statePost.balance(currentAddress), HexPrefix::Add, 1);
+			string before = "0x" + toCompactHex(_stateOrig.balance(currentAddress), 1);
+			string after = "0x" + toCompactHex(_statePost.balance(currentAddress), 1);
 			record.push_back(before);
 			record.push_back("->");
 			record.push_back(after);
@@ -187,22 +187,22 @@ json_spirit::mObject fillJsonWithState(State const& _state, eth::AccountMaskMap 
 
 		json_spirit::mObject o;
 		if (mapEmpty || _map.at(a.first).hasBalance())
-			o["balance"] = toCompactHex(_state.balance(a.first), HexPrefix::Add, 1);
+			o["balance"] = "0x" + toCompactHex(_state.balance(a.first), 1);
 		if (mapEmpty || _map.at(a.first).hasNonce())
-			o["nonce"] = toCompactHex(_state.getNonce(a.first), HexPrefix::Add, 1);
+			o["nonce"] = "0x" + toCompactHex(_state.getNonce(a.first), 1);
 
 		if (mapEmpty || _map.at(a.first).hasStorage())
 		{
 			json_spirit::mObject store;
 			for (auto const& s: _state.storage(a.first))
-				store[toCompactHex(s.second.first, HexPrefix::Add, 1)] = toCompactHex(s.second.second, HexPrefix::Add, 1);
+				store["0x" + toCompactHex(s.second.first, 1)] = toCompactHex(s.second.second, 1);
 			o["storage"] = store;
 		}
 
 		if (mapEmpty || _map.at(a.first).hasCode())
 		{
 			if (_state.code(a.first).size() > 0)
-				o["code"] = toHex(_state.code(a.first), 2, HexPrefix::Add);
+				o["code"] = "0x" + toHex(_state.code(a.first));
 			else
 				o["code"] = "";
 		}

--- a/test/tools/libtesteth/ImportTest.cpp
+++ b/test/tools/libtesteth/ImportTest.cpp
@@ -138,7 +138,7 @@ bytes ImportTest::executeTest()
 								json_spirit::mObject obj = fillJsonWithState(search2->second.first, search2->second.second);
 								for (auto& adr: obj)
 								{
-									if (adr.first == "0x" + toString(m_envInfo->author()))
+									if (adr.first == toHexPrefixed(m_envInfo->author()))
 									{
 										if (adr.second.get_obj().count("balance"))
 										{

--- a/test/tools/libtesteth/ImportTest.cpp
+++ b/test/tools/libtesteth/ImportTest.cpp
@@ -105,8 +105,8 @@ bytes ImportTest::executeTest()
 				//basic genesis
 				json_spirit::mObject genesisObj = TestBlockChain::defaultGenesisBlockJson();
 				genesisObj["coinbase"] = toString(m_envInfo->author());
-				genesisObj["gasLimit"] = "0x" + toCompactHex(m_envInfo->gasLimit());
-				genesisObj["timestamp"] = "0x" + toCompactHex(m_envInfo->timestamp() - 50);
+				genesisObj["gasLimit"] = toCompactHexPrefix(m_envInfo->gasLimit());
+				genesisObj["timestamp"] = toCompactHexPrefix(m_envInfo->timestamp() - 50);
 				testObj["genesisBlockHeader"] = genesisObj;
 				testObj["pre"] = fillJsonWithState(m_statePre);
 
@@ -144,7 +144,7 @@ bytes ImportTest::executeTest()
 										{
 											u256 expectCoinbaseBalance = toInt(adr.second.get_obj()["balance"]);
 											expectCoinbaseBalance += u256("5000000000000000000");
-											adr.second.get_obj()["balance"] = "0x" + toCompactHex(expectCoinbaseBalance);
+											adr.second.get_obj()["balance"] = toCompactHexPrefix(expectCoinbaseBalance);
 										}
 									}
 								}
@@ -167,9 +167,9 @@ bytes ImportTest::executeTest()
 
 				//rewrite header section for a block by the statetest parameters
 				json_spirit::mObject rewriteHeader;
-				rewriteHeader["gasLimit"] = "0x" + toCompactHex(m_envInfo->gasLimit());
-				rewriteHeader["difficulty"] = "0x" + toCompactHex(m_envInfo->difficulty());
-				rewriteHeader["timestamp"] = "0x" + toCompactHex(m_envInfo->timestamp());
+				rewriteHeader["gasLimit"] = toCompactHexPrefix(m_envInfo->gasLimit());
+				rewriteHeader["difficulty"] = toCompactHexPrefix(m_envInfo->difficulty());
+				rewriteHeader["timestamp"] = toCompactHexPrefix(m_envInfo->timestamp());
 				rewriteHeader["updatePoW"] = "1";
 
 				json_spirit::mArray blocksArr;
@@ -278,7 +278,7 @@ json_spirit::mObject& ImportTest::makeAllFieldsHex(json_spirit::mObject& _o, boo
 			for (auto const& j: value.get_array())
 			{
 				str = j.get_str();
-				arr.push_back((str.substr(0, 2) == "0x") ? str : "0x" + toCompactHex(toInt(str), 1));
+				arr.push_back((str.substr(0, 2) == "0x") ? str : toCompactHexPrefix(toInt(str), 1));
 			}
 			_o[key] = arr;
 			continue;
@@ -288,7 +288,7 @@ json_spirit::mObject& ImportTest::makeAllFieldsHex(json_spirit::mObject& _o, boo
 		if (isHash)
 			_o[key] = (str.substr(0, 2) == "0x" || str.empty()) ? str : "0x" + str;
 		else
-			_o[key] = (str.substr(0, 2) == "0x") ? str : "0x" + toCompactHex(toInt(str), 1);
+			_o[key] = (str.substr(0, 2) == "0x") ? str : toCompactHexPrefix(toInt(str), 1);
 	}
 	return _o;
 }
@@ -480,13 +480,13 @@ int ImportTest::compareStates(State const& _stateExpect, State const& _statePost
 				map<h256, pair<u256, u256>> stateStorage = _statePost.storage(a.first);
 				for (auto const& s: _stateExpect.storage(a.first))
 					CHECK((stateStorage[s.first] == s.second),
-					TestOutputHelper::testName() + " Check State: " << a.first << ": incorrect storage [0x" + toCompactHex(s.second.first) << "] = 0x" << toCompactHex(stateStorage[s.first].second) << ", expected [0x" << toCompactHex(s.second.first) << "] = " << toCompactHex(s.second.second));
+					TestOutputHelper::testName() + " Check State: " << a.first << ": incorrect storage [" << toCompactHexPrefix(s.second.first) << "] = " << toCompactHexPrefix(stateStorage[s.first].second) << ", expected [" << toCompactHexPrefix(s.second.first) << "] = " << toCompactHexPrefix(s.second.second));
 
 				//Check for unexpected storage values
 				map<h256, pair<u256, u256>> expectedStorage = _stateExpect.storage(a.first);
 				for (auto const& s: _statePost.storage(a.first))
 					CHECK((expectedStorage[s.first] == s.second),
-					TestOutputHelper::testName() + " Check State: " << a.first <<  ": incorrect storage [0x" + toCompactHex(s.second.first) << "] = 0x" << toCompactHex(s.second.second) << ", expected [0x" << toCompactHex(s.second.first) << "] = " << toCompactHex(expectedStorage[s.first].second));
+					TestOutputHelper::testName() + " Check State: " << a.first << ": incorrect storage [" << toCompactHexPrefix(s.second.first) << "] = " << toCompactHexPrefix(s.second.second) << ", expected [" << toCompactHexPrefix(s.second.first) << "] = " << toCompactHexPrefix(expectedStorage[s.first].second));
 			}
 
 			if (addressOptions.hasCode())
@@ -634,7 +634,7 @@ void ImportTest::checkGeneralTestSectionSearch(json_spirit::mObject const& _expe
 				}
 			}			
 			else if (_expects.count("hash"))
-				BOOST_CHECK_MESSAGE(_expects.at("hash").get_str() == "0x" + toHex(tr.postState.rootHash().asBytes()), TestOutputHelper::testName() + " Expected another postState hash! expected: " + _expects.at("hash").get_str() + " actual: " + toHex(tr.postState.rootHash().asBytes()) + " in " + trInfo);
+				BOOST_CHECK_MESSAGE(_expects.at("hash").get_str() == toHexPrefix(tr.postState.rootHash().asBytes()), TestOutputHelper::testName() + " Expected another postState hash! expected: " + _expects.at("hash").get_str() + " actual: " + toHex(tr.postState.rootHash().asBytes()) + " in " + trInfo);
 			else
 				BOOST_ERROR(TestOutputHelper::testName() + " Expect section or postState missing some fields!");
 
@@ -698,7 +698,7 @@ int ImportTest::exportTest(bytes const& _output)
 			obj["gas"] = tr.gasInd;
 			obj["value"] = tr.valInd;
 			obj2["indexes"] = obj;
-			obj2["hash"] = "0x" + toHex(tr.postState.rootHash().asBytes());
+			obj2["hash"] = toHexPrefix(tr.postState.rootHash().asBytes());
 			obj2["logs"] = exportLog(tr.output.second.log());
 
 			//Print the post state if transaction has failed on expect section
@@ -724,7 +724,7 @@ int ImportTest::exportTest(bytes const& _output)
 	else
 	{
 		// export output
-		m_testObject["out"] = (_output.size() > 4096 && !Options::get().fulloutput) ? "#" + toString(_output.size()) : "0x" + toHex(_output);
+		m_testObject["out"] = (_output.size() > 4096 && !Options::get().fulloutput) ? "#" + toString(_output.size()) : toHexPrefix(_output);
 
 		// compare expected output with post output
 		if (m_testObject.count("expectOut") > 0)

--- a/test/tools/libtesteth/ImportTest.cpp
+++ b/test/tools/libtesteth/ImportTest.cpp
@@ -105,8 +105,8 @@ bytes ImportTest::executeTest()
 				//basic genesis
 				json_spirit::mObject genesisObj = TestBlockChain::defaultGenesisBlockJson();
 				genesisObj["coinbase"] = toString(m_envInfo->author());
-				genesisObj["gasLimit"] = toCompactHexPrefix(m_envInfo->gasLimit());
-				genesisObj["timestamp"] = toCompactHexPrefix(m_envInfo->timestamp() - 50);
+				genesisObj["gasLimit"] = toCompactHexPrefixed(m_envInfo->gasLimit());
+				genesisObj["timestamp"] = toCompactHexPrefixed(m_envInfo->timestamp() - 50);
 				testObj["genesisBlockHeader"] = genesisObj;
 				testObj["pre"] = fillJsonWithState(m_statePre);
 
@@ -144,7 +144,7 @@ bytes ImportTest::executeTest()
 										{
 											u256 expectCoinbaseBalance = toInt(adr.second.get_obj()["balance"]);
 											expectCoinbaseBalance += u256("5000000000000000000");
-											adr.second.get_obj()["balance"] = toCompactHexPrefix(expectCoinbaseBalance);
+											adr.second.get_obj()["balance"] = toCompactHexPrefixed(expectCoinbaseBalance);
 										}
 									}
 								}
@@ -167,9 +167,9 @@ bytes ImportTest::executeTest()
 
 				//rewrite header section for a block by the statetest parameters
 				json_spirit::mObject rewriteHeader;
-				rewriteHeader["gasLimit"] = toCompactHexPrefix(m_envInfo->gasLimit());
-				rewriteHeader["difficulty"] = toCompactHexPrefix(m_envInfo->difficulty());
-				rewriteHeader["timestamp"] = toCompactHexPrefix(m_envInfo->timestamp());
+				rewriteHeader["gasLimit"] = toCompactHexPrefixed(m_envInfo->gasLimit());
+				rewriteHeader["difficulty"] = toCompactHexPrefixed(m_envInfo->difficulty());
+				rewriteHeader["timestamp"] = toCompactHexPrefixed(m_envInfo->timestamp());
 				rewriteHeader["updatePoW"] = "1";
 
 				json_spirit::mArray blocksArr;
@@ -278,7 +278,7 @@ json_spirit::mObject& ImportTest::makeAllFieldsHex(json_spirit::mObject& _o, boo
 			for (auto const& j: value.get_array())
 			{
 				str = j.get_str();
-				arr.push_back((str.substr(0, 2) == "0x") ? str : toCompactHexPrefix(toInt(str), 1));
+				arr.push_back((str.substr(0, 2) == "0x") ? str : toCompactHexPrefixed(toInt(str), 1));
 			}
 			_o[key] = arr;
 			continue;
@@ -288,7 +288,7 @@ json_spirit::mObject& ImportTest::makeAllFieldsHex(json_spirit::mObject& _o, boo
 		if (isHash)
 			_o[key] = (str.substr(0, 2) == "0x" || str.empty()) ? str : "0x" + str;
 		else
-			_o[key] = (str.substr(0, 2) == "0x") ? str : toCompactHexPrefix(toInt(str), 1);
+			_o[key] = (str.substr(0, 2) == "0x") ? str : toCompactHexPrefixed(toInt(str), 1);
 	}
 	return _o;
 }
@@ -480,13 +480,13 @@ int ImportTest::compareStates(State const& _stateExpect, State const& _statePost
 				map<h256, pair<u256, u256>> stateStorage = _statePost.storage(a.first);
 				for (auto const& s: _stateExpect.storage(a.first))
 					CHECK((stateStorage[s.first] == s.second),
-					TestOutputHelper::testName() + " Check State: " << a.first << ": incorrect storage [" << toCompactHexPrefix(s.second.first) << "] = " << toCompactHexPrefix(stateStorage[s.first].second) << ", expected [" << toCompactHexPrefix(s.second.first) << "] = " << toCompactHexPrefix(s.second.second));
+					TestOutputHelper::testName() + " Check State: " << a.first << ": incorrect storage [" << toCompactHexPrefixed(s.second.first) << "] = " << toCompactHexPrefixed(stateStorage[s.first].second) << ", expected [" << toCompactHexPrefixed(s.second.first) << "] = " << toCompactHexPrefixed(s.second.second));
 
 				//Check for unexpected storage values
 				map<h256, pair<u256, u256>> expectedStorage = _stateExpect.storage(a.first);
 				for (auto const& s: _statePost.storage(a.first))
 					CHECK((expectedStorage[s.first] == s.second),
-					TestOutputHelper::testName() + " Check State: " << a.first << ": incorrect storage [" << toCompactHexPrefix(s.second.first) << "] = " << toCompactHexPrefix(s.second.second) << ", expected [" << toCompactHexPrefix(s.second.first) << "] = " << toCompactHexPrefix(expectedStorage[s.first].second));
+					TestOutputHelper::testName() + " Check State: " << a.first << ": incorrect storage [" << toCompactHexPrefixed(s.second.first) << "] = " << toCompactHexPrefixed(s.second.second) << ", expected [" << toCompactHexPrefixed(s.second.first) << "] = " << toCompactHexPrefixed(expectedStorage[s.first].second));
 			}
 
 			if (addressOptions.hasCode())
@@ -634,7 +634,7 @@ void ImportTest::checkGeneralTestSectionSearch(json_spirit::mObject const& _expe
 				}
 			}			
 			else if (_expects.count("hash"))
-				BOOST_CHECK_MESSAGE(_expects.at("hash").get_str() == toHexPrefix(tr.postState.rootHash().asBytes()), TestOutputHelper::testName() + " Expected another postState hash! expected: " + _expects.at("hash").get_str() + " actual: " + toHex(tr.postState.rootHash().asBytes()) + " in " + trInfo);
+				BOOST_CHECK_MESSAGE(_expects.at("hash").get_str() == toHexPrefixed(tr.postState.rootHash().asBytes()), TestOutputHelper::testName() + " Expected another postState hash! expected: " + _expects.at("hash").get_str() + " actual: " + toHex(tr.postState.rootHash().asBytes()) + " in " + trInfo);
 			else
 				BOOST_ERROR(TestOutputHelper::testName() + " Expect section or postState missing some fields!");
 
@@ -698,7 +698,7 @@ int ImportTest::exportTest(bytes const& _output)
 			obj["gas"] = tr.gasInd;
 			obj["value"] = tr.valInd;
 			obj2["indexes"] = obj;
-			obj2["hash"] = toHexPrefix(tr.postState.rootHash().asBytes());
+			obj2["hash"] = toHexPrefixed(tr.postState.rootHash().asBytes());
 			obj2["logs"] = exportLog(tr.output.second.log());
 
 			//Print the post state if transaction has failed on expect section
@@ -724,7 +724,7 @@ int ImportTest::exportTest(bytes const& _output)
 	else
 	{
 		// export output
-		m_testObject["out"] = (_output.size() > 4096 && !Options::get().fulloutput) ? "#" + toString(_output.size()) : toHexPrefix(_output);
+		m_testObject["out"] = (_output.size() > 4096 && !Options::get().fulloutput) ? "#" + toString(_output.size()) : toHexPrefixed(_output);
 
 		// compare expected output with post output
 		if (m_testObject.count("expectOut") > 0)

--- a/test/tools/libtesteth/ImportTest.cpp
+++ b/test/tools/libtesteth/ImportTest.cpp
@@ -105,8 +105,8 @@ bytes ImportTest::executeTest()
 				//basic genesis
 				json_spirit::mObject genesisObj = TestBlockChain::defaultGenesisBlockJson();
 				genesisObj["coinbase"] = toString(m_envInfo->author());
-				genesisObj["gasLimit"] = toCompactHex(m_envInfo->gasLimit(), HexPrefix::Add);
-				genesisObj["timestamp"] = toCompactHex(m_envInfo->timestamp() - 50, HexPrefix::Add);
+				genesisObj["gasLimit"] = "0x" + toCompactHex(m_envInfo->gasLimit());
+				genesisObj["timestamp"] = "0x" + toCompactHex(m_envInfo->timestamp() - 50);
 				testObj["genesisBlockHeader"] = genesisObj;
 				testObj["pre"] = fillJsonWithState(m_statePre);
 
@@ -144,7 +144,7 @@ bytes ImportTest::executeTest()
 										{
 											u256 expectCoinbaseBalance = toInt(adr.second.get_obj()["balance"]);
 											expectCoinbaseBalance += u256("5000000000000000000");
-											adr.second.get_obj()["balance"] = toCompactHex(expectCoinbaseBalance, HexPrefix::Add);
+											adr.second.get_obj()["balance"] = "0x" + toCompactHex(expectCoinbaseBalance);
 										}
 									}
 								}
@@ -167,9 +167,9 @@ bytes ImportTest::executeTest()
 
 				//rewrite header section for a block by the statetest parameters
 				json_spirit::mObject rewriteHeader;
-				rewriteHeader["gasLimit"] = toCompactHex(m_envInfo->gasLimit(), HexPrefix::Add);
-				rewriteHeader["difficulty"] = toCompactHex(m_envInfo->difficulty(), HexPrefix::Add);
-				rewriteHeader["timestamp"] = toCompactHex(m_envInfo->timestamp(), HexPrefix::Add);
+				rewriteHeader["gasLimit"] = "0x" + toCompactHex(m_envInfo->gasLimit());
+				rewriteHeader["difficulty"] = "0x" + toCompactHex(m_envInfo->difficulty());
+				rewriteHeader["timestamp"] = "0x" + toCompactHex(m_envInfo->timestamp());
 				rewriteHeader["updatePoW"] = "1";
 
 				json_spirit::mArray blocksArr;
@@ -278,7 +278,7 @@ json_spirit::mObject& ImportTest::makeAllFieldsHex(json_spirit::mObject& _o, boo
 			for (auto const& j: value.get_array())
 			{
 				str = j.get_str();
-				arr.push_back((str.substr(0, 2) == "0x") ? str : toCompactHex(toInt(str), HexPrefix::Add, 1));
+				arr.push_back((str.substr(0, 2) == "0x") ? str : "0x" + toCompactHex(toInt(str), 1));
 			}
 			_o[key] = arr;
 			continue;
@@ -288,7 +288,7 @@ json_spirit::mObject& ImportTest::makeAllFieldsHex(json_spirit::mObject& _o, boo
 		if (isHash)
 			_o[key] = (str.substr(0, 2) == "0x" || str.empty()) ? str : "0x" + str;
 		else
-			_o[key] = (str.substr(0, 2) == "0x") ? str : toCompactHex(toInt(str), HexPrefix::Add, 1);
+			_o[key] = (str.substr(0, 2) == "0x") ? str : "0x" + toCompactHex(toInt(str), 1);
 	}
 	return _o;
 }
@@ -480,13 +480,13 @@ int ImportTest::compareStates(State const& _stateExpect, State const& _statePost
 				map<h256, pair<u256, u256>> stateStorage = _statePost.storage(a.first);
 				for (auto const& s: _stateExpect.storage(a.first))
 					CHECK((stateStorage[s.first] == s.second),
-					TestOutputHelper::testName() + " Check State: " << a.first << ": incorrect storage [" << toCompactHex(s.second.first, HexPrefix::Add) << "] = " << toCompactHex(stateStorage[s.first].second, HexPrefix::Add) << ", expected [" << toCompactHex(s.second.first, HexPrefix::Add) << "] = " << toCompactHex(s.second.second, HexPrefix::Add));
+					TestOutputHelper::testName() + " Check State: " << a.first << ": incorrect storage [0x" + toCompactHex(s.second.first) << "] = 0x" << toCompactHex(stateStorage[s.first].second) << ", expected [0x" << toCompactHex(s.second.first) << "] = " << toCompactHex(s.second.second));
 
 				//Check for unexpected storage values
 				map<h256, pair<u256, u256>> expectedStorage = _stateExpect.storage(a.first);
 				for (auto const& s: _statePost.storage(a.first))
 					CHECK((expectedStorage[s.first] == s.second),
-					TestOutputHelper::testName() + " Check State: " << a.first <<  ": incorrect storage [" << toCompactHex(s.second.first, HexPrefix::Add) << "] = " << toCompactHex(s.second.second, HexPrefix::Add) << ", expected [" << toCompactHex(s.second.first, HexPrefix::Add) << "] = " << toCompactHex(expectedStorage[s.first].second, HexPrefix::Add));
+					TestOutputHelper::testName() + " Check State: " << a.first <<  ": incorrect storage [0x" + toCompactHex(s.second.first) << "] = 0x" << toCompactHex(s.second.second) << ", expected [0x" << toCompactHex(s.second.first) << "] = " << toCompactHex(expectedStorage[s.first].second));
 			}
 
 			if (addressOptions.hasCode())
@@ -634,7 +634,7 @@ void ImportTest::checkGeneralTestSectionSearch(json_spirit::mObject const& _expe
 				}
 			}			
 			else if (_expects.count("hash"))
-				BOOST_CHECK_MESSAGE(_expects.at("hash").get_str() == toHex(tr.postState.rootHash().asBytes(), 2, HexPrefix::Add), TestOutputHelper::testName() + " Expected another postState hash! expected: " + _expects.at("hash").get_str() + " actual: " + toHex(tr.postState.rootHash().asBytes()) + " in " + trInfo);
+				BOOST_CHECK_MESSAGE(_expects.at("hash").get_str() == "0x" + toHex(tr.postState.rootHash().asBytes()), TestOutputHelper::testName() + " Expected another postState hash! expected: " + _expects.at("hash").get_str() + " actual: " + toHex(tr.postState.rootHash().asBytes()) + " in " + trInfo);
 			else
 				BOOST_ERROR(TestOutputHelper::testName() + " Expect section or postState missing some fields!");
 
@@ -698,7 +698,7 @@ int ImportTest::exportTest(bytes const& _output)
 			obj["gas"] = tr.gasInd;
 			obj["value"] = tr.valInd;
 			obj2["indexes"] = obj;
-			obj2["hash"] = toHex(tr.postState.rootHash().asBytes(), 2, HexPrefix::Add);
+			obj2["hash"] = "0x" + toHex(tr.postState.rootHash().asBytes());
 			obj2["logs"] = exportLog(tr.output.second.log());
 
 			//Print the post state if transaction has failed on expect section
@@ -724,7 +724,7 @@ int ImportTest::exportTest(bytes const& _output)
 	else
 	{
 		// export output
-		m_testObject["out"] = (_output.size() > 4096 && !Options::get().fulloutput) ? "#" + toString(_output.size()) : toHex(_output, 2, HexPrefix::Add);
+		m_testObject["out"] = (_output.size() > 4096 && !Options::get().fulloutput) ? "#" + toString(_output.size()) : "0x" + toHex(_output);
 
 		// compare expected output with post output
 		if (m_testObject.count("expectOut") > 0)

--- a/test/tools/libtesteth/TestHelper.cpp
+++ b/test/tools/libtesteth/TestHelper.cpp
@@ -162,7 +162,7 @@ json_spirit::mArray exportLog(eth::LogEntries const& _logs)
 		for (auto const& t: l.topics)
 			topics.push_back(toString(t));
 		o["topics"] = topics;
-		o["data"] = toHex(l.data, 2, HexPrefix::Add);
+		o["data"] = "0x" + toHex(l.data);
 		o["bloom"] = toString(l.bloom());
 		ret.push_back(o);
 	}

--- a/test/tools/libtesteth/TestHelper.cpp
+++ b/test/tools/libtesteth/TestHelper.cpp
@@ -162,7 +162,7 @@ json_spirit::mArray exportLog(eth::LogEntries const& _logs)
 		for (auto const& t: l.topics)
 			topics.push_back(toString(t));
 		o["topics"] = topics;
-		o["data"] = toHexPrefix(l.data);
+		o["data"] = toHexPrefixed(l.data);
 		o["bloom"] = toString(l.bloom());
 		ret.push_back(o);
 	}

--- a/test/tools/libtesteth/TestHelper.cpp
+++ b/test/tools/libtesteth/TestHelper.cpp
@@ -157,13 +157,13 @@ json_spirit::mArray exportLog(eth::LogEntries const& _logs)
 	for (LogEntry const& l: _logs)
 	{
 		json_spirit::mObject o;
-		o["address"] = toString(l.address);
+		o["address"] = toHex(l.address);
 		json_spirit::mArray topics;
 		for (auto const& t: l.topics)
-			topics.push_back(toString(t));
+			topics.push_back(toHex(t));
 		o["topics"] = topics;
 		o["data"] = toHexPrefixed(l.data);
-		o["bloom"] = toString(l.bloom());
+		o["bloom"] = toHex(l.bloom());
 		ret.push_back(o);
 	}
 	return ret;

--- a/test/tools/libtesteth/TestHelper.cpp
+++ b/test/tools/libtesteth/TestHelper.cpp
@@ -162,7 +162,7 @@ json_spirit::mArray exportLog(eth::LogEntries const& _logs)
 		for (auto const& t: l.topics)
 			topics.push_back(toString(t));
 		o["topics"] = topics;
-		o["data"] = "0x" + toHex(l.data);
+		o["data"] = toHexPrefix(l.data);
 		o["bloom"] = toString(l.bloom());
 		ret.push_back(o);
 	}

--- a/test/unittests/libdevcore/core.cpp
+++ b/test/unittests/libdevcore/core.cpp
@@ -33,18 +33,18 @@ BOOST_AUTO_TEST_CASE(toHex)
 {
 	dev::bytes b = dev::fromHex("f0e1d2c3b4a59687");
 	BOOST_CHECK_EQUAL(dev::toHex(b), "f0e1d2c3b4a59687");
-	BOOST_CHECK_EQUAL(dev::toHexPrefix(b), "0xf0e1d2c3b4a59687");
+	BOOST_CHECK_EQUAL(dev::toHexPrefixed(b), "0xf0e1d2c3b4a59687");
 
 	dev::h256 h("705a1849c02140e7197fbde82987a9eb623f97e32fc479a3cd8e4b3b52dcc4b2");
 	BOOST_CHECK_EQUAL(dev::toHex(h), "705a1849c02140e7197fbde82987a9eb623f97e32fc479a3cd8e4b3b52dcc4b2");
-	BOOST_CHECK_EQUAL(dev::toHexPrefix(h), "0x705a1849c02140e7197fbde82987a9eb623f97e32fc479a3cd8e4b3b52dcc4b2");
+	BOOST_CHECK_EQUAL(dev::toHexPrefixed(h), "0x705a1849c02140e7197fbde82987a9eb623f97e32fc479a3cd8e4b3b52dcc4b2");
 }
 
 BOOST_AUTO_TEST_CASE(toCompactHex)
 {
 	dev::u256 i("0x123456789abcdef");
 	BOOST_CHECK_EQUAL(dev::toCompactHex(i), "0123456789abcdef");
-	BOOST_CHECK_EQUAL(dev::toCompactHexPrefix(i), "0x0123456789abcdef");
+	BOOST_CHECK_EQUAL(dev::toCompactHexPrefixed(i), "0x0123456789abcdef");
 }
 
 BOOST_AUTO_TEST_CASE(byteRef)

--- a/test/unittests/libdevcore/core.cpp
+++ b/test/unittests/libdevcore/core.cpp
@@ -29,6 +29,20 @@ using namespace dev::test;
 
 BOOST_FIXTURE_TEST_SUITE(CoreLibTests, TestOutputHelper)
 
+BOOST_AUTO_TEST_CASE(toHex)
+{
+	dev::bytes b = dev::fromHex("f0e1d2c3b4a59687");
+	BOOST_CHECK_EQUAL(dev::toHex(b), "f0e1d2c3b4a59687");
+	BOOST_CHECK_EQUAL(dev::toHexPrefix(b), "0xf0e1d2c3b4a59687");
+}
+
+BOOST_AUTO_TEST_CASE(toCompactHex)
+{
+	dev::u256 i("0x123456789abcdef");
+	BOOST_CHECK_EQUAL(dev::toCompactHex(i), "0123456789abcdef");
+	BOOST_CHECK_EQUAL(dev::toCompactHexPrefix(i), "0x0123456789abcdef");
+}
+
 BOOST_AUTO_TEST_CASE(byteRef)
 {	
 	cnote << "bytesRef copyTo and toString...";

--- a/test/unittests/libdevcore/core.cpp
+++ b/test/unittests/libdevcore/core.cpp
@@ -34,6 +34,10 @@ BOOST_AUTO_TEST_CASE(toHex)
 	dev::bytes b = dev::fromHex("f0e1d2c3b4a59687");
 	BOOST_CHECK_EQUAL(dev::toHex(b), "f0e1d2c3b4a59687");
 	BOOST_CHECK_EQUAL(dev::toHexPrefix(b), "0xf0e1d2c3b4a59687");
+
+	dev::h256 h("705a1849c02140e7197fbde82987a9eb623f97e32fc479a3cd8e4b3b52dcc4b2");
+	BOOST_CHECK_EQUAL(dev::toHex(h), "705a1849c02140e7197fbde82987a9eb623f97e32fc479a3cd8e4b3b52dcc4b2");
+	BOOST_CHECK_EQUAL(dev::toHexPrefix(h), "0x705a1849c02140e7197fbde82987a9eb623f97e32fc479a3cd8e4b3b52dcc4b2");
 }
 
 BOOST_AUTO_TEST_CASE(toCompactHex)

--- a/test/unittests/libdevcrypto/MemTrie.cpp
+++ b/test/unittests/libdevcrypto/MemTrie.cpp
@@ -148,7 +148,7 @@ public:
 		assert(m_value.size());
 		std::cerr << _indent;
 		if (m_ext.size())
-			std::cerr << toHex(m_ext, 1) << ": ";
+			std::cerr << toHex(m_ext) << ": ";
 		else
 			std::cerr << "@: ";
 		std::cerr << m_value << std::endl;
@@ -175,7 +175,7 @@ public:
 #if ENABLE_DEBUG_PRINT
 	virtual void debugPrintBody(std::string const& _indent) const
 	{
-		std::cerr << _indent << toHex(m_ext, 1) << ": ";
+		std::cerr << _indent << toHex(m_ext) << ": ";
 		m_next->debugPrint(_indent + "  ");
 	}
 #endif

--- a/test/unittests/libdevcrypto/trie.cpp
+++ b/test/unittests/libdevcrypto/trie.cpp
@@ -122,8 +122,8 @@ BOOST_AUTO_TEST_CASE(hex_encoded_securetrie_test)
 				BOOST_CHECK_EQUAL(ht.root(), ft.root());
 			}
 			BOOST_REQUIRE(!o["root"].is_null());
-			BOOST_CHECK_EQUAL(o["root"].get_str(), toHexPrefix(ht.root().asArray()));
-			BOOST_CHECK_EQUAL(o["root"].get_str(), toHexPrefix(ft.root().asArray()));
+			BOOST_CHECK_EQUAL(o["root"].get_str(), toHexPrefixed(ht.root().asArray()));
+			BOOST_CHECK_EQUAL(o["root"].get_str(), toHexPrefixed(ft.root().asArray()));
 		}
 	}
 }
@@ -189,7 +189,7 @@ BOOST_AUTO_TEST_CASE(trie_test_anyorder)
 				BOOST_CHECK_EQUAL(ht.root(), ft.root());
 			}
 			BOOST_REQUIRE(!o["root"].is_null());
-			BOOST_CHECK_EQUAL(o["root"].get_str(), toHexPrefix(t.root().asArray()));
+			BOOST_CHECK_EQUAL(o["root"].get_str(), toHexPrefixed(t.root().asArray()));
 			BOOST_CHECK_EQUAL(ht.root(), ft.root());
 		}
 	}
@@ -277,7 +277,7 @@ BOOST_AUTO_TEST_CASE(trie_tests_ordered)
 		}
 
 		BOOST_REQUIRE(!o["root"].is_null());
-		BOOST_CHECK_EQUAL(o["root"].get_str(), toHexPrefix(t.root().asArray()));
+		BOOST_CHECK_EQUAL(o["root"].get_str(), toHexPrefixed(t.root().asArray()));
 	}
 }
 

--- a/test/unittests/libdevcrypto/trie.cpp
+++ b/test/unittests/libdevcrypto/trie.cpp
@@ -122,8 +122,8 @@ BOOST_AUTO_TEST_CASE(hex_encoded_securetrie_test)
 				BOOST_CHECK_EQUAL(ht.root(), ft.root());
 			}
 			BOOST_REQUIRE(!o["root"].is_null());
-			BOOST_CHECK_EQUAL(o["root"].get_str(), "0x" + toHex(ht.root().asArray()));
-			BOOST_CHECK_EQUAL(o["root"].get_str(), "0x" + toHex(ft.root().asArray()));
+			BOOST_CHECK_EQUAL(o["root"].get_str(), toHexPrefix(ht.root().asArray()));
+			BOOST_CHECK_EQUAL(o["root"].get_str(), toHexPrefix(ft.root().asArray()));
 		}
 	}
 }
@@ -189,7 +189,7 @@ BOOST_AUTO_TEST_CASE(trie_test_anyorder)
 				BOOST_CHECK_EQUAL(ht.root(), ft.root());
 			}
 			BOOST_REQUIRE(!o["root"].is_null());
-			BOOST_CHECK_EQUAL(o["root"].get_str(), "0x" + toHex(t.root().asArray()));
+			BOOST_CHECK_EQUAL(o["root"].get_str(), toHexPrefix(t.root().asArray()));
 			BOOST_CHECK_EQUAL(ht.root(), ft.root());
 		}
 	}
@@ -277,7 +277,7 @@ BOOST_AUTO_TEST_CASE(trie_tests_ordered)
 		}
 
 		BOOST_REQUIRE(!o["root"].is_null());
-		BOOST_CHECK_EQUAL(o["root"].get_str(), "0x" + toHex(t.root().asArray()));
+		BOOST_CHECK_EQUAL(o["root"].get_str(), toHexPrefix(t.root().asArray()));
 	}
 }
 

--- a/test/unittests/libethcore/difficulty.cpp
+++ b/test/unittests/libethcore/difficulty.cpp
@@ -134,11 +134,11 @@ void fillDifficulty(string const& _testFileFullName, Ethash& _sealEngine)
 			string tmptest = c_testDifficulty;
 			std::map<string, string> replaceMap;
 			replaceMap["[N]"] = toString(testN);
-			replaceMap["[PDIFF]"] = "0x" + toCompactHex(pDiff);
-			replaceMap["[PSTAMP]"] = "0x" + toCompactHex(pStamp);
-			replaceMap["[СSTAMP]"] = "0x" + toCompactHex(cStamp);
-			replaceMap["[CNUM]"] = "0x" + toCompactHex(cNum);
-			replaceMap["[CDIFF]"] = "0x" + toCompactHex(_sealEngine.calculateDifficulty(current, parent));
+			replaceMap["[PDIFF]"] = toCompactHexPrefix(pDiff);
+			replaceMap["[PSTAMP]"] = toCompactHexPrefix(pStamp);
+			replaceMap["[СSTAMP]"] = toCompactHexPrefix(cStamp);
+			replaceMap["[CNUM]"] = toCompactHexPrefix(cNum);
+			replaceMap["[CDIFF]"] = toCompactHexPrefix(_sealEngine.calculateDifficulty(current, parent));
 
 			dev::test::RandomCode::parseTestWithTypes(tmptest, replaceMap);
 			finalTest << tmptest;
@@ -291,11 +291,11 @@ BOOST_AUTO_TEST_CASE(difficultyTestsCustomMainNetwork)
 					string tmptest = c_testDifficulty;
 					std::map<string, string> replaceMap;
 					replaceMap["[N]"] = toString(testN);
-					replaceMap["[PDIFF]"] = "0x" + toCompactHex(pDiff);
-					replaceMap["[PSTAMP]"] = "0x" + toCompactHex(pStamp);
-					replaceMap["[СSTAMP]"] = "0x" + toCompactHex(cStamp);
-					replaceMap["[CNUM]"] = "0x" + toCompactHex(cNum);
-					replaceMap["[CDIFF]"] = "0x" + toCompactHex(sealEngine.calculateDifficulty(current, parent));
+					replaceMap["[PDIFF]"] = toCompactHexPrefix(pDiff);
+					replaceMap["[PSTAMP]"] = toCompactHexPrefix(pStamp);
+					replaceMap["[СSTAMP]"] = toCompactHexPrefix(cStamp);
+					replaceMap["[CNUM]"] = toCompactHexPrefix(cNum);
+					replaceMap["[CDIFF]"] = toCompactHexPrefix(sealEngine.calculateDifficulty(current, parent));
 
 					dev::test::RandomCode::parseTestWithTypes(tmptest, replaceMap);
 					finalTest << tmptest;

--- a/test/unittests/libethcore/difficulty.cpp
+++ b/test/unittests/libethcore/difficulty.cpp
@@ -134,11 +134,11 @@ void fillDifficulty(string const& _testFileFullName, Ethash& _sealEngine)
 			string tmptest = c_testDifficulty;
 			std::map<string, string> replaceMap;
 			replaceMap["[N]"] = toString(testN);
-			replaceMap["[PDIFF]"] = toCompactHexPrefix(pDiff);
-			replaceMap["[PSTAMP]"] = toCompactHexPrefix(pStamp);
-			replaceMap["[СSTAMP]"] = toCompactHexPrefix(cStamp);
-			replaceMap["[CNUM]"] = toCompactHexPrefix(cNum);
-			replaceMap["[CDIFF]"] = toCompactHexPrefix(_sealEngine.calculateDifficulty(current, parent));
+			replaceMap["[PDIFF]"] = toCompactHexPrefixed(pDiff);
+			replaceMap["[PSTAMP]"] = toCompactHexPrefixed(pStamp);
+			replaceMap["[СSTAMP]"] = toCompactHexPrefixed(cStamp);
+			replaceMap["[CNUM]"] = toCompactHexPrefixed(cNum);
+			replaceMap["[CDIFF]"] = toCompactHexPrefixed(_sealEngine.calculateDifficulty(current, parent));
 
 			dev::test::RandomCode::parseTestWithTypes(tmptest, replaceMap);
 			finalTest << tmptest;
@@ -291,11 +291,11 @@ BOOST_AUTO_TEST_CASE(difficultyTestsCustomMainNetwork)
 					string tmptest = c_testDifficulty;
 					std::map<string, string> replaceMap;
 					replaceMap["[N]"] = toString(testN);
-					replaceMap["[PDIFF]"] = toCompactHexPrefix(pDiff);
-					replaceMap["[PSTAMP]"] = toCompactHexPrefix(pStamp);
-					replaceMap["[СSTAMP]"] = toCompactHexPrefix(cStamp);
-					replaceMap["[CNUM]"] = toCompactHexPrefix(cNum);
-					replaceMap["[CDIFF]"] = toCompactHexPrefix(sealEngine.calculateDifficulty(current, parent));
+					replaceMap["[PDIFF]"] = toCompactHexPrefixed(pDiff);
+					replaceMap["[PSTAMP]"] = toCompactHexPrefixed(pStamp);
+					replaceMap["[СSTAMP]"] = toCompactHexPrefixed(cStamp);
+					replaceMap["[CNUM]"] = toCompactHexPrefixed(cNum);
+					replaceMap["[CDIFF]"] = toCompactHexPrefixed(sealEngine.calculateDifficulty(current, parent));
 
 					dev::test::RandomCode::parseTestWithTypes(tmptest, replaceMap);
 					finalTest << tmptest;

--- a/test/unittests/libethcore/difficulty.cpp
+++ b/test/unittests/libethcore/difficulty.cpp
@@ -134,11 +134,11 @@ void fillDifficulty(string const& _testFileFullName, Ethash& _sealEngine)
 			string tmptest = c_testDifficulty;
 			std::map<string, string> replaceMap;
 			replaceMap["[N]"] = toString(testN);
-			replaceMap["[PDIFF]"] = toCompactHex(pDiff, HexPrefix::Add);
-			replaceMap["[PSTAMP]"] = toCompactHex(pStamp, HexPrefix::Add);
-			replaceMap["[СSTAMP]"] = toCompactHex(cStamp, HexPrefix::Add);
-			replaceMap["[CNUM]"] = toCompactHex(cNum, HexPrefix::Add);
-			replaceMap["[CDIFF]"] = toCompactHex(_sealEngine.calculateDifficulty(current, parent), HexPrefix::Add);			
+			replaceMap["[PDIFF]"] = "0x" + toCompactHex(pDiff);
+			replaceMap["[PSTAMP]"] = "0x" + toCompactHex(pStamp);
+			replaceMap["[СSTAMP]"] = "0x" + toCompactHex(cStamp);
+			replaceMap["[CNUM]"] = "0x" + toCompactHex(cNum);
+			replaceMap["[CDIFF]"] = "0x" + toCompactHex(_sealEngine.calculateDifficulty(current, parent));
 
 			dev::test::RandomCode::parseTestWithTypes(tmptest, replaceMap);
 			finalTest << tmptest;
@@ -291,11 +291,11 @@ BOOST_AUTO_TEST_CASE(difficultyTestsCustomMainNetwork)
 					string tmptest = c_testDifficulty;
 					std::map<string, string> replaceMap;
 					replaceMap["[N]"] = toString(testN);
-					replaceMap["[PDIFF]"] = toCompactHex(pDiff, HexPrefix::Add);
-					replaceMap["[PSTAMP]"] = toCompactHex(pStamp, HexPrefix::Add);
-					replaceMap["[СSTAMP]"] = toCompactHex(cStamp, HexPrefix::Add);
-					replaceMap["[CNUM]"] = toCompactHex(cNum, HexPrefix::Add);
-					replaceMap["[CDIFF]"] = toCompactHex(sealEngine.calculateDifficulty(current, parent), HexPrefix::Add);
+					replaceMap["[PDIFF]"] = "0x" + toCompactHex(pDiff);
+					replaceMap["[PSTAMP]"] = "0x" + toCompactHex(pStamp);
+					replaceMap["[СSTAMP]"] = "0x" + toCompactHex(cStamp);
+					replaceMap["[CNUM]"] = "0x" + toCompactHex(cNum);
+					replaceMap["[CDIFF]"] = "0x" + toCompactHex(sealEngine.calculateDifficulty(current, parent));
 
 					dev::test::RandomCode::parseTestWithTypes(tmptest, replaceMap);
 					finalTest << tmptest;

--- a/test/unittests/libweb3jsonrpc/jsonrpc.cpp
+++ b/test/unittests/libweb3jsonrpc/jsonrpc.cpp
@@ -75,7 +75,7 @@ struct Setup
 string fromAscii(string _s)
 {
 	bytes b = asBytes(_s);
-	return "0x" + toHex(b);
+	return toHexPrefix(b);
 }
 
 BOOST_FIXTURE_TEST_SUITE(environment, Setup)

--- a/test/unittests/libweb3jsonrpc/jsonrpc.cpp
+++ b/test/unittests/libweb3jsonrpc/jsonrpc.cpp
@@ -75,7 +75,7 @@ struct Setup
 string fromAscii(string _s)
 {
 	bytes b = asBytes(_s);
-	return toHex(b, 2, HexPrefix::Add);
+	return "0x" + toHex(b);
 }
 
 BOOST_FIXTURE_TEST_SUITE(environment, Setup)

--- a/test/unittests/libweb3jsonrpc/jsonrpc.cpp
+++ b/test/unittests/libweb3jsonrpc/jsonrpc.cpp
@@ -75,7 +75,7 @@ struct Setup
 string fromAscii(string _s)
 {
 	bytes b = asBytes(_s);
-	return toHexPrefix(b);
+	return toHexPrefixed(b);
 }
 
 BOOST_FIXTURE_TEST_SUITE(environment, Setup)


### PR DESCRIPTION
toHex was slow enough to show up in test CPU profiles. Make it disappear
from the profile.

Also remove weird _w parameter. All callers ignore it or use 2 (the
default value) so they can pass _prefix. Remove _prefix too because it's
shorter to say "0x" + toHex(...) if a prefix is needed.