### PR TITLE
standardized vmtrace logs

### DIFF
--- a/libethereum/Executive.cpp
+++ b/libethereum/Executive.cpp
@@ -130,6 +130,7 @@ void StandardTrace::operator()(uint64_t _steps, uint64_t PC, Instruction inst, b
 	r["pc"] = toString(PC);
 	r["gas"] = toString(gas);
 	r["gasCost"] = toString(gasCost);
+	r["depth"] = toString(ext.depth);
 	if (!!newMemSize)
 		r["memexpand"] = toString(newMemSize);
 

--- a/test/tools/libtesteth/ImportTest.cpp
+++ b/test/tools/libtesteth/ImportTest.cpp
@@ -228,13 +228,11 @@ std::tuple<eth::State, ImportTest::ExecOutput, eth::ChangeLog> ImportTest::execu
 		unique_ptr<SealEngineFace> se(ChainParams(genesisInfo(_sealEngineNetwork)).createSealEngine());
 		if (Options::get().jsontrace)
 		{
-			Json::Value trace;
 			StandardTrace st;
 			st.setShowMnemonics();
 			st.setOptions(Options::get().jsontraceOptions);
 			out = initialState.execute(_env, *se.get(), _tr, Permanence::Uncommitted, st.onOp());
-			Json::Reader().parse(st.json(), trace);
-			cout << trace;
+			cout << st.json();
 		}
 		else
 			out = initialState.execute(_env, *se.get(), _tr, Permanence::Uncommitted);


### PR DESCRIPTION
This fixes the VM trace logs to be aligned with the other clients, following the work-in-progress standard format https://github.com/ethereum/tests/issues/249.

Some edge cases still remain, which might cause the cpp trace to differ under some circumstances, but this is a good start (traces are equivalent for all EIP158 state tests).