### PR TITLE
Remove TestHelper.h includes from unit tests

### DIFF
--- a/test/unittests/libdevcore/Base36.cpp
+++ b/test/unittests/libdevcore/Base36.cpp
@@ -20,8 +20,8 @@
  */
 
 #include <boost/test/unit_test.hpp>
-#include <test/tools/libtesteth/TestHelper.h>
 #include <libdevcore/Base64.h>
+#include <test/tools/libtesteth/TestOutputHelper.h>
 
 using namespace std;
 using namespace dev;

--- a/test/unittests/libdevcore/CommonJS.cpp
+++ b/test/unittests/libdevcore/CommonJS.cpp
@@ -22,7 +22,7 @@
 
 #include <boost/test/unit_test.hpp>
 #include <libdevcore/CommonJS.h>
-#include <test/tools/libtesteth/TestHelper.h>
+#include <test/tools/libtesteth/TestOutputHelper.h>
 
 using namespace dev;
 using namespace std;

--- a/test/unittests/libdevcore/FixedHash.cpp
+++ b/test/unittests/libdevcore/FixedHash.cpp
@@ -19,9 +19,10 @@
  * @date 2015
  */
 
+#include <boost/test/unit_test.hpp>
 #include <libdevcore/FixedHash.h>
 #include <libdevcore/SHA3.h>
-#include <test/tools/libtesteth/TestHelper.h>
+#include <test/tools/libtesteth/TestOutputHelper.h>
 
 using namespace std;
 using namespace dev;

--- a/test/unittests/libdevcore/RangeMask.cpp
+++ b/test/unittests/libdevcore/RangeMask.cpp
@@ -20,7 +20,8 @@
  */
 
 #include <libdevcore/RangeMask.h>
-#include <test/tools/libtesteth/TestHelper.h>
+#include <test/tools/libtesteth/TestOutputHelper.h>
+#include <boost/test/unit_test.hpp>
 
 using namespace std;
 using namespace dev;

--- a/test/unittests/libdevcore/core.cpp
+++ b/test/unittests/libdevcore/core.cpp
@@ -23,7 +23,7 @@
 #include <boost/test/unit_test.hpp>
 #include <libdevcore/CommonIO.h>
 #include <libdevcore/Log.h>
-#include <test/tools/libtesteth/TestHelper.h>
+#include <test/tools/libtesteth/TestOutputHelper.h>
 
 using namespace dev::test;
 

--- a/test/unittests/libdevcore/rlp.cpp
+++ b/test/unittests/libdevcore/rlp.cpp
@@ -20,17 +20,19 @@
  * RLP test functions.
  */
 
-#include <fstream>
-#include <sstream>
-
 #include <libdevcore/Log.h>
 #include <libdevcore/RLP.h>
 #include <libdevcore/Common.h>
 #include <libdevcore/CommonIO.h>
-#include <algorithm>
 #include <json_spirit/JsonSpiritHeaders.h>
+#include <test/tools/libtesteth/TestOutputHelper.h>
 #include <test/tools/libtesteth/TestHelper.h>
+
 #include <boost/filesystem.hpp>
+#include <boost/test/unit_test.hpp>
+#include <fstream>
+#include <sstream>
+#include <algorithm>
 
 using namespace std;
 using namespace dev;

--- a/test/unittests/libdevcrypto/AES.cpp
+++ b/test/unittests/libdevcrypto/AES.cpp
@@ -21,7 +21,7 @@
 #include <libdevcore/SHA3.h>
 #include <libdevcore/Log.h>
 #include <libdevcrypto/AES.h>
-#include <test/tools/libtesteth/TestHelper.h>
+#include <test/tools/libtesteth/TestOutputHelper.h>
 
 using namespace std;
 using namespace dev;

--- a/test/unittests/libdevcrypto/SecretStore.cpp
+++ b/test/unittests/libdevcrypto/SecretStore.cpp
@@ -25,7 +25,7 @@
 #include <libdevcore/TrieHash.h>
 #include <libdevcore/TransientDirectory.h>
 #include "MemTrie.h"
-#include <test/tools/libtesteth/TestHelper.h>
+#include <test/tools/libtesteth/TestOutputHelper.h>
 using namespace std;
 using namespace dev;
 using namespace dev::test;

--- a/test/unittests/libdevcrypto/crypto.cpp
+++ b/test/unittests/libdevcrypto/crypto.cpp
@@ -38,7 +38,9 @@
 #include <libdevcore/SHA3.h>
 #include <libdevcrypto/Hash.h>
 #include <libdevcrypto/CryptoPP.h>
-#include <test/tools/libtesteth/TestHelper.h>
+#include <libethereum/Transaction.h>
+#include <test/tools/libtesteth/TestOutputHelper.h>
+#include <test/tools/libtesteth/Options.h>
 
 using namespace std;
 using namespace dev;

--- a/test/unittests/libdevcrypto/hexPrefix.cpp
+++ b/test/unittests/libdevcrypto/hexPrefix.cpp
@@ -22,7 +22,7 @@
 #include <libdevcore/CommonIO.h>
 #include <libdevcore/Base64.h>
 #include <libdevcore/TrieCommon.h>
-#include <test/tools/libtesteth/TestHelper.h>
+#include <test/tools/libtesteth/TestOutputHelper.h>
 
 using namespace std;
 using namespace dev;

--- a/test/unittests/libdevcrypto/trie.cpp
+++ b/test/unittests/libdevcrypto/trie.cpp
@@ -21,8 +21,10 @@
 #include <libdevcore/CommonIO.h>
 #include <libdevcore/TrieDB.h>
 #include <libdevcore/TrieHash.h>
+#include <libdevcore/MemoryDB.h>
 #include "MemTrie.h"
-#include <test/tools/libtesteth/TestHelper.h>
+#include <test/tools/libtesteth/TestOutputHelper.h>
+#include <test/tools/libtesteth/Options.h>
 
 using namespace std;
 using namespace dev;

--- a/test/unittests/libethashseal/EthashTest.cpp
+++ b/test/unittests/libethashseal/EthashTest.cpp
@@ -19,7 +19,7 @@
  */
 
 #include <boost/test/unit_test.hpp>
-#include <test/tools/libtesteth/TestHelper.h>
+#include <test/tools/libtesteth/TestOutputHelper.h>
 #include <libethashseal/Ethash.h>
 
 using namespace std;

--- a/test/unittests/libethcore/commonjs.cpp
+++ b/test/unittests/libethcore/commonjs.cpp
@@ -22,7 +22,7 @@
 #include <boost/test/unit_test.hpp>
 #include <libdevcore/Log.h>
 #include <libethcore/CommonJS.h>
-#include <test/tools/libtesteth/TestHelper.h>
+#include <test/tools/libtesteth/TestOutputHelper.h>
 
 using namespace std;
 using namespace dev;

--- a/test/unittests/libp2p/capability.cpp
+++ b/test/unittests/libp2p/capability.cpp
@@ -27,7 +27,8 @@ along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 #include <libp2p/Session.h>
 #include <libp2p/Capability.h>
 #include <libp2p/HostCapability.h>
-#include <test/tools/libtesteth/TestHelper.h>
+#include <test/tools/libtesteth/TestOutputHelper.h>
+#include <test/tools/libtesteth/Options.h>
 
 using namespace std;
 using namespace dev;

--- a/test/unittests/libp2p/eip-8.cpp
+++ b/test/unittests/libp2p/eip-8.cpp
@@ -25,7 +25,7 @@
 #include <libp2p/Host.h>
 #include <libp2p/RLPXSocket.h>
 #include <libp2p/RLPxHandshake.h>
-#include <test/tools/libtesteth/TestHelper.h>
+#include <test/tools/libtesteth/TestOutputHelper.h>
 
 using namespace std;
 using namespace dev;

--- a/test/unittests/libp2p/net.cpp
+++ b/test/unittests/libp2p/net.cpp
@@ -20,13 +20,14 @@
  */
 
 #include <boost/test/unit_test.hpp>
+#include <test/tools/libtesteth/Options.h>
+#include <test/tools/libtesteth/TestOutputHelper.h>
 
 #include <libdevcore/Worker.h>
 #include <libdevcore/Assertions.h>
 #include <libdevcrypto/Common.h>
 #include <libp2p/UDP.h>
 #include <libp2p/NodeTable.h>
-#include <test/tools/libtesteth/TestHelper.h>
 
 using namespace std;
 using namespace dev;

--- a/test/unittests/libp2p/peer.cpp
+++ b/test/unittests/libp2p/peer.cpp
@@ -20,13 +20,14 @@
  * Peer Network test functions.
  */
 
-#include <boost/test/unit_test.hpp>
-#include <chrono>
-#include <thread>
+#include <test/tools/libtesteth/TestOutputHelper.h>
+#include <test/tools/libtesteth/Options.h>
 #include <libp2p/Host.h>
-#include <test/tools/libtesteth/TestHelper.h>
 #include <libp2p/Capability.h>
 #include <libp2p/HostCapability.h>
+#include <chrono>
+#include <thread>
+#include <boost/test/unit_test.hpp>
 
 using namespace std;
 using namespace dev;

--- a/test/unittests/libp2p/rlpx.cpp
+++ b/test/unittests/libp2p/rlpx.cpp
@@ -36,7 +36,7 @@
 #include <libp2p/RLPxHandshake.h>
 #include <libp2p/RLPXFrameWriter.h>
 #include <libp2p/RLPXFrameReader.h>
-#include <test/tools/libtesteth/TestHelper.h>
+#include <test/tools/libtesteth/TestOutputHelper.h>
 
 using namespace std;
 using namespace dev;

--- a/test/unittests/libweb3core/memorydb.cpp
+++ b/test/unittests/libweb3core/memorydb.cpp
@@ -23,7 +23,7 @@
 #include <boost/test/unit_test.hpp>
 #include <iostream>
 #include <libdevcore/MemoryDB.h>
-#include <test/tools/libtesteth/TestHelper.h>
+#include <test/tools/libtesteth/TestOutputHelper.h>
 
 using namespace std;
 using namespace dev;

--- a/test/unittests/libweb3core/overlaydb.cpp
+++ b/test/unittests/libweb3core/overlaydb.cpp
@@ -23,7 +23,7 @@
 #include <boost/test/unit_test.hpp>
 #include <libdevcore/TransientDirectory.h>
 #include <libdevcore/OverlayDB.h>
-#include <test/tools/libtesteth/TestHelper.h>
+#include <test/tools/libtesteth/TestOutputHelper.h>
 
 using namespace std;
 using namespace dev;

--- a/test/unittests/libweb3jsonrpc/AccountHolder.cpp
+++ b/test/unittests/libweb3jsonrpc/AccountHolder.cpp
@@ -21,7 +21,7 @@
 
 #include <boost/test/unit_test.hpp>
 #include <libweb3jsonrpc/AccountHolder.h>
-#include <test/tools/libtesteth/TestHelper.h>
+#include <test/tools/libtesteth/TestOutputHelper.h>
 
 using namespace std;
 using namespace dev;

--- a/test/unittests/libweb3jsonrpc/Client.cpp
+++ b/test/unittests/libweb3jsonrpc/Client.cpp
@@ -32,7 +32,7 @@
 #include <libethcore/KeyManager.h>
 #include <libwebthree/WebThree.h>
 #include <libp2p/Network.h>
-#include <test/tools/libtesteth/TestHelper.h>
+#include <test/tools/libtesteth/TestOutputHelper.h>
 
 // This is defined by some weird windows header - workaround for now.
 #undef GetMessage

--- a/test/unittests/libweb3jsonrpc/jsonrpc.cpp
+++ b/test/unittests/libweb3jsonrpc/jsonrpc.cpp
@@ -35,7 +35,7 @@
 #include <jsonrpccpp/server/connectors/httpserver.h>
 #include <set>
 #include "../JsonSpiritHeaders.h"
-#include <test/tools/libtesteth/TestHelper.h>
+#include <test/tools/libtesteth/TestOutputHelper.h>
 #include "WebThreeStubClient.h"
 
 BOOST_FIXTURE_TEST_SUITE(jsonrpc, TestOutputHelper)

--- a/test/unittests/libwhisper/bloomFilter.cpp
+++ b/test/unittests/libwhisper/bloomFilter.cpp
@@ -22,7 +22,7 @@ along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 #include <boost/test/unit_test.hpp>
 #include <libdevcore/SHA3.h>
 #include <libwhisper/BloomFilter.h>
-#include <test/tools/libtesteth/TestHelper.h>
+#include <test/tools/libtesteth/TestOutputHelper.h>
 
 using namespace std;
 using namespace dev;

--- a/test/unittests/libwhisper/whisperMessage.cpp
+++ b/test/unittests/libwhisper/whisperMessage.cpp
@@ -21,7 +21,7 @@ along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <boost/test/unit_test.hpp>
 #include <libwhisper/Message.h>
-#include <test/tools/libtesteth/TestHelper.h>
+#include <test/tools/libtesteth/TestOutputHelper.h>
 
 using namespace std;
 using namespace dev;

--- a/test/unittests/libwhisper/whisperTopic.cpp
+++ b/test/unittests/libwhisper/whisperTopic.cpp
@@ -26,7 +26,7 @@
 #include <libp2p/Session.h>
 #include <libwhisper/WhisperPeer.h>
 #include <libwhisper/WhisperHost.h>
-#include <test/tools/libtesteth/TestHelper.h>
+#include <test/tools/libtesteth/TestOutputHelper.h>
 
 using namespace std;
 using namespace dev;


### PR DESCRIPTION
Many unit tests included TestHelper.h, but most of them just needed TestOutputHelper.h,
which is included from TestHelper.h.  So this commit replaces many TestHelper.in includes
with TestOutputHelper.h includes.

Sometimes, additional includes were necessary, but all compilation units got simpler.