### PR TITLE
--vmtrace option causes an error when -DVMTRACE=1 was not specified

### DIFF
--- a/test/tools/libtesteth/Options.cpp
+++ b/test/tools/libtesteth/Options.cpp
@@ -133,8 +133,13 @@ Options::Options(int argc, char** argv)
 			VMFactory::setKind(VMKind::JIT);
 		else if (arg == "--vmtrace")
 		{
+#if ETH_VMTRACE
 			vmtrace = true;
 			g_logVerbosity = 13;
+#else
+			cerr << "--vmtrace option requires a build with cmake -DVMTRACE=1\n";
+			exit(1);
+#endif
 		}
 		else if (arg == "--jsontrace")
 		{


### PR DESCRIPTION
When `testeth` is not build with `-DVMTRACE=1` configuration, `testeth -- --vmtrace` should fail.  This PR implements that.