### PR TITLE
Use MainNetworkTest for ethvm default.

### DIFF
--- a/ethvm/main.cpp
+++ b/ethvm/main.cpp
@@ -141,7 +141,7 @@ int main(int argc, char** argv)
 	u256 gasPrice = 0;
 	bool styledJson = true;
 	StandardTrace st;
-	Network networkName = Network::MainNetwork;
+	Network networkName = Network::MainNetworkTest;
 	BlockHeader blockHeader; // fake block to be executed in
 	blockHeader.setGasLimit(maxBlockGasLimit());
 	bytes data;


### PR DESCRIPTION
Gives much faster startup.  Main is still available as command line argument.