### PR TITLE
Trying to cache .ccache directory on macOS Travis run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -103,6 +103,7 @@ cache:
         - ~/.ethash
         - ~/.local
         - ~/Library/Caches/Homebrew
+        - ~/.ccache
         # Cache whole deps dir hoping you will not need to download and
         # build external dependencies next build.
         - $TRAVIS_BUILD_DIR/deps

--- a/.travis.yml
+++ b/.travis.yml
@@ -108,7 +108,7 @@ cache:
         # build external dependencies next build.
         - $TRAVIS_BUILD_DIR/deps
 install:
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then clang --version; travis_wait 80 brew install llvm; $(brew --prefix llvm)/bin/clang --version; export PATH=$(brew --prefix llvm)/bin:$PATH; export CC=$(brew --prefix llvm)/bin/clang; export CXX=$(brew --prefix llvm)/bin/clang++; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then clang --version; travis_wait 160 brew install llvm; $(brew --prefix llvm)/bin/clang --version; export PATH=$(brew --prefix llvm)/bin:$PATH; export CC=$(brew --prefix llvm)/bin/clang; export CXX=$(brew --prefix llvm)/bin/clang++; fi
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./scripts/install_cmake.sh; fi
     - ./scripts/install_deps.sh
 before_script:


### PR DESCRIPTION
For this PR, I want to run Travis twice on Mac.  The first run should populate `.ccache` and store it; the second run should use the populated `.ccache`.