### PR TITLE
Replace polling with conditional variables

### DIFF
--- a/libdevcore/Worker.h
+++ b/libdevcore/Worker.h
@@ -99,8 +99,9 @@ private:
 
 	unsigned m_idleWaitMs = 0;
 	
-	mutable Mutex x_work;						///< Lock for the network existance.
+	mutable Mutex x_work;						///< Lock for the network existance and m_state_notifier.
 	std::unique_ptr<std::thread> m_work;		///< The network thread.
+    mutable std::condition_variable m_state_notifier; //< Notification when m_state changes.
 	std::atomic<WorkerState> m_state = {WorkerState::Starting};
 };
 

--- a/libethashseal/Ethash.cpp
+++ b/libethashseal/Ethash.cpp
@@ -60,6 +60,12 @@ Ethash::Ethash()
 	});
 }
 
+Ethash::~Ethash()
+{
+	// onSolutionFound closure sometimes has references to destroyed members.
+	m_farm.onSolutionFound({});
+}
+
 strings Ethash::sealers() const
 {
 	return {"cpu"};

--- a/libethashseal/Ethash.h
+++ b/libethashseal/Ethash.h
@@ -37,6 +37,7 @@ class Ethash: public SealEngineBase
 {
 public:
 	Ethash();
+	~Ethash();
 
 	std::string name() const override { return "Ethash"; }
 	unsigned revision() const override { return 1; }


### PR DESCRIPTION
This pull-request replaces some `while(something) sleep(20ms)` with conditional variables.

The BlockchainTest filling might be faster now.
```
zsh
[13:57] yh@sri: ~/src/cpp-ethereum/build(faster_blockchaintest_filling|…)$ time (repeat 10 ETHEREUM_TEST_PATH="../../tests" ./test/testeth -t 'StateTestsGeneral' -- --filltests --fillchain --singletest returndatacopy_following_revert --verbosity 9 --singlenet EIP158)

[this branch]
( repeat 10; do; ETHEREUM_TEST_PATH="../../tests" ./test/testeth -t  --      )  49,03s user 2,96s system 110% cpu 47,018 total

[develop]
( repeat 10; do; ETHEREUM_TEST_PATH="../../tests" ./test/testeth -t  --      )  62,84s user 2,81s system 107% cpu 1:00,95 total
```