### PR TITLE
TestOutputHelper as RAII

### DIFF
--- a/test/tools/fuzzTesting/createRandomTest.cpp
+++ b/test/tools/fuzzTesting/createRandomTest.cpp
@@ -49,7 +49,7 @@ int createRandomTest()
 	}
 	else
 	{
-		TestOutputHelper::initTest();
+		TestOutputHelper testOutputHelper;
 		return fillRandomTest(dev::test::doStateTests, c_testExampleStateTest);
 	}
 }
@@ -67,7 +67,7 @@ int fillRandomTest(std::function<json_spirit::mValue(json_spirit::mValue&, bool)
 		dev::test::RandomCode::parseTestWithTypes(newTest, nullReplaceMap);
 		json_spirit::read_string(newTest, v);
 		v = _doTests(v, true); //filltests
-		_doTests(v, false);	//checktest
+		_doTests(v, false); //checktest
 	}
 	catch (dev::Exception const& _e)
 	{

--- a/test/tools/jsontests/BlockChainTests.cpp
+++ b/test/tools/jsontests/BlockChainTests.cpp
@@ -108,9 +108,8 @@ void testBCTest(json_spirit::mObject const& _o);
 //percent output for many tests in one file
 json_spirit::mValue doBlockchainTests(json_spirit::mValue const& _v, bool _fillin)
 {
-	TestOutputHelper::initTest(_v.get_obj().size());	//Count how many tests in the json object (read from .json file)
+	TestOutputHelper testOutputHelper(_v.get_obj().size());	//Count how many tests in the json object (read from .json file)
 	json_spirit::mValue ret = doBlockchainTestNoLog(_v, _fillin); //Do the test / test generation
-	TestOutputHelper::finishTest(); //Calculate the time of test execution and add it to the log
 	return ret;
 }
 

--- a/test/tools/jsontests/BlockChainTestsBoost.cpp
+++ b/test/tools/jsontests/BlockChainTestsBoost.cpp
@@ -44,13 +44,12 @@ class bcTestFixture {
 				}
 				else
 				{
-					dev::test::TestOutputHelper::initTest();
+					dev::test::TestOutputHelper testOutputHelper;
 					string copyto = dev::test::getTestPath() + "/BlockchainTests/bcForgedTest/" + file.filename().string();
 					clog << "Copying " + fillersPath + "/" + file.filename().string();
 					clog << " TO " << copyto;
 					dev::test::copyFile(fillersPath + "/" + file.filename().string(), dev::test::getTestPath() + "/BlockchainTests/bcForgedTest/" + file.filename().string());
 					BOOST_REQUIRE_MESSAGE(boost::filesystem::exists(copyto), "Error when copying the test file!");
-					dev::test::TestOutputHelper::finishTest();
 				}
 			}
 			return;
@@ -81,13 +80,12 @@ class bcTestFixture {
 		if (test::Options::get().filltests)
 			testcount += testcount / test::getNetworks().size();
 
-		test::TestOutputHelper::initTest(testcount);
+		test::TestOutputHelper testOutputHelper(testcount);
 		for (auto const& file: files)
 		{
 			test::TestOutputHelper::setCurrentTestFileName(file.filename().string());
 			test::executeTests(file.filename().string(), "/BlockchainTests/" + _folder, "/BlockchainTestsFiller/" + _folder, dev::test::doBlockchainTestNoLog);
 		}
-		test::TestOutputHelper::finishTest();
 	}
 };
 
@@ -114,13 +112,12 @@ class bcTransitionFixture {
 		if (test::Options::get().filltests)
 			testcount *= 2;
 
-		test::TestOutputHelper::initTest(testcount);
+		test::TestOutputHelper testOutputHelper(testcount);
 		for (auto const& file: files)
 		{
 			test::TestOutputHelper::setCurrentTestFileName(file.filename().string());
 			test::executeTests(file.filename().string(), "/BlockchainTests/" + _subfolder + _folder, "/BlockchainTestsFiller/" + _subfolder +_folder, dev::test::doTransitionTest);
 		}
-		test::TestOutputHelper::finishTest();
 	}
 };
 
@@ -146,13 +143,12 @@ class bcGeneralTestsFixture
 		std::vector<boost::filesystem::path> files = test::getJsonFiles(test::getTestPath() + "/BlockchainTests/" +_folder);
 		int testcount = files.size() * test::getNetworks().size();  //each file contains a test per network fork
 
-		test::TestOutputHelper::initTest(testcount);
+		test::TestOutputHelper testOutputHelper(testcount);
 		for (auto const& file: files)
 		{
 			test::TestOutputHelper::setCurrentTestFileName(file.filename().string());
 			test::executeTests(file.filename().string(), "/BlockchainTests/" + _folder, "/BlockchainTests/" +_folder, dev::test::doBlockchainTestNoLog);
 		}
-		test::TestOutputHelper::finishTest();
 	}
 };
 

--- a/test/tools/jsontests/StateTests.cpp
+++ b/test/tools/jsontests/StateTests.cpp
@@ -141,15 +141,13 @@ public:
 
 		if (test::Options::get().filltests)
 			fileCount *= 2; //tests are checked when filled and after they been filled
-		test::TestOutputHelper::initTest(fileCount);
+		test::TestOutputHelper testOutputHelper(fileCount);
 
 		for (auto const& file: files)
 		{
 			test::TestOutputHelper::setCurrentTestFileName(file.filename().string());
 			test::executeTests(file.filename().string(), "/GeneralStateTests/"+_folder, "/GeneralStateTestsFiller/"+_folder, dev::test::doStateTests);
 		}
-
-		test::TestOutputHelper::finishTest();
 	}
 };
 

--- a/test/tools/jsontests/vm.cpp
+++ b/test/tools/jsontests/vm.cpp
@@ -296,8 +296,9 @@ namespace dev { namespace test {
 
 json_spirit::mValue doVMTests(json_spirit::mValue const& _input, bool _fillin)
 {
-	if (string(boost::unit_test::framework::current_test_case().p_name) != "vmRandom")
-		TestOutputHelper::initTest(_input.get_obj().size());
+	unique_ptr<TestOutputHelper> testOutputHelper;
+	if (string(boost::unit_test::framework::current_test_case().p_name) != "vmRandom") // TODO: remove this hard-coding
+		testOutputHelper.reset(new TestOutputHelper(_input.get_obj().size()));
 
 	json_spirit::mValue v = json_spirit::mObject();
 	json_spirit::mObject& output = v.get_obj();
@@ -472,7 +473,6 @@ json_spirit::mValue doVMTests(json_spirit::mValue const& _input, bool _fillin)
 		}
 	}
 
-	TestOutputHelper::finishTest();
 	return v;
 }
 
@@ -563,8 +563,7 @@ BOOST_AUTO_TEST_CASE(vmRandom)
 
 	std::vector<boost::filesystem::path> testFiles = test::getJsonFiles(testPath);
 
-	test::TestOutputHelper::initTest();
-	test::TestOutputHelper::setMaxTests(testFiles.size());
+	test::TestOutputHelper testOutputHelper(testFiles.size());
 
 	for (auto& path: testFiles)
 	{

--- a/test/tools/jsontests/vm.cpp
+++ b/test/tools/jsontests/vm.cpp
@@ -296,10 +296,12 @@ namespace dev { namespace test {
 
 json_spirit::mValue doVMTests(json_spirit::mValue const& _input, bool _fillin)
 {
-	unique_ptr<TestOutputHelper> testOutputHelper;
-	if (string(boost::unit_test::framework::current_test_case().p_name) != "vmRandom") // TODO: remove this hard-coding
-		testOutputHelper.reset(new TestOutputHelper(_input.get_obj().size()));
+	TestOutputHelper testOutputHelper(_input.get_obj().size());
+	return doVMTestsNoLog(_input, _fillin);
+}
 
+json_spirit::mValue doVMTestsNoLog(json_spirit::mValue const& _input, bool _fillin)
+{
 	json_spirit::mValue v = json_spirit::mObject();
 	json_spirit::mObject& output = v.get_obj();
 	for (auto& i: _input.get_obj())
@@ -575,7 +577,7 @@ BOOST_AUTO_TEST_CASE(vmRandom)
 			BOOST_REQUIRE_MESSAGE(s.length() > 0, "Content of " + path.string() + " is empty. Have you cloned the 'tests' repo branch develop and set ETHEREUM_TEST_PATH to its path?");
 			json_spirit::read_string(s, v);
 			test::Listener::notifySuiteStarted(path.filename().string());
-			doVMTests(v, false);
+			doVMTestsNoLog(v, false);
 		}
 		catch (Exception const& _e)
 		{

--- a/test/tools/libtesteth/TestHelper.h
+++ b/test/tools/libtesteth/TestHelper.h
@@ -118,7 +118,10 @@ int createRandomTest();	//returns 0 if succeed, 1 if there was an error;
 //When _fillin is true, _input is supposed to contain a filler.  Otherwise, _input is also a filled test.
 json_spirit::mValue doTransactionTests(json_spirit::mValue const& _input, bool _fillin);
 json_spirit::mValue doStateTests(json_spirit::mValue const& _input, bool _fillin);
+// Call doVMTests() if you have neither called TestOutputHelper::initTest() nor created a TestOutputHelper object.
 json_spirit::mValue doVMTests(json_spirit::mValue const& _input, bool _fillin);
+// Call doVMTestsNoLog() if you have called TestOutputHelper::initTest() or created a TestOutputHelper object (in special cases like vmRandom).
+json_spirit::mValue doVMTestsNoLog(json_spirit::mValue const& _input, bool _fillin);
 json_spirit::mValue doBlockchainTests(json_spirit::mValue const& _input, bool _fillin);
 json_spirit::mValue doBlockchainTestNoLog(json_spirit::mValue const& _input, bool _fillin);
 json_spirit::mValue doTransitionTest(json_spirit::mValue const& _input, bool _fillin);

--- a/test/tools/libtesteth/TestOutputHelper.h
+++ b/test/tools/libtesteth/TestOutputHelper.h
@@ -31,7 +31,6 @@ class TestOutputHelper
 {
 public:
 	TestOutputHelper(size_t _maxTests = 1) { TestOutputHelper::initTest(_maxTests); }
-	static void initTest(size_t _maxTests = 1);
 	static bool passTest(std::string const& _testName);
 	static void setMaxTests(int _count) { m_maxTests = _count; }
 	static void setCurrentTestFileName(std::string const& _name) { m_currentTestFileName = _name; }
@@ -39,10 +38,11 @@ public:
 	static std::string const& testName() { return m_currentTestName; }
 	static std::string const& caseName() { return m_currentTestCaseName; }
 	static std::string const& testFileName() { return m_currentTestFileName; }
-	static void finishTest();
 	static void printTestExecStats();
 	~TestOutputHelper() { TestOutputHelper::finishTest(); }
 private:
+	static void initTest(size_t _maxTests = 1);
+	static void finishTest();
 	static Timer m_timer;
 	static size_t m_currTest;
 	static size_t m_maxTests;

--- a/test/unittests/libethcore/difficulty.cpp
+++ b/test/unittests/libethcore/difficulty.cpp
@@ -106,7 +106,7 @@ void fillDifficulty(string const& _testFileFullName, Ethash& _sealEngine)
 	int testN = 0;
 	ostringstream finalTest;
 	finalTest << "{\n";
-	dev::test::TestOutputHelper::initTest(900);
+	dev::test::TestOutputHelper testOutputHelper(900);
 
 	for (int stampDelta = 0; stampDelta < 45; stampDelta+=2)
 	{
@@ -158,7 +158,7 @@ void testDifficulty(string const& _testFileFullName, Ethash& _sealEngine, Networ
 	string s = contentsString(_testFileFullName);
 	BOOST_REQUIRE_MESSAGE(s.length() > 0, "Contents of '" << _testFileFullName << "' is empty. Have you cloned the 'tests' repo branch develop?");
 	js::read_string(s, v);
-	dev::test::TestOutputHelper::initTest(v.get_obj().size());
+	dev::test::TestOutputHelper testOutputHelper(v.get_obj().size());
 
 	for (auto& i: v.get_obj())
 	{
@@ -186,7 +186,6 @@ void testDifficulty(string const& _testFileFullName, Ethash& _sealEngine, Networ
 		//Manual formula test
 		checkCalculatedDifficulty(current, parent, _n, _sealEngine.chainParams(), "(" + i.first + ")");
 	}
-	dev::test::TestOutputHelper::finishTest();
 }
 
 BOOST_AUTO_TEST_SUITE(DifficultyTests)

--- a/test/unittests/libethereum/ClientBase.cpp
+++ b/test/unittests/libethereum/ClientBase.cpp
@@ -22,7 +22,7 @@
 #include <boost/test/unit_test.hpp>
 #include <libdevcore/CommonJS.h>
 #include <libethashseal/Ethash.h>
-#include <test/tools/libtesteth/TestHelper.h>
+#include <test/tools/libtesteth/TestOutputHelper.h>
 #include <test/tools/libtesteth/TestUtils.h>
 #include <test/tools/libtestutils/FixedClient.h>
 
@@ -35,7 +35,7 @@ BOOST_FIXTURE_TEST_SUITE(ClientBase, ParallelClientBaseFixture)
 
 BOOST_AUTO_TEST_CASE(blocks)
 {
-	test::TestOutputHelper::initTest();
+	TestOutputHelper testOutputHelper{};
 	enumerateClients([](Json::Value const& _json, dev::eth::ClientBase& _client) -> void
 	{
 		auto compareState = [&_client](Json::Value const& _o, string const& _name, BlockNumber _blockNumber) -> void


### PR DESCRIPTION
TestOutputHelper class has a constructor that calls `initTest()` and a destructor that calls `finishTest()`.  This PR, instead of calling `initTest()` and `finishTest()` manually, creates a `TestOutputHelper` object and let its constructor and destructor do the job.

I tried to keep the original behavior as much as possible, but there were some `initTest()` without `finishTest()`. These missing `finishTest()` calls had to be added.