### PR TITLE
Allow "ALL" as a network name in the "expect" section

### DIFF
--- a/test/tools/jsontests/BlockChainTests.cpp
+++ b/test/tools/jsontests/BlockChainTests.cpp
@@ -151,7 +151,8 @@ void spellCheckNetworkNamesInExpectField(json_spirit::mArray const& _expects)
 		json_spirit::mObject const& expectObj = expect.get_obj();
 			ImportTest::parseJsonStrValueIntoVector(expectObj.at("network"), netlist);
 			for (string const& networkName: netlist)
-				(void)stringToNetId(networkName);
+				if (networkName != "ALL") // "ALL" is allowed as a wildcard.
+					(void)stringToNetId(networkName);
 	}
 }
 


### PR DESCRIPTION
This fixes a bug I introduced in #4435 .  "ALL" should be allowed as a network name.