### PR TITLE
Display more informative messages by not rethrowing an exception

### DIFF
--- a/test/tools/jsontests/StateTests.cpp
+++ b/test/tools/jsontests/StateTests.cpp
@@ -41,6 +41,8 @@ namespace dev {  namespace test {
 
 json_spirit::mValue doStateTests(json_spirit::mValue const& _input, bool _fillin)
 {
+	BOOST_REQUIRE_MESSAGE(_input.type() == obj_type,
+		TestOutputHelper::testFileName() + " A GeneralStateTest file should contain an object.");
 	BOOST_REQUIRE_MESSAGE(!_fillin || _input.get_obj().size() == 1,
 		TestOutputHelper::testFileName() + " A GeneralStateTest filler should contain only one test.");
 	json_spirit::mValue v = json_spirit::mObject();
@@ -48,6 +50,8 @@ json_spirit::mValue doStateTests(json_spirit::mValue const& _input, bool _fillin
 	for (auto& i: _input.get_obj())
 	{
 		string const testname = i.first;
+		BOOST_REQUIRE_MESSAGE(i.second.type() == obj_type,
+			TestOutputHelper::testFileName() + " should contain an object under a test name.");
 		json_spirit::mObject const& inputTest = i.second.get_obj();
 		v.get_obj()[testname] = json_spirit::mObject();
 		json_spirit::mObject& outputTest = v.get_obj()[testname].get_obj();
@@ -86,14 +90,17 @@ json_spirit::mValue doStateTests(json_spirit::mValue const& _input, bool _fillin
 		else
 		{
 			BOOST_REQUIRE_MESSAGE(inputTest.count("post") > 0, testname + " post not set!");
+			BOOST_REQUIRE_MESSAGE(inputTest.at("post").type() == obj_type, testname + " post field is not an object.");
 
 			//check post hashes against cpp client on all networks
 			mObject post = inputTest.at("post").get_obj();
 			vector<size_t> wrongTransactionsIndexes;
 			for (mObject::const_iterator i = post.begin(); i != post.end(); ++i)
 			{
+				BOOST_REQUIRE_MESSAGE(i->second.type() == array_type, testname + " post field should contain an array for each network.");
 				for (auto const& exp: i->second.get_array())
 				{
+					BOOST_REQUIRE_MESSAGE(exp.type() == obj_type, " post field should contain an array of objects for each network.");
 					if (!Options::get().singleTestNet.empty() && i->first != Options::get().singleTestNet)
 						continue;
 					if (test::isDisabledNetwork(test::stringToNetId(i->first)))

--- a/test/tools/libtesteth/TestHelper.cpp
+++ b/test/tools/libtesteth/TestHelper.cpp
@@ -461,10 +461,6 @@ void executeTests(const string& _name, const string& _testPathAppendix, const st
 	{
 		BOOST_ERROR(TestOutputHelper::testName() + " Failed test with Exception: " << diagnostic_information(_e));
 	}
-	catch (std::exception const& _e)
-	{
-		BOOST_ERROR(TestOutputHelper::testName() + " Failed test with Exception: " << _e.what());
-	}
 }
 
 void removeComments(json_spirit::mValue& _obj)


### PR DESCRIPTION
This PR makes debugging easier when the fillers are malformed.

**Before this PR:**

```
75%...
100%
/home/yh/src/cpp-ethereum/test/tools/libtesteth/TestHelper.cpp(525): error: in "VMTests/vmtests": suicide Failed test with Exception: value type is 2 not 1
Test Case "vmArithmeticTest":
24%...
```
TestHelper.cpp(535) is not informative because it's a line that catches all errors.

**After this PR:**
```
50%...
75%...
100%
unknown location(0): fatal error: in "VMTests/vmtests": std::runtime_error: value type is 2 not 1
/home/yh/src/cpp-ethereum/test/tools/jsontests/vm.cpp(441): last checkpoint
Test Case "vmArithmeticTest":
24%...
```
vm.cpp(441), aha, it's a problem in "logs" field!


Both outputs are taken from
```
test/testeth -t 'VMTests' -- --filltests
```