### PR TITLE
Remove ChainOperationParams::u256Param that looks up parameters by strings

### DIFF
--- a/eth/main.cpp
+++ b/eth/main.cpp
@@ -849,7 +849,7 @@ int main(int argc, char** argv)
 	if (!privateChain.empty())
 	{
 		chainParams.extraData = sha3(privateChain).asBytes();
-		chainParams.difficulty = chainParams.u256Param("minimumDifficulty");
+		chainParams.difficulty = chainParams.minimumDifficulty;
 		chainParams.gasLimit = u256(1) << 32;
 	}
 	// TODO: Open some other API path
@@ -917,7 +917,7 @@ int main(int argc, char** argv)
 	if (testingMode)
 	{
 		chainParams.sealEngineName = "NoProof";
-		chainParams.otherParams["allowFutureBlocks"] = true;
+		chainParams.allowFutureBlocks = true;
 	}
 
 	dev::WebThreeDirect web3(

--- a/ethvm/main.cpp
+++ b/ethvm/main.cpp
@@ -44,7 +44,7 @@ namespace
 {
 int64_t maxBlockGasLimit()
 {
-	static int64_t limit = ChainParams(genesisInfo(Network::MainNetwork)).u256Param("maxGasLimit").convert_to<int64_t>();
+	static int64_t limit = ChainParams(genesisInfo(Network::MainNetwork)).maxGasLimit.convert_to<int64_t>();
 	return limit;
 }
 

--- a/libethcore/ChainOperationParams.cpp
+++ b/libethcore/ChainOperationParams.cpp
@@ -41,46 +41,33 @@ PrecompiledContract::PrecompiledContract(
 	}, _exec, _startingBlock)
 {}
 
-ChainOperationParams::ChainOperationParams()
+ChainOperationParams::ChainOperationParams():
+	m_blockReward("0x4563918244F40000"),
+	minGasLimit(0x1388),
+	maxGasLimit("0x7fffffffffffffff"),
+	gasLimitBoundDivisor(0x0400),
+	networkID(0x0),
+	minimumDifficulty(0x020000),
+	difficultyBoundDivisor(0x0800),
+	durationLimit(0x0d),
+	registrar("0x5e70c0bbcd5636e0f9f9316e9f8633feb64d4050")
 {
-	otherParams = std::unordered_map<std::string, std::string>{
-		{"minGasLimit", "0x1388"},
-		{"maxGasLimit", "0x7fffffffffffffff"},
-		{"gasLimitBoundDivisor", "0x0400"},
-		{"minimumDifficulty", "0x020000"},
-		{"difficultyBoundDivisor", "0x0800"},
-		{"durationLimit", "0x0d"},
-		{"registrar", "5e70c0bbcd5636e0f9f9316e9f8633feb64d4050"},
-		{"networkID", "0x0"}
-	};
-	m_blockReward = u256("0x4563918244F40000");
 }
 
 EVMSchedule const& ChainOperationParams::scheduleForBlockNumber(u256 const& _blockNumber) const
 {
-	if (_blockNumber >= u256Param("constantinopleForkBlock"))
+	if (_blockNumber >= constantinopleForkBlock)
 		return ConstantinopleSchedule;
-	else if (_blockNumber >= u256Param("byzantiumForkBlock"))
+	else if (_blockNumber >= byzantiumForkBlock)
 		return ByzantiumSchedule;
-	else if (_blockNumber >= u256Param("EIP158ForkBlock"))
+	else if (_blockNumber >= EIP158ForkBlock)
 		return EIP158Schedule;
-	else if (_blockNumber >= u256Param("EIP150ForkBlock"))
+	else if (_blockNumber >= EIP150ForkBlock)
 		return EIP150Schedule;
-	else if (_blockNumber >= u256Param("homesteadForkBlock"))
+	else if (_blockNumber >= homesteadForkBlock)
 		return HomesteadSchedule;
 	else
 		return FrontierSchedule;
-}
-
-u256 ChainOperationParams::u256Param(string const& _name) const
-{
-	std::string at("");
-
-	auto it = otherParams.find(_name);
-	if (it != otherParams.end())
-		at = it->second;
-
-	return u256(fromBigEndian<u256>(fromHex(at)));
 }
 
 u256 ChainOperationParams::blockReward(EVMSchedule const& _schedule) const

--- a/libethcore/ChainOperationParams.h
+++ b/libethcore/ChainOperationParams.h
@@ -82,25 +82,26 @@ public:
 	u256 maximumExtraDataSize = 1024;
 	u256 accountStartNonce = 0;
 	bool tieBreakingGas = true;
+	u256 minGasLimit;
+	u256 maxGasLimit;
+	u256 gasLimitBoundDivisor;
+	u256 homesteadForkBlock;
+	u256 EIP150ForkBlock;
+	u256 EIP158ForkBlock;
+	u256 byzantiumForkBlock;
+	u256 constantinopleForkBlock;
+	u256 daoHardforkBlock;
+	int chainID = 0; // Distinguishes different chains (mainnet, Ropsten, etc).
+	int networkID = 0; // Distinguishes different sub protocols.
+
+	u256 minimumDifficulty;
+	u256 difficultyBoundDivisor;
+	u256 durationLimit;
+	bool allowFutureBlocks = false;
+	u256 registrar;
 
 	/// Precompiled contracts as specified in the chain params.
 	std::unordered_map<Address, PrecompiledContract> precompiled;
-
-	/**
-	 * @brief Additional parameters.
-	 *
-	 * e.g. Ethash specific:
-	 * - minGasLimit
-	 * - maxGasLimit
-	 * - gasLimitBoundDivisor
-	 * - minimumDifficulty
-	 * - difficultyBoundDivisor
-	 * - durationLimit
-	 */
-	std::unordered_map<std::string, std::string> otherParams;
-
-	/// Convenience method to get an otherParam as a u256 int.
-	u256 u256Param(std::string const& _name) const;
 };
 
 }

--- a/libethcore/SealEngine.cpp
+++ b/libethcore/SealEngine.cpp
@@ -45,19 +45,19 @@ void SealEngineFace::populateFromParent(BlockHeader& _bi, BlockHeader const& _pa
 
 void SealEngineFace::verifyTransaction(ImportRequirements::value _ir, TransactionBase const& _t, BlockHeader const& _header, u256 const&) const
 {
-	if ((_ir & ImportRequirements::TransactionSignatures) && _header.number() < chainParams().u256Param("EIP158ForkBlock") && _t.isReplayProtected())
+	if ((_ir & ImportRequirements::TransactionSignatures) && _header.number() < chainParams().EIP158ForkBlock && _t.isReplayProtected())
 		BOOST_THROW_EXCEPTION(InvalidSignature());
 
-	if ((_ir & ImportRequirements::TransactionSignatures) && _header.number() < chainParams().u256Param("constantinopleForkBlock") && _t.hasZeroSignature())
+	if ((_ir & ImportRequirements::TransactionSignatures) && _header.number() < chainParams().constantinopleForkBlock && _t.hasZeroSignature())
 		BOOST_THROW_EXCEPTION(InvalidSignature());
 
 	if ((_ir & ImportRequirements::TransactionBasic) &&
-		_header.number() >= chainParams().u256Param("constantinopleForkBlock") &&
+		_header.number() >= chainParams().constantinopleForkBlock &&
 		_t.hasZeroSignature() &&
 		(_t.value() != 0 || _t.gasPrice() != 0 || _t.nonce() != 0))
 			BOOST_THROW_EXCEPTION(InvalidZeroSignatureTransaction() << errinfo_got((bigint)_t.gasPrice()) << errinfo_got((bigint)_t.value()) << errinfo_got((bigint)_t.nonce()));
 
-	if (_header.number() >= chainParams().u256Param("homesteadForkBlock") && (_ir & ImportRequirements::TransactionSignatures) && _t.hasSignature())
+	if (_header.number() >= chainParams().homesteadForkBlock && (_ir & ImportRequirements::TransactionSignatures) && _t.hasSignature())
 		_t.checkLowS();
 }
 

--- a/libethereum/Block.cpp
+++ b/libethereum/Block.cpp
@@ -631,7 +631,7 @@ u256 Block::enact(VerifiedBlockRef const& _block, BlockChain const& _bc)
 		applyRewards(rewarded, _bc.sealEngine()->blockReward(m_currentBlock.number()));
 
 	// Commit all cached state changes to the state trie.
-	bool removeEmptyAccounts = m_currentBlock.number() >= _bc.chainParams().u256Param("EIP158ForkBlock"); // TODO: use EVMSchedule
+	bool removeEmptyAccounts = m_currentBlock.number() >= _bc.chainParams().EIP158ForkBlock; // TODO: use EVMSchedule
 	DEV_TIMED_ABOVE("commit", 500)
 		m_state.commit(removeEmptyAccounts ? State::CommitBehaviour::RemoveEmptyAccounts : State::CommitBehaviour::KeepEmptyAccounts);
 
@@ -688,7 +688,7 @@ void Block::applyRewards(vector<BlockHeader> const& _uncleBlockHeaders, u256 con
 
 void Block::performIrregularModifications()
 {
-	u256 daoHardfork = m_sealEngine->chainParams().u256Param("daoHardforkBlock");
+	u256 const& daoHardfork = m_sealEngine->chainParams().daoHardforkBlock;
 	if (daoHardfork != 0 && info().number() == daoHardfork)
 	{
 		Address recipient("0xbf4ed7b27f1d666546e30d74d50d173d20bca754");
@@ -701,9 +701,9 @@ void Block::performIrregularModifications()
 
 void Block::updateBlockhashContract()
 {
-	u256 const blockNumber = info().number();
+	u256 const& blockNumber = info().number();
 
-	u256 const constantinopleForkBlock = m_sealEngine->chainParams().u256Param("constantinopleForkBlock");
+	u256 const& constantinopleForkBlock = m_sealEngine->chainParams().constantinopleForkBlock;
 	if (blockNumber == constantinopleForkBlock)
 	{
 		m_state.createContract(c_blockhashContractAddress);
@@ -801,7 +801,7 @@ void Block::commitToSeal(BlockChain const& _bc, bytes const& _extraData)
 	applyRewards(uncleBlockHeaders, _bc.sealEngine()->blockReward(m_currentBlock.number()));
 
 	// Commit any and all changes to the trie that are in the cache, then update the state root accordingly.
-	bool removeEmptyAccounts = m_currentBlock.number() >= _bc.chainParams().u256Param("EIP158ForkBlock"); // TODO: use EVMSchedule
+	bool removeEmptyAccounts = m_currentBlock.number() >= _bc.chainParams().EIP158ForkBlock; // TODO: use EVMSchedule
 	DEV_TIMED_ABOVE("commit", 500)
 		m_state.commit(removeEmptyAccounts ? State::CommitBehaviour::RemoveEmptyAccounts : State::CommitBehaviour::KeepEmptyAccounts);
 

--- a/libethereum/BlockChain.cpp
+++ b/libethereum/BlockChain.cpp
@@ -751,7 +751,7 @@ void BlockChain::checkBlockIsNew(VerifiedBlockRef const& _block) const
 void BlockChain::checkBlockTimestamp(BlockHeader const& _header) const
 {
 	// Check it's not crazy
-	if (_header.timestamp() > utcTime() && !m_params.otherParams.count("allowFutureBlocks"))
+	if (_header.timestamp() > utcTime() && !m_params.allowFutureBlocks)
 	{
 		clog(BlockChainChat) << _header.hash() << ": Future time " << _header.timestamp() << " (now at " << utcTime() << ")";
 		// Block has a timestamp in the future. This is no good.

--- a/libethereum/ChainParams.cpp
+++ b/libethereum/ChainParams.cpp
@@ -65,21 +65,30 @@ ChainParams ChainParams::loadConfig(string const& _json, h256 const& _stateRoot)
 	cp.maximumExtraDataSize = u256(fromBigEndian<u256>(fromHex(params["maximumExtraDataSize"].get_str())));
 	cp.tieBreakingGas = params.count("tieBreakingGas") ? params["tieBreakingGas"].get_bool() : true;
 	cp.setBlockReward(u256(fromBigEndian<u256>(fromHex(params["blockReward"].get_str()))));
-	for (auto i: params)
+
+	auto setOptionalU256Parameter = [&params](u256 &_destination, string const& _name)
 	{
-		if (i.first != "accountStartNonce" && i.first != "maximumExtraDataSize" &&
-			i.first != "blockReward" && i.first != "tieBreakingGas" && i.first != "allowFutureBlocks")
-			cp.otherParams[i.first] = i.second.get_str();
-		else
-		{
-			if (i.first == "allowFutureBlocks")
-			{
-				// The value in otherParams is irrelevant, we only check for the presence of the key.
-				if (i.second.type() != json_spirit::bool_type || i.second.get_bool())
-					cp.otherParams[i.first] = "true";
-			}
-		}
-	}
+		if (params.count(_name))
+			_destination = u256(fromBigEndian<u256>(fromHex(params.at(_name).get_str())));
+	};
+	setOptionalU256Parameter(cp.minGasLimit, "minGasLimit");
+	setOptionalU256Parameter(cp.maxGasLimit, "maxGasLimit");
+	setOptionalU256Parameter(cp.gasLimitBoundDivisor, "gasLimitBoundDivisor");
+	setOptionalU256Parameter(cp.homesteadForkBlock, "homesteadForkBlock");
+	setOptionalU256Parameter(cp.EIP150ForkBlock, "EIP150ForkBlock");
+	setOptionalU256Parameter(cp.EIP158ForkBlock, "EIP158ForkBlock");
+	setOptionalU256Parameter(cp.byzantiumForkBlock, "byzantiumForkBlock");
+	setOptionalU256Parameter(cp.constantinopleForkBlock, "constantinopleForkBlock");
+	setOptionalU256Parameter(cp.daoHardforkBlock, "daoHardforkBlock");
+	setOptionalU256Parameter(cp.minimumDifficulty, "minimumDifficulty");
+	setOptionalU256Parameter(cp.difficultyBoundDivisor, "difficultyBoundDivisor");
+	setOptionalU256Parameter(cp.durationLimit, "durationLimit");
+
+	if (params.count("chainID"))
+		cp.chainID = int(u256(fromBigEndian<u256>(fromHex(params.at("chainID").get_str()))));
+	if (params.count("networkID"))
+		cp.networkID = int(u256(fromBigEndian<u256>(fromHex(params.at("networkID").get_str()))));
+	cp.allowFutureBlocks = params.count("allowFutureBlocks");
 
 	// genesis
 	string genesisStr = json_spirit::write_string(obj["genesis"], false);

--- a/libethereum/Executive.cpp
+++ b/libethereum/Executive.cpp
@@ -271,7 +271,7 @@ bool Executive::call(CallParameters const& _p, u256 const& _gasPrice, Address co
 			// because the bug in both Geth and Parity led to deleting RIPEMD precompiled in this case
 			// see https://github.com/ethereum/go-ethereum/pull/3341/files#diff-2433aa143ee4772026454b8abd76b9dd
 			// We mark the account as touched here, so that is can be removed among other touched empty accounts (after tx finalization)
-			if (m_envInfo.number() >= m_sealEngine.chainParams().u256Param("EIP158ForkBlock"))
+			if (m_envInfo.number() >= m_sealEngine.chainParams().EIP158ForkBlock)
 				m_s.addBalance(_p.codeAddress, 0);
 			
 			return true;	// true actually means "all finished - nothing more to be done regarding go().
@@ -356,7 +356,7 @@ bool Executive::executeCreate(Address const& _sender, u256 const& _endowment, u2
 	m_s.transferBalance(_sender, m_newAddress, _endowment);
 
 	u256 newNonce = m_s.requireAccountStartNonce();
-	if (m_envInfo.number() >= m_sealEngine.chainParams().u256Param("EIP158ForkBlock"))
+	if (m_envInfo.number() >= m_sealEngine.chainParams().EIP158ForkBlock)
 		newNonce += 1;
 	m_s.setNonce(m_newAddress, newNonce);
 

--- a/libethereum/ExtVM.cpp
+++ b/libethereum/ExtVM.cpp
@@ -149,7 +149,7 @@ h256 ExtVM::blockHash(u256 _number)
 	if (_number >= currentNumber || _number < (std::max<u256>(256, currentNumber) - 256))
 		return h256();
 
-	if (currentNumber < m_sealEngine.chainParams().u256Param("constantinopleForkBlock") + 256)
+	if (currentNumber < m_sealEngine.chainParams().constantinopleForkBlock + 256)
 	{
 		h256 const parentHash = envInfo().header().parentHash();
 		h256s const lastHashes = envInfo().lastHashes().precedingHashes(parentHash);

--- a/libethereum/State.cpp
+++ b/libethereum/State.cpp
@@ -568,14 +568,14 @@ std::pair<ExecutionResult, TransactionReceipt> State::execute(EnvInfo const& _en
 			m_cache.clear();
 			break;
 		case Permanence::Committed:
-			removeEmptyAccounts = _envInfo.number() >= _sealEngine.chainParams().u256Param("EIP158ForkBlock");
+			removeEmptyAccounts = _envInfo.number() >= _sealEngine.chainParams().EIP158ForkBlock;
 			commit(removeEmptyAccounts ? State::CommitBehaviour::RemoveEmptyAccounts : State::CommitBehaviour::KeepEmptyAccounts);
 			break;
 		case Permanence::Uncommitted:
 			break;
 	}
 
-	TransactionReceipt const receipt = _envInfo.number() >= _sealEngine.chainParams().u256Param("byzantiumForkBlock") ?
+	TransactionReceipt const receipt = _envInfo.number() >= _sealEngine.chainParams().byzantiumForkBlock ?
 		TransactionReceipt(statusCode, startGasUsed + e.gasUsed(), e.logs()) :
 		TransactionReceipt(rootHash(), startGasUsed + e.gasUsed(), e.logs());
 	return make_pair(res, receipt);

--- a/libwebthree/WebThree.cpp
+++ b/libwebthree/WebThree.cpp
@@ -56,11 +56,11 @@ WebThreeDirect::WebThreeDirect(
 		Ethash::init();
 		NoProof::init();
 		if (_params.sealEngineName == "Ethash")
-			m_ethereum.reset(new eth::EthashClient(_params, (int)_params.u256Param("networkID"), &m_net, shared_ptr<GasPricer>(), _dbPath, _we));
+			m_ethereum.reset(new eth::EthashClient(_params, (int)_params.networkID, &m_net, shared_ptr<GasPricer>(), _dbPath, _we));
 		else if (_params.sealEngineName == "NoProof" && _testing)
-			m_ethereum.reset(new eth::ClientTest(_params, (int)_params.u256Param("networkID"), &m_net, shared_ptr<GasPricer>(), _dbPath, _we));
+			m_ethereum.reset(new eth::ClientTest(_params, (int)_params.networkID, &m_net, shared_ptr<GasPricer>(), _dbPath, _we));
 		else
-			m_ethereum.reset(new eth::Client(_params, (int)_params.u256Param("networkID"), &m_net, shared_ptr<GasPricer>(), _dbPath, _we));
+			m_ethereum.reset(new eth::Client(_params, (int)_params.networkID, &m_net, shared_ptr<GasPricer>(), _dbPath, _we));
 		string bp = DEV_QUOTED(ETH_BUILD_PLATFORM);
 		vector<string> bps;
 		boost::split(bps, bp, boost::is_any_of("/"));

--- a/test/tools/jsontests/TransactionTests.cpp
+++ b/test/tools/jsontests/TransactionTests.cpp
@@ -55,7 +55,7 @@ json_spirit::mValue doTransactionTests(json_spirit::mValue const& _input, bool _
 		BlockHeader bh;
 		bh.setNumber(transactionBlock);
 		bh.setGasLimit(u256("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"));
-		bool onConstantinople = (transactionBlock >= se->chainParams().u256Param("constantinopleForkBlock"));
+		bool onConstantinople = (transactionBlock >= se->chainParams().constantinopleForkBlock);
 
 		if (_fillin)
 		{

--- a/test/tools/libtesteth/BlockChainHelper.cpp
+++ b/test/tools/libtesteth/BlockChainHelper.cpp
@@ -374,7 +374,7 @@ void TestBlock::verify(TestBlockChain const& _bc) const
 	}
 	catch (Exception const& _e)
 	{
-		u256 daoHardfork = _bc.interface().sealEngine()->chainParams().u256Param("daoHardforkBlock");
+		u256 const& daoHardfork = _bc.interface().sealEngine()->chainParams().daoHardforkBlock;
 		if ((m_blockHeader.number() >= daoHardfork && m_blockHeader.number() <= daoHardfork + 9) || m_blockHeader.number() == 0)
 		{
 			string exWhat {	_e.what() };

--- a/test/tools/libtesteth/ImportTest.cpp
+++ b/test/tools/libtesteth/ImportTest.cpp
@@ -232,7 +232,7 @@ std::tuple<eth::State, ImportTest::ExecOutput, eth::ChangeLog> ImportTest::execu
 		ImportTest::checkBalance(_preState, initialState);
 
 		//Finalize the state manually (clear logs)
-		bool removeEmptyAccounts = m_envInfo->number() >= se->chainParams().u256Param("EIP158ForkBlock");
+		bool removeEmptyAccounts = m_envInfo->number() >= se->chainParams().EIP158ForkBlock;
 		initialState.commit(removeEmptyAccounts ? State::CommitBehaviour::RemoveEmptyAccounts : State::CommitBehaviour::KeepEmptyAccounts);
 		return std::make_tuple(initialState, out, changeLog);
 	}

--- a/test/unittests/libethashseal/EthashTest.cpp
+++ b/test/unittests/libethashseal/EthashTest.cpp
@@ -32,7 +32,7 @@ BOOST_FIXTURE_TEST_SUITE(EthashTests, TestOutputHelper)
 BOOST_AUTO_TEST_CASE(calculateDifficultyByzantiumWithoutUncles)
 {
 	ChainOperationParams params;
-	params.otherParams["byzantiumForkBlock"] = "0x1000";
+	params.byzantiumForkBlock = u256(0x1000);
 
 	Ethash ethash;
 	ethash.setChainParams(params);
@@ -54,7 +54,7 @@ BOOST_AUTO_TEST_CASE(calculateDifficultyByzantiumWithoutUncles)
 BOOST_AUTO_TEST_CASE(calculateDifficultyByzantiumWithUncles)
 {
 	ChainOperationParams params;
-	params.otherParams["byzantiumForkBlock"] = "0x1000";
+	params.byzantiumForkBlock = u256(0x1000);
 
 	Ethash ethash;
 	ethash.setChainParams(params);
@@ -77,7 +77,7 @@ BOOST_AUTO_TEST_CASE(calculateDifficultyByzantiumWithUncles)
 BOOST_AUTO_TEST_CASE(calculateDifficultyByzantiumMaxAdjustment)
 {
 	ChainOperationParams params;
-	params.otherParams["byzantiumForkBlock"] = "0x1000";
+	params.byzantiumForkBlock = u256(0x1000);
 
 	Ethash ethash;
 	ethash.setChainParams(params);

--- a/test/unittests/libethcore/SealEngineTest.cpp
+++ b/test/unittests/libethcore/SealEngineTest.cpp
@@ -32,7 +32,7 @@ BOOST_FIXTURE_TEST_SUITE(SealEngineTests, TestOutputHelper)
 BOOST_AUTO_TEST_CASE(UnsignedTransactionIsValidBeforeConstantinople)
 {
 	ChainOperationParams params;
-	params.otherParams["constantinopleForkBlock"] = "0x1000";
+	params.constantinopleForkBlock = u256(0x1000);
 
 	Ethash ethash;
 	ethash.setChainParams(params);

--- a/test/unittests/libethcore/difficulty.cpp
+++ b/test/unittests/libethcore/difficulty.cpp
@@ -45,12 +45,12 @@ std::string const c_testDifficulty = R"(
 void checkCalculatedDifficulty(BlockHeader const& _bi, BlockHeader const& _parent, eth::Network _n, ChainOperationParams const& _p, string const& _testName = "")
 {
 	u256 difficulty = _bi.difficulty();
-	u256 frontierDiff = _p.u256Param("homesteadForkBlock");
+	u256 const& frontierDiff = _p.homesteadForkBlock;
 
 	//The ultimate formula (Homestead)
 	if (_bi.number() > frontierDiff)
 	{
-		u256 minimumDifficulty = _p.u256Param("minimumDifficulty");
+		u256 const& minimumDifficulty = _p.minimumDifficulty;
 		bigint block_diff = _parent.difficulty();
 
 		bigint a = (_parent.difficulty() / 2048);
@@ -81,9 +81,9 @@ void checkCalculatedDifficulty(BlockHeader const& _bi, BlockHeader const& _paren
 	break;
 	default:
 		cerr << "testing undefined network difficulty";
-		durationLimit = _p.u256Param("durationLimit");
-		minimumDifficulty = _p.u256Param("minimumDifficulty");
-		difficultyBoundDivisor = _p.u256Param("difficultyBoundDivisor");
+		durationLimit = _p.durationLimit;
+		minimumDifficulty = _p.minimumDifficulty;
+		difficultyBoundDivisor = _p.difficultyBoundDivisor;
 		break;
 	}
 


### PR DESCRIPTION
Instead, introduced a number of u256 fields in ChainOperationParams.

I found one place that still looked up "MetropolisForkBlock".  I replaced it with `.constantinopleForkBlock`.