### PR TITLE
--jsontrace option for testeth

### DIFF
--- a/test/tools/libtesteth/ImportTest.cpp
+++ b/test/tools/libtesteth/ImportTest.cpp
@@ -219,10 +219,23 @@ std::tuple<eth::State, ImportTest::ExecOutput, eth::ChangeLog> ImportTest::execu
 	assert(m_envInfo);
 
 	State initialState = _preState;
+	ExecOutput out(std::make_pair(eth::ExecutionResult(), eth::TransactionReceipt(h256(), u256(), eth::LogEntries())));
 	try
 	{
 		unique_ptr<SealEngineFace> se(ChainParams(genesisInfo(_sealEngineNetwork)).createSealEngine());
-		ExecOutput out = initialState.execute(_env, *se.get(), _tr, Permanence::Uncommitted);
+		if (Options::get().jsontrace)
+		{
+			Json::Value trace;
+			StandardTrace st;
+			st.setShowMnemonics();
+			st.setOptions(Options::get().jsontraceOptions);
+			out = initialState.execute(_env, *se.get(), _tr, Permanence::Uncommitted, st.onOp());
+			Json::Reader().parse(st.json(), trace);
+			cout << trace;
+		}
+		else
+			out = initialState.execute(_env, *se.get(), _tr, Permanence::Uncommitted);
+
 		eth::ChangeLog changeLog = initialState.changeLog();
 		ImportTest::checkBalance(_preState, initialState);
 
@@ -241,8 +254,7 @@ std::tuple<eth::State, ImportTest::ExecOutput, eth::ChangeLog> ImportTest::execu
 	}
 
 	initialState.commit(State::CommitBehaviour::KeepEmptyAccounts);
-	ExecOutput emptyOutput(std::make_pair(eth::ExecutionResult(), eth::TransactionReceipt(h256(), u256(), eth::LogEntries())));
-	return std::make_tuple(initialState, emptyOutput, initialState.changeLog());
+	return std::make_tuple(initialState, out, initialState.changeLog());
 }
 
 json_spirit::mObject& ImportTest::makeAllFieldsHex(json_spirit::mObject& _o, bool _isHeader)

--- a/test/tools/libtesteth/Options.h
+++ b/test/tools/libtesteth/Options.h
@@ -22,6 +22,7 @@
 #include <test/tools/libtestutils/Common.h>
 #include <test/tools/libtesteth/JsonSpiritHeaders.h>
 #include <libdevcore/Exceptions.h>
+#include <libethereum/Executive.h>
 
 namespace dev
 {
@@ -54,6 +55,8 @@ public:
 	bool statediff = false;///< Fill full post state in General tests
 	bool fulloutput = false;///< Replace large output to just it's length
 	bool createRandomTest = false; ///< Generate random test
+	bool jsontrace = false; ///< Vmtrace to stdout in json format
+	eth::StandardTrace::DebugOptions jsontraceOptions; ///< output config for jsontrace
 	std::string testpath;	///< Custom test folder path
 	Verbosity logVerbosity = Verbosity::NiceReport;
 


### PR DESCRIPTION
vmtrace in json format for state tests. (using interface as in RPC debug method)
usage:
```
./testeth -t StateTestsGeneral/stCallCodes -- --singletest callcodecallcall_100_SuicideEnd --jsontrace '{ "disableStorage" : true }' --singlenet Metropolis
Running 1 test case...
Test Case "stCallCodes": 
100%
[
	{
		"gas" : "2979000",
		"gasCost" : "3",
		"memory" : [],
		"op" : "PUSH1",
		"pc" : "0",
		"stack" : []
	},
	{
		"gas" : "2978997",
		"gasCost" : "3",
		"op" : "PUSH1",
		"pc" : "2",
		"stack" : 
		[
			"0x40"
		]
	},
	{
		"gas" : "2978994",
		"gasCost" : "3",
		"op" : "PUSH1",
		"pc" : "4",
		"stack" : 
		[
			"0x40",
			"0x00"
		]
	},
```