### PR TITLE
Throw an exception instead of declaring one

### DIFF
--- a/libethereum/TransactionReceipt.cpp
+++ b/libethereum/TransactionReceipt.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "TransactionReceipt.h"
+#include <libethcore/Exceptions.h>
 
 using namespace std;
 using namespace dev;
@@ -29,7 +30,7 @@ TransactionReceipt::TransactionReceipt(bytesConstRef _rlp)
 {
 	RLP r(_rlp);
 	if (!r.isList() || r.itemCount() < 3 || r.itemCount() > 4)
-		DEV_SIMPLE_EXCEPTION(InvalidTransactionReceiptFormat);
+		BOOST_THROW_EXCEPTION(InvalidTransactionReceiptFormat());
 		
 	size_t gasUsedIndex = 0;
 	if (r.itemCount() == 4)


### PR DESCRIPTION
When some malformed transaction is found, the intention seems like throwing an exception, but the code somehow declares an exception.