### PR TITLE
remove checkstate option

### DIFF
--- a/test/tools/jsontests/BlockChainTests.cpp
+++ b/test/tools/jsontests/BlockChainTests.cpp
@@ -354,12 +354,10 @@ void fillBCTest(json_spirit::mObject& _o)
 			if (testChain.addBlock(alterBlock))
 				cnote << "The most recent best Block now is " <<  importBlockNumber << "in chain" << chainname << "at test " << testName;
 
-			if (test::Options::get().checkstate)
-			{
-				bool isException = (blObj.count("expectException"+test::netIdToString(test::TestBlockChain::s_sealEngineNetwork))
-									|| blObj.count("expectExceptionALL"));
-				BOOST_REQUIRE_MESSAGE(!isException, "block import expected exception, but no exception was thrown!");
-			}
+			bool isException = (blObj.count("expectException"+test::netIdToString(test::TestBlockChain::s_sealEngineNetwork))
+								|| blObj.count("expectExceptionALL"));
+			BOOST_REQUIRE_MESSAGE(!isException, "block import expected exception, but no exception was thrown!");
+
 			if (_o.count("noBlockChainHistory") == 0)
 			{
 				importedBlocks.push_back(alterBlock);
@@ -393,8 +391,7 @@ void fillBCTest(json_spirit::mObject& _o)
 		AccountMaskMap expectStateMap;
 		State stateExpect(State::Null);
 		ImportTest::importState(_o["expect"].get_obj(), stateExpect, expectStateMap);
-		if (ImportTest::compareStates(stateExpect, testChain.topBlock().state(), expectStateMap, Options::get().checkstate ? WhenError::Throw : WhenError::DontThrow))
-			if (Options::get().checkstate)
+		if (ImportTest::compareStates(stateExpect, testChain.topBlock().state(), expectStateMap, WhenError::Throw))
 				cerr << testName << endl;
 		_o.erase(_o.find("expect"));
 	}
@@ -841,9 +838,6 @@ mObject writeBlockHeaderToJson(BlockHeader const& _bi)
 
 void checkExpectedException(mObject& _blObj, Exception const& _e)
 {
-	if (!test::Options::get().checkstate)
-		return;
-
 	string exWhat {	_e.what() };
 	bool isNetException = (_blObj.count("expectException"+test::netIdToString(test::TestBlockChain::s_sealEngineNetwork)) > 0);
 	bool isAllNetException = (_blObj.count("expectExceptionALL") > 0);

--- a/test/tools/jsontests/TransactionTests.cpp
+++ b/test/tools/jsontests/TransactionTests.cpp
@@ -94,11 +94,7 @@ void doTransactionTests(json_spirit::mValue& _v, bool _fillin)
 				if (o.count("expect") > 0)
 				{
 					bool expectInValid = (o["expect"].get_str() == "invalid");
-					if (Options::get().checkstate)
-							BOOST_CHECK_MESSAGE(expectInValid, testname + " Check state: Transaction '" << i.first << "' is expected to be valid!");
-						else
-							BOOST_WARN_MESSAGE(expectInValid, testname + " Check state: Transaction '" << i.first << "' is expected to be valid!");
-
+					BOOST_CHECK_MESSAGE(expectInValid, testname + " Check state: Transaction '" << i.first << "' is expected to be valid!");
 					o.erase(o.find("expect"));
 				}
 			}
@@ -107,11 +103,7 @@ void doTransactionTests(json_spirit::mValue& _v, bool _fillin)
 			if (o.count("expect") > 0)
 			{
 				bool expectValid = (o["expect"].get_str() == "valid");
-				if (Options::get().checkstate)
-						BOOST_CHECK_MESSAGE(expectValid, testname + " Check state: Transaction '" << i.first << "' is expected to be invalid!");
-					else
-						BOOST_WARN_MESSAGE(expectValid, testname + " Check state: Transaction '" << i.first << "' is expected to be invalid!");
-
+				BOOST_CHECK_MESSAGE(expectValid, testname + " Check state: Transaction '" << i.first << "' is expected to be invalid!");
 				o.erase(o.find("expect"));
 			}
 		}

--- a/test/tools/jsontests/vm.cpp
+++ b/test/tools/jsontests/vm.cpp
@@ -390,7 +390,7 @@ void doVMTests(json_spirit::mValue& _v, bool _fillin)
 					AccountMaskMap expectStateMap;
 					ImportTest::importState(mValue(fev.exportState()).get_obj(), postState);
 					ImportTest::importState(o["expect"].get_obj(), expectState, expectStateMap);
-					ImportTest::compareStates(expectState, postState, expectStateMap, Options::get().checkstate ? WhenError::Throw : WhenError::DontThrow);
+					ImportTest::compareStates(expectState, postState, expectStateMap, WhenError::Throw);
 					o.erase(o.find("expect"));
 				}
 				BOOST_REQUIRE_MESSAGE(o.count("expect") == 0, testname + " expect should have been erased!");
@@ -408,7 +408,7 @@ void doVMTests(json_spirit::mValue& _v, bool _fillin)
 					AccountMaskMap expectStateMap;
 					ImportTest::importState(o["post"].get_obj(), postState);
 					ImportTest::importState(o["expect"].get_obj(), expectState, expectStateMap);
-					ImportTest::compareStates(expectState, postState, expectStateMap, Options::get().checkstate ? WhenError::Throw : WhenError::DontThrow);
+					ImportTest::compareStates(expectState, postState, expectStateMap, WhenError::Throw);
 					o.erase(o.find("expect"));
 				}
 
@@ -421,11 +421,7 @@ void doVMTests(json_spirit::mValue& _v, bool _fillin)
 				if (o.count("expectOut") > 0)
 				{
 					std::string warning = " Check State: Error! Unexpected output: " + o["out"].get_str() + " Expected: " + o["expectOut"].get_str();
-					if (Options::get().checkstate)
-						BOOST_CHECK_MESSAGE(o["out"].get_str() == o["expectOut"].get_str(), warning);
-					else
-						BOOST_WARN_MESSAGE(o["out"].get_str() == o["expectOut"].get_str(), warning);
-
+					BOOST_CHECK_MESSAGE(o["out"].get_str() == o["expectOut"].get_str(), warning);
 					o.erase(o.find("expectOut"));
 				}
 

--- a/test/tools/libtesteth/ImportTest.cpp
+++ b/test/tools/libtesteth/ImportTest.cpp
@@ -641,7 +641,7 @@ void ImportTest::checkGeneralTestSectionSearch(json_spirit::mObject const& _expe
 					_search->second.second = stateMap;
 					return;
 				}
-				int errcode = compareStates(expectState, postState, stateMap, Options::get().checkstate ? WhenError::Throw : WhenError::DontThrow);
+				int errcode = compareStates(expectState, postState, stateMap, WhenError::Throw);
 				if (errcode > 0)
 				{
 					cerr << trInfo << std::endl;
@@ -717,12 +717,9 @@ int ImportTest::exportTest(bytes const& _output)
 			obj2["logs"] = exportLog(tr.output.second.log());
 
 			//Print the post state if transaction has failed on expect section
-			if (Options::get().checkstate)
-			{
-				auto it = std::find(std::begin(stateIndexesToPrint), std::end(stateIndexesToPrint), i);
-				if (it != std::end(stateIndexesToPrint))
-					obj2["postState"] = fillJsonWithState(tr.postState);
-			}
+			auto it = std::find(std::begin(stateIndexesToPrint), std::end(stateIndexesToPrint), i);
+			if (it != std::end(stateIndexesToPrint))
+				obj2["postState"] = fillJsonWithState(tr.postState);
 
 			if (Options::get().statediff)
 				obj2["stateDiff"] = fillJsonWithStateChange(m_statePre, tr.postState, tr.changeLog);
@@ -745,15 +742,11 @@ int ImportTest::exportTest(bytes const& _output)
 		if (m_testObject.count("expectOut") > 0)
 		{
 			std::string warning = "Check State: Error! Unexpected output: " + m_testObject["out"].get_str() + " Expected: " + m_testObject["expectOut"].get_str();
-			if (Options::get().checkstate)
-			{
-				bool statement = (m_testObject["out"].get_str() == m_testObject["expectOut"].get_str());
-				BOOST_CHECK_MESSAGE(statement, warning);
-				if (!statement)
-					err = 1;
-			}
-			else
-				BOOST_WARN_MESSAGE(m_testObject["out"].get_str() == m_testObject["expectOut"].get_str(), warning);
+
+			bool statement = (m_testObject["out"].get_str() == m_testObject["expectOut"].get_str());
+			BOOST_CHECK_MESSAGE(statement, warning);
+			if (!statement)
+				err = 1;
 
 			m_testObject.erase(m_testObject.find("expectOut"));
 		}
@@ -764,7 +757,7 @@ int ImportTest::exportTest(bytes const& _output)
 			eth::AccountMaskMap stateMap;
 			State expectState(0, OverlayDB(), eth::BaseState::Empty);
 			importState(m_testObject["expect"].get_obj(), expectState, stateMap);
-			compareStates(expectState, m_statePost, stateMap, Options::get().checkstate ? WhenError::Throw : WhenError::DontThrow);
+			compareStates(expectState, m_statePost, stateMap, WhenError::Throw);
 			m_testObject.erase(m_testObject.find("expect"));
 		}
 

--- a/test/tools/libtesteth/Options.cpp
+++ b/test/tools/libtesteth/Options.cpp
@@ -60,7 +60,6 @@ void printHelp()
 
 	cout << std::endl << "Test Generation" << std::endl;
 	cout << setw(30) << "--filltests" << setw(25) << "Run test fillers" << std::endl;
-	cout << setw(30) << "--checkstate" << setw(25) << "Enable expect section state checks" << std::endl;
 	cout << setw(30) << "--fillchain" << setw(25) << "When filling the state tests, fill tests as blockchain instead" << std::endl;
 	cout << setw(30) << "--randomcode <MaxOpcodeNum>" << setw(25) << "Generate smart random EVM code" << std::endl;
 	cout << setw(30) << "--createRandomTest" << setw(25) << "Create random test and output it to the console" << std::endl;
@@ -168,8 +167,6 @@ Options::Options(int argc, char** argv)
 			inputLimits = true;
 		else if (arg == "--bigdata")
 			bigData = true;
-		else if (arg == "--checkstate")
-			checkstate = true;
 		else if (arg == "--wallet")
 			wallet = true;
 		else if (arg == "--all")

--- a/test/tools/libtesteth/Options.h
+++ b/test/tools/libtesteth/Options.h
@@ -51,7 +51,6 @@ public:
 	std::string statsOutFile; ///< Stats output file. "out" for standard output
 	bool exectimelog = false; ///< Print execution time for each test suite
 	std::string rCurrentTestSuite; ///< Remember test suite before boost overwrite (for random tests)
-	bool checkstate = false;///< Throw error when checking test states
 	bool statediff = false;///< Fill full post state in General tests
 	bool fulloutput = false;///< Replace large output to just it's length
 	bool createRandomTest = false; ///< Generate random test


### PR DESCRIPTION
testeth --checkstate option was always used otherwise tests were not checked for correctness when filling