### PR TITLE
Separate input and output in doStateTests()

### DIFF
--- a/test/tools/jsontests/StateTests.cpp
+++ b/test/tools/jsontests/StateTests.cpp
@@ -49,8 +49,8 @@ json_spirit::mValue doStateTests(json_spirit::mValue const& _input, bool _fillin
 	{
 		string const testname = i.first;
 		json_spirit::mObject const& inputTest = i.second.get_obj();
-		v.get_obj()[testname] = inputTest;
-		json_spirit::mObject& o = v.get_obj()[testname].get_obj();
+		v.get_obj()[testname] = json_spirit::mObject();
+		json_spirit::mObject& outputTest = v.get_obj()[testname].get_obj();
 
 		if (_fillin && !TestOutputHelper::testFileName().empty())
 			BOOST_REQUIRE_MESSAGE(testname + "Filler.json" == TestOutputHelper::testFileName(),
@@ -63,11 +63,11 @@ json_spirit::mValue doStateTests(json_spirit::mValue const& _input, bool _fillin
 		if (_fillin == false && Options::get().fillchain)
 			continue;
 
-		BOOST_REQUIRE_MESSAGE(o.count("env") > 0, testname + " env not set!");
-		BOOST_REQUIRE_MESSAGE(o.count("pre") > 0, testname + " pre not set!");
-		BOOST_REQUIRE_MESSAGE(o.count("transaction") > 0, testname + " transaction not set!");
+		BOOST_REQUIRE_MESSAGE(inputTest.count("env") > 0, testname + " env not set!");
+		BOOST_REQUIRE_MESSAGE(inputTest.count("pre") > 0, testname + " pre not set!");
+		BOOST_REQUIRE_MESSAGE(inputTest.count("transaction") > 0, testname + " transaction not set!");
 
-		ImportTest importer(o, testType::GeneralStateTest);
+		ImportTest importer(inputTest, outputTest, testType::GeneralStateTest);
 
 		Listener::ExecTimeGuard guard{i.first};
 		importer.executeTest();
@@ -85,10 +85,10 @@ json_spirit::mValue doStateTests(json_spirit::mValue const& _input, bool _fillin
 		}
 		else
 		{
-			BOOST_REQUIRE_MESSAGE(o.count("post") > 0, testname + " post not set!");
+			BOOST_REQUIRE_MESSAGE(inputTest.count("post") > 0, testname + " post not set!");
 
 			//check post hashes against cpp client on all networks
-			mObject post = o["post"].get_obj();
+			mObject post = inputTest.at("post").get_obj();
 			vector<size_t> wrongTransactionsIndexes;
 			for (mObject::const_iterator i = post.begin(); i != post.end(); ++i)
 			{

--- a/test/tools/jsontests/StateTests.cpp
+++ b/test/tools/jsontests/StateTests.cpp
@@ -43,12 +43,14 @@ json_spirit::mValue doStateTests(json_spirit::mValue const& _input, bool _fillin
 {
 	BOOST_REQUIRE_MESSAGE(!_fillin || _input.get_obj().size() == 1,
 		TestOutputHelper::testFileName() + " A GeneralStateTest filler should contain only one test.");
-	json_spirit::mValue v = _input;  // TODO: avoid copying and only add valid fields into the new object.
+	json_spirit::mValue v = json_spirit::mObject();
 
-	for (auto& i: v.get_obj())
+	for (auto& i: _input.get_obj())
 	{
-		string testname = i.first;
-		json_spirit::mObject& o = i.second.get_obj();
+		string const testname = i.first;
+		json_spirit::mObject const& inputTest = i.second.get_obj();
+		v.get_obj()[testname] = inputTest;
+		json_spirit::mObject& o = v.get_obj()[testname].get_obj();
 
 		if (_fillin && !TestOutputHelper::testFileName().empty())
 			BOOST_REQUIRE_MESSAGE(testname + "Filler.json" == TestOutputHelper::testFileName(),

--- a/test/tools/libtesteth/ImportTest.h
+++ b/test/tools/libtesteth/ImportTest.h
@@ -39,15 +39,15 @@ enum class testType
 class ImportTest
 {
 public:
-	ImportTest(json_spirit::mObject& _o, testType _testTemplate);
+	ImportTest(json_spirit::mObject const& _input, json_spirit::mObject& _output, testType _testTemplate);
 
 	// imports
-	void importEnv(json_spirit::mObject& _o);
+	void importEnv(json_spirit::mObject const& _o);
 	static void importState(json_spirit::mObject const& _o, eth::State& _state);
 	static void importState(json_spirit::mObject const& _o, eth::State& _state, eth::AccountMaskMap& o_mask);
 	static void importTransaction (json_spirit::mObject const& _o, eth::Transaction& o_tr);
 	void importTransaction(json_spirit::mObject const& _o);
-	static json_spirit::mObject& makeAllFieldsHex(json_spirit::mObject& _o, bool _isHeader = false);
+	static json_spirit::mObject makeAllFieldsHex(json_spirit::mObject const& _o, bool _isHeader = false);
 	static void parseJsonStrValueIntoVector(json_spirit::mValue const& _json, std::vector<std::string>& _out);
 
 	//check functions
@@ -92,7 +92,8 @@ private:
 	using TrExpectSection = std::pair<transactionToExecute, StateAndMap>;
 	void checkGeneralTestSectionSearch(json_spirit::mObject const& _expects, std::vector<size_t>& _errorTransactions, std::string const& _network = "", TrExpectSection* _search = NULL) const;
 
-	json_spirit::mObject& m_testObject;
+	json_spirit::mObject const& m_testInputObject;
+	json_spirit::mObject& m_testOutputObject;
 	testType m_testType;
 };
 


### PR DESCRIPTION
The behaviors of `testeth -t StateTestsGeneral/stExample` and `testeth -t StateTestsGeneral/stExample -- --filltests` do not change.