### PR TITLE
Further refactoring on doBlockchainTest

### DIFF
--- a/test/tools/jsontests/BlockChainTests.cpp
+++ b/test/tools/jsontests/BlockChainTests.cpp
@@ -103,7 +103,7 @@ void checkExpectedException(mObject& _blObj, Exception const& _e);
 void checkBlocks(TestBlock const& _blockFromFields, TestBlock const& _blockFromRlp, string const& _testname);
 bigint calculateMiningReward(u256 const& _blNumber, u256 const& _unNumber1, u256 const& _unNumber2, SealEngineFace const& _sealEngine);
 json_spirit::mObject fillBCTest(json_spirit::mObject const& _input);
-void testBCTest(json_spirit::mObject& _o);
+void testBCTest(json_spirit::mObject const& _o);
 
 //percent output for many tests in one file
 json_spirit::mValue doBlockchainTests(json_spirit::mValue const& _v, bool _fillin)
@@ -440,10 +440,10 @@ json_spirit::mObject fillBCTest(json_spirit::mObject const& _input)
 	return output;
 }
 
-void testBCTest(json_spirit::mObject& _o)
+void testBCTest(json_spirit::mObject const& _o)
 {
 	string testName = TestOutputHelper::testName();
-	TestBlock genesisBlock(_o["genesisBlockHeader"].get_obj(), _o["pre"].get_obj());
+	TestBlock genesisBlock(_o.at("genesisBlockHeader").get_obj(), _o.at("pre").get_obj());
 	TestBlockChain blockchain(genesisBlock);
 
 	TestBlockChain testChain(genesisBlock);
@@ -451,11 +451,11 @@ void testBCTest(json_spirit::mObject& _o)
 
 	if (_o.count("genesisRLP") > 0)
 	{
-		TestBlock genesisFromRLP(_o["genesisRLP"].get_str());
+		TestBlock genesisFromRLP(_o.at("genesisRLP").get_str());
 		checkBlocks(genesisBlock, genesisFromRLP, testName);
 	}
 
-	for (auto const& bl: _o["blocks"].get_array())
+	for (auto const& bl: _o.at("blocks").get_array())
 	{
 		mObject blObj = bl.get_obj();
 		TestBlock blockFromRlp;
@@ -572,8 +572,8 @@ void testBCTest(json_spirit::mObject& _o)
 	//Check lastblock hash
 	BOOST_REQUIRE((_o.count("lastblockhash") > 0));
 	string lastTrueBlockHash = toHexPrefixed(testChain.topBlock().blockHeader().hash(WithSeal));
-	BOOST_CHECK_MESSAGE(lastTrueBlockHash == _o["lastblockhash"].get_str(),
-			testName + "Boost check: lastblockhash does not match " + lastTrueBlockHash + " expected: " + _o["lastblockhash"].get_str());
+	BOOST_CHECK_MESSAGE(lastTrueBlockHash == _o.at("lastblockhash").get_str(),
+			testName + "Boost check: lastblockhash does not match " + lastTrueBlockHash + " expected: " + _o.at("lastblockhash").get_str());
 
 	//Check final state (just to be sure)
 	BOOST_CHECK_MESSAGE(toString(testChain.topBlock().state().rootHash()) ==
@@ -582,7 +582,7 @@ void testBCTest(json_spirit::mObject& _o)
 
 	State postState(State::Null); //Compare post states
 	BOOST_REQUIRE((_o.count("postState") > 0));
-	ImportTest::importState(_o["postState"].get_obj(), postState);
+	ImportTest::importState(_o.at("postState").get_obj(), postState);
 	ImportTest::compareStates(postState, testChain.topBlock().state());
 	ImportTest::compareStates(postState, blockchain.topBlock().state());
 }

--- a/test/tools/jsontests/BlockChainTests.cpp
+++ b/test/tools/jsontests/BlockChainTests.cpp
@@ -155,15 +155,12 @@ json_spirit::mValue doBlockchainTestNoLog(json_spirit::mValue const& _input, boo
 	{
 		string const& testname = i->first;
 		json_spirit::mObject const& inputTest = i->second.get_obj();
-		v.get_obj()[testname] = inputTest;
-		json_spirit::mObject& outputTest = v.get_obj()[testname].get_obj();
 
 		//Select test by name if --singletest is set and not filling state tests as blockchain
 		if (!Options::get().fillchain && !TestOutputHelper::passTest(testname))
-		{
-			outputTest.clear(); //don't add irrelevant tests to the final file when filling
 			continue;
-		}
+
+		v.get_obj()[testname] = inputTest;
 
 		BOOST_REQUIRE_MESSAGE(inputTest.count("genesisBlockHeader"),
 			"\"genesisBlockHeader\" field is not found. filename: " + TestOutputHelper::testFileName() +

--- a/test/tools/jsontests/BlockChainTests.cpp
+++ b/test/tools/jsontests/BlockChainTests.cpp
@@ -146,8 +146,7 @@ json_spirit::mValue doTransitionTest(json_spirit::mValue const& _input, bool _fi
 
 json_spirit::mValue doBlockchainTestNoLog(json_spirit::mValue const& _input, bool _fillin)
 {
-	json_spirit::mValue v = json_spirit::mObject();
-	json_spirit::mObject& tests = v.get_obj();
+	json_spirit::mObject tests;
 
 	// range-for is not used because iterators are necessary for removing elements later.
 	for (auto i = _input.get_obj().begin(); i != _input.get_obj().end(); i++)
@@ -221,7 +220,7 @@ json_spirit::mValue doBlockchainTestNoLog(json_spirit::mValue const& _input, boo
 		}
 	}
 
-	return v;
+	return tests;
 }
 
 json_spirit::mObject fillBCTest(json_spirit::mObject const& _input)

--- a/test/tools/jsontests/BlockChainTests.cpp
+++ b/test/tools/jsontests/BlockChainTests.cpp
@@ -185,7 +185,7 @@ json_spirit::mValue doBlockchainTestNoLog(json_spirit::mValue const& _input, boo
 				dev::test::TestBlockChain::s_sealEngineNetwork = network;
 				string newtestname = testname + "_" + test::netIdToString(network);
 
-				json_spirit::mObject jObj = outputTest;
+				json_spirit::mObject jObj = inputTest;
 				if (inputTest.count("expect"))
 				{
 					//prepare the corresponding expect section for the test
@@ -227,7 +227,7 @@ json_spirit::mValue doBlockchainTestNoLog(json_spirit::mValue const& _input, boo
 			dev::test::TestBlockChain::s_sealEngineNetwork = stringToNetId(inputTest.at("network").get_str());
 			if (test::isDisabledNetwork(dev::test::TestBlockChain::s_sealEngineNetwork))
 				continue;
-			testBCTest(outputTest);
+			testBCTest(inputTest);
 		}
 	}
 

--- a/test/tools/jsontests/BlockChainTests.cpp
+++ b/test/tools/jsontests/BlockChainTests.cpp
@@ -153,22 +153,23 @@ json_spirit::mValue doBlockchainTestNoLog(json_spirit::mValue const& _input, boo
 	// range-for is not used because iterators are necessary for removing elements later.
 	for (auto i = _input.get_obj().begin(); i != _input.get_obj().end(); i++)
 	{
-		string testname = i->first;
-		v.get_obj()[testname] = i->second.get_obj();
-		json_spirit::mObject& o = v.get_obj()[testname].get_obj();
+		string const& testname = i->first;
+		json_spirit::mObject const& inputTest = i->second.get_obj();
+		v.get_obj()[testname] = inputTest;
+		json_spirit::mObject& outputTest = v.get_obj()[testname].get_obj();
 
 		//Select test by name if --singletest is set and not filling state tests as blockchain
 		if (!Options::get().fillchain && !TestOutputHelper::passTest(testname))
 		{
-			o.clear(); //don't add irrelevant tests to the final file when filling
+			outputTest.clear(); //don't add irrelevant tests to the final file when filling
 			continue;
 		}
 
-		BOOST_REQUIRE_MESSAGE(o.count("genesisBlockHeader"),
+		BOOST_REQUIRE_MESSAGE(outputTest.count("genesisBlockHeader"),
 			"\"genesisBlockHeader\" field is not found. filename: " + TestOutputHelper::testFileName() +
 			" testname: " + TestOutputHelper::testName()
 		);
-		BOOST_REQUIRE_MESSAGE(o.count("pre"),
+		BOOST_REQUIRE_MESSAGE(outputTest.count("pre"),
 			"\"pre\" field is not found. filename: " + TestOutputHelper::testFileName() +
 			" testname: " + TestOutputHelper::testName()
 		);
@@ -184,11 +185,11 @@ json_spirit::mValue doBlockchainTestNoLog(json_spirit::mValue const& _input, boo
 				dev::test::TestBlockChain::s_sealEngineNetwork = network;
 				string newtestname = testname + "_" + test::netIdToString(network);
 
-				json_spirit::mObject jObj = o;
-				if (o.count("expect"))
+				json_spirit::mObject jObj = outputTest;
+				if (outputTest.count("expect"))
 				{
 					//prepare the corresponding expect section for the test
-					json_spirit::mArray& expects = o["expect"].get_array();
+					json_spirit::mArray& expects = outputTest["expect"].get_array();
 					bool found = false;
 
 					for (auto& expect : expects)
@@ -219,14 +220,14 @@ json_spirit::mValue doBlockchainTestNoLog(json_spirit::mValue const& _input, boo
 		}
 		else
 		{
-			BOOST_REQUIRE_MESSAGE(o.count("network"),
+			BOOST_REQUIRE_MESSAGE(outputTest.count("network"),
 				"\"network\" field is not found. filename: " + TestOutputHelper::testFileName() +
 				" testname: " + TestOutputHelper::testName()
 			);
-			dev::test::TestBlockChain::s_sealEngineNetwork = stringToNetId(o["network"].get_str());
+			dev::test::TestBlockChain::s_sealEngineNetwork = stringToNetId(outputTest["network"].get_str());
 			if (test::isDisabledNetwork(dev::test::TestBlockChain::s_sealEngineNetwork))
 				continue;
-			testBCTest(o);
+			testBCTest(outputTest);
 		}
 	}
 

--- a/test/tools/jsontests/BlockChainTests.cpp
+++ b/test/tools/jsontests/BlockChainTests.cpp
@@ -147,8 +147,7 @@ json_spirit::mValue doTransitionTest(json_spirit::mValue const& _input, bool _fi
 json_spirit::mValue doBlockchainTestNoLog(json_spirit::mValue const& _input, bool _fillin)
 {
 	json_spirit::mValue v = json_spirit::mObject();
-	map<string, json_spirit::mObject> tests;
-	vector<string> erase_list;
+	json_spirit::mObject& tests = v.get_obj();
 
 	// range-for is not used because iterators are necessary for removing elements later.
 	for (auto i = _input.get_obj().begin(); i != _input.get_obj().end(); i++)
@@ -159,8 +158,6 @@ json_spirit::mValue doBlockchainTestNoLog(json_spirit::mValue const& _input, boo
 		//Select test by name if --singletest is set and not filling state tests as blockchain
 		if (!Options::get().fillchain && !TestOutputHelper::passTest(testname))
 			continue;
-
-		v.get_obj()[testname] = inputTest;
 
 		BOOST_REQUIRE_MESSAGE(inputTest.count("genesisBlockHeader"),
 			"\"genesisBlockHeader\" field is not found. filename: " + TestOutputHelper::testFileName() +
@@ -210,10 +207,6 @@ json_spirit::mValue doBlockchainTestNoLog(json_spirit::mValue const& _input, boo
 				jObjOutput["network"] = test::netIdToString(network);
 				tests[newtestname] = jObjOutput;
 			}
-
-			// will be deleted once after the loop.
-			// removing an element while in this loop causes memory corruption.
-			erase_list.push_back(testname);
 		}
 		else
 		{
@@ -228,18 +221,6 @@ json_spirit::mValue doBlockchainTestNoLog(json_spirit::mValue const& _input, boo
 		}
 	}
 
-	//Delete source test from the json
-	for (auto testname: erase_list)
-		v.get_obj().erase(v.get_obj().find(testname));
-
-	//Add generated tests to the result file
-	if (_fillin)
-	{
-		BOOST_CHECK_MESSAGE(v.get_obj().size() == 0, " Test Filler is incorrect. Still having the test source when generating from filler " + TestOutputHelper::testName());
-		json_spirit::mObject& obj = v.get_obj();
-		for (auto& test : tests)
-			obj[test.first] = test.second;
-	}
 	return v;
 }
 

--- a/test/tools/jsontests/BlockChainTests.cpp
+++ b/test/tools/jsontests/BlockChainTests.cpp
@@ -185,7 +185,7 @@ json_spirit::mValue doBlockchainTestNoLog(json_spirit::mValue const& _input, boo
 				dev::test::TestBlockChain::s_sealEngineNetwork = network;
 				string newtestname = testname + "_" + test::netIdToString(network);
 
-				json_spirit::mObject jObj = inputTest;
+				json_spirit::mObject jObjOutput = inputTest;
 				if (inputTest.count("expect"))
 				{
 					//prepare the corresponding expect section for the test
@@ -200,18 +200,18 @@ json_spirit::mValue doBlockchainTestNoLog(json_spirit::mValue const& _input, boo
 						if (std::find(netlist.begin(), netlist.end(), test::netIdToString(network)) != netlist.end() ||
 							std::find(netlist.begin(), netlist.end(), "ALL") != netlist.end())
 						{
-							jObj["expect"] = expectObj.at("result");
+							jObjOutput["expect"] = expectObj.at("result");
 							found = true;
 							break;
 						}
 					}
 					if (!found)
-						jObj.erase(jObj.find("expect"));
+						jObjOutput.erase(jObjOutput.find("expect"));
 				}
 				TestOutputHelper::setCurrentTestName(newtestname);
-				jObj = fillBCTest(jObj);
-				jObj["network"] = test::netIdToString(network);
-				tests[newtestname] = jObj;
+				jObjOutput = fillBCTest(jObjOutput);
+				jObjOutput["network"] = test::netIdToString(network);
+				tests[newtestname] = jObjOutput;
 			}
 
 			// will be deleted once after the loop.

--- a/test/tools/jsontests/BlockChainTests.cpp
+++ b/test/tools/jsontests/BlockChainTests.cpp
@@ -165,11 +165,11 @@ json_spirit::mValue doBlockchainTestNoLog(json_spirit::mValue const& _input, boo
 			continue;
 		}
 
-		BOOST_REQUIRE_MESSAGE(outputTest.count("genesisBlockHeader"),
+		BOOST_REQUIRE_MESSAGE(inputTest.count("genesisBlockHeader"),
 			"\"genesisBlockHeader\" field is not found. filename: " + TestOutputHelper::testFileName() +
 			" testname: " + TestOutputHelper::testName()
 		);
-		BOOST_REQUIRE_MESSAGE(outputTest.count("pre"),
+		BOOST_REQUIRE_MESSAGE(inputTest.count("pre"),
 			"\"pre\" field is not found. filename: " + TestOutputHelper::testFileName() +
 			" testname: " + TestOutputHelper::testName()
 		);
@@ -186,21 +186,21 @@ json_spirit::mValue doBlockchainTestNoLog(json_spirit::mValue const& _input, boo
 				string newtestname = testname + "_" + test::netIdToString(network);
 
 				json_spirit::mObject jObj = outputTest;
-				if (outputTest.count("expect"))
+				if (inputTest.count("expect"))
 				{
 					//prepare the corresponding expect section for the test
-					json_spirit::mArray& expects = outputTest["expect"].get_array();
+					json_spirit::mArray const& expects = inputTest.at("expect").get_array();
 					bool found = false;
 
 					for (auto& expect : expects)
 					{
 						vector<string> netlist;
-						json_spirit::mObject& expectObj = expect.get_obj();
-						ImportTest::parseJsonStrValueIntoVector(expectObj["network"], netlist);
+						json_spirit::mObject const& expectObj = expect.get_obj();
+						ImportTest::parseJsonStrValueIntoVector(expectObj.at("network"), netlist);
 						if (std::find(netlist.begin(), netlist.end(), test::netIdToString(network)) != netlist.end() ||
 							std::find(netlist.begin(), netlist.end(), "ALL") != netlist.end())
 						{
-							jObj["expect"] = expectObj["result"];
+							jObj["expect"] = expectObj.at("result");
 							found = true;
 							break;
 						}
@@ -220,11 +220,11 @@ json_spirit::mValue doBlockchainTestNoLog(json_spirit::mValue const& _input, boo
 		}
 		else
 		{
-			BOOST_REQUIRE_MESSAGE(outputTest.count("network"),
+			BOOST_REQUIRE_MESSAGE(inputTest.count("network"),
 				"\"network\" field is not found. filename: " + TestOutputHelper::testFileName() +
 				" testname: " + TestOutputHelper::testName()
 			);
-			dev::test::TestBlockChain::s_sealEngineNetwork = stringToNetId(outputTest["network"].get_str());
+			dev::test::TestBlockChain::s_sealEngineNetwork = stringToNetId(inputTest.at("network").get_str());
 			if (test::isDisabledNetwork(dev::test::TestBlockChain::s_sealEngineNetwork))
 				continue;
 			testBCTest(outputTest);

--- a/test/unittests/libtesteth/blockchainTest.cpp
+++ b/test/unittests/libtesteth/blockchainTest.cpp
@@ -18,11 +18,133 @@
  * Unit tests for blockchain test filling/execution.
  */
 
-#include <boost/test/unit_test.hpp>
 #include <test/tools/libtesteth/TestOutputHelper.h>
+#include <test/tools/libtesteth/TestHelper.h>
+
+#include <boost/test/unit_test.hpp>
 
 using namespace dev::test;
 
 BOOST_FIXTURE_TEST_SUITE(BlockChainTestSuite, TestOutputHelper)
+
+BOOST_AUTO_TEST_CASE(fillingExpectationOnMultipleNetworks)
+{
+	std::string const s = R"(
+		{
+			"BLOCKHASH_Bounds" : {
+			"blocks" : [
+			],
+			"expect" : [
+				{
+					"network" : ["Frontier", "Homestead"],
+					"result" : {
+						"0x1000000000000000000000000000000000000000" : {
+							"balance" : "0x00"
+						},
+						"0x1000000000000000000000000000000000000001" : {
+							"balance" : "0x00"
+						}
+					}
+				}
+			],
+			"genesisBlockHeader" : {
+				"bloom" : "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+				"coinbase" : "2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+				"difficulty" : "131072",
+				"extraData" : "0x42",
+				"gasLimit" : "0x7fffffffffffffff",
+				"gasUsed" : "0",
+				"mixHash" : "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+				"nonce" : "0x0102030405060708",
+				"number" : "0",
+				"parentHash" : "0x0000000000000000000000000000000000000000000000000000000000000000",
+				"receiptTrie" : "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+				"stateRoot" : "0xf99eb1626cfa6db435c0836235942d7ccaa935f1ae247d3f1c21e495685f903a",
+				"timestamp" : "0x03b6",
+				"transactionsTrie" : "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+				"uncleHash" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+			},
+			"pre" : {
+				"0x1000000000000000000000000000000000000000" : {
+					"balance" : "0x00",
+					"code" : "0x60004060005563ffffffff4060015567ffffffffffffffff406002556fffffffffffffffffffffffffffffffff406003557fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff40600455",
+					"nonce" : "0x00",
+					"storage" : {
+					}
+				},
+			"0x1000000000000000000000000000000000000001" : {
+				"balance" : "0x00",
+				"code" : "0x60004060005563ffffffff4060015567ffffffffffffffff406002556fffffffffffffffffffffffffffffffff406003557fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff40600455",
+				"nonce" : "0x00",
+				"storage" : {
+				}
+			}
+		}
+	)";
+	json_spirit::mValue input;
+	json_spirit::read_string(s, input);
+	json_spirit::mValue output = doBlockchainTestNoLog(input, true);
+	BOOST_CHECK_MESSAGE(output.get_obj().size() == getNetworks().size(), "A wrong number of tests were generated.");
+}
+
+BOOST_AUTO_TEST_CASE_EXPECTED_FAILURES(fillingWithWrongExpectation, 2)
+BOOST_AUTO_TEST_CASE(fillingWithWrongExpectation)
+{
+	std::string const s = R"(
+		{
+			"BLOCKHASH_Bounds" : {
+			"blocks" : [
+			],
+			"expect" : [
+				{
+					"network" : ["Frontier", "Homestead"],
+					"result" : {
+						"0x1000000000000000000000000000000000000000" : {
+							"balance" : "0x01"
+						},
+						"0x1000000000000000000000000000000000000001" : {
+							"balance" : "0x00"
+						}
+					}
+				}
+			],
+			"genesisBlockHeader" : {
+				"bloom" : "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+				"coinbase" : "2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+				"difficulty" : "131072",
+				"extraData" : "0x42",
+				"gasLimit" : "0x7fffffffffffffff",
+				"gasUsed" : "0",
+				"mixHash" : "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+				"nonce" : "0x0102030405060708",
+				"number" : "0",
+				"parentHash" : "0x0000000000000000000000000000000000000000000000000000000000000000",
+				"receiptTrie" : "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+				"stateRoot" : "0xf99eb1626cfa6db435c0836235942d7ccaa935f1ae247d3f1c21e495685f903a",
+				"timestamp" : "0x03b6",
+				"transactionsTrie" : "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+				"uncleHash" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+			},
+			"pre" : {
+				"0x1000000000000000000000000000000000000000" : {
+					"balance" : "0x00",
+					"code" : "0x60004060005563ffffffff4060015567ffffffffffffffff406002556fffffffffffffffffffffffffffffffff406003557fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff40600455",
+					"nonce" : "0x00",
+					"storage" : {
+					}
+				},
+			"0x1000000000000000000000000000000000000001" : {
+				"balance" : "0x00",
+				"code" : "0x60004060005563ffffffff4060015567ffffffffffffffff406002556fffffffffffffffffffffffffffffffff406003557fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff40600455",
+				"nonce" : "0x00",
+				"storage" : {
+				}
+			}
+		}
+	)";
+	json_spirit::mValue input;
+	json_spirit::read_string(s, input);
+	doBlockchainTestNoLog(input, true);
+}
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/unittests/libtesteth/blockchainTest.cpp
+++ b/test/unittests/libtesteth/blockchainTest.cpp
@@ -1,0 +1,28 @@
+/*
+	This file is part of cpp-ethereum.
+
+	cpp-ethereum is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	cpp-ethereum is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/** @file blockchainTest.cpp
+ * Unit tests for blockchain test filling/execution.
+ */
+
+#include <boost/test/unit_test.hpp>
+#include <test/tools/libtesteth/TestOutputHelper.h>
+
+using namespace dev::test;
+
+BOOST_FIXTURE_TEST_SUITE(BlockChainTestSuite, TestOutputHelper)
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This PR further separates input and output in blockchaintest filling.  The code became a bit shorter.