### PR TITLE
BlockChain unit tests improvements

### DIFF
--- a/libethashseal/GenesisInfo.cpp
+++ b/libethashseal/GenesisInfo.cpp
@@ -25,6 +25,7 @@ using namespace dev;
 
 //Test configurations
 #include "genesis/test/mainNetworkTest.cpp"
+#include "genesis/test/mainNetworkNoProofTest.cpp"
 #include "genesis/test/frontierNoProofTest.cpp"
 #include "genesis/test/frontierTest.cpp"
 #include "genesis/test/homesteadTest.cpp"
@@ -54,6 +55,7 @@ std::string const& dev::eth::genesisInfo(Network _n)
 
 	//Test genesis
 	case Network::MainNetworkTest: return c_genesisInfoMainNetworkTest;
+	case Network::MainNetworkNoProofTest: return c_genesisInfoMainNetworkNoProofTest;
 	case Network::FrontierNoProofTest: return c_genesisInfoFrontierNoProofTest;
 	case Network::FrontierTest: return c_genesisInfoFrontierTest;
 	case Network::HomesteadTest: return c_genesisInfoHomesteadTest;

--- a/libethashseal/GenesisInfo.h
+++ b/libethashseal/GenesisInfo.h
@@ -48,6 +48,7 @@ enum class Network
 	FrontierNoProofTest = 77, ///< Frontier rules + NoProof seal engine
 	ConstantinopleTest = 78, ///< ByzantiumTest + Constantinople active from block 0
 	ConstantinopleTransitionTest = 79, ///< ByzantiumTest + Constantinople active from block 2
+	MainNetworkNoProofTest = 80, ///< MainNetwork rules without genesis accounts + NoProof seal engine
 
 	//TransitionTest networks
 	FrontierToHomesteadAt5 = 100,

--- a/libethashseal/genesis/test/mainNetworkNoProofTest.cpp
+++ b/libethashseal/genesis/test/mainNetworkNoProofTest.cpp
@@ -1,0 +1,64 @@
+/*
+		This file is part of cpp-ethereum.
+
+		cpp-ethereum is free software: you can redistribute it and/or modify
+		it under the terms of the GNU General Public License as published by
+		the Free Software Foundation, either version 3 of the License, or
+		(at your option) any later version.
+
+		cpp-ethereum is distributed in the hope that it will be useful,
+		but WITHOUT ANY WARRANTY; without even the implied warranty of
+		MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+		GNU General Public License for more details.
+
+		You should have received a copy of the GNU General Public License
+		along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "../../GenesisInfo.h"
+
+static std::string const c_genesisInfoMainNetworkNoProofTest = std::string() +
+R"E(
+{
+	"sealEngine": "NoProof",
+	"params": {
+		"accountStartNonce": "0x00",
+		"homesteadForkBlock": "0x118c30",
+		"daoHardforkBlock": "0x1d4c00",
+		"EIP150ForkBlock": "0x259518",
+		"EIP158ForkBlock": "0x28d138",
+		"byzantiumForkBlock": "0x2dc6c0",
+		"constantinopleForkBlock": "0x2f36ca",
+		"networkID" : "0x01",
+		"chainID": "0x01",
+		"maximumExtraDataSize": "0x20",
+		"tieBreakingGas": false,
+		"minGasLimit": "0x1388",
+		"maxGasLimit": "7fffffffffffffff",
+		"gasLimitBoundDivisor": "0x0400",
+		"minimumDifficulty": "0x020000",
+		"difficultyBoundDivisor": "0x0800",
+		"durationLimit": "0x0d",
+		"blockReward": "0x4563918244F40000"
+	},
+	"genesis": {
+		"nonce": "0x0000000000000042",
+		"difficulty": "0x400000000",
+		"mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+		"author": "0x0000000000000000000000000000000000000000",
+		"timestamp": "0x00",
+		"parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+		"extraData": "0x11bbe8db4e347b4e8c937c1c8370e4b5ed33adb3db69cbdb7a38e1e50b1b82fa",
+		"gasLimit": "0x1388"
+	},
+	"accounts": {
+		"0000000000000000000000000000000000000001": { "precompiled": { "name": "ecrecover", "linear": { "base": 3000, "word": 0 } } },
+		"0000000000000000000000000000000000000002": { "precompiled": { "name": "sha256", "linear": { "base": 60, "word": 12 } } },
+		"0000000000000000000000000000000000000003": { "precompiled": { "name": "ripemd160", "linear": { "base": 600, "word": 120 } } },
+		"0000000000000000000000000000000000000004": { "precompiled": { "name": "identity", "linear": { "base": 15, "word": 3 } } },
+		"0000000000000000000000000000000000000005": { "precompiled": { "name": "modexp", "startBlock" : "0x2dc6c0" } }
+		"0000000000000000000000000000000000000006": { "precompiled": { "name": "alt_bn128_G1_add", "startBlock" : "0x2dc6c0", "linear": { "base": 500, "word": 0 } } },
+		"0000000000000000000000000000000000000007": { "precompiled": { "name": "alt_bn128_G1_mul", "startBlock" : "0x2dc6c0", "linear": { "base": 2000, "word": 0 } } },
+		"0000000000000000000000000000000000000008": { "precompiled": { "name": "alt_bn128_pairing_product", "startBlock" : "0x2dc6c0" } }
+	}
+}
+)E";

--- a/test/tools/libtesteth/BlockChainHelper.h
+++ b/test/tools/libtesteth/BlockChainHelper.h
@@ -19,6 +19,7 @@
 
 #pragma once
 #include "JsonSpiritHeaders.h"
+#include "TestOutputHelper.h"
 #include <libethereum/BlockChain.h>
 #include <libethereum/TransactionQueue.h>
 #include <libdevcore/TransientDirectory.h>
@@ -143,6 +144,22 @@ class NetworkSelector
 public:
 	explicit NetworkSelector(eth::Network _network) { TestBlockChain::s_sealEngineNetwork = _network; }
 	~NetworkSelector() { TestBlockChain::s_sealEngineNetwork = eth::Network::FrontierTest; } // reset to default
+};
+
+class FrontierNoProofTestFixture: public TestOutputHelper
+{
+public:
+	FrontierNoProofTestFixture(): networkSelector(Network::FrontierNoProofTest) {}
+
+	NetworkSelector networkSelector;
+};
+
+class MainNetworkNoProofTestFixture: public TestOutputHelper
+{
+public:
+	MainNetworkNoProofTestFixture(): networkSelector(Network::MainNetworkNoProofTest) {}
+
+	NetworkSelector networkSelector;
 };
 
 }}

--- a/test/unittests/libethereum/Block.cpp
+++ b/test/unittests/libethereum/Block.cpp
@@ -48,14 +48,6 @@ BOOST_AUTO_TEST_CASE(bStructures)
 }
 #endif
 
-class FrontierNoProofTestFixture: public TestOutputHelper
-{
-public:
-	FrontierNoProofTestFixture(): networkSelector(eth::Network::FrontierNoProofTest) {}
-
-	NetworkSelector networkSelector;
-};
-
 BOOST_FIXTURE_TEST_SUITE(FrontierBlockSuite, FrontierNoProofTestFixture)
 
 BOOST_AUTO_TEST_CASE(bStates)

--- a/test/unittests/libethereum/BlockChain.cpp
+++ b/test/unittests/libethereum/BlockChain.cpp
@@ -539,4 +539,27 @@ BOOST_AUTO_TEST_CASE(updateStats)
 	}
 }
 
+BOOST_AUTO_TEST_CASE(insertWithoutParent)
+{
+	NetworkSelector networkSelector(Network::FrontierNoProofTest);
+
+	TestBlockChain bc(TestBlockChain::defaultGenesisBlock());
+	TestTransaction tr = TestTransaction::defaultTransaction();
+	TestBlock block;
+	block.mine(bc);
+
+	BlockHeader header = block.blockHeader();
+	header.setNumber(10);
+	block.setBlockHeader(header);
+
+	BlockChain& bcRef = bc.interfaceUnsafe();
+
+	bcRef.insertWithoutParent(block.bytes(), block.receipts(), 0x040000);
+	BOOST_CHECK_EQUAL(bcRef.number(), 10);
+
+	bcRef.setChainStartBlockNumber(10);
+	BOOST_REQUIRE_EQUAL(bcRef.chainStartBlockNumber(), 10);
+}
+
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
1. New test for new method `BlockChain::insertWithoutParent()`

2. Make BlockChain unit tests use chain parameters with `NoProof` seal engine, which makes them faster and more isolated by skipping full mining