### PR TITLE
Refactoring of  import performance logging in BlockChain class

### DIFF
--- a/libdevcore/CommonIO.h
+++ b/libdevcore/CommonIO.h
@@ -262,11 +262,17 @@ template <class _S, class _T> _S& operator<<(_S& _out, std::shared_ptr<_T> const
 
 /// Converts arbitrary value to string representation using std::stringstream.
 template <class _T>
-std::string toString(_T const& _t)
+inline std::string toString(_T const& _t)
 {
 	std::ostringstream o;
 	o << _t;
 	return o.str();
+}
+
+template <>
+inline std::string toString<std::string>(std::string const& _s)
+{
+	return _s;
 }
 
 }


### PR DESCRIPTION
Extracting the code for logging performance from `BlockChain::import()` to separate class.

The slow import log messages look like this after it:
```
SLOW IMPORT: { "blockHash": "2e147b2bΓÇª", "blockNumber": 4040513, "gasPerSecond": 4516244, "transactions": 30, "gasUsed": 3327384, "preliminaryChecks": 0.003652, "enactment": 0.736759, "collation": 2e-05, "writing": 0.007356, "checkBest": 0.003482, "total": 0.75144  }
```
(the same as before, maybe order changed somewhat)

This is a step towards a refactoring of `BlockChain::import()` needed for snapshot sync/import.