### PR TITLE
Insert a space between the test name and the error messages

### DIFF
--- a/test/tools/jsontests/StateTests.cpp
+++ b/test/tools/jsontests/StateTests.cpp
@@ -60,9 +60,9 @@ void doStateTests(json_spirit::mValue& _v, bool _fillin)
 		if (_fillin == false && Options::get().fillchain)
 			continue;
 
-		BOOST_REQUIRE_MESSAGE(o.count("env") > 0, testname + "env not set!");
-		BOOST_REQUIRE_MESSAGE(o.count("pre") > 0, testname + "pre not set!");
-		BOOST_REQUIRE_MESSAGE(o.count("transaction") > 0, testname + "transaction not set!");
+		BOOST_REQUIRE_MESSAGE(o.count("env") > 0, testname + " env not set!");
+		BOOST_REQUIRE_MESSAGE(o.count("pre") > 0, testname + " pre not set!");
+		BOOST_REQUIRE_MESSAGE(o.count("transaction") > 0, testname + " transaction not set!");
 
 		ImportTest importer(o, testType::GeneralStateTest);
 
@@ -77,7 +77,7 @@ void doStateTests(json_spirit::mValue& _v, bool _fillin)
 			if (importer.exportTest(bytes()))
 				cerr << testname << endl;
 #else
-			BOOST_THROW_EXCEPTION(Exception() << errinfo_comment(testname + "You can not fill tests when FATDB is switched off"));
+			BOOST_THROW_EXCEPTION(Exception() << errinfo_comment(testname + " You can not fill tests when FATDB is switched off"));
 #endif
 		}
 		else

--- a/test/tools/jsontests/vm.cpp
+++ b/test/tools/jsontests/vm.cpp
@@ -308,9 +308,9 @@ void doVMTests(json_spirit::mValue& _v, bool _fillin)
 			continue;
 		}
 
-		BOOST_REQUIRE_MESSAGE(o.count("env") > 0, testname + "env not set!");
-		BOOST_REQUIRE_MESSAGE(o.count("pre") > 0, testname + "pre not set!");
-		BOOST_REQUIRE_MESSAGE(o.count("exec") > 0, testname + "exec not set!");
+		BOOST_REQUIRE_MESSAGE(o.count("env") > 0, testname + " env not set!");
+		BOOST_REQUIRE_MESSAGE(o.count("pre") > 0, testname + " pre not set!");
+		BOOST_REQUIRE_MESSAGE(o.count("exec") > 0, testname + " exec not set!");
 
 		TestLastBlockHashes lastBlockHashes(h256s(256, h256()));
 		eth::EnvInfo env = FakeExtVM::importEnv(o["env"].get_obj(), lastBlockHashes);


### PR DESCRIPTION
Before this PR, `testeth` sometimes showed an error message like:
```
fatal error: in StateTestsGeneral/stStaticCall: static_call_value_inheritpre not set!
```

This PR inserts a space between the test name and the message:
```
fatal error: in StateTestsGeneral/stStaticCall: static_call_value_inherit pre not set!
```
