### PR TITLE
Precompiled failure means no transfer

### DIFF
--- a/libethereum/Executive.cpp
+++ b/libethereum/Executive.cpp
@@ -282,14 +282,14 @@ bool Executive::call(CallParameters const& _p, u256 const& _gasPrice, Address co
 			bytes output;
 			bool success;
 			tie(success, output) = m_sealEngine.executePrecompiled(_p.codeAddress, _p.data, m_envInfo.number());
+			size_t outputSize = output.size();
+			m_output = owning_bytes_ref{std::move(output), 0, outputSize};
 			if (!success)
 			{
 				m_gas = 0;
 				m_excepted = TransactionException::OutOfGas;
-				return true;
+				return true;	// true means no need to run go().
 			}
-			size_t outputSize = output.size();
-			m_output = owning_bytes_ref{std::move(output), 0, outputSize};
 		}
 	}
 	else

--- a/libethereum/Executive.cpp
+++ b/libethereum/Executive.cpp
@@ -286,6 +286,7 @@ bool Executive::call(CallParameters const& _p, u256 const& _gasPrice, Address co
 			{
 				m_gas = 0;
 				m_excepted = TransactionException::OutOfGas;
+				return true;
 			}
 			size_t outputSize = output.size();
 			m_output = owning_bytes_ref{std::move(output), 0, outputSize};


### PR DESCRIPTION
Before this PR, even when a precompiled contract fails, the balance transfer into the precompiled contract was kept.

This issue became visible for ecadd and ecmul contracts that sometimes fail.

Fixes https://github.com/ethereum/cpp-ethereum/issues/4416