### PR TITLE
[WIP] generalize test execution logic

### DIFF
--- a/test/tools/jsontests/StateTests.cpp
+++ b/test/tools/jsontests/StateTests.cpp
@@ -118,28 +118,7 @@ public:
 		string casename = boost::unit_test::framework::current_test_case().p_name;
 		if (casename == "stQuadraticComplexityTest" && !test::Options::get().quadratic)
 			return;
-		fillAllFilesInFolder(casename);
-	}
-
-	void fillAllFilesInFolder(string const& _folder)
-	{
-		std::string fillersPath = test::getTestPath() + "/src/GeneralStateTestsFiller/" + _folder;
-
-		string filter = test::Options::get().singleTestName.empty() ? string() : test::Options::get().singleTestName + "Filler";
-		std::vector<boost::filesystem::path> files = test::getJsonFiles(fillersPath, filter);
-		int fileCount = files.size();
-
-		if (test::Options::get().filltests)
-			fileCount *= 2; //tests are checked when filled and after they been filled
-		test::TestOutputHelper::initTest(fileCount);
-
-		for (auto const& file: files)
-		{
-			test::TestOutputHelper::setCurrentTestFileName(file.filename().string());
-			test::executeTests(file.filename().string(), "/GeneralStateTests/"+_folder, "/GeneralStateTestsFiller/"+_folder, dev::test::doStateTests);
-		}
-
-		test::TestOutputHelper::finishTest();
+		test::executeTests2(test::testType::StateTestsGeneral, casename);
 	}
 };
 

--- a/test/tools/libtesteth/TestHelper.cpp
+++ b/test/tools/libtesteth/TestHelper.cpp
@@ -460,6 +460,34 @@ void userDefinedTest(std::function<json_spirit::mValue(json_spirit::mValue const
 	}
 }
 
+void executeTests2(test::testType _type, const std::string& _testFolder)
+{
+	string testSuiteFolder;
+	std::function<json_spirit::mValue(json_spirit::mValue const&, bool)> doTests;
+	switch (_type)
+	{
+		case test::testType::StateTestsGeneral:
+			testSuiteFolder = "GeneralStateTests"; //test::c_StateTestsGeneral;
+			doTests = test::doStateTests;
+			break;
+		default:
+		break;
+	}
+	std::string fillersPath = test::getTestPath() + "/src/" + testSuiteFolder + "Filler/" + _testFolder;
+	string filter = test::Options::get().singleTestName.empty() ? string() : test::Options::get().singleTestName + "Filler";
+	std::vector<boost::filesystem::path> files = test::getJsonFiles(fillersPath, filter);
+	int fileCount = files.size();
+	if (test::Options::get().filltests)
+		fileCount *= 2; //tests are checked when filled and after they been filled
+	test::TestOutputHelper::initTest(fileCount);
+	for (auto const& file: files)
+	{
+		test::TestOutputHelper::setCurrentTestFileName(file.filename().string());
+		test::executeTests(file.filename().string(), "/" + testSuiteFolder + "/" + _testFolder, "/" + testSuiteFolder + "Filler/"+ _testFolder, doTests);
+	}
+	test::TestOutputHelper::finishTest();
+}
+
 void executeTests(const string& _name, const string& _testPathAppendix, const string& _fillerPathAppendix, std::function<json_spirit::mValue(json_spirit::mValue const&, bool)> doTests, bool _addFillerSuffix)
 {
 	string testPath = getTestPath() + _testPathAppendix;

--- a/test/tools/libtesteth/TestHelper.h
+++ b/test/tools/libtesteth/TestHelper.h
@@ -60,7 +60,10 @@ struct ValueTooLarge: virtual Exception {};
 struct MissingFields : virtual Exception {};
 bigint const c_max256plus1 = bigint(1) << 256;
 extern std::string const c_StateTestsGeneral;
-
+enum class testType
+{
+	StateTestsGeneral
+};
 
 class ZeroGasPricer: public eth::GasPricer
 {
@@ -107,6 +110,7 @@ dev::eth::BlockHeader constructHeader(
 	bytes const& _extraData);
 void updateEthashSeal(dev::eth::BlockHeader& _header, h256 const& _mixHash, dev::eth::Nonce const& _nonce);
 void executeTests(const std::string& _name, const std::string& _testPathAppendix, const std::string& _fillerPathAppendix, std::function<json_spirit::mValue(json_spirit::mValue const&, bool)> doTests, bool _addFillerSuffix = true);
+void executeTests2(test::testType _type, const std::string& _testFolder);
 void userDefinedTest(std::function<json_spirit::mValue(json_spirit::mValue const&, bool)> doTests);
 RLPStream createRLPStreamFromTransactionFields(json_spirit::mObject const& _tObj);
 json_spirit::mObject fillJsonWithStateChange(eth::State const& _stateOrig, eth::State const& _statePost, eth::ChangeLog const& _changeLog);


### PR DESCRIPTION
this is a first step to replace common logic of executing test files from different suites and folders. 
eventually this should remove original test::executeTests function and replace it with refactored version introduced in this PR. 

@pirapira  I could this step by step by merging small PRs. so it would be easy to review