### PR TITLE
Fix parsing of receipt RLP

### DIFF
--- a/libethereum/TransactionReceipt.cpp
+++ b/libethereum/TransactionReceipt.cpp
@@ -39,7 +39,7 @@ TransactionReceipt::TransactionReceipt(bytesConstRef _rlp)
 
 	if (r[0].size() == 32)
 		m_statusCodeOrStateRoot = (h256)r[0];
-	else if (r[0].size() == 1)
+	else if (r[0].isInt())
 		m_statusCodeOrStateRoot = (uint8_t)r[0];
 	else
 		BOOST_THROW_EXCEPTION(InvalidTransactionReceiptFormat());


### PR DESCRIPTION
 0 status code has 0 size in RLP, we shouldn't assume status code is always 1 byte.