### PR TITLE
Inserting a block to BlockChain without enacting transactions

### DIFF
--- a/libethereum/BlockChain.cpp
+++ b/libethereum/BlockChain.cpp
@@ -45,7 +45,6 @@ using namespace dev;
 using namespace dev::eth;
 namespace fs = boost::filesystem;
 
-#define ETH_CATCH 1
 #define ETH_TIMED_IMPORTS 1
 
 #if defined(_WIN32)
@@ -682,9 +681,7 @@ ImportRoute BlockChain::import(VerifiedBlockRef const& _block, OverlayDB const& 
 
 	BlockReceipts br;
 	u256 td;
-#if ETH_CATCH
 	try
-#endif
 	{
 		// Check transactions are valid and that they result in a state equivalent to our state_root.
 		// Get total difficulty increase and update state, checking it.
@@ -704,7 +701,6 @@ ImportRoute BlockChain::import(VerifiedBlockRef const& _block, OverlayDB const& 
 		checkConsistency();
 #endif // ETH_PARANOIA
 	}
-#if ETH_CATCH
 	catch (BadRoot& ex)
 	{
 		cwarn << "*** BadRoot error! Trying to import" << _block.info.hash() << "needed root" << ex.root;
@@ -717,7 +713,6 @@ ImportRoute BlockChain::import(VerifiedBlockRef const& _block, OverlayDB const& 
 		addBlockInfo(ex, _block.info, _block.block.toBytes());
 		throw;
 	}
-#endif // ETH_CATCH
 
 	// All ok - insert into DB
 	bytes const receipts = br.rlp();
@@ -1089,6 +1084,7 @@ tuple<h256s, h256, unsigned> BlockChain::treeRoute(h256 const& _from, h256 const
 
 	BlockDetails const fromDetails = details(_from);
 	BlockDetails const toDetails = details(_to);
+	// Needed to handle a special case when the parent of inserted block is not present in DB.
 	if (fromDetails.isNull() || toDetails.isNull())
 		return make_tuple(h256s(), h256(), 0);
 

--- a/libethereum/BlockChain.h
+++ b/libethereum/BlockChain.h
@@ -138,7 +138,7 @@ public:
 	/// block/header and receipts directly into the databases.
 	void insert(bytes const& _block, bytesConstRef _receipts, bool _mustBeNew = true);
 	void insert(VerifiedBlockRef _block, bytesConstRef _receipts, bool _mustBeNew = true);
-	/// insert that doesn't require parent to be imported, useful when we don't have the full blockchain (like restoring from partial snapshot)
+	/// Insert that doesn't require parent to be imported, useful when we don't have the full blockchain (like restoring from partial snapshot).
 	ImportRoute insertWithoutParent(bytes const& _block, bytesConstRef _receipts, u256 const& _number, u256 const& _totalDifficulty);
 
 	/// Returns true if the given block is known (though not necessarily a part of the canon chain).

--- a/libethereum/BlockChain.h
+++ b/libethereum/BlockChain.h
@@ -62,6 +62,7 @@ static const h256s NullH256s;
 
 class State;
 class Block;
+class ImportPerformanceLogger;
 
 DEV_SIMPLE_EXCEPTION(AlreadyHaveBlock);
 DEV_SIMPLE_EXCEPTION(FutureTime);
@@ -137,6 +138,8 @@ public:
 	/// block/header and receipts directly into the databases.
 	void insert(bytes const& _block, bytesConstRef _receipts, bool _mustBeNew = true);
 	void insert(VerifiedBlockRef _block, bytesConstRef _receipts, bool _mustBeNew = true);
+	/// insert that doesn't require parent to be imported, useful when we don't have the full blockchain (like restoring from partial snapshot)
+	ImportRoute insertWithoutParent(bytes const& _block, bytesConstRef _receipts, u256 const& _number, u256 const& _totalDifficulty);
 
 	/// Returns true if the given block is known (though not necessarily a part of the canon chain).
 	bool isKnown(h256 const& _hash, bool _isCurrent = true) const;
@@ -320,6 +323,10 @@ private:
 	void open(std::string const& _path, WithExisting _we, ProgressCallback const& _pc);
 	/// Finalise everything and close the database.
 	void close();
+
+	ImportRoute insertBlockAndExtras(VerifiedBlockRef const& _block, bytesConstRef _receipts, u256 const& _number, u256 const& _totalDifficulty, ImportPerformanceLogger& _performanceLogger);
+	void checkBlockIsNew(VerifiedBlockRef const& _block) const;
+	void checkBlockTimestamp(BlockHeader const& _header) const;
 
 	template<class T, class K, unsigned N> T queryExtras(K const& _h, std::unordered_map<K, T>& _m, boost::shared_mutex& _x, T const& _n, ldb::DB* _extrasDB = nullptr) const
 	{

--- a/libethereum/ImportPerformanceLogger.cpp
+++ b/libethereum/ImportPerformanceLogger.cpp
@@ -15,7 +15,8 @@
 	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file 
- */
+*  Class for logging of importing a Block into BlockChain.
+*/
 
 #include "ImportPerformanceLogger.h"
 
@@ -24,6 +25,17 @@
 
 using namespace dev;
 using namespace eth;
+
+namespace
+{
+
+template <class ValueType>
+static std::string pairToString(std::pair<std::string const, ValueType> const& _pair)
+{
+	return "\"" + _pair.first + "\": " + toString(_pair.second);
+}
+
+}
 
 std::string ImportPerformanceLogger::constructReport(double _totalElapsed, std::unordered_map<std::string, std::string> const& _additionalValues)
 {

--- a/libethereum/ImportPerformanceLogger.cpp
+++ b/libethereum/ImportPerformanceLogger.cpp
@@ -1,0 +1,47 @@
+/*
+	This file is part of cpp-ethereum.
+
+	cpp-ethereum is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	cpp-ethereum is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/** @file 
+ */
+
+#include "ImportPerformanceLogger.h"
+
+#include <boost/algorithm/string.hpp>
+#include <boost/range/adaptors.hpp>
+
+using namespace dev;
+using namespace eth;
+
+std::string ImportPerformanceLogger::constructReport(double _totalElapsed, std::unordered_map<std::string, std::string> const& _additionalValues)
+{
+	static std::string const Separator = ", ";
+
+	std::string result;
+	if (!_additionalValues.empty())
+	{
+		auto const keyValuesAdditional = _additionalValues | boost::adaptors::transformed(pairToString<std::string>);
+		result += boost::algorithm::join(keyValuesAdditional, Separator);
+		result += Separator;
+	}
+
+	m_stages.emplace("total", _totalElapsed);
+	auto const keyValuesStages = m_stages | boost::adaptors::transformed(pairToString<double>);
+	result += boost::algorithm::join(keyValuesStages, Separator);
+
+	return result;
+}
+
+

--- a/libethereum/ImportPerformanceLogger.h
+++ b/libethereum/ImportPerformanceLogger.h
@@ -15,7 +15,7 @@
 	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file 
- *  Class for logging of importing a Block into BlockChain
+ *  Class for logging of importing a Block into BlockChain.
  */
 
 #pragma once
@@ -57,17 +57,11 @@ public:
 	}
 
 private:
-	template <class ValueType>
-	static std::string pairToString(std::pair<std::string const, ValueType> const& _pair)
-	{
-		return "\"" + _pair.first + "\": " + toString(_pair.second);
-	}
-
 	std::string constructReport(double _totalElapsed, std::unordered_map<std::string, std::string> const& _additionalValues);
 
 	Timer m_totalTimer;
-	std::unordered_map<std::string, double> m_stages;
 	Timer m_stageTimer;
+	std::unordered_map<std::string, double> m_stages;
 };
 
 }

--- a/libethereum/ImportPerformanceLogger.h
+++ b/libethereum/ImportPerformanceLogger.h
@@ -1,0 +1,74 @@
+/*
+	This file is part of cpp-ethereum.
+
+	cpp-ethereum is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	cpp-ethereum is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/** @file 
+ *  Class for logging of importing a Block into BlockChain
+ */
+
+#pragma once
+
+#include <libdevcore/Common.h>
+#include <libdevcore/Log.h>
+
+#include <unordered_map>
+#include <string>
+
+namespace dev
+{
+
+namespace eth
+{
+
+class ImportPerformanceLogger
+{
+public:
+	void onStageFinished(std::string const& _name)
+	{
+		m_stages[_name] = m_stageTimer.elapsed();
+		m_stageTimer.restart();
+	}
+
+	double stageDuration(std::string const& _name) const
+	{
+		auto const it = m_stages.find(_name);
+		return it != m_stages.end() ? it->second : 0;
+	}
+
+	void onFinished(std::unordered_map<std::string, std::string> const& _additionalValues)
+	{
+		double const totalElapsed = m_totalTimer.elapsed();
+		if (totalElapsed > 0.5)
+		{
+			cnote << "SLOW IMPORT: { " << constructReport(totalElapsed, _additionalValues) << " }";
+		}
+	}
+
+private:
+	template <class ValueType>
+	static std::string pairToString(std::pair<std::string const, ValueType> const& _pair)
+	{
+		return "\"" + _pair.first + "\": " + toString(_pair.second);
+	}
+
+	std::string constructReport(double _totalElapsed, std::unordered_map<std::string, std::string> const& _additionalValues);
+
+	Timer m_totalTimer;
+	std::unordered_map<std::string, double> m_stages;
+	Timer m_stageTimer;
+};
+
+}
+}


### PR DESCRIPTION
Essentially this is refactoring to split "behemoth of a method" `BlockChain::import` into two methods: `BlockChain::import` and private `BlockChain::insertBlockAndExtras`, then adding new public method `BlockChain::insertWithoutParent` that reuses `BlockChain::insertBlockAndExtras`.

`BlockChain::insertWithoutParent` will be used to import blocks from snapshot in future PR.

Also there is some removing and moving the code around `BlockChain::import`.