### PR TITLE
[WIP] libtesteth: add transaction RLP to state tests

### DIFF
--- a/test/tools/jsontests/StateTests.cpp
+++ b/test/tools/jsontests/StateTests.cpp
@@ -64,7 +64,7 @@ void doStateTests(json_spirit::mValue& _v, bool _fillin)
 		BOOST_REQUIRE_MESSAGE(o.count("pre") > 0, testname + "pre not set!");
 		BOOST_REQUIRE_MESSAGE(o.count("transaction") > 0, testname + "transaction not set!");
 
-		ImportTest importer(o, testType::GeneralStateTest);
+		ImportTest importer(o);
 
 		Listener::ExecTimeGuard guard{i.first};
 		importer.executeTest();
@@ -74,8 +74,7 @@ void doStateTests(json_spirit::mValue& _v, bool _fillin)
 		if (_fillin)
 		{
 #if ETH_FATDB
-			if (importer.exportTest(bytes()))
-				cerr << testname << endl;
+			importer.exportTest();
 #else
 			BOOST_THROW_EXCEPTION(Exception() << errinfo_comment(testname + "You can not fill tests when FATDB is switched off"));
 #endif

--- a/test/tools/jsontests/StateTests.cpp
+++ b/test/tools/jsontests/StateTests.cpp
@@ -60,10 +60,6 @@ void doStateTests(json_spirit::mValue& _v, bool _fillin)
 		if (_fillin == false && Options::get().fillchain)
 			continue;
 
-		BOOST_REQUIRE_MESSAGE(o.count("env") > 0, testname + "env not set!");
-		BOOST_REQUIRE_MESSAGE(o.count("pre") > 0, testname + "pre not set!");
-		BOOST_REQUIRE_MESSAGE(o.count("transaction") > 0, testname + "transaction not set!");
-
 		ImportTest importer(o);
 
 		Listener::ExecTimeGuard guard{i.first};

--- a/test/tools/libtesteth/ImportTest.cpp
+++ b/test/tools/libtesteth/ImportTest.cpp
@@ -76,7 +76,7 @@ bytes ImportTest::executeTest()
 
 			std::tie(tr.postState, tr.output, tr.changeLog) =
 				executeTransaction(net, *m_envInfo, m_statePre, tr.transaction);
-			tr.netId = net;
+			tr.netId = netIdToString(net);
 			transactionResults.push_back(tr);
 		}
 	}
@@ -117,8 +117,8 @@ bytes ImportTest::executeTest()
 				std::vector<string> checkedNetworks;
 				for (auto const& net : networks)
 				{
-					tr.netId = net;
-					if (std::find(checkedNetworks.begin(), checkedNetworks.end(), test::netIdToString(net)) != checkedNetworks.end())
+					tr.netId = netIdToString(net);
+					if (std::find(checkedNetworks.begin(), checkedNetworks.end(), tr.netId) != checkedNetworks.end())
 						continue;
 
 					TrExpectSection search {tr, smap};
@@ -589,10 +589,10 @@ void ImportTest::checkGeneralTestSectionSearch(json_spirit::mObject const& _expe
 	for(size_t i = 0; i < lookTransactions.size(); i++)
 	{
 		transactionToExecute const& tr = lookTransactions[i];
-		if (inArray(network, netIdToString(tr.netId)) || network[0] == "ALL")
+		if (inArray(network, tr.netId) || network[0] == "ALL")
 		if ((inArray(d, tr.dataInd) || d[0] == -1) && (inArray(g, tr.gasInd) || g[0] == -1) && (inArray(v, tr.valInd) || v[0] == -1))
 		{
-			string trInfo = netIdToString(tr.netId) + " data: " + toString(tr.dataInd) + " gas: " + toString(tr.gasInd) + " val: " + toString(tr.valInd);
+			string trInfo = tr.netId + " data: " + toString(tr.dataInd) + " gas: " + toString(tr.gasInd) + " val: " + toString(tr.valInd);
 			if (_expects.count("result"))
 			{
 				Options const& opt = Options::get();
@@ -649,11 +649,11 @@ void ImportTest::traceStateDiff()
 
 	for(auto const& tr : m_transactions)
 	{
-		if (network == netIdToString(tr.netId) || network == "ALL")
+		if (network == tr.netId || network == "ALL")
 		if ((d == tr.dataInd || d == -1) && (g == tr.gasInd || g == -1) && (v == tr.valInd || v == -1))
 		{
 			std::ostringstream log;
-			log << "trNetID: " << netIdToString(tr.netId) << endl;
+			log << "trNetID: " << tr.netId << endl;
 			log << "trDataInd: " << tr.dataInd << " tdGasInd: " << tr.gasInd << " trValInd: " << tr.valInd << std::endl;
 			dev::LogOutputStream<eth::StateTrace, false>() << log.str();
 			fillJsonWithStateChange(m_statePre, tr.postState, tr.changeLog); //output std log
@@ -695,7 +695,7 @@ void ImportTest::exportTest()
 		if (Options::get().statediff)
 			obj2["stateDiff"] = fillJsonWithStateChange(m_statePre, tr.postState, tr.changeLog);
 
-		postState[netIdToString(tr.netId)].push_back(obj2);
+		postState[tr.netId].push_back(obj2);
 	}
 
 	json_spirit::mObject obj;

--- a/test/tools/libtesteth/ImportTest.cpp
+++ b/test/tools/libtesteth/ImportTest.cpp
@@ -515,25 +515,6 @@ bool inArray(vector<T> const& _array, const T _val)
 	return false;
 }
 
-void ImportTest::checkAllowedNetwork(std::vector<std::string> const& _networks)
-{
-	vector<eth::Network> const& allnetworks = test::getNetworks();
-	vector<string> allowedNetowks;
-	allowedNetowks.push_back("ALL");
-	for (auto const& net : allnetworks)
-		allowedNetowks.push_back(test::netIdToString(net));
-
-	for (auto const& net: _networks)
-	{
-		if (!inArray(allowedNetowks, net))
-		{
-			//Can't use boost at this point
-			std::cerr << TestOutputHelper::testName() + " Specified Network not found: " + net << endl;
-			exit(1);
-		}
-	}
-}
-
 void ImportTest::checkGeneralTestSection(json_spirit::mObject const& _expects, vector<size_t>& _errorTransactions, string const& _network) const
 {
 	checkGeneralTestSectionSearch(_expects, _errorTransactions, _network, NULL);
@@ -551,7 +532,7 @@ void ImportTest::checkGeneralTestSectionSearch(json_spirit::mObject const& _expe
 		network.push_back(_network);
 
 	BOOST_CHECK_MESSAGE(network.size() > 0, TestOutputHelper::testName() + " Network array not set!");
-	checkAllowedNetwork(network);
+	Options::checkAllowedNetwork(network);
 
 	if (!Options::get().singleTestNet.empty())
 	{

--- a/test/tools/libtesteth/ImportTest.h
+++ b/test/tools/libtesteth/ImportTest.h
@@ -29,17 +29,10 @@ namespace dev
 namespace test
 {
 
-enum class testType
-{
-	BlockChainTests,
-	GeneralStateTest,
-	Other
-};
-
 class ImportTest
 {
 public:
-	ImportTest(json_spirit::mObject& _o, testType _testTemplate);
+	ImportTest(json_spirit::mObject& _o);
 
 	// imports
 	void importEnv(json_spirit::mObject& _o);
@@ -56,7 +49,7 @@ public:
 	static void checkBalance(eth::State const& _pre, eth::State const& _post, bigint _miningReward = 0);
 
 	bytes executeTest();
-	int exportTest(bytes const& _output);
+	void exportTest();
 	static int compareStates(eth::State const& _stateExpect, eth::State const& _statePost, eth::AccountMaskMap const _expectedStateOptions = eth::AccountMaskMap(), WhenError _throw = WhenError::Throw);
 	void checkGeneralTestSection(json_spirit::mObject const& _expects, std::vector<size_t>& _errorTransactions, std::string const& _network="") const;
 	void traceStateDiff();
@@ -93,7 +86,6 @@ private:
 	void checkGeneralTestSectionSearch(json_spirit::mObject const& _expects, std::vector<size_t>& _errorTransactions, std::string const& _network = "", TrExpectSection* _search = NULL) const;
 
 	json_spirit::mObject& m_testObject;
-	testType m_testType;
 };
 
 } //namespace test

--- a/test/tools/libtesteth/ImportTest.h
+++ b/test/tools/libtesteth/ImportTest.h
@@ -69,7 +69,7 @@ private:
 	struct transactionToExecute
 	{
 		transactionToExecute(int d, int g, int v, eth::Transaction const& t):
-			dataInd(d), gasInd(g), valInd(v), transaction(t), postState(0), netId(eth::Network::MainNetwork),
+			dataInd(d), gasInd(g), valInd(v), transaction(t), postState(0), netId(""),
 			output(std::make_pair(eth::ExecutionResult(), eth::TransactionReceipt(h256(), u256(), eth::LogEntries()))) {}
 		int dataInd;
 		int gasInd;
@@ -77,7 +77,7 @@ private:
 		eth::Transaction transaction;
 		eth::State postState;
 		eth::ChangeLog changeLog;
-		eth::Network netId;
+		std::string netId;
 		ExecOutput output;
 	};
 	std::vector<transactionToExecute> m_transactions;

--- a/test/tools/libtesteth/ImportTest.h
+++ b/test/tools/libtesteth/ImportTest.h
@@ -43,9 +43,7 @@ public:
 	static json_spirit::mObject& makeAllFieldsHex(json_spirit::mObject& _o, bool _isHeader = false);
 	static void parseJsonStrValueIntoVector(json_spirit::mValue const& _json, std::vector<std::string>& _out);
 
-	//check functions
-	//check that networks in the vector are allowed
-	static void checkAllowedNetwork(std::vector<std::string> const& _networks);
+	// check functions
 	static void checkBalance(eth::State const& _pre, eth::State const& _post, bigint _miningReward = 0);
 
 	bytes executeTest();

--- a/test/tools/libtesteth/Options.cpp
+++ b/test/tools/libtesteth/Options.cpp
@@ -68,6 +68,23 @@ void printHelp()
 	cout << setw(30) << "--help" << setw(25) << "Display list of command arguments" << std::endl;
 }
 
+void Options::checkAllowedNetwork(std::vector<std::string> const& _networks)
+{
+	std::set<string> allowed;
+	allowed.insert("ALL");
+	for (auto const& net : test::getNetworks())
+		allowed.insert(test::netIdToString(net));
+
+	for (auto const& net: _networks)
+	{
+		if (!allowed.count(net))
+		{
+			std::cerr << TestOutputHelper::testName() + " Specified Network not found: " + net << endl;
+			exit(1);
+		}
+	}
+}
+
 Options::Options(int argc, char** argv)
 {
 	trDataIndex = -1;
@@ -181,7 +198,7 @@ Options::Options(int argc, char** argv)
 		{
 			throwIfNoArgumentFollows();
 			singleTestNet = std::string{argv[++i]};
-			ImportTest::checkAllowedNetwork({singleTestNet});
+			checkAllowedNetwork({singleTestNet});
 		}
 		else if (arg == "--fulloutput")
 			fulloutput = true;

--- a/test/tools/libtesteth/Options.h
+++ b/test/tools/libtesteth/Options.h
@@ -75,6 +75,9 @@ public:
 	bool wallet = false;
 	/// @}
 
+	// Checks that all networks in the vector are valid. Exits otherwise.
+	static void checkAllowedNetwork(std::vector<std::string> const& _networks);
+
 	/// Get reference to options
 	/// The first time used, options are parsed with argc, argv
 	static Options const& get(int argc = 0, char** argv = 0);


### PR DESCRIPTION
The general state test format changes so the post state includes the RLP
of the (signed) transaction. This makes it easier to run the tests
because no signing is required. It's also slightly more powerful because
any signature scheme can be tested.

The first few commits are refactoring changes.
