### PR TITLE
Support syncing without the full previous chain

### DIFF
--- a/libethereum/BlockChain.h
+++ b/libethereum/BlockChain.h
@@ -67,6 +67,8 @@ class ImportPerformanceLogger;
 DEV_SIMPLE_EXCEPTION(AlreadyHaveBlock);
 DEV_SIMPLE_EXCEPTION(FutureTime);
 DEV_SIMPLE_EXCEPTION(TransientError);
+DEV_SIMPLE_EXCEPTION(FailedToWriteChainStart);
+DEV_SIMPLE_EXCEPTION(UnknownBlockNumber);
 
 struct BlockChainChat: public LogChannel { static const char* name(); static const int verbosity = 5; };
 struct BlockChainNote: public LogChannel { static const char* name(); static const int verbosity = 3; };
@@ -311,6 +313,9 @@ public:
 	SealEngineFace* sealEngine() const { return m_sealEngine.get(); }
 
 	BlockHeader const& genesis() const;
+
+	unsigned chainStartBlockNumber() const;
+	void setChainStartBlockNumber(unsigned _number);
 
 private:
 	static h256 chunkId(unsigned _level, unsigned _index) { return h256(_index * 0xff + _level); }

--- a/libethereum/BlockChain.h
+++ b/libethereum/BlockChain.h
@@ -314,7 +314,9 @@ public:
 
 	BlockHeader const& genesis() const;
 
+	/// @returns first block number of the chain, non-zero when we have partial chain e.g. after snapshot import.
 	unsigned chainStartBlockNumber() const;
+	/// Change the chain start block.
 	void setChainStartBlockNumber(unsigned _number);
 
 private:

--- a/libethereum/BlockChainSync.h
+++ b/libethereum/BlockChainSync.h
@@ -142,6 +142,7 @@ private:
 	mutable RecursiveMutex x_sync;
 	SyncState m_state = SyncState::Idle;		///< Current sync state
 	h256Hash m_knownNewHashes; 					///< New hashes we know about use for logging only
+	unsigned m_chainStartBlock = 0;
 	unsigned m_startingBlock = 0;      	    	///< Last block number for the start of sync
 	unsigned m_highestBlock = 0;       	     	///< Highest block number seen
 	std::unordered_set<unsigned> m_downloadingHeaders;		///< Set of block body numbers being downloaded


### PR DESCRIPTION
Methods for saving to Extras DB block hash of the block where our part of the chain starts (will be used after importing snapshot)

BlockChainSync uses chain start block number to avoid downloading earlier blocks.