### PR TITLE
add tr rlp to state tests

### DIFF
--- a/test/tools/libtesteth/ImportTest.cpp
+++ b/test/tools/libtesteth/ImportTest.cpp
@@ -700,6 +700,7 @@ int ImportTest::exportTest(bytes const& _output)
 			obj2["indexes"] = obj;
 			obj2["hash"] = toHex(tr.postState.rootHash().asBytes(), 2, HexPrefix::Add);
 			obj2["logs"] = exportLog(tr.output.second.log());
+			obj2["tr"] = toHex(tr.transaction.rlp(), 2, HexPrefix::Add);
 
 			//Print the post state if transaction has failed on expect section
 			if (Options::get().checkstate)


### PR DESCRIPTION
this leaves the current state tests as it is but adds a tr RLP to the final test 
so you could use both indexes and transaction rlp.
@fjl  please check that you could parse this RLP and it is correct

use ``` ./testeth -t StateTestsGeneral -- --filltests --checkstate  ``` to produce new format to the test repository