### PR TITLE
Copy "network" field in fillBCTest()

### DIFF
--- a/test/tools/jsontests/BlockChainTests.cpp
+++ b/test/tools/jsontests/BlockChainTests.cpp
@@ -264,9 +264,6 @@ json_spirit::mObject fillBCTest(json_spirit::mObject const& _input)
 	string chainnetwork = "default";
 	std::map<string, ChainBranch*> chainMap = { {chainname , new ChainBranch(genesisBlock)}};
 
-	if (_input.count("noBlockChainHistory") > 0)
-		output["noBlockChainHistory"] = _input.at("noBlockChainHistory");
-
 	if (_input.count("network") > 0)
 		output["network"] = _input.at("network");
 

--- a/test/tools/jsontests/BlockChainTests.cpp
+++ b/test/tools/jsontests/BlockChainTests.cpp
@@ -267,6 +267,9 @@ json_spirit::mObject fillBCTest(json_spirit::mObject const& _input)
 	if (_input.count("noBlockChainHistory") > 0)
 		output["noBlockChainHistory"] = _input.at("noBlockChainHistory");
 
+	if (_input.count("network") > 0)
+		output["network"] = _input.at("network");
+
 	for (auto const& bl: _input.at("blocks").get_array())
 	{
 		mObject const& blObjInput = bl.get_obj();


### PR DESCRIPTION
Before this commit
```
test/testeth -t 'TransitionTests/bcEIP158ToByzantium' -- --filltests --singletest  ByzantiumTransition
```
yielded an error
```
BlockChainTests.cpp(127): fatal error: in "TransitionTests/bcEIP158ToByzantium": critical check o.count("network") has failed
```

After this commit, the same command succeeds.