### PR TITLE
Fix the network id in --fillchain

### DIFF
--- a/test/tools/libtesteth/ImportTest.cpp
+++ b/test/tools/libtesteth/ImportTest.cpp
@@ -117,13 +117,9 @@ bytes ImportTest::executeTest()
 				vector<size_t> stateIndexesToPrint; //not used
 				json_spirit::mArray expetSectionArray;
 
-				//gather the expect sections for such a transaction on all networks (if defined)
-				std::vector<string> checkedNetworks;
 				for (auto const& net : networks)
 				{
 					tr.netId = net;
-					if (std::find(checkedNetworks.begin(), checkedNetworks.end(), test::netIdToString(net)) != checkedNetworks.end())
-						continue;
 
 					// Calculate the block reward
 					ChainParams const chainParams{genesisInfo(net)};
@@ -154,10 +150,6 @@ bytes ImportTest::executeTest()
 
 							json_spirit::mObject expetSectionObj;
 							expetSectionObj["network"] = test::netIdToString(net);
-							std::vector<string> networks;
-							ImportTest::parseJsonStrValueIntoVector(exp.get_obj().at("network"), networks);
-							for(auto const& netname : networks)
-								checkedNetworks.push_back(netname);
 							expetSectionObj["result"] = obj;
 							expetSectionArray.push_back(expetSectionObj);
 							break;

--- a/test/tools/libtesteth/ImportTest.cpp
+++ b/test/tools/libtesteth/ImportTest.cpp
@@ -153,7 +153,7 @@ bytes ImportTest::executeTest()
 							}
 
 							json_spirit::mObject expetSectionObj;
-							expetSectionObj["network"] = exp.get_obj().at("network");
+							expetSectionObj["network"] = test::netIdToString(net);
 							std::vector<string> networks;
 							ImportTest::parseJsonStrValueIntoVector(exp.get_obj().at("network"), networks);
 							for(auto const& netname : networks)


### PR DESCRIPTION
Fixes https://github.com/ethereum/cpp-ethereum/issues/4401

The problem happened when the expectation section in the filler contained

```
network : ["ALL"]
```

In that case, many expectations of network = "ALL" was created, instead of
many expectations of different networks ("Frontier", "Homestead", ...).