### PR TITLE
EIP649 reward reduction and difficulty bomb delay

### DIFF
--- a/libethashseal/Ethash.cpp
+++ b/libethashseal/Ethash.cpp
@@ -215,7 +215,18 @@ u256 Ethash::calculateDifficulty(BlockHeader const& _bi, BlockHeader const& _par
 	}
 
 	bigint o = target;
-	unsigned periodCount = unsigned(_parent.number() + 1) / c_expDiffPeriod;
+	unsigned exponentialIceAgeBlockNumber = unsigned(_parent.number() + 1);
+
+	// EIP-649 modifies exponentialIceAgeBlockNumber
+	if (_bi.number() >= chainParams().u256Param("byzantiumForkBlock"))
+	{
+		if (exponentialIceAgeBlockNumber >= 3000000)
+			exponentialIceAgeBlockNumber -= 3000000;
+		else
+			exponentialIceAgeBlockNumber = 0;
+	}
+
+	unsigned periodCount = exponentialIceAgeBlockNumber / c_expDiffPeriod;
 	if (periodCount > 1)
 		o += (bigint(1) << (periodCount - 2));	// latter will eventually become huge, so ensure it's a bigint.
 

--- a/libethcore/ChainOperationParams.cpp
+++ b/libethcore/ChainOperationParams.cpp
@@ -67,10 +67,10 @@ u256 ChainOperationParams::u256Param(string const& _name) const
 	return u256(fromBigEndian<u256>(fromHex(at)));
 }
 
-u256 ChainOperationParams::blockReward(bool isByzantiumOrLater) const
+u256 ChainOperationParams::blockReward(EVMSchedule const& _schedule) const
 {
-	if (isByzantiumOrLater)
-		return 3 * ether;
+	if (_schedule.blockRewardOverwrite)
+		return *_schedule.blockRewardOverwrite;
 	else
 		return m_blockReward;
 }

--- a/libethcore/ChainOperationParams.cpp
+++ b/libethcore/ChainOperationParams.cpp
@@ -75,7 +75,7 @@ u256 ChainOperationParams::blockReward(bool isByzantiumOrLater) const
 		return m_blockReward;
 }
 
-void ChainOperationParams::setBlockReward(u256 const& newBlockReward)
+void ChainOperationParams::setBlockReward(u256 const& _newBlockReward)
 {
-	m_blockReward = newBlockReward;
+	m_blockReward = _newBlockReward;
 }

--- a/libethcore/ChainOperationParams.cpp
+++ b/libethcore/ChainOperationParams.cpp
@@ -53,7 +53,7 @@ ChainOperationParams::ChainOperationParams()
 		{"registrar", "5e70c0bbcd5636e0f9f9316e9f8633feb64d4050"},
 		{"networkID", "0x0"}
 	};
-	blockReward = u256("0x4563918244F40000");
+	m_blockReward = u256("0x4563918244F40000");
 }
 
 u256 ChainOperationParams::u256Param(string const& _name) const
@@ -65,4 +65,17 @@ u256 ChainOperationParams::u256Param(string const& _name) const
 		at = it->second;
 
 	return u256(fromBigEndian<u256>(fromHex(at)));
+}
+
+u256 ChainOperationParams::blockReward(bool isByzantiumOrLater) const
+{
+	if (isByzantiumOrLater)
+		return 3 * ether;
+	else
+		return m_blockReward;
+}
+
+void ChainOperationParams::setBlockReward(u256 const& newBlockReward)
+{
+	m_blockReward = newBlockReward;
 }

--- a/libethcore/ChainOperationParams.h
+++ b/libethcore/ChainOperationParams.h
@@ -73,7 +73,11 @@ struct ChainOperationParams
 	std::string sealEngineName = "NoProof";
 
 	/// General chain params.
-	u256 blockReward = 0;
+private:
+	u256 m_blockReward;
+public:
+	u256 blockReward(bool isByzantiumOrLater) const;
+	void setBlockReward(u256 const& blockReward);
 	u256 maximumExtraDataSize = 1024;
 	u256 accountStartNonce = 0;
 	bool tieBreakingGas = true;

--- a/libethcore/ChainOperationParams.h
+++ b/libethcore/ChainOperationParams.h
@@ -76,8 +76,8 @@ struct ChainOperationParams
 private:
 	u256 m_blockReward;
 public:
-	u256 blockReward(bool isByzantiumOrLater) const;
-	void setBlockReward(u256 const& blockReward);
+	u256 blockReward(EVMSchedule const& _schedule) const;
+	void setBlockReward(u256 const& _newBlockReward);
 	u256 maximumExtraDataSize = 1024;
 	u256 accountStartNonce = 0;
 	bool tieBreakingGas = true;

--- a/libethcore/EVMSchedule.h
+++ b/libethcore/EVMSchedule.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <array>
+#include <boost/optional.hpp>
 
 namespace dev
 {
@@ -71,6 +72,8 @@ struct EVMSchedule
 	unsigned blockhashGas = 20;
 	unsigned maxCodeSize = unsigned(-1);
 
+	boost::optional<u256> blockRewardOverwrite;
+
 	bool staticCallDepthLimit() const { return !eip150Mode; }
 	bool suicideChargesNewAccountGas() const { return eip150Mode; }
 	bool emptinessIsNonexistence() const { return eip158Mode; }
@@ -109,6 +112,7 @@ static const EVMSchedule ByzantiumSchedule = []
 	schedule.haveRevert = true;
 	schedule.haveReturnData = true;
 	schedule.haveStaticCall = true;
+	schedule.blockRewardOverwrite = {3 * ether};
 	return schedule;
 }();
 

--- a/libethcore/SealEngine.cpp
+++ b/libethcore/SealEngine.cpp
@@ -85,3 +85,9 @@ EVMSchedule const& SealEngineBase::evmSchedule(u256 const& _blockNumber) const
 	else
 		return FrontierSchedule;
 }
+
+u256 SealEngineBase::blockReward(u256 const& _blockNumber) const
+{
+	EVMSchedule const& schedule{evmSchedule(_blockNumber)};
+	return chainParams().blockReward(schedule);
+}

--- a/libethcore/SealEngine.h
+++ b/libethcore/SealEngine.h
@@ -76,6 +76,7 @@ public:
 	void setChainParams(ChainOperationParams const& _params) { m_params = _params; }
 	SealEngineFace* withChainParams(ChainOperationParams const& _params) { setChainParams(_params); return this; }
 	virtual EVMSchedule const& evmSchedule(u256 const& _blockNumber) const = 0;
+	virtual u256 blockReward(u256 const& _blockNumber) const = 0;
 
 	virtual bool isPrecompiled(Address const& _a, u256 const& _blockNumber) const
 	{
@@ -106,6 +107,7 @@ public:
 	}
 	void onSealGenerated(std::function<void(bytes const&)> const& _f) override { m_onSealGenerated = _f; }
 	EVMSchedule const& evmSchedule(u256 const& _blockNumber) const override;
+	u256 blockReward(u256 const& _blockNumber) const override;
 
 protected:
 	std::function<void(bytes const& s)> m_onSealGenerated;

--- a/libethereum/Block.cpp
+++ b/libethereum/Block.cpp
@@ -626,8 +626,9 @@ u256 Block::enact(VerifiedBlockRef const& _block, BlockChain const& _bc)
 			}
 		}
 
+	bool byzantiumReward = m_currentBlock.number() >= _bc.chainParams().u256Param("ByzantiumForkBlock");
 	DEV_TIMED_ABOVE("applyRewards", 500)
-		applyRewards(rewarded, _bc.chainParams().blockReward);
+		applyRewards(rewarded, _bc.chainParams().blockReward(byzantiumReward));
 
 	// Commit all cached state changes to the state trie.
 	bool removeEmptyAccounts = m_currentBlock.number() >= _bc.chainParams().u256Param("EIP158ForkBlock");
@@ -796,7 +797,8 @@ void Block::commitToSeal(BlockChain const& _bc, bytes const& _extraData)
 	RLPStream(unclesCount).appendRaw(unclesData.out(), unclesCount).swapOut(m_currentUncles);
 
 	// Apply rewards last of all.
-	applyRewards(uncleBlockHeaders, _bc.chainParams().blockReward);
+	bool byzantiumReward = m_currentBlock.number() >= _bc.chainParams().u256Param("ByzantiumForkBlock");
+	applyRewards(uncleBlockHeaders, _bc.chainParams().blockReward(byzantiumReward));
 
 	// Commit any and all changes to the trie that are in the cache, then update the state root accordingly.
 	bool removeEmptyAccounts = m_currentBlock.number() >= _bc.chainParams().u256Param("EIP158ForkBlock");

--- a/libethereum/Block.cpp
+++ b/libethereum/Block.cpp
@@ -627,9 +627,8 @@ u256 Block::enact(VerifiedBlockRef const& _block, BlockChain const& _bc)
 		}
 
 	assert(_bc.sealEngine());
-	EVMSchedule const schedule = _bc.sealEngine()->evmSchedule(m_currentBlock.number());
 	DEV_TIMED_ABOVE("applyRewards", 500)
-		applyRewards(rewarded, _bc.chainParams().blockReward(schedule));
+		applyRewards(rewarded, _bc.sealEngine()->blockReward(m_currentBlock.number()));
 
 	// Commit all cached state changes to the state trie.
 	bool removeEmptyAccounts = m_currentBlock.number() >= _bc.chainParams().u256Param("EIP158ForkBlock"); // TODO: use EVMSchedule
@@ -799,8 +798,7 @@ void Block::commitToSeal(BlockChain const& _bc, bytes const& _extraData)
 
 	// Apply rewards last of all.
 	assert(_bc.sealEngine());
-	EVMSchedule const schedule = _bc.sealEngine()->evmSchedule(m_currentBlock.number());
-	applyRewards(uncleBlockHeaders, _bc.chainParams().blockReward(schedule));
+	applyRewards(uncleBlockHeaders, _bc.sealEngine()->blockReward(m_currentBlock.number()));
 
 	// Commit any and all changes to the trie that are in the cache, then update the state root accordingly.
 	bool removeEmptyAccounts = m_currentBlock.number() >= _bc.chainParams().u256Param("EIP158ForkBlock"); // TODO: use EVMSchedule

--- a/libethereum/ChainParams.cpp
+++ b/libethereum/ChainParams.cpp
@@ -64,7 +64,7 @@ ChainParams ChainParams::loadConfig(string const& _json, h256 const& _stateRoot)
 	cp.accountStartNonce = u256(fromBigEndian<u256>(fromHex(params["accountStartNonce"].get_str())));
 	cp.maximumExtraDataSize = u256(fromBigEndian<u256>(fromHex(params["maximumExtraDataSize"].get_str())));
 	cp.tieBreakingGas = params.count("tieBreakingGas") ? params["tieBreakingGas"].get_bool() : true;
-	cp.blockReward = u256(fromBigEndian<u256>(fromHex(params["blockReward"].get_str())));
+	cp.setBlockReward(u256(fromBigEndian<u256>(fromHex(params["blockReward"].get_str()))));
 	for (auto i: params)
 	{
 		if (i.first != "accountStartNonce" && i.first != "maximumExtraDataSize" &&

--- a/test/tools/jsontests/BlockChainTests.cpp
+++ b/test/tools/jsontests/BlockChainTests.cpp
@@ -101,7 +101,7 @@ void eraseJsonSectionForInvalidBlock(mObject& _blObj);
 void checkJsonSectionForInvalidBlock(mObject& _blObj);
 void checkExpectedException(mObject& _blObj, Exception const& _e);
 void checkBlocks(TestBlock const& _blockFromFields, TestBlock const& _blockFromRlp, string const& _testname);
-bigint calculateMiningReward(u256 const& _blNumber, u256 const& _unNumber1, u256 const& _unNumber2, EVMSchedule const& _schedule);
+bigint calculateMiningReward(u256 const& _blNumber, u256 const& _unNumber1, u256 const& _unNumber2, SealEngineFace const& _sealEngine);
 json_spirit::mObject fillBCTest(json_spirit::mObject const& _input);
 void testBCTest(json_spirit::mObject& _o);
 
@@ -553,10 +553,9 @@ void testBCTest(json_spirit::mObject& _o)
 		//check the balance before and after the block according to mining rules
 		if (blockFromFields.blockHeader().parentHash() == preHash)
 		{
-			assert(testChain.interface().sealEngine());
-			EVMSchedule const schedule = testChain.interface().sealEngine()->evmSchedule(testChain.topBlock().blockHeader().number());
 			State const postState = testChain.topBlock().state();
-			bigint reward = calculateMiningReward(testChain.topBlock().blockHeader().number(), uncleNumbers.size() >= 1 ? uncleNumbers[0] : 0, uncleNumbers.size() >= 2 ? uncleNumbers[1] : 0, schedule);
+			assert(testChain.interface().sealEngine());
+			bigint reward = calculateMiningReward(testChain.topBlock().blockHeader().number(), uncleNumbers.size() >= 1 ? uncleNumbers[0] : 0, uncleNumbers.size() >= 2 ? uncleNumbers[1] : 0, *testChain.interface().sealEngine());
 			ImportTest::checkBalance(preState, postState, reward);
 		}
 		else
@@ -587,10 +586,9 @@ void testBCTest(json_spirit::mObject& _o)
 	ImportTest::compareStates(postState, blockchain.topBlock().state());
 }
 
-bigint calculateMiningReward(u256 const& _blNumber, u256 const& _unNumber1, u256 const& _unNumber2, EVMSchedule const& _schedule)
+bigint calculateMiningReward(u256 const& _blNumber, u256 const& _unNumber1, u256 const& _unNumber2, SealEngineFace const& _sealEngine)
 {
-	unique_ptr<SealEngineFace> se(ChainParams(genesisInfo(test::TestBlockChain::s_sealEngineNetwork)).createSealEngine());
-	bigint const baseReward = se->chainParams().blockReward(_schedule);
+	bigint const baseReward = _sealEngine.blockReward(_blNumber);
 	bigint reward = baseReward;
 	//INCLUDE_UNCLE = BASE_REWARD / 32
 	//UNCLE_REWARD  = BASE_REWARD * (8 - Bn + Un) / 8

--- a/test/tools/jsontests/BlockChainTests.cpp
+++ b/test/tools/jsontests/BlockChainTests.cpp
@@ -101,7 +101,7 @@ void eraseJsonSectionForInvalidBlock(mObject& _blObj);
 void checkJsonSectionForInvalidBlock(mObject& _blObj);
 void checkExpectedException(mObject& _blObj, Exception const& _e);
 void checkBlocks(TestBlock const& _blockFromFields, TestBlock const& _blockFromRlp, string const& _testname);
-bigint calculateMiningReward(u256 const& _blNumber, u256 const& _unNumber1, u256 const& _unNumber2, bool isByzantiumOrLater);
+bigint calculateMiningReward(u256 const& _blNumber, u256 const& _unNumber1, u256 const& _unNumber2, EVMSchedule const& _schedule);
 json_spirit::mObject fillBCTest(json_spirit::mObject const& _input);
 void testBCTest(json_spirit::mObject& _o);
 
@@ -553,9 +553,10 @@ void testBCTest(json_spirit::mObject& _o)
 		//check the balance before and after the block according to mining rules
 		if (blockFromFields.blockHeader().parentHash() == preHash)
 		{
-			bool const isByzantiumOrLater = testChain.interface().number() >= testChain.interface().chainParams().u256Param("ByzantiumBlockNumber");
+			assert(testChain.interface().sealEngine());
+			EVMSchedule const schedule = testChain.interface().sealEngine()->evmSchedule(testChain.topBlock().blockHeader().number());
 			State const postState = testChain.topBlock().state();
-			bigint reward = calculateMiningReward(testChain.topBlock().blockHeader().number(), uncleNumbers.size() >= 1 ? uncleNumbers[0] : 0, uncleNumbers.size() >= 2 ? uncleNumbers[1] : 0, isByzantiumOrLater);
+			bigint reward = calculateMiningReward(testChain.topBlock().blockHeader().number(), uncleNumbers.size() >= 1 ? uncleNumbers[0] : 0, uncleNumbers.size() >= 2 ? uncleNumbers[1] : 0, schedule);
 			ImportTest::checkBalance(preState, postState, reward);
 		}
 		else
@@ -586,7 +587,7 @@ void testBCTest(json_spirit::mObject& _o)
 	ImportTest::compareStates(postState, blockchain.topBlock().state());
 }
 
-bigint calculateMiningReward(u256 const& _blNumber, u256 const& _unNumber1, u256 const& _unNumber2, bool isByzantium)
+bigint calculateMiningReward(u256 const& _blNumber, u256 const& _unNumber1, u256 const& _unNumber2, EVMSchedule const& _schedule)
 {
 	unique_ptr<SealEngineFace> se(ChainParams(genesisInfo(test::TestBlockChain::s_sealEngineNetwork)).createSealEngine());
 	bigint const baseReward = se->chainParams().blockReward(_schedule);

--- a/test/tools/jsontests/BlockChainTests.cpp
+++ b/test/tools/jsontests/BlockChainTests.cpp
@@ -101,7 +101,7 @@ void eraseJsonSectionForInvalidBlock(mObject& _blObj);
 void checkJsonSectionForInvalidBlock(mObject& _blObj);
 void checkExpectedException(mObject& _blObj, Exception const& _e);
 void checkBlocks(TestBlock const& _blockFromFields, TestBlock const& _blockFromRlp, string const& _testname);
-bigint calculateMiningReward(u256 const& _blNumber, u256 const& _unNumber1 = 0, u256 const& _unNumber2 = 0);
+bigint calculateMiningReward(u256 const& _blNumber, u256 const& _unNumber1, u256 const& _unNumber2, bool isByzantiumOrLater);
 json_spirit::mObject fillBCTest(json_spirit::mObject const& _input);
 void testBCTest(json_spirit::mObject& _o);
 
@@ -553,8 +553,9 @@ void testBCTest(json_spirit::mObject& _o)
 		//check the balance before and after the block according to mining rules
 		if (blockFromFields.blockHeader().parentHash() == preHash)
 		{
+			bool const isByzantiumOrLater = testChain.interface().number() >= testChain.interface().chainParams().u256Param("ByzantiumBlockNumber");
 			State const postState = testChain.topBlock().state();
-			bigint reward = calculateMiningReward(testChain.topBlock().blockHeader().number(), uncleNumbers.size() >= 1 ? uncleNumbers[0] : 0, uncleNumbers.size() >= 2 ? uncleNumbers[1] : 0);
+			bigint reward = calculateMiningReward(testChain.topBlock().blockHeader().number(), uncleNumbers.size() >= 1 ? uncleNumbers[0] : 0, uncleNumbers.size() >= 2 ? uncleNumbers[1] : 0, isByzantiumOrLater);
 			ImportTest::checkBalance(preState, postState, reward);
 		}
 		else
@@ -585,10 +586,10 @@ void testBCTest(json_spirit::mObject& _o)
 	ImportTest::compareStates(postState, blockchain.topBlock().state());
 }
 
-bigint calculateMiningReward(u256 const& _blNumber, u256 const& _unNumber1, u256 const& _unNumber2)
+bigint calculateMiningReward(u256 const& _blNumber, u256 const& _unNumber1, u256 const& _unNumber2, bool isByzantium)
 {
 	unique_ptr<SealEngineFace> se(ChainParams(genesisInfo(test::TestBlockChain::s_sealEngineNetwork)).createSealEngine());
-	bigint baseReward = se->chainParams().blockReward;
+	bigint baseReward = se->chainParams().blockReward(isByzantium);
 	bigint reward = baseReward;
 	//INCLUDE_UNCLE = BASE_REWARD / 32
 	//UNCLE_REWARD  = BASE_REWARD * (8 - Bn + Un) / 8

--- a/test/tools/jsontests/BlockChainTests.cpp
+++ b/test/tools/jsontests/BlockChainTests.cpp
@@ -589,7 +589,7 @@ void testBCTest(json_spirit::mObject& _o)
 bigint calculateMiningReward(u256 const& _blNumber, u256 const& _unNumber1, u256 const& _unNumber2, bool isByzantium)
 {
 	unique_ptr<SealEngineFace> se(ChainParams(genesisInfo(test::TestBlockChain::s_sealEngineNetwork)).createSealEngine());
-	bigint baseReward = se->chainParams().blockReward(isByzantium);
+	bigint const baseReward = se->chainParams().blockReward(_schedule);
 	bigint reward = baseReward;
 	//INCLUDE_UNCLE = BASE_REWARD / 32
 	//UNCLE_REWARD  = BASE_REWARD * (8 - Bn + Un) / 8


### PR DESCRIPTION
The reward-reduction and difficulty bomb delay have been both implemented.

Tests are updated so that `testeth` with no options passes.