### PR TITLE
Add State Tests for Unused Opcodes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,4 +4,5 @@
 	branch = develop
 [submodule "test/tests"]
 	path = test/jsontests
-	url = https://github.com/ethereum/tests.git
+	url = https://github.com/jwasinger/tests.git
+  branch = invalid-ops

--- a/.gitmodules
+++ b/.gitmodules
@@ -5,4 +5,3 @@
 [submodule "test/tests"]
 	path = test/jsontests
 	url = https://github.com/ethereum/tests.git
-  branch = invalid-ops

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,5 +4,5 @@
 	branch = develop
 [submodule "test/tests"]
 	path = test/jsontests
-	url = https://github.com/jwasinger/tests.git
+	url = https://github.com/ethereum/tests.git
   branch = invalid-ops

--- a/test/tools/jsontests/StateTests.cpp
+++ b/test/tools/jsontests/StateTests.cpp
@@ -193,4 +193,7 @@ BOOST_AUTO_TEST_CASE(stZeroKnowledge){}
 BOOST_AUTO_TEST_CASE(stAttackTest){}
 BOOST_AUTO_TEST_CASE(stMemoryStressTest){}
 BOOST_AUTO_TEST_CASE(stQuadraticComplexityTest){}
+
+//Invalid Opcode Tests
+BOOST_AUTO_TEST_CASE(stBadOpcode){}
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Based on an issue discovered by @cdetrio (https://gist.github.com/cdetrio/2776a57db1594f679ceef11d05bfc9a9).  This pull adds tests to make sure that clients aren't implementing unused opcodes: SSIZE, SLOADBYTES, SSTOREBYTES.

Corresponding pull request for tests: https://github.com/ethereum/tests/pull/261