### PR TITLE
cmake: forward CMAKE_CXX_COMPILER to some subprojects

### DIFF
--- a/cmake/ProjectCryptopp.cmake
+++ b/cmake/ProjectCryptopp.cmake
@@ -155,6 +155,8 @@ ExternalProject_Add(cryptopp
         -DCMAKE_POSITION_INDEPENDENT_CODE=${BUILD_SHARED_LIBS}
         -DBUILD_SHARED=Off
         -DBUILD_TESTING=Off
+        -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+        -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
     LOG_CONFIGURE 1
     # Overwrite build and install commands to force Release build on MSVC.
     BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> --config Release

--- a/cmake/ProjectJsonCpp.cmake
+++ b/cmake/ProjectJsonCpp.cmake
@@ -24,6 +24,8 @@ ExternalProject_Add(jsoncpp
                ${_only_release_configuration}
                -DJSONCPP_WITH_TESTS=Off
                -DJSONCPP_WITH_PKGCONFIG_SUPPORT=Off
+               -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+               -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
     LOG_CONFIGURE 1
     BUILD_COMMAND ""
     ${_overwrite_install_command}

--- a/cmake/ProjectJsonRpcCpp.cmake
+++ b/cmake/ProjectJsonRpcCpp.cmake
@@ -4,6 +4,8 @@ find_package(MHD REQUIRED)
 
 set(CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
                -DCMAKE_BUILD_TYPE=Release
+               -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+               -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
                # Build static lib but suitable to be included in a shared lib.
                -DCMAKE_POSITION_INDEPENDENT_CODE=${BUILD_SHARED_LIBS}
                -DBUILD_STATIC_LIBS=On

--- a/cmake/ProjectSecp256k1.cmake
+++ b/cmake/ProjectSecp256k1.cmake
@@ -15,6 +15,8 @@ ExternalProject_Add(secp256k1
         ${CMAKE_CURRENT_LIST_DIR}/secp256k1/CMakeLists.txt <SOURCE_DIR>
     CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
                -DCMAKE_POSITION_INDEPENDENT_CODE=${BUILD_SHARED_LIBS}
+               -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+               -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
                ${_only_release_configuration}
     LOG_CONFIGURE 1
     BUILD_COMMAND ""

--- a/cmake/ProjectSnark.cmake
+++ b/cmake/ProjectSnark.cmake
@@ -14,6 +14,8 @@ ExternalProject_Add(snark
         -DGMPXX_LIBRARIES=${MPIR_LIBRARY}
         -DCURVE=ALT_BN128 -DPERFORMANCE=Off -DWITH_PROCPS=Off
         -DUSE_PT_COMPRESSION=Off
+        -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+        -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
     BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> --config Release
     INSTALL_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> --config Release --target install
 )


### PR DESCRIPTION
This makes cpp-ethereum build with non-default clang on macOS. Specifically, using `cmake -DCMAKE_CXX_COMPILER=$(brew --prefix llvm)/bin/clang++` works now.