### PR TITLE
Fix VM test filling by adapting to new logs format

### DIFF
--- a/test/tools/jsontests/vm.cpp
+++ b/test/tools/jsontests/vm.cpp
@@ -443,8 +443,6 @@ json_spirit::mValue doVMTests(json_spirit::mValue const& _input, bool _fillin)
 				dev::test::FakeExtVM test(eth::EnvInfo{BlockHeader{}, lastBlockHashes, 0});
 				test.importState(testInput.at("post").get_obj());
 				test.importCallCreates(testInput.at("callcreates").get_array());
-				test.sub.logs = importLog(testInput.at("logs").get_array());
-
 
 				checkOutput(output, testInput);
 
@@ -461,7 +459,7 @@ json_spirit::mValue doVMTests(json_spirit::mValue const& _input, bool _fillin)
 
 				checkCallCreates(fev.callcreates, test.callcreates);
 
-				checkLog(fev.sub.logs, test.sub.logs);
+				BOOST_CHECK_EQUAL(exportLog(fev.sub.logs), testInput.at("logs").get_str());
 			}
 			else	// Exception expected
 				BOOST_CHECK(vmExceptionOccured);

--- a/test/tools/libtesteth/TestHelper.cpp
+++ b/test/tools/libtesteth/TestHelper.cpp
@@ -387,18 +387,6 @@ void checkStorage(map<u256, u256> const& _expectedStore, map<u256, u256> const& 
 	}
 }
 
-void checkLog(LogEntries const& _resultLogs, LogEntries const& _expectedLogs)
-{
-	BOOST_REQUIRE_EQUAL(_resultLogs.size(), _expectedLogs.size());
-
-	for (size_t i = 0; i < _resultLogs.size(); ++i)
-	{
-		BOOST_CHECK_EQUAL(_resultLogs[i].address, _expectedLogs[i].address);
-		BOOST_CHECK_EQUAL(_resultLogs[i].topics, _expectedLogs[i].topics);
-		BOOST_CHECK(_resultLogs[i].data == _expectedLogs[i].data);
-	}
-}
-
 void checkCallCreates(eth::Transactions const& _resultCallCreates, eth::Transactions const& _expectedCallCreates)
 {
 	BOOST_REQUIRE_EQUAL(_resultCallCreates.size(), _expectedCallCreates.size());

--- a/test/tools/libtesteth/TestHelper.h
+++ b/test/tools/libtesteth/TestHelper.h
@@ -89,7 +89,6 @@ eth::LogEntries importLog(json_spirit::mArray const& _o);
 std::string exportLog(eth::LogEntries const& _logs);
 void checkOutput(bytesConstRef _output, json_spirit::mObject const& _o);
 void checkStorage(std::map<u256, u256> _expectedStore, std::map<u256, u256> _resultStore, Address _expectedAddr);
-void checkLog(eth::LogEntries const& _resultLogs, eth::LogEntries const& _expectedLogs);
 void checkCallCreates(eth::Transactions const& _resultCallCreates, eth::Transactions const& _expectedCallCreates);
 dev::eth::BlockHeader constructHeader(
 	h256 const& _parentHash,


### PR DESCRIPTION
Recently `exportLogs` was modified to output the hash of logs.

VMTest execution was not updated.

Before this PR
```
ETHEREUM_TEST_PATH='../../tests' test/testeth -t 'VMTests' -- --filltests --singletest suicide
```
failed because the filled test contained the hash of logs while the test execution expected an array.

This PR fixes #4353 .