### PR TITLE
Separate input and output in doTest functions

### DIFF
--- a/test/tools/jsontests/StateTests.cpp
+++ b/test/tools/jsontests/StateTests.cpp
@@ -39,12 +39,13 @@ using namespace dev::eth;
 
 namespace dev {  namespace test {
 
-void doStateTests(json_spirit::mValue& _v, bool _fillin)
+json_spirit::mValue doStateTests(json_spirit::mValue const& _input, bool _fillin)
 {
-	BOOST_REQUIRE_MESSAGE(!_fillin || _v.get_obj().size() == 1,
+	BOOST_REQUIRE_MESSAGE(!_fillin || _input.get_obj().size() == 1,
 		TestOutputHelper::testFileName() + " A GeneralStateTest filler should contain only one test.");
+	json_spirit::mValue v = _input;  // TODO: avoid copying and only add valid fields into the new object.
 
-	for (auto& i: _v.get_obj())
+	for (auto& i: v.get_obj())
 	{
 		string testname = i.first;
 		json_spirit::mObject& o = i.second.get_obj();
@@ -103,6 +104,7 @@ void doStateTests(json_spirit::mValue& _v, bool _fillin)
 				importer.traceStateDiff();
 		}
 	}
+	return v;
 }
 } }// Namespace Close
 

--- a/test/tools/jsontests/TransactionTests.cpp
+++ b/test/tools/jsontests/TransactionTests.cpp
@@ -34,11 +34,12 @@ using namespace dev::eth;
 
 namespace dev {  namespace test {
 
-void doTransactionTests(json_spirit::mValue& _v, bool _fillin)
+json_spirit::mValue doTransactionTests(json_spirit::mValue const& _input, bool _fillin)
 {
-	TestOutputHelper::initTest(_v);
+	json_spirit::mValue v = _input; // TODO: avoid copying and only add valid fields into the new object.
+	TestOutputHelper::initTest(v);
 	unique_ptr<SealEngineFace> se(ChainParams(genesisInfo(eth::Network::MainNetworkTest)).createSealEngine());
-	for (auto& i: _v.get_obj())
+	for (auto& i: v.get_obj())
 	{
 		string testname = i.first;
 		json_spirit::mObject& o = i.second.get_obj();
@@ -159,6 +160,7 @@ void doTransactionTests(json_spirit::mValue& _v, bool _fillin)
 		}
 	}//for
 	dev::test::TestOutputHelper::finishTest();
+	return v;
 }//doTransactionTests
 
 } }// Namespace Close

--- a/test/tools/jsontests/vm.cpp
+++ b/test/tools/jsontests/vm.cpp
@@ -292,12 +292,13 @@ eth::OnOpFunc FakeExtVM::simpleTrace() const
 
 namespace dev { namespace test {
 
-void doVMTests(json_spirit::mValue& _v, bool _fillin)
+json_spirit::mValue doVMTests(json_spirit::mValue const& _input, bool _fillin)
 {
+	json_spirit::mValue v = _input; // TODO: avoid copying and only add valid fields into the new object.
 	if (string(boost::unit_test::framework::current_test_case().p_name) != "vmRandom")
-		TestOutputHelper::initTest(_v);
+		TestOutputHelper::initTest(v);
 
-	for (auto& i: _v.get_obj())
+	for (auto& i: v.get_obj())
 	{
 		string testname = i.first;
 		json_spirit::mObject& o = i.second.get_obj();
@@ -470,6 +471,7 @@ void doVMTests(json_spirit::mValue& _v, bool _fillin)
 	}
 
 	TestOutputHelper::finishTest();
+	return v;
 }
 
 } } // namespace close

--- a/test/tools/libtesteth/TestHelper.cpp
+++ b/test/tools/libtesteth/TestHelper.cpp
@@ -421,7 +421,7 @@ void checkCallCreates(eth::Transactions _resultCallCreates, eth::Transactions _e
 	}
 }
 
-void userDefinedTest(std::function<void(json_spirit::mValue&, bool)> doTests)
+void userDefinedTest(std::function<json_spirit::mValue(json_spirit::mValue const&, bool)> doTests)
 {
 	if (!Options::get().singleTest)
 		return;
@@ -469,7 +469,7 @@ void userDefinedTest(std::function<void(json_spirit::mValue&, bool)> doTests)
 	}
 }
 
-void executeTests(const string& _name, const string& _testPathAppendix, const string& _fillerPathAppendix, std::function<void(json_spirit::mValue&, bool)> doTests, bool _addFillerSuffix)
+void executeTests(const string& _name, const string& _testPathAppendix, const string& _fillerPathAppendix, std::function<json_spirit::mValue(json_spirit::mValue const&, bool)> doTests, bool _addFillerSuffix)
 {
 	string testPath = getTestPath() + _testPathAppendix;
 	string testFillerPath = getTestPath() + "/src" + _fillerPathAppendix;
@@ -500,9 +500,9 @@ void executeTests(const string& _name, const string& _testPathAppendix, const st
 
 			json_spirit::read_string(s, v);
 			removeComments(v);
-			doTests(v, true);
-			addClientInfo(v, testfilename);
-			writeFile(testPath + "/" + name + ".json", asBytes(json_spirit::write_string(v, true)));
+			json_spirit::mValue output = doTests(v, true);
+			addClientInfo(output, testfilename);
+			writeFile(testPath + "/" + name + ".json", asBytes(json_spirit::write_string(output, true)));
 		}
 		catch (Exception const& _e)
 		{

--- a/test/tools/libtesteth/TestHelper.h
+++ b/test/tools/libtesteth/TestHelper.h
@@ -157,8 +157,8 @@ dev::eth::BlockHeader constructHeader(
 	u256 const& _timestamp,
 	bytes const& _extraData);
 void updateEthashSeal(dev::eth::BlockHeader& _header, h256 const& _mixHash, dev::eth::Nonce const& _nonce);
-void executeTests(const std::string& _name, const std::string& _testPathAppendix, const std::string& _fillerPathAppendix, std::function<void(json_spirit::mValue&, bool)> doTests, bool _addFillerSuffix = true);
-void userDefinedTest(std::function<void(json_spirit::mValue&, bool)> doTests);
+void executeTests(const std::string& _name, const std::string& _testPathAppendix, const std::string& _fillerPathAppendix, std::function<json_spirit::mValue(json_spirit::mValue const&, bool)> doTests, bool _addFillerSuffix = true);
+void userDefinedTest(std::function<json_spirit::mValue(json_spirit::mValue const&, bool)> doTests);
 RLPStream createRLPStreamFromTransactionFields(json_spirit::mObject const& _tObj);
 json_spirit::mObject fillJsonWithStateChange(eth::State const& _stateOrig, eth::State const& _statePost, eth::ChangeLog const& _changeLog);
 json_spirit::mObject fillJsonWithState(eth::State const& _state);
@@ -167,12 +167,14 @@ json_spirit::mObject fillJsonWithTransaction(eth::Transaction const& _txn);
 
 //Fill Test Functions
 int createRandomTest(std::vector<char*> const& _parameters);
-void doTransactionTests(json_spirit::mValue& _v, bool _fillin);
-void doStateTests(json_spirit::mValue& v, bool _fillin);
-void doVMTests(json_spirit::mValue& v, bool _fillin);
-void doBlockchainTests(json_spirit::mValue& _v, bool _fillin);
-void doBlockchainTestNoLog(json_spirit::mValue& _v, bool _fillin);
-void doTransitionTest(json_spirit::mValue& _v, bool _fillin);
+//do*Tests(_input, _fillin) always return a filled test.
+//When _fillin is true, _input is supposed to contain a filler.  Otherwise, _input is also a filled test.
+json_spirit::mValue doTransactionTests(json_spirit::mValue const& _input, bool _fillin);
+json_spirit::mValue doStateTests(json_spirit::mValue const& _input, bool _fillin);
+json_spirit::mValue doVMTests(json_spirit::mValue const& _input, bool _fillin);
+json_spirit::mValue doBlockchainTests(json_spirit::mValue const& _input, bool _fillin);
+json_spirit::mValue doBlockchainTestNoLog(json_spirit::mValue const& _input, bool _fillin);
+json_spirit::mValue doTransitionTest(json_spirit::mValue const& _input, bool _fillin);
 void doRlpTests(json_spirit::mValue& v, bool _fillin);
 void addClientInfo(json_spirit::mValue& v, std::string const& _testSource);
 void removeComments(json_spirit::mValue& _obj);

--- a/test/tools/libtesteth/TestOutputHelper.cpp
+++ b/test/tools/libtesteth/TestOutputHelper.cpp
@@ -49,7 +49,7 @@ void TestOutputHelper::initTest(int _maxTests)
 	m_currTest = 0;
 }
 
-void TestOutputHelper::initTest(json_spirit::mValue& _v)
+void TestOutputHelper::initTest(json_spirit::mValue const& _v)
 {
 	Ethash::init();
 	BasicAuthority::init();

--- a/test/tools/libtesteth/TestOutputHelper.h
+++ b/test/tools/libtesteth/TestOutputHelper.h
@@ -32,7 +32,7 @@ class TestOutputHelper
 public:
 	TestOutputHelper() { TestOutputHelper::initTest(); }
 	static void initTest(int _maxTests = 1);
-	static void initTest(json_spirit::mValue& _v);
+	static void initTest(json_spirit::mValue const& _v);
 	static bool passTest(std::string const& _testName);
 	static void setMaxTests(int _count) { m_maxTests = _count; }
 	static void setCurrentTestFileName(std::string const& _name) { m_currentTestFileName = _name; }


### PR DESCRIPTION
Currently, various `doTest(json_spirit::mValue&)` functions modify the JSON value.  Sometimes a filler is given but gradually morphed into a finished test.  I discussed this structure with @winsvega and @gumb0.  The conclusion was we should separate the input and the output.

This PR just changes the type of `doTest` so that it takes a const reference and returns a JSON value.  The internal workings of each function are not changed yet.