### PR TITLE
Fix parameter name convention.

### DIFF
--- a/CodingStandards.txt
+++ b/CodingStandards.txt
@@ -87,7 +87,7 @@ All other entities' first alpha is lower case.
 
 4. Variable prefixes:
 
-a. Leading underscore "_" to parameter names (both normal and template).
+a. Leading underscore "_" to parameter names.
 - Exception: "o_parameterName" when it is used exclusively for output. See 6(f).
 - Exception: "io_parameterName" when it is used for both input and output. See 6(f).
 b. Leading "c_" to const variables (unless part of an external API).


### PR DESCRIPTION
Remove mention of template parameters from the rule of underscore prefix for parameter names. 
There's point 3.b contradicting it, prescribing first letter uppercase.