### PR TITLE
Remove the blockhash contract when it is empty

### DIFF
--- a/libethereum/Block.cpp
+++ b/libethereum/Block.cpp
@@ -720,7 +720,7 @@ void Block::updateBlockhashContract()
 			e.go();
 		e.finalize();
 
-		m_state.commit(State::CommitBehaviour::KeepEmptyAccounts);
+		m_state.commit(State::CommitBehaviour::RemoveEmptyAccounts);
 	}
 }
 


### PR DESCRIPTION
During Constantinople Blockchaintests, `constantinopleForkBlock` is set to zero, but the block zero is never processed, so the blockhash contract stays empty.  After that, in block number one, the blockhash contract is called, so it is created in the trie as an empty account.  And the empty blockhash contract stays because the commit behavior was not `RemoveEmptyAccounts`.

This PR changes the commit behavior.  I'm discussing with @winsvega what to do about the blockhash contract deployment.

Fixes #4457.

Work in progress: filling blockchaintests on this PR.