### PR TITLE
Fix for leaking unix sockets in IPC RPC

### DIFF
--- a/libweb3jsonrpc/UnixSocketServer.cpp
+++ b/libweb3jsonrpc/UnixSocketServer.cpp
@@ -111,7 +111,7 @@ void UnixDomainSocketServer::Listen()
 			DEV_GUARDED(x_sockets)
 				m_sockets.insert(connection);
 
-			std::thread handler([this, connection](){ GenerateResponse(connection); });
+			std::thread handler([this, connection](){ GenerateResponse(connection); CloseConnection(connection);});
 			handler.detach();
 		}
 	}
@@ -119,6 +119,7 @@ void UnixDomainSocketServer::Listen()
 
 void UnixDomainSocketServer::CloseConnection(int _socket)
 {
+	shutdown(_socket, SHUT_RDWR);
 	close(_socket);
 }
 


### PR DESCRIPTION
Currently sockets in libweb3jsonrpc/UnixSocketServer.cpp are not closed after a request is completed. After performing many IPC requests, the sockets hang around and eventually exhaust available file descriptors. This is easily verified by lsof-ing the process after performing IPC requests.

This pull request closes sockets after the response is generated, and also adds shutdown(sock. O_RDRW) to CloseConnection to ensure sockets are closed in a timely manner.