### PR TITLE
Fix typo homstead

### DIFF
--- a/libethashseal/Ethash.cpp
+++ b/libethashseal/Ethash.cpp
@@ -201,7 +201,7 @@ u256 Ethash::calculateDifficulty(BlockHeader const& _bi, BlockHeader const& _par
 	auto durationLimit = chainParams().u256Param("durationLimit");
 
 	bigint target;	// stick to a bigint for the target. Don't want to risk going negative.
-	if (_bi.number() < chainParams().u256Param("homsteadForkBlock"))
+	if (_bi.number() < chainParams().u256Param("homesteadForkBlock"))
 		// Frontier-era difficulty adjustment
 		target = _bi.timestamp() >= _parent.timestamp() + durationLimit ? _parent.difficulty() - (_parent.difficulty() / difficultyBoundDivisor) : (_parent.difficulty() + (_parent.difficulty() / difficultyBoundDivisor));
 	else

--- a/libethashseal/genesis/mainNetwork.cpp
+++ b/libethashseal/genesis/mainNetwork.cpp
@@ -23,7 +23,7 @@ R"E(
 	"sealEngine": "Ethash",
 	"params": {
 		"accountStartNonce": "0x00",
-		"homsteadForkBlock": "0x118c30",
+		"homesteadForkBlock": "0x118c30",
 		"daoHardforkBlock": "0x1d4c00",
 		"EIP150ForkBlock": "0x259518",
 		"EIP158ForkBlock": "0x28d138",

--- a/libethashseal/genesis/ropsten.cpp
+++ b/libethashseal/genesis/ropsten.cpp
@@ -22,7 +22,7 @@ R"E(
 	"sealEngine": "Ethash",
 	"params": {
 		"accountStartNonce": "0x00",
-		"homsteadForkBlock": "0x00",
+		"homesteadForkBlock": "0x00",
 		"EIP150ForkBlock": "0x00",
 		"EIP158ForkBlock": "0x0a",
 		"byzantiumForkBlock": "0xfffffffffffffff",

--- a/libethashseal/genesis/test/EIP158ToByzantiumAt5Test.cpp
+++ b/libethashseal/genesis/test/EIP158ToByzantiumAt5Test.cpp
@@ -22,7 +22,7 @@ R"E(
 	"sealEngine": "Ethash",
 	"params": {
 		"accountStartNonce": "0x00",
-		"homsteadForkBlock": "0x00",
+		"homesteadForkBlock": "0x00",
 		"daoHardforkBlock": "0xfffffffffffffff",
 		"EIP150ForkBlock": "0x00",
 		"EIP158ForkBlock": "0x00",

--- a/libethashseal/genesis/test/byzantiumTest.cpp
+++ b/libethashseal/genesis/test/byzantiumTest.cpp
@@ -23,7 +23,7 @@ R"E(
 	"params": {
 		"accountStartNonce": "0x00",
 		"maximumExtraDataSize": "0x20",
-		"homsteadForkBlock": "0x00",
+		"homesteadForkBlock": "0x00",
 		"daoHardforkBlock": "0xfffffffffffffff",
 		"EIP150ForkBlock": "0x00",
 		"EIP158ForkBlock": "0x00",

--- a/libethashseal/genesis/test/byzantiumTransitionTest.cpp
+++ b/libethashseal/genesis/test/byzantiumTransitionTest.cpp
@@ -23,7 +23,7 @@ R"E(
 	"params": {
 		"accountStartNonce": "0x00",
 		"maximumExtraDataSize": "0x20",
-		"homsteadForkBlock": "0x00",
+		"homesteadForkBlock": "0x00",
 		"daoHardforkBlock": "0xfffffffffffffff",
 		"EIP150ForkBlock": "0x00",
 		"EIP158ForkBlock": "0x00",

--- a/libethashseal/genesis/test/constantinopleTest.cpp
+++ b/libethashseal/genesis/test/constantinopleTest.cpp
@@ -23,7 +23,7 @@ R"E(
 	"params": {
 		"accountStartNonce": "0x00",
 		"maximumExtraDataSize": "0x20",
-		"homsteadForkBlock": "0x00",
+		"homesteadForkBlock": "0x00",
 		"daoHardforkBlock": "0xfffffffffffffff",
 		"EIP150ForkBlock": "0x00",
 		"EIP158ForkBlock": "0x00",

--- a/libethashseal/genesis/test/constantinopleTransitionTest.cpp
+++ b/libethashseal/genesis/test/constantinopleTransitionTest.cpp
@@ -23,7 +23,7 @@ R"E(
 	"params": {
 		"accountStartNonce": "0x00",
 		"maximumExtraDataSize": "0x20",
-		"homsteadForkBlock": "0x00",
+		"homesteadForkBlock": "0x00",
 		"daoHardforkBlock": "0xfffffffffffffff",
 		"EIP150ForkBlock": "0x00",
 		"EIP158ForkBlock": "0x00",

--- a/libethashseal/genesis/test/eip150Test.cpp
+++ b/libethashseal/genesis/test/eip150Test.cpp
@@ -23,7 +23,7 @@ R"E(
 	"params": {
 		"accountStartNonce": "0x00",
 		"maximumExtraDataSize": "0x20",
-		"homsteadForkBlock": "0x00",
+		"homesteadForkBlock": "0x00",
 		"daoHardforkBlock": "0xfffffffffffffff",
 		"EIP150ForkBlock": "0x00",
 		"EIP158ForkBlock": "0xfffffffffffffff",

--- a/libethashseal/genesis/test/eip158Test.cpp
+++ b/libethashseal/genesis/test/eip158Test.cpp
@@ -23,7 +23,7 @@ R"E(
 	"params": {
 		"accountStartNonce": "0x00",
 		"maximumExtraDataSize": "0x20",
-		"homsteadForkBlock": "0x00",
+		"homesteadForkBlock": "0x00",
 		"daoHardforkBlock": "0xfffffffffffffff",
 		"EIP150ForkBlock": "0x00",
 		"EIP158ForkBlock": "0x00",

--- a/libethashseal/genesis/test/frontierNoProofTest.cpp
+++ b/libethashseal/genesis/test/frontierNoProofTest.cpp
@@ -23,7 +23,7 @@ R"E(
 	"sealEngine": "NoProof",
 	"params":{
 		"accountStartNonce": "0x00",
-		"homsteadForkBlock": "0xffffffffffffffff",
+		"homesteadForkBlock": "0xffffffffffffffff",
 		"daoHardforkBlock": "0xfffffffffffffff",
 		"EIP150ForkBlock": "0xfffffffffffffff",
 		"EIP158ForkBlock": "0xfffffffffffffff",

--- a/libethashseal/genesis/test/frontierTest.cpp
+++ b/libethashseal/genesis/test/frontierTest.cpp
@@ -23,7 +23,7 @@ R"E(
 	"sealEngine": "Ethash",
 	"params":{
 		"accountStartNonce": "0x00",
-		"homsteadForkBlock": "0xffffffffffffffff",
+		"homesteadForkBlock": "0xffffffffffffffff",
 		"daoHardforkBlock": "0xfffffffffffffff",
 		"EIP150ForkBlock": "0xfffffffffffffff",
 		"EIP158ForkBlock": "0xfffffffffffffff",

--- a/libethashseal/genesis/test/frontierToHomesteadAt5Test.cpp
+++ b/libethashseal/genesis/test/frontierToHomesteadAt5Test.cpp
@@ -22,7 +22,7 @@ R"E(
 	"sealEngine": "Ethash",
 	"params": {
 		"accountStartNonce": "0x00",
-		"homsteadForkBlock": "0x05",
+		"homesteadForkBlock": "0x05",
 		"daoHardforkBlock": "0xfffffffffffffff",
 		"EIP150ForkBlock": "0xfffffffffffffff",
 		"EIP158ForkBlock": "0xfffffffffffffff",

--- a/libethashseal/genesis/test/homesteadTest.cpp
+++ b/libethashseal/genesis/test/homesteadTest.cpp
@@ -24,7 +24,7 @@ R"E(
 	"params": {
 		"accountStartNonce": "0x00",
 		"maximumExtraDataSize": "0x20",
-		"homsteadForkBlock": "0x00",
+		"homesteadForkBlock": "0x00",
 		"daoHardforkBlock": "0xfffffffffffffff",
 		"EIP150ForkBlock": "0xfffffffffffffff",
 		"EIP158ForkBlock": "0xfffffffffffffff",

--- a/libethashseal/genesis/test/homesteadToDaoAt5Test.cpp
+++ b/libethashseal/genesis/test/homesteadToDaoAt5Test.cpp
@@ -22,7 +22,7 @@ R"E(
 	"sealEngine": "Ethash",
 	"params": {
 		"accountStartNonce": "0x00",
-		"homsteadForkBlock": "0xfffffffffffffff",
+		"homesteadForkBlock": "0xfffffffffffffff",
 		"daoHardforkBlock": "0x05",
 		"EIP150ForkBlock": "0xfffffffffffffff",
 		"EIP158ForkBlock": "0xfffffffffffffff",

--- a/libethashseal/genesis/test/homesteadToEIP150At5Test.cpp
+++ b/libethashseal/genesis/test/homesteadToEIP150At5Test.cpp
@@ -22,7 +22,7 @@ R"E(
 	"sealEngine": "Ethash",
 	"params": {
 		"accountStartNonce": "0x00",
-		"homsteadForkBlock": "0x00",
+		"homesteadForkBlock": "0x00",
 		"daoHardforkBlock": "0xfffffffffffffff",
 		"EIP150ForkBlock": "0x05",
 		"EIP158ForkBlock": "0xfffffffffffffff",

--- a/libethashseal/genesis/test/mainNetworkTest.cpp
+++ b/libethashseal/genesis/test/mainNetworkTest.cpp
@@ -22,7 +22,7 @@ R"E(
 	"sealEngine": "Ethash",
 	"params": {
 		"accountStartNonce": "0x00",
-		"homsteadForkBlock": "0x118c30",
+		"homesteadForkBlock": "0x118c30",
 		"daoHardforkBlock": "0x1d4c00",
 		"EIP150ForkBlock": "0x259518",
 		"EIP158ForkBlock": "0x28d138",

--- a/libethashseal/genesis/test/transitionnetTest.cpp
+++ b/libethashseal/genesis/test/transitionnetTest.cpp
@@ -22,7 +22,7 @@ R"E(
 	"sealEngine": "Ethash",
 	"params": {
 		"accountStartNonce": "0x00",
-		"homsteadForkBlock": "0x05",
+		"homesteadForkBlock": "0x05",
 		"daoHardforkBlock": "0x08",
 		"EIP150ForkBlock": "0x0a",
 		"EIP158ForkBlock": "0x0e",

--- a/libethcore/ChainOperationParams.cpp
+++ b/libethcore/ChainOperationParams.cpp
@@ -66,7 +66,7 @@ EVMSchedule const& ChainOperationParams::scheduleForBlockNumber(u256 const& _blo
 		return EIP158Schedule;
 	else if (_blockNumber >= u256Param("EIP150ForkBlock"))
 		return EIP150Schedule;
-	else if (_blockNumber >= u256Param("homsteadForkBlock"))
+	else if (_blockNumber >= u256Param("homesteadForkBlock"))
 		return HomesteadSchedule;
 	else
 		return FrontierSchedule;

--- a/libethcore/SealEngine.cpp
+++ b/libethcore/SealEngine.cpp
@@ -57,7 +57,7 @@ void SealEngineFace::verifyTransaction(ImportRequirements::value _ir, Transactio
 		(_t.value() != 0 || _t.gasPrice() != 0 || _t.nonce() != 0))
 			BOOST_THROW_EXCEPTION(InvalidZeroSignatureTransaction() << errinfo_got((bigint)_t.gasPrice()) << errinfo_got((bigint)_t.value()) << errinfo_got((bigint)_t.nonce()));
 
-	if (_header.number() >= chainParams().u256Param("homsteadForkBlock") && (_ir & ImportRequirements::TransactionSignatures) && _t.hasSignature())
+	if (_header.number() >= chainParams().u256Param("homesteadForkBlock") && (_ir & ImportRequirements::TransactionSignatures) && _t.hasSignature())
 		_t.checkLowS();
 }
 

--- a/test/unittests/libethcore/difficulty.cpp
+++ b/test/unittests/libethcore/difficulty.cpp
@@ -44,7 +44,7 @@ std::string const c_testDifficulty = R"(
 void checkCalculatedDifficulty(BlockHeader const& _bi, BlockHeader const& _parent, Network _n, ChainOperationParams const& _p, string const& _testName = "")
 {
 	u256 difficulty = _bi.difficulty();
-	u256 frontierDiff = _p.u256Param("homsteadForkBlock");
+	u256 frontierDiff = _p.u256Param("homesteadForkBlock");
 
 	//The ultimate formula (Homestead)
 	if (_bi.number() > frontierDiff)
@@ -256,8 +256,8 @@ BOOST_AUTO_TEST_CASE(difficultyTestsCustomMainNetwork)
 
 	if (dev::test::Options::get().filltests)
 	{
-		u256 homsteadBlockNumber = 1000000;
-		std::vector<u256> blockNumberVector = {homsteadBlockNumber - 100000, homsteadBlockNumber, homsteadBlockNumber + 100000};
+		u256 homesteadBlockNumber = 1000000;
+		std::vector<u256> blockNumberVector = {homesteadBlockNumber - 100000, homesteadBlockNumber, homesteadBlockNumber + 100000};
 		std::vector<u256> parentDifficultyVector = {1000, 2048, 4000, 1000000};
 		std::vector<int> timestampDeltaVector = {0, 1, 8, 10, 13, 20, 100, 800, 1000, 1500};
 


### PR DESCRIPTION
There were many occurrences of "homstead", but it should be "homestead"