### PR TITLE
Remove a vptr race condition

### DIFF
--- a/libdevcore/Worker.h
+++ b/libdevcore/Worker.h
@@ -91,9 +91,11 @@ protected:
 	/// Blocks caller into worker thread has finished.
 //	void join() const { Guard l(x_work); try { if (m_work) m_work->join(); } catch (...) {} }
 
-private:
 	/// Stop and never start again.
+	/// This has to be called in the destructor of any derived class.  Otherwise the worker thread will try to lookup vptrs.
 	void terminate();
+
+private:
 
 	std::string m_name;
 

--- a/libethashseal/EthashCPUMiner.cpp
+++ b/libethashseal/EthashCPUMiner.cpp
@@ -41,6 +41,7 @@ EthashCPUMiner::EthashCPUMiner(GenericMiner<EthashProofOfWork>::ConstructionInfo
 
 EthashCPUMiner::~EthashCPUMiner()
 {
+	terminate();
 }
 
 void EthashCPUMiner::kickOff()

--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -80,6 +80,7 @@ Client::Client(
 Client::~Client()
 {
 	stopWorking();
+	terminate();
 }
 
 void Client::init(p2p::Host* _extNet, std::string const& _dbPath, WithExisting _forceAction, u256 _networkId)

--- a/libethereum/EthereumHost.cpp
+++ b/libethereum/EthereumHost.cpp
@@ -394,6 +394,7 @@ EthereumHost::EthereumHost(BlockChain const& _ch, OverlayDB const& _db, Transact
 
 EthereumHost::~EthereumHost()
 {
+	terminate();
 }
 
 bool EthereumHost::ensureInitialised()

--- a/libp2p/Host.cpp
+++ b/libp2p/Host.cpp
@@ -119,6 +119,7 @@ Host::Host(string const& _clientVersion, NetworkPreferences const& _n, bytesCons
 Host::~Host()
 {
 	stop();
+	terminate();
 }
 
 void Host::start()

--- a/libwhisper/WhisperHost.cpp
+++ b/libwhisper/WhisperHost.cpp
@@ -38,6 +38,7 @@ WhisperHost::WhisperHost(bool _storeMessagesInDB): Worker("shh"), m_storeMessage
 WhisperHost::~WhisperHost()
 {
 	saveMessagesToBD();
+	terminate();
 }
 
 void WhisperHost::streamMessage(h256 _m, RLPStream& _s) const

--- a/test/tools/jsontests/BlockChainTests.cpp
+++ b/test/tools/jsontests/BlockChainTests.cpp
@@ -412,7 +412,6 @@ json_spirit::mObject fillBCTest(json_spirit::mObject const& _input)
 		}
 
 		blArray.push_back(blObj);  //json data
-		this_thread::sleep_for(chrono::seconds(1));
 	}//each blocks
 
 	if (_input.count("expect") > 0)


### PR DESCRIPTION
There was a race condition involving a worker thread that looks up vptrs.
The worker thread was joined by the base class's destructor, not the derived class's destructor.
So the worker thread kept working, looking up vptrs, even after the derived object was destroyed.

After fixing this problem, I saw I can remove one sleep(1 second) in BlockchainTest execution.

Thread sanitizer helped a lot.

With this command
```
ETHEREUM_TEST_PATH='../../tests' test/testeth -t 'BlockchainTests' -- --filltests --singletest  randomStatetest319BC
```
I saw
```
WARNING: ThreadSanitizer: data race on vptr (ctor/dtor vs virtual call) (pid=8000)                          
  Write of size 8 at 0x7b4c00002e78 by main thread:                                                                                                                                                                                                 
    #0 ~Worker /home/yh/src/cpp-ethereum/test/../libdevcore/Worker.h:64 (testeth+0x820eef)                                                                                                                                                                 
    #1 ~EthashCPUMiner /home/yh/src/cpp-ethereum/libethashseal/EthashCPUMiner.cpp:44 (testeth+0x9064ed)                                                                                                                                                    
    #2 ~EthashCPUMiner /home/yh/src/cpp-ethereum/libethashseal/EthashCPUMiner.cpp:43 (testeth+0x906559)                                                                                                                                       
    #3 std::_Sp_counted_ptr<dev::eth::GenericMiner<dev::eth::EthashProofOfWork>*, (__gnu_cxx::_Lock_policy)2>::_M_dispose() /usr/bin/../lib/gcc/x86_64-linux-gnu/6.3.0/../../../../include/c++/6.3.0/bits/shared_ptr_base.h:372 (discriminator 1) (testeth+
0x8f95e0)                                    
    #4 std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() /usr/bin/../lib/gcc/x86_64-linux-gnu/6.3.0/../../../../include/c++/6.3.0/bits/shared_ptr_base.h:150 (testeth+0x7b62d8)                                                              
    #5 ~__shared_count /usr/bin/../lib/gcc/x86_64-linux-gnu/6.3.0/../../../../include/c++/6.3.0/bits/shared_ptr_base.h:662 (testeth+0x7b629e)                                                                                                              
    #6 ~__shared_ptr /usr/bin/../lib/gcc/x86_64-linux-gnu/6.3.0/../../../../include/c++/6.3.0/bits/shared_ptr_base.h:928 (testeth+0x8dd25d)                                                                                                                
    #7 void std::_Destroy<std::shared_ptr<dev::eth::GenericMiner<dev::eth::EthashProofOfWork> > >(std::shared_ptr<dev::eth::GenericMiner<dev::eth::EthashProofOfWork> >*) /usr/bin/../lib/gcc/x86_64-linux-gnu/6.3.0/../../../../include/c++/6.3.0/bits/stl
_construct.h:93 (testeth+0x8dd1f9)                                                                                                                                                                                                                         
    #8 void std::_Destroy_aux<false>::__destroy<std::shared_ptr<dev::eth::GenericMiner<dev::eth::EthashProofOfWork> >*>(std::shared_ptr<dev::eth::GenericMiner<dev::eth::EthashProofOfWork> >*, std::shared_ptr<dev::eth::GenericMiner<dev::eth::EthashProo
fOfWork> >*) /usr/bin/../lib/gcc/x86_64-linux-gnu/6.3.0/../../../../include/c++/6.3.0/bits/stl_construct.h:103 (discriminator 1) (testeth+0x8dd1bf)                                    
    #9 void std::_Destroy<std::shared_ptr<dev::eth::GenericMiner<dev::eth::EthashProofOfWork> >*>(std::shared_ptr<dev::eth::GenericMiner<dev::eth::EthashProofOfWork> >*, std::shared_ptr<dev::eth::GenericMiner<dev::eth::EthashProofOfWork> >*) /usr/bin/
../lib/gcc/x86_64-linux-gnu/6.3.0/../../../../include/c++/6.3.0/bits/stl_construct.h:126 (testeth+0x8dd170)

  Previous read of size 8 at 0x7b4c00002e78 by thread T34:                                                                                                                
    #0 operator() /home/yh/src/cpp-ethereum/libdevcore/Worker.cpp:60 (testeth+0xb75567)                                                                                                                                                                
    #1 void std::_Bind_simple<dev::Worker::startWorking()::$_0 ()>::_M_invoke<>(std::_Index_tuple<>) /usr/bin/../lib/gcc/x86_64-linux-gnu/6.3.0/../../../../include/c++/6.3.0/functional:1390 (discriminator 2) (testeth+0xb753d9)
    #2 std::_Bind_simple<dev::Worker::startWorking()::$_0 ()>::operator()() /usr/bin/../lib/gcc/x86_64-linux-gnu/6.3.0/../../../../include/c++/6.3.0/functional:1380 (testeth+0xb75389)
    #3 std::thread::_State_impl<std::_Bind_simple<dev::Worker::startWorking()::$_0 ()> >::_M_run() /usr/bin/../lib/gcc/x86_64-linux-gnu/6.3.0/../../../../include/c++/6.3.0/thread:197 (testeth+0xb7524d)                                                  
    #4 std::error_code::default_error_condition() const ??:? (libstdc++.so.6+0xbb83e)
```