### PR TITLE
CMake: Set CMAKE_CONFIGURATION_TYPES only when needed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,9 @@ set(CPP_ETHEREUM_DIR "${CMAKE_CURRENT_LIST_DIR}" CACHE PATH "Path to the root di
 include(EthPolicy)
 eth_policy()
 
-set(CMAKE_CONFIGURATION_TYPES Debug Release RelWithDebInfo)
+if(CMAKE_CONFIGURATION_TYPES)
+    set(CMAKE_CONFIGURATION_TYPES "Debug;Release;RelWithDebInfo" CACHE STRING "" FORCE)
+endif()
 
 # Map current configuration to congigurations of imported targets.
 set(CMAKE_MAP_IMPORTED_CONFIG_DEBUG RelWithDebInfo Release)


### PR DESCRIPTION
This fixes the condition in https://github.com/ethereum/cpp-ethereum/blob/864b2e8da4fabba0beeddadd1a9fed25b0e31d4e/cmake/EthOptions.cmake#L3.

CMAKE_CONFIGURATION_TYPES is also used to detect "multi-configuration" generators in CMake (like Visual Studio). We should to set the value if not using multi-configuration generator.