### PR TITLE
Remove options that can be replaced with --all

### DIFF
--- a/test/tools/jsontests/BlockChainTestsBoost.cpp
+++ b/test/tools/jsontests/BlockChainTestsBoost.cpp
@@ -57,8 +57,11 @@ class bcTestFixture {
 		}
 
 		//skip wallet test as it takes too much time (250 blocks) run it with --all flag
-		if (casename == "bcWalletTest" && !test::Options::get().wallet)
+		if (casename == "bcWalletTest" && !test::Options::get().all)
+		{
+			cnote << "Skipping " << casename << " because --all option is not specified.\n";
 			return;
+		}
 
 		fillAllFilesInFolder(casename);
 	}

--- a/test/tools/jsontests/BlockChainTestsBoost.cpp
+++ b/test/tools/jsontests/BlockChainTestsBoost.cpp
@@ -135,6 +135,9 @@ class bcGeneralTestsFixture
 			return;
 
 		string casename = boost::unit_test::framework::current_test_case().p_name;
+		//skip this test suite if not run with --all flag (cases are already tested in state tests)
+		if (!test::Options::get().all)
+			cnote << "Skipping hive test " << casename << ". Use --all to run it.\n";
 		runAllFilesInFolder("GeneralStateTests/" + casename);
 	}
 

--- a/test/tools/jsontests/BlockChainTestsBoost.cpp
+++ b/test/tools/jsontests/BlockChainTestsBoost.cpp
@@ -128,7 +128,7 @@ class bcGeneralTestsFixture
 	{
 		//general tests are filled from state tests
 		//skip this test suite if not run with --all flag (cases are already tested in state tests)
-		if (test::Options::get().filltests || !test::Options::get().performance)
+		if (test::Options::get().filltests || !test::Options::get().all)
 			return;
 
 		string casename = boost::unit_test::framework::current_test_case().p_name;

--- a/test/tools/jsontests/StateTests.cpp
+++ b/test/tools/jsontests/StateTests.cpp
@@ -116,8 +116,11 @@ public:
 	generaltestfixture()
 	{
 		string casename = boost::unit_test::framework::current_test_case().p_name;
-		if (casename == "stQuadraticComplexityTest" && !test::Options::get().quadratic)
+		if (casename == "stQuadraticComplexityTest" && !test::Options::get().all)
+		{
+			cnote << "Skipping " << casename << " because --all option is not specified.\n";
 			return;
+		}
 		fillAllFilesInFolder(casename);
 	}
 

--- a/test/tools/jsontests/TransactionTests.cpp
+++ b/test/tools/jsontests/TransactionTests.cpp
@@ -240,7 +240,7 @@ BOOST_AUTO_TEST_CASE(ttWrongRLPTransaction)
 
 BOOST_AUTO_TEST_CASE(tt10mbDataFieldHomestead)
 {
-	if (test::Options::get().bigData)
+	if (test::Options::get().all)
 	{
 		auto start = chrono::steady_clock::now();
 
@@ -250,11 +250,13 @@ BOOST_AUTO_TEST_CASE(tt10mbDataFieldHomestead)
 		auto duration(chrono::duration_cast<chrono::milliseconds>(end - start));
 		cnote << "test duration: " << duration.count() << " milliseconds.\n";
 	}
+	else
+		cnote << "tt10mbDataFieldHomestead skipped because --all option was not specified.\n";
 }
 
 BOOST_AUTO_TEST_CASE(tt10mbDataField)
 {
-	if (test::Options::get().bigData)
+	if (test::Options::get().all)
 	{
 		auto start = chrono::steady_clock::now();
 
@@ -264,6 +266,8 @@ BOOST_AUTO_TEST_CASE(tt10mbDataField)
 		auto duration(chrono::duration_cast<chrono::milliseconds>(end - start));
 		cnote << "test duration: " << duration.count() << " milliseconds.\n";
 	}
+	else
+		cnote << "tt10mbDataField skipped because --all option was not specified.";
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/tools/jsontests/vm.cpp
+++ b/test/tools/jsontests/vm.cpp
@@ -528,18 +528,24 @@ BOOST_AUTO_TEST_CASE(vmPerformanceTest)
 {
 	if (test::Options::get().all)
 		dev::test::executeTests("vmPerformanceTest", "/VMTests", "/VMTestsFiller", dev::test::doVMTests);
+	else
+		cnote << "vmPerformanceTest is skipped because --all option is not specified.\n";
 }
 
 BOOST_AUTO_TEST_CASE(vmInputLimitsTest)
 {
 	if (test::Options::get().all)
 		dev::test::executeTests("vmInputLimits", "/VMTests", "/VMTestsFiller", dev::test::doVMTests);
+	else
+		cnote << "vmInputLimitsTest is skipped because --all option is not specified.\n";
 }
 
 BOOST_AUTO_TEST_CASE(vmInputLimitsLightTest)
 {
 	if (test::Options::get().all)
 		dev::test::executeTests("vmInputLimitsLight", "/VMTests", "/VMTestsFiller", dev::test::doVMTests);
+	else
+		cnote << "vmInputLimitsLightTest is skipped because --all option is not specified\n";
 }
 
 BOOST_AUTO_TEST_CASE(vmRandom)

--- a/test/tools/jsontests/vm.cpp
+++ b/test/tools/jsontests/vm.cpp
@@ -526,7 +526,7 @@ BOOST_AUTO_TEST_CASE(vmSystemOperationsTest)
 
 BOOST_AUTO_TEST_CASE(vmPerformanceTest)
 {
-	if (test::Options::get().performance)
+	if (test::Options::get().all)
 		dev::test::executeTests("vmPerformanceTest", "/VMTests", "/VMTestsFiller", dev::test::doVMTests);
 }
 

--- a/test/tools/jsontests/vm.cpp
+++ b/test/tools/jsontests/vm.cpp
@@ -532,13 +532,13 @@ BOOST_AUTO_TEST_CASE(vmPerformanceTest)
 
 BOOST_AUTO_TEST_CASE(vmInputLimitsTest)
 {
-	if (test::Options::get().inputLimits)
+	if (test::Options::get().all)
 		dev::test::executeTests("vmInputLimits", "/VMTests", "/VMTestsFiller", dev::test::doVMTests);
 }
 
 BOOST_AUTO_TEST_CASE(vmInputLimitsLightTest)
 {
-	if (test::Options::get().inputLimits)
+	if (test::Options::get().all)
 		dev::test::executeTests("vmInputLimitsLight", "/VMTests", "/VMTestsFiller", dev::test::doVMTests);
 }
 

--- a/test/tools/libtesteth/Options.cpp
+++ b/test/tools/libtesteth/Options.cpp
@@ -50,7 +50,6 @@ void printHelp()
 	cout << setw(30) << "--statediff" << setw(25) << "Trace state difference for state tests\n";
 
 	cout << "\nAdditional Tests\n";
-	cout << setw(30) << "--performance" << setw(25) << "Enable perfomance tests\n";
 	cout << setw(30) << "--quadratic" << setw(25) << "Enable quadratic complexity tests\n";
 	cout << setw(30) << "--memory" << setw(25) << "Enable memory consuming tests\n";
 	cout << setw(30) << "--inputLimits" << setw(25) << "Enable inputLimits tests\n";
@@ -162,8 +161,6 @@ Options::Options(int argc, char** argv)
 		}
 		else if (arg == "--exectimelog")
 			exectimelog = true;
-		else if (arg == "--performance")
-			performance = true;
 		else if (arg == "--quadratic")
 			quadratic = true;
 		else if (arg == "--memory")
@@ -176,7 +173,7 @@ Options::Options(int argc, char** argv)
 			wallet = true;
 		else if (arg == "--all")
 		{
-			performance = true;
+			all = true;
 			quadratic = true;
 			memory = true;
 			inputLimits = true;
@@ -290,11 +287,11 @@ Options::Options(int argc, char** argv)
 	if (createRandomTest)
 	{
 		if (trValueIndex >= 0 || trGasIndex >= 0 || trDataIndex >= 0 || nonetwork || singleTest
-			|| performance || quadratic || memory || inputLimits || bigData || wallet
+			|| all || quadratic || memory || inputLimits || bigData || wallet
 			|| stats || filltests || fillchain)
 		{
 			cerr << "--createRandomTest cannot be used with any of the options: " <<
-					"trValueIndex, trGasIndex, trDataIndex, nonetwork, singleTest, performance, " <<
+					"trValueIndex, trGasIndex, trDataIndex, nonetwork, singleTest, all, " <<
 					"quadratic, memory, inputLimits, bigData, wallet, stats, filltests, fillchain" << endl;
 			exit(1);
 		}

--- a/test/tools/libtesteth/Options.cpp
+++ b/test/tools/libtesteth/Options.cpp
@@ -50,7 +50,6 @@ void printHelp()
 	cout << setw(30) << "--statediff" << setw(25) << "Trace state difference for state tests\n";
 
 	cout << "\nAdditional Tests\n";
-	cout << setw(30) << "--inputLimits" << setw(25) << "Enable inputLimits tests\n";
 	cout << setw(30) << "--bigdata" << setw(25) << "Enable bigdata tests\n";
 	cout << setw(30) << "--all" << setw(25) << "Enable all tests\n";
 
@@ -158,14 +157,11 @@ Options::Options(int argc, char** argv)
 		}
 		else if (arg == "--exectimelog")
 			exectimelog = true;
-		else if (arg == "--inputlimits")
-			inputLimits = true;
 		else if (arg == "--bigdata")
 			bigData = true;
 		else if (arg == "--all")
 		{
 			all = true;
-			inputLimits = true;
 			bigData = true;
 		}
 		else if (arg == "--singletest")
@@ -275,11 +271,11 @@ Options::Options(int argc, char** argv)
 	if (createRandomTest)
 	{
 		if (trValueIndex >= 0 || trGasIndex >= 0 || trDataIndex >= 0 || nonetwork || singleTest
-			|| all || inputLimits || bigData || stats || filltests || fillchain)
+			|| all || bigData || stats || filltests || fillchain)
 		{
 			cerr << "--createRandomTest cannot be used with any of the options: " <<
 					"trValueIndex, trGasIndex, trDataIndex, nonetwork, singleTest, all, " <<
-					"inputLimits, bigData, stats, filltests, fillchain" << endl;
+					"bigData, stats, filltests, fillchain" << endl;
 			exit(1);
 		}
 	}

--- a/test/tools/libtesteth/Options.cpp
+++ b/test/tools/libtesteth/Options.cpp
@@ -50,7 +50,6 @@ void printHelp()
 	cout << setw(30) << "--statediff" << setw(25) << "Trace state difference for state tests\n";
 
 	cout << "\nAdditional Tests\n";
-	cout << setw(30) << "--memory" << setw(25) << "Enable memory consuming tests\n";
 	cout << setw(30) << "--inputLimits" << setw(25) << "Enable inputLimits tests\n";
 	cout << setw(30) << "--bigdata" << setw(25) << "Enable bigdata tests\n";
 	cout << setw(30) << "--wallet" << setw(25) << "Enable wallet tests\n";
@@ -160,8 +159,6 @@ Options::Options(int argc, char** argv)
 		}
 		else if (arg == "--exectimelog")
 			exectimelog = true;
-		else if (arg == "--memory")
-			memory = true;
 		else if (arg == "--inputlimits")
 			inputLimits = true;
 		else if (arg == "--bigdata")
@@ -171,7 +168,6 @@ Options::Options(int argc, char** argv)
 		else if (arg == "--all")
 		{
 			all = true;
-			memory = true;
 			inputLimits = true;
 			bigData = true;
 			wallet = true;
@@ -283,12 +279,12 @@ Options::Options(int argc, char** argv)
 	if (createRandomTest)
 	{
 		if (trValueIndex >= 0 || trGasIndex >= 0 || trDataIndex >= 0 || nonetwork || singleTest
-			|| all || memory || inputLimits || bigData || wallet
+			|| all || inputLimits || bigData || wallet
 			|| stats || filltests || fillchain)
 		{
 			cerr << "--createRandomTest cannot be used with any of the options: " <<
 					"trValueIndex, trGasIndex, trDataIndex, nonetwork, singleTest, all, " <<
-					"memory, inputLimits, bigData, wallet, stats, filltests, fillchain" << endl;
+					"inputLimits, bigData, wallet, stats, filltests, fillchain" << endl;
 			exit(1);
 		}
 	}

--- a/test/tools/libtesteth/Options.cpp
+++ b/test/tools/libtesteth/Options.cpp
@@ -50,7 +50,6 @@ void printHelp()
 	cout << setw(30) << "--statediff" << setw(25) << "Trace state difference for state tests\n";
 
 	cout << "\nAdditional Tests\n";
-	cout << setw(30) << "--quadratic" << setw(25) << "Enable quadratic complexity tests\n";
 	cout << setw(30) << "--memory" << setw(25) << "Enable memory consuming tests\n";
 	cout << setw(30) << "--inputLimits" << setw(25) << "Enable inputLimits tests\n";
 	cout << setw(30) << "--bigdata" << setw(25) << "Enable bigdata tests\n";
@@ -161,8 +160,6 @@ Options::Options(int argc, char** argv)
 		}
 		else if (arg == "--exectimelog")
 			exectimelog = true;
-		else if (arg == "--quadratic")
-			quadratic = true;
 		else if (arg == "--memory")
 			memory = true;
 		else if (arg == "--inputlimits")
@@ -174,7 +171,6 @@ Options::Options(int argc, char** argv)
 		else if (arg == "--all")
 		{
 			all = true;
-			quadratic = true;
 			memory = true;
 			inputLimits = true;
 			bigData = true;
@@ -287,12 +283,12 @@ Options::Options(int argc, char** argv)
 	if (createRandomTest)
 	{
 		if (trValueIndex >= 0 || trGasIndex >= 0 || trDataIndex >= 0 || nonetwork || singleTest
-			|| all || quadratic || memory || inputLimits || bigData || wallet
+			|| all || memory || inputLimits || bigData || wallet
 			|| stats || filltests || fillchain)
 		{
 			cerr << "--createRandomTest cannot be used with any of the options: " <<
 					"trValueIndex, trGasIndex, trDataIndex, nonetwork, singleTest, all, " <<
-					"quadratic, memory, inputLimits, bigData, wallet, stats, filltests, fillchain" << endl;
+					"memory, inputLimits, bigData, wallet, stats, filltests, fillchain" << endl;
 			exit(1);
 		}
 	}

--- a/test/tools/libtesteth/Options.cpp
+++ b/test/tools/libtesteth/Options.cpp
@@ -52,7 +52,6 @@ void printHelp()
 	cout << "\nAdditional Tests\n";
 	cout << setw(30) << "--inputLimits" << setw(25) << "Enable inputLimits tests\n";
 	cout << setw(30) << "--bigdata" << setw(25) << "Enable bigdata tests\n";
-	cout << setw(30) << "--wallet" << setw(25) << "Enable wallet tests\n";
 	cout << setw(30) << "--all" << setw(25) << "Enable all tests\n";
 
 	cout << "\nTest Generation\n";
@@ -163,14 +162,11 @@ Options::Options(int argc, char** argv)
 			inputLimits = true;
 		else if (arg == "--bigdata")
 			bigData = true;
-		else if (arg == "--wallet")
-			wallet = true;
 		else if (arg == "--all")
 		{
 			all = true;
 			inputLimits = true;
 			bigData = true;
-			wallet = true;
 		}
 		else if (arg == "--singletest")
 		{
@@ -279,12 +275,11 @@ Options::Options(int argc, char** argv)
 	if (createRandomTest)
 	{
 		if (trValueIndex >= 0 || trGasIndex >= 0 || trDataIndex >= 0 || nonetwork || singleTest
-			|| all || inputLimits || bigData || wallet
-			|| stats || filltests || fillchain)
+			|| all || inputLimits || bigData || stats || filltests || fillchain)
 		{
 			cerr << "--createRandomTest cannot be used with any of the options: " <<
 					"trValueIndex, trGasIndex, trDataIndex, nonetwork, singleTest, all, " <<
-					"inputLimits, bigData, wallet, stats, filltests, fillchain" << endl;
+					"inputLimits, bigData, stats, filltests, fillchain" << endl;
 			exit(1);
 		}
 	}

--- a/test/tools/libtesteth/Options.cpp
+++ b/test/tools/libtesteth/Options.cpp
@@ -50,7 +50,6 @@ void printHelp()
 	cout << setw(30) << "--statediff" << setw(25) << "Trace state difference for state tests\n";
 
 	cout << "\nAdditional Tests\n";
-	cout << setw(30) << "--bigdata" << setw(25) << "Enable bigdata tests\n";
 	cout << setw(30) << "--all" << setw(25) << "Enable all tests\n";
 
 	cout << "\nTest Generation\n";
@@ -157,13 +156,8 @@ Options::Options(int argc, char** argv)
 		}
 		else if (arg == "--exectimelog")
 			exectimelog = true;
-		else if (arg == "--bigdata")
-			bigData = true;
 		else if (arg == "--all")
-		{
 			all = true;
-			bigData = true;
-		}
 		else if (arg == "--singletest")
 		{
 			throwIfNoArgumentFollows();
@@ -271,11 +265,11 @@ Options::Options(int argc, char** argv)
 	if (createRandomTest)
 	{
 		if (trValueIndex >= 0 || trGasIndex >= 0 || trDataIndex >= 0 || nonetwork || singleTest
-			|| all || bigData || stats || filltests || fillchain)
+			|| all || stats || filltests || fillchain)
 		{
 			cerr << "--createRandomTest cannot be used with any of the options: " <<
 					"trValueIndex, trGasIndex, trDataIndex, nonetwork, singleTest, all, " <<
-					"bigData, stats, filltests, fillchain" << endl;
+					"stats, filltests, fillchain" << endl;
 			exit(1);
 		}
 	}

--- a/test/tools/libtesteth/Options.h
+++ b/test/tools/libtesteth/Options.h
@@ -72,7 +72,6 @@ public:
 	bool nonetwork = false;///< For libp2p
 	bool inputLimits = false;
 	bool bigData = false;
-	bool wallet = false;
 	/// @}
 
 	/// Get reference to options

--- a/test/tools/libtesteth/Options.h
+++ b/test/tools/libtesteth/Options.h
@@ -70,7 +70,6 @@ public:
 	int trValueIndex;	///< GeneralState value
 	bool all = false;	///< Running every test, including time consuming ones.
 	bool nonetwork = false;///< For libp2p
-	bool inputLimits = false;
 	bool bigData = false;
 	/// @}
 

--- a/test/tools/libtesteth/Options.h
+++ b/test/tools/libtesteth/Options.h
@@ -70,7 +70,6 @@ public:
 	int trValueIndex;	///< GeneralState value
 	bool all = false;	///< Running every test, including time consuming ones.
 	bool nonetwork = false;///< For libp2p
-	bool quadratic = false;///< Time consuming tests
 	bool memory = false;
 	bool inputLimits = false;
 	bool bigData = false;

--- a/test/tools/libtesteth/Options.h
+++ b/test/tools/libtesteth/Options.h
@@ -70,7 +70,6 @@ public:
 	int trValueIndex;	///< GeneralState value
 	bool all = false;	///< Running every test, including time consuming ones.
 	bool nonetwork = false;///< For libp2p
-	bool memory = false;
 	bool inputLimits = false;
 	bool bigData = false;
 	bool wallet = false;

--- a/test/tools/libtesteth/Options.h
+++ b/test/tools/libtesteth/Options.h
@@ -70,7 +70,6 @@ public:
 	int trValueIndex;	///< GeneralState value
 	bool all = false;	///< Running every test, including time consuming ones.
 	bool nonetwork = false;///< For libp2p
-	bool bigData = false;
 	/// @}
 
 	/// Get reference to options

--- a/test/tools/libtesteth/Options.h
+++ b/test/tools/libtesteth/Options.h
@@ -68,7 +68,7 @@ public:
 	int trDataIndex;	///< GeneralState data
 	int trGasIndex;		///< GeneralState gas
 	int trValueIndex;	///< GeneralState value
-	bool performance = false;
+	bool all = false;	///< Running every test, including time consuming ones.
 	bool nonetwork = false;///< For libp2p
 	bool quadratic = false;///< Time consuming tests
 	bool memory = false;

--- a/test/tools/libtesteth/TestHelper.cpp
+++ b/test/tools/libtesteth/TestHelper.cpp
@@ -142,7 +142,7 @@ eth::Network stringToNetId(string const& _netname)
 bool isDisabledNetwork(eth::Network _net)
 {
 	Options const& opt = Options::get();
-	if (opt.performance || opt.filltests || opt.createRandomTest)
+	if (opt.all || opt.filltests || opt.createRandomTest)
 		return false;
 	switch (_net)
 	{

--- a/test/unittests/libdevcrypto/crypto.cpp
+++ b/test/unittests/libdevcrypto/crypto.cpp
@@ -799,7 +799,7 @@ BOOST_AUTO_TEST_CASE(recoverVgt3)
 
 BOOST_AUTO_TEST_CASE(PerfSHA256_32, *utf::disabled() *utf::label("perf"))
 {
-	if (!test::Options::get().performance)
+	if (!test::Options::get().all)
 		return;
 
 	h256 hash;
@@ -811,7 +811,7 @@ BOOST_AUTO_TEST_CASE(PerfSHA256_32, *utf::disabled() *utf::label("perf"))
 
 BOOST_AUTO_TEST_CASE(PerfSHA256_4000, *utf::disabled() *utf::label("perf"))
 {
-	if (!test::Options::get().performance)
+	if (!test::Options::get().all)
 		return;
 
 	static const size_t dataSize = 4097;

--- a/test/unittests/libdevcrypto/crypto.cpp
+++ b/test/unittests/libdevcrypto/crypto.cpp
@@ -800,7 +800,10 @@ BOOST_AUTO_TEST_CASE(recoverVgt3)
 BOOST_AUTO_TEST_CASE(PerfSHA256_32, *utf::disabled() *utf::label("perf"))
 {
 	if (!test::Options::get().all)
+	{
+		clog << "Skipping test Crypto/devcrypto/PerfSHA256_32. Use --all to run it.\n";
 		return;
+	}
 
 	h256 hash;
 	for (auto i = 0; i < 1000000; ++i)
@@ -812,7 +815,10 @@ BOOST_AUTO_TEST_CASE(PerfSHA256_32, *utf::disabled() *utf::label("perf"))
 BOOST_AUTO_TEST_CASE(PerfSHA256_4000, *utf::disabled() *utf::label("perf"))
 {
 	if (!test::Options::get().all)
+	{
+		clog << "Skipping test Crypto/devcrypto/PerfSHA256_4000. Use --all to run it.\n";
 		return;
+	}
 
 	static const size_t dataSize = 4097;
 	bytes data(dataSize);

--- a/test/unittests/libdevcrypto/trie.cpp
+++ b/test/unittests/libdevcrypto/trie.cpp
@@ -612,6 +612,8 @@ BOOST_AUTO_TEST_CASE(triePerf)
 		perfTestTrie<SpecificTrieDB<HashedGenericTrieDB<MemoryDB>, h256>>("HashedGenericTrieDB");
 		perfTestTrie<SpecificTrieDB<FatGenericTrieDB<MemoryDB>, h256>>("FatGenericTrieDB");
 	}
+	else
+		clog << "Skipping hive test Crypto/Trie/triePerf. Use --all or --performance to run it.\n";
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/unittests/libdevcrypto/trie.cpp
+++ b/test/unittests/libdevcrypto/trie.cpp
@@ -606,7 +606,7 @@ template<typename Trie> void perfTestTrie(char const* _name)
 
 BOOST_AUTO_TEST_CASE(triePerf)
 {
-	if (test::Options::get().performance)
+	if (test::Options::get().all)
 	{
 		perfTestTrie<SpecificTrieDB<GenericTrieDB<MemoryDB>, h256>>("GenericTrieDB");
 		perfTestTrie<SpecificTrieDB<HashedGenericTrieDB<MemoryDB>, h256>>("HashedGenericTrieDB");

--- a/test/unittests/libp2p/capability.cpp
+++ b/test/unittests/libp2p/capability.cpp
@@ -102,7 +102,10 @@ BOOST_FIXTURE_TEST_SUITE(p2pCapability, P2PFixture)
 BOOST_AUTO_TEST_CASE(capability)
 {
 	if (test::Options::get().nonetwork)
+	{
+		clog << "Skipping test p2pCapability/capability. --nonetwork flag is set.\n";
 		return;
+	}
 
 	VerbosityHolder verbosityHolder(10);
 	cnote << "Testing Capability...";

--- a/test/unittests/libp2p/net.cpp
+++ b/test/unittests/libp2p/net.cpp
@@ -160,7 +160,10 @@ public:
 BOOST_AUTO_TEST_CASE(requestTimeout)
 {
 	if (test::Options::get().nonetwork)
+	{
+		clog << "Skipping test network/net/requestTimeout. --nonetwork flag is set.\n";
 		return;
+	}
 
 	using TimePoint = std::chrono::steady_clock::time_point;
 	using RequestTimeout = std::pair<NodeID, TimePoint>;
@@ -230,7 +233,10 @@ BOOST_AUTO_TEST_CASE(isIPAddressType)
 BOOST_AUTO_TEST_CASE(neighboursPacketLength)
 {
 	if (test::Options::get().nonetwork)
+	{
+		clog << "Skipping test network/net/neighboursPacketLength. --nonetwork flag is set.\n";
 		return;
+	}
 
 	KeyPair k = KeyPair::create();
 	std::vector<std::pair<KeyPair,unsigned>> testNodes(TestNodeTable::createTestNodes(16));
@@ -258,7 +264,10 @@ BOOST_AUTO_TEST_CASE(neighboursPacketLength)
 BOOST_AUTO_TEST_CASE(neighboursPacket)
 {
 	if (test::Options::get().nonetwork)
+	{
+		clog << "Skipping test network/net/neighboursPacket. --nonetwork flag is set.\n";
 		return;
+	}
 
 	KeyPair k = KeyPair::create();
 	std::vector<std::pair<KeyPair,unsigned>> testNodes(TestNodeTable::createTestNodes(16));
@@ -295,7 +304,10 @@ BOOST_AUTO_TEST_CASE(test_findnode_neighbours)
 BOOST_AUTO_TEST_CASE(kademlia)
 {
 	if (test::Options::get().nonetwork)
+	{
+		clog << "Skipping test network/net/kademlia. --nonetwork flag is set.\n";
 		return;
+	}
 
 	TestNodeTableHost node(8);
 	node.start();
@@ -313,7 +325,10 @@ BOOST_AUTO_TEST_CASE(kademlia)
 BOOST_AUTO_TEST_CASE(udpOnce)
 {
 	if (test::Options::get().nonetwork)
+	{
+		clog << "Skipping test network/net/udpOnce. --nonetwork flag is set.\n";
 		return;
+	}
 
 	UDPDatagram d(bi::udp::endpoint(boost::asio::ip::address::from_string("127.0.0.1"), 30300), bytes({65,65,65,65}));
 	TestUDPSocket a; a.m_socket->connect(); a.start();
@@ -368,7 +383,10 @@ BOOST_FIXTURE_TEST_SUITE(netTypes, TestOutputHelper)
 BOOST_AUTO_TEST_CASE(unspecifiedNode)
 {
 	if (test::Options::get().nonetwork)
+	{
+		clog << "Skipping test network/net/unspecifiedNode. --nonetwork flag is set.\n";
 		return;
+	}
 
 	Node n = UnspecifiedNode;
 	BOOST_REQUIRE(!n);

--- a/test/unittests/libp2p/peer.cpp
+++ b/test/unittests/libp2p/peer.cpp
@@ -66,7 +66,10 @@ BOOST_FIXTURE_TEST_SUITE(p2p, P2PFixture)
 BOOST_AUTO_TEST_CASE(host)
 {
 	if (test::Options::get().nonetwork)
+	{
+		clog << "Skipping test libp2p/p2p/host. --nonetwork flag is set.\n";
 		return;
+	}
 
 	VerbosityHolder setTemporaryLevel(10);
 
@@ -127,7 +130,10 @@ BOOST_AUTO_TEST_CASE(host)
 BOOST_AUTO_TEST_CASE(networkConfig)
 {
 	if (test::Options::get().nonetwork)
+	{
+		clog << "Skipping test libp2p/p2p/networkConfig. --nonetwork flag is set.\n";
 		return;
+	}
 
 	Host save("Test", NetworkPreferences(false));
 	bytes store(save.saveNetwork());
@@ -139,7 +145,10 @@ BOOST_AUTO_TEST_CASE(networkConfig)
 BOOST_AUTO_TEST_CASE(saveNodes)
 {
 	if (test::Options::get().nonetwork)
+	{
+		clog << "Skipping test libp2p/p2p/saveNodes. --nonetwork flag is set.\n";
 		return;
+	}
 
 	VerbosityHolder setTemporaryLevel(2);
 
@@ -208,7 +217,10 @@ BOOST_FIXTURE_TEST_SUITE(p2pPeer, P2PFixture)
 BOOST_AUTO_TEST_CASE(requirePeer)
 {
 	if (test::Options::get().nonetwork)
+	{
+		clog << "Skipping test libp2p/p2pPeer/requirePeer. --nonetwork flag is set.\n";
 		return;
+	}
 
 	VerbosityHolder setTemporaryLevel(10);
 
@@ -285,7 +297,10 @@ BOOST_FIXTURE_TEST_SUITE(peerTypes, TestOutputHelper)
 BOOST_AUTO_TEST_CASE(emptySharedPeer)
 {
 	if (test::Options::get().nonetwork)
+	{
+		clog << "Skipping test libp2p/peerTypes/emptySharedPeer. --nonetwork flag is set.\n";
 		return;
+	}
 
 	shared_ptr<Peer> p;
 	BOOST_REQUIRE(!p);


### PR DESCRIPTION
This PR removes options that can be replaced with `--all`.

Fixes #4392.  Fixes #4393.