### PR TITLE
remove fields with '//' prefix from .json tests when filling

### DIFF
--- a/test/tools/jsontests/BlockChainTests.cpp
+++ b/test/tools/jsontests/BlockChainTests.cpp
@@ -832,7 +832,6 @@ mObject writeBlockHeaderToJson(BlockHeader const& _bi)
 	o["mixHash"] = toString(Ethash::mixHash(_bi));
 	o["nonce"] = toString(Ethash::nonce(_bi));
 	o["hash"] = toString(_bi.hash());
-	ImportTest::makeAllFieldsHex(o, true);
 	return o;
 }
 

--- a/test/tools/jsontests/TransactionTests.cpp
+++ b/test/tools/jsontests/TransactionTests.cpp
@@ -81,7 +81,7 @@ void doTransactionTests(json_spirit::mValue& _v, bool _fillin)
 					BOOST_CHECK_MESSAGE(toString(txFromFields.sender()) == expectSender, "Error filling transaction test " + TestOutputHelper::testName() + ": expected another sender address! (got: " + toString(txFromFields.sender()) + "), expected: (" + expectSender + ")");
 				}
 				o["sender"] = toString(txFromFields.sender());
-				o["transaction"] = ImportTest::makeAllFieldsHex(tObj);
+				o["transaction"] = tObj;
 				o["hash"] = toString(txFromFields.sha3());
 			}
 			catch(Exception const& _e)

--- a/test/tools/libtesteth/FillJsonFunctions.cpp
+++ b/test/tools/libtesteth/FillJsonFunctions.cpp
@@ -48,7 +48,6 @@ json_spirit::mObject fillJsonWithTransaction(Transaction const& _txn)
 	txObject["v"] = toCompactHexPrefixed(_txn.signature().v + 27, 1);
 	txObject["to"] = _txn.isCreation() ? "" : toHexPrefixed(_txn.receiveAddress());
 	txObject["value"] = toCompactHexPrefixed(_txn.value(), 1);
-	ImportTest::makeAllFieldsHex(txObject);
 	return txObject;
 }
 

--- a/test/tools/libtesteth/TestHelper.cpp
+++ b/test/tools/libtesteth/TestHelper.cpp
@@ -539,21 +539,24 @@ void postParseJson(json_spirit::mValue& _obj)
 {
 	if(_obj.type() == json_spirit::obj_type)
 	{
+		std::list<string> removeList;
 		for (auto& i: _obj.get_obj())
 		{
 			if (i.first.substr(0, 2) == "//")
 			{
-				_obj.get_obj().erase(_obj.get_obj().find(i.first));
+				removeList.push_back(i.first);
 				continue;
 			}
 
 			if (i.second.type() != json_spirit::str_type)
 			{
+				postParseJson(i.second);
 				if (i.first != "_info" && i.second.type() == json_spirit::obj_type)
 					i.second = ImportTest::makeAllFieldsHex(i.second.get_obj(), i.first == "env" ? true : false);
-				postParseJson(i.second);
 			}
 		}
+		for(auto& i: removeList)
+			_obj.get_obj().erase(_obj.get_obj().find(i));
 	}
 	else if (_obj.type() == json_spirit::array_type)
 	{

--- a/test/tools/libtesteth/TestHelper.h
+++ b/test/tools/libtesteth/TestHelper.h
@@ -158,6 +158,7 @@ dev::eth::BlockHeader constructHeader(
 	bytes const& _extraData);
 void updateEthashSeal(dev::eth::BlockHeader& _header, h256 const& _mixHash, dev::eth::Nonce const& _nonce);
 void executeTests(const std::string& _name, const std::string& _testPathAppendix, const std::string& _fillerPathAppendix, std::function<void(json_spirit::mValue&, bool)> doTests, bool _addFillerSuffix = true);
+void postParseJson(json_spirit::mValue& _obj);
 void userDefinedTest(std::function<void(json_spirit::mValue&, bool)> doTests);
 RLPStream createRLPStreamFromTransactionFields(json_spirit::mObject const& _tObj);
 json_spirit::mObject fillJsonWithStateChange(eth::State const& _stateOrig, eth::State const& _statePost, eth::ChangeLog const& _changeLog);

--- a/test/tools/libtesteth/TestHelper.h
+++ b/test/tools/libtesteth/TestHelper.h
@@ -158,7 +158,7 @@ dev::eth::BlockHeader constructHeader(
 	bytes const& _extraData);
 void updateEthashSeal(dev::eth::BlockHeader& _header, h256 const& _mixHash, dev::eth::Nonce const& _nonce);
 void executeTests(const std::string& _name, const std::string& _testPathAppendix, const std::string& _fillerPathAppendix, std::function<void(json_spirit::mValue&, bool)> doTests, bool _addFillerSuffix = true);
-void postParseJson(json_spirit::mValue& _obj);
+void postParseJson(json_spirit::mValue& _obj, std::string const& _testfilename = "");
 void userDefinedTest(std::function<void(json_spirit::mValue&, bool)> doTests);
 RLPStream createRLPStreamFromTransactionFields(json_spirit::mObject const& _tObj);
 json_spirit::mObject fillJsonWithStateChange(eth::State const& _stateOrig, eth::State const& _statePost, eth::ChangeLog const& _changeLog);


### PR DESCRIPTION
refactoring makeAllFieldsHex function