### PR TITLE
Remove expect sections when filling VM test

### DIFF
--- a/test/tools/jsontests/vm.cpp
+++ b/test/tools/jsontests/vm.cpp
@@ -311,6 +311,8 @@ void doVMTests(json_spirit::mValue& _v, bool _fillin)
 		BOOST_REQUIRE_MESSAGE(o.count("env") > 0, testname + " env not set!");
 		BOOST_REQUIRE_MESSAGE(o.count("pre") > 0, testname + " pre not set!");
 		BOOST_REQUIRE_MESSAGE(o.count("exec") > 0, testname + " exec not set!");
+		if (! _fillin)
+			BOOST_REQUIRE_MESSAGE(o.count("expect") == 0, testname + " expect set!");
 
 		TestLastBlockHashes lastBlockHashes(h256s(256, h256()));
 		eth::EnvInfo env = FakeExtVM::importEnv(o["env"].get_obj(), lastBlockHashes);
@@ -378,12 +380,29 @@ void doVMTests(json_spirit::mValue& _v, bool _fillin)
 		{
 			o["env"] = mValue(fev.exportEnv());
 			o["exec"] = mValue(fev.exportExec());
-			if (!vmExceptionOccured)
+			if (vmExceptionOccured)
+			{
+				if (o.count("expect") > 0)
+				{
+					BOOST_REQUIRE_MESSAGE(o.count("expect") == 1, testname + " multiple expect set!");
+					State postState(State::Null);
+					State expectState(State::Null);
+					AccountMaskMap expectStateMap;
+					ImportTest::importState(mValue(fev.exportState()).get_obj(), postState);
+					ImportTest::importState(o["expect"].get_obj(), expectState, expectStateMap);
+					ImportTest::compareStates(expectState, postState, expectStateMap, Options::get().checkstate ? WhenError::Throw : WhenError::DontThrow);
+					o.erase(o.find("expect"));
+				}
+				BOOST_REQUIRE_MESSAGE(o.count("expect") == 0, testname + " expect should have been erased!");
+			}
+			else
 			{
 				o["post"] = mValue(fev.exportState());
 
 				if (o.count("expect") > 0)
 				{
+					BOOST_REQUIRE_MESSAGE(o.count("expect") == 1, testname + " multiple expect set!");
+
 					State postState(State::Null);
 					State expectState(State::Null);
 					AccountMaskMap expectStateMap;
@@ -392,6 +411,8 @@ void doVMTests(json_spirit::mValue& _v, bool _fillin)
 					ImportTest::compareStates(expectState, postState, expectStateMap, Options::get().checkstate ? WhenError::Throw : WhenError::DontThrow);
 					o.erase(o.find("expect"));
 				}
+
+				BOOST_REQUIRE_MESSAGE(o.count("expect") == 0, testname + " expect should have been erased!");
 
 				o["callcreates"] = fev.exportCallCreates();
 				o["out"] = output.size() > 4096 ? "#" + toString(output.size()) : toHexPrefixed(output);


### PR DESCRIPTION
This PR
* makes testeth fails when it sees "expect" sections in a filled VM test; and
* makes sure that the filled VM test does not contain "expect" sections

Fixes #4280 