### PR TITLE
Add 0x in some error messages

### DIFF
--- a/test/tools/jsontests/BlockChainTests.cpp
+++ b/test/tools/jsontests/BlockChainTests.cpp
@@ -817,7 +817,7 @@ void compareBlocks(TestBlock const& _a, TestBlock const& _b)
 	if (sha3(RLP(_a.bytes())[0].data()) != sha3(RLP(_b.bytes())[0].data()))
 	{
 		cnote << "block header mismatch\n";
-		cnote << toHex(RLP(_a.bytes())[0].data()) << "vs" << toHex(RLP(_b.bytes())[0].data());
+		cnote << toHexPrefixed(RLP(_a.bytes())[0].data()) << "vs" << toHexPrefixed(RLP(_b.bytes())[0].data());
 	}
 
 	if (sha3(RLP(_a.bytes())[1].data()) != sha3(RLP(_b.bytes())[1].data()))

--- a/test/tools/libtesteth/ImportTest.cpp
+++ b/test/tools/libtesteth/ImportTest.cpp
@@ -491,7 +491,7 @@ int ImportTest::compareStates(State const& _stateExpect, State const& _statePost
 
 			if (addressOptions.hasCode())
 				CHECK((_stateExpect.code(a.first) == _statePost.code(a.first)),
-				TestOutputHelper::testName() + " Check State: " << a.first <<  ": incorrect code '" << toHex(_statePost.code(a.first)) << "', expected '" << toHex(_stateExpect.code(a.first)) << "'");
+				TestOutputHelper::testName() + " Check State: " << a.first <<  ": incorrect code '" << toHexPrefixed(_statePost.code(a.first)) << "', expected '" << toHexPrefixed(_stateExpect.code(a.first)) << "'");
 		}
 	}
 
@@ -637,7 +637,7 @@ void ImportTest::checkGeneralTestSectionSearch(json_spirit::mObject const& _expe
 			{
 				//checking filled state test against client
 				BOOST_CHECK_MESSAGE(_expects.at("hash").get_str() == toHexPrefixed(tr.postState.rootHash().asBytes()),
-									TestOutputHelper::testName() + " on " + test::netIdToString(tr.netId) + ": Expected another postState hash! expected: " + _expects.at("hash").get_str() + " actual: " + toHex(tr.postState.rootHash().asBytes()) + " in " + trInfo);
+									TestOutputHelper::testName() + " on " + test::netIdToString(tr.netId) + ": Expected another postState hash! expected: " + _expects.at("hash").get_str() + " actual: " + toHexPrefixed(tr.postState.rootHash().asBytes()) + " in " + trInfo);
 				if (_expects.count("logs"))
 					BOOST_CHECK_MESSAGE(_expects.at("logs").get_str() == exportLog(tr.output.second.log()),
 									TestOutputHelper::testName() + " on " + test::netIdToString(tr.netId) + " Transaction log mismatch! expected: " + _expects.at("logs").get_str() + " actual: " + exportLog(tr.output.second.log()) + " in " + trInfo);


### PR DESCRIPTION
In test fillers and test files, state roots are expected to contain the 0x prefix.
This commit adds such prefixes in error messages so that it's easier to edit the test files using the error messages.

For example,
```
test/tools/libtesteth/ImportTest.cpp(640): error: in "StateTestsGeneral/stExample": add11 on Byzantium: Expected another postState hash! expected: 0x07454a767e5f04461256f3812ffca930443c04a47d05ce3f38940c4a14b8c479 actual: 17454a767e5f04461256f3812ffca930443c04a47d05ce3f38940c4a14b8c479 in Byzantium data: 0 gas: 0 val: 0
```
becomes
```
test/tools/libtesteth/ImportTest.cpp(640): error: in "StateTestsGeneral/stExample": add11 on Byzantium: Expected another postState hash! expected: 0x07454a767e5f04461256f3812ffca930443c04a47d05ce3f38940c4a14b8c479 actual: 0x17454a767e5f04461256f3812ffca930443c04a47d05ce3f38940c4a14b8c479 in Byzantium data: 0 gas: 0 val: 0
```