### PR TITLE
Bugfix: use the result of makeAllFieldsHex() so that "0x" is added

### DIFF
--- a/test/tools/jsontests/BlockChainTests.cpp
+++ b/test/tools/jsontests/BlockChainTests.cpp
@@ -862,7 +862,7 @@ mObject writeBlockHeaderToJson(BlockHeader const& _bi)
 	o["mixHash"] = toString(Ethash::mixHash(_bi));
 	o["nonce"] = toString(Ethash::nonce(_bi));
 	o["hash"] = toString(_bi.hash());
-	ImportTest::makeAllFieldsHex(o, true);
+	o = ImportTest::makeAllFieldsHex(o, true);
 	return o;
 }
 

--- a/test/tools/libtesteth/FillJsonFunctions.cpp
+++ b/test/tools/libtesteth/FillJsonFunctions.cpp
@@ -48,7 +48,7 @@ json_spirit::mObject fillJsonWithTransaction(Transaction const& _txn)
 	txObject["v"] = toCompactHexPrefixed(_txn.signature().v + 27, 1);
 	txObject["to"] = _txn.isCreation() ? "" : toHexPrefixed(_txn.receiveAddress());
 	txObject["value"] = toCompactHexPrefixed(_txn.value(), 1);
-	ImportTest::makeAllFieldsHex(txObject);
+	txObject = ImportTest::makeAllFieldsHex(txObject);
 	return txObject;
 }
 


### PR DESCRIPTION
After 6d77b62de340f7dfce783262db87a1a3b8725e5d, "0x" was not added to certain fields.

The commit changed `makeAllFieldsHex()` so that it returns a json rather than modifiying the json object in place.
However, the commit forgot to modify all usage of `makeAllFieldsHex()`.

Fixes #4365 