### PR TITLE
generalize test execution logic

### DIFF
--- a/test/tools/jsontests/vm.cpp
+++ b/test/tools/jsontests/vm.cpp
@@ -28,7 +28,6 @@
 #include <libevm/ExtVMFace.h>
 #include <boost/filesystem.hpp>
 
-
 using namespace std;
 using namespace json_spirit;
 using namespace dev;
@@ -295,176 +294,181 @@ eth::OnOpFunc FakeExtVM::simpleTrace() const
 
 namespace dev { namespace test {
 
-json_spirit::mValue doVMTests(json_spirit::mValue const& _input, bool _fillin)
+class VmTestSuite: public TestSute
 {
-	json_spirit::mValue v = json_spirit::mObject();
-	json_spirit::mObject& output = v.get_obj();
-	for (auto& i: _input.get_obj())
+	json_spirit::mValue doTests(json_spirit::mValue const& _input, bool _fillin) const override
 	{
-		string const& testname = i.first;
-		json_spirit::mObject const& testInput = i.second.get_obj();
-		if (!TestOutputHelper::passTest(testname))
-			continue;
-
-		output[testname] = json_spirit::mObject();
-		json_spirit::mObject& testOutput = output[testname].get_obj(); // TODO: avoid copying and add valid fields one by one
-
-		BOOST_REQUIRE_MESSAGE(testInput.count("env") > 0, testname + " env not set!");
-		BOOST_REQUIRE_MESSAGE(testInput.count("pre") > 0, testname + " pre not set!");
-		BOOST_REQUIRE_MESSAGE(testInput.count("exec") > 0, testname + " exec not set!");
-		// testOutput["pre"], ["env"] and ["exec"] will be filled later
-		if (! _fillin)
-			BOOST_REQUIRE_MESSAGE(testInput.count("expect") == 0, testname + " expect set!");
-
-		TestLastBlockHashes lastBlockHashes(h256s(256, h256()));
-		eth::EnvInfo env = FakeExtVM::importEnv(testInput.at("env").get_obj(), lastBlockHashes);
-		FakeExtVM fev(env);
-		fev.importState(testInput.at("pre").get_obj());
-
-		if (_fillin)
-			testOutput["pre"] = mValue(fev.exportState());
-
-		fev.importExec(testInput.at("exec").get_obj());
-		if (fev.code.empty())
+		json_spirit::mValue v = json_spirit::mObject();
+		json_spirit::mObject& output = v.get_obj();
+		for (auto& i: _input.get_obj())
 		{
-			fev.thisTxCode = get<3>(fev.addresses.at(fev.myAddress));
-			fev.code = fev.thisTxCode;
-		}
-		fev.codeHash = sha3(fev.code);
+			string const& testname = i.first;
+			json_spirit::mObject const& testInput = i.second.get_obj();
+			if (!TestOutputHelper::passTest(testname))
+				continue;
 
-		owning_bytes_ref output;
-		bool vmExceptionOccured = false;
-		try
-		{
-			auto vm = eth::VMFactory::create();
-			auto vmtrace = Options::get().vmtrace ? fev.simpleTrace() : OnOpFunc{};
+			output[testname] = json_spirit::mObject();
+			json_spirit::mObject& testOutput = output[testname].get_obj(); // TODO: avoid copying and add valid fields one by one
+
+			BOOST_REQUIRE_MESSAGE(testInput.count("env") > 0, testname + " env not set!");
+			BOOST_REQUIRE_MESSAGE(testInput.count("pre") > 0, testname + " pre not set!");
+			BOOST_REQUIRE_MESSAGE(testInput.count("exec") > 0, testname + " exec not set!");
+			// testOutput["pre"], ["env"] and ["exec"] will be filled later
+			if (! _fillin)
+				BOOST_REQUIRE_MESSAGE(testInput.count("expect") == 0, testname + " expect set!");
+
+			TestLastBlockHashes lastBlockHashes(h256s(256, h256()));
+			eth::EnvInfo env = FakeExtVM::importEnv(testInput.at("env").get_obj(), lastBlockHashes);
+			FakeExtVM fev(env);
+			fev.importState(testInput.at("pre").get_obj());
+
+			if (_fillin)
+				testOutput["pre"] = mValue(fev.exportState());
+
+			fev.importExec(testInput.at("exec").get_obj());
+			if (fev.code.empty())
 			{
-				Listener::ExecTimeGuard guard{i.first};
-				auto gas = static_cast<int64_t>(fev.gas);
-				output = vm->exec(fev.gas, fev, vmtrace);
-				gas -= static_cast<int64_t>(fev.gas);
-				guard.setGasUsed(gas);
+				fev.thisTxCode = get<3>(fev.addresses.at(fev.myAddress));
+				fev.code = fev.thisTxCode;
 			}
-		}
-		catch (VMException const&)
-		{
-			cnote << "    Safe VM Exception\n";
-			vmExceptionOccured = true;
-		}
+			fev.codeHash = sha3(fev.code);
 
-		// delete null entries in storage for the sake of comparison
-
-		for (auto  &a: fev.addresses)
-		{
-			vector<u256> keystoDelete;
-			for (auto &s: get<2>(a.second))
+			owning_bytes_ref output;
+			bool vmExceptionOccured = false;
+			try
 			{
-				if (s.second == 0)
-					keystoDelete.push_back(s.first);
-			}
-			for (auto const key: keystoDelete )
-			{
-				get<2>(a.second).erase(key);
-			}
-		}
-
-		if (_fillin)
-		{
-			testOutput["env"] = mValue(fev.exportEnv());
-			testOutput["exec"] = mValue(fev.exportExec());
-			if (vmExceptionOccured)
-			{
-				if (testInput.count("expect") > 0)
+				auto vm = eth::VMFactory::create();
+				auto vmtrace = Options::get().vmtrace ? fev.simpleTrace() : OnOpFunc{};
 				{
-					BOOST_REQUIRE_MESSAGE(testInput.count("expect") == 1, testname + " multiple expect set!");
-					State postState(State::Null);
-					State expectState(State::Null);
-					AccountMaskMap expectStateMap;
-					ImportTest::importState(mValue(fev.exportState()).get_obj(), postState);
-					ImportTest::importState(testInput.at("expect").get_obj(), expectState, expectStateMap);
-					ImportTest::compareStates(expectState, postState, expectStateMap, WhenError::Throw);
+					Listener::ExecTimeGuard guard{i.first};
+					auto gas = static_cast<int64_t>(fev.gas);
+					output = vm->exec(fev.gas, fev, vmtrace);
+					gas -= static_cast<int64_t>(fev.gas);
+					guard.setGasUsed(gas);
 				}
-				BOOST_REQUIRE_MESSAGE(testOutput.count("expect") == 0, testname + " expect should have been erased!");
+			}
+			catch (VMException const&)
+			{
+				cnote << "    Safe VM Exception\n";
+				vmExceptionOccured = true;
+			}
+
+			// delete null entries in storage for the sake of comparison
+
+			for (auto  &a: fev.addresses)
+			{
+				vector<u256> keystoDelete;
+				for (auto &s: get<2>(a.second))
+				{
+					if (s.second == 0)
+						keystoDelete.push_back(s.first);
+				}
+				for (auto const key: keystoDelete )
+				{
+					get<2>(a.second).erase(key);
+				}
+			}
+
+			if (_fillin)
+			{
+				testOutput["env"] = mValue(fev.exportEnv());
+				testOutput["exec"] = mValue(fev.exportExec());
+				if (vmExceptionOccured)
+				{
+					if (testInput.count("expect") > 0)
+					{
+						BOOST_REQUIRE_MESSAGE(testInput.count("expect") == 1, testname + " multiple expect set!");
+						State postState(State::Null);
+						State expectState(State::Null);
+						AccountMaskMap expectStateMap;
+						ImportTest::importState(mValue(fev.exportState()).get_obj(), postState);
+						ImportTest::importState(testInput.at("expect").get_obj(), expectState, expectStateMap);
+						ImportTest::compareStates(expectState, postState, expectStateMap, WhenError::Throw);
+					}
+					BOOST_REQUIRE_MESSAGE(testOutput.count("expect") == 0, testname + " expect should have been erased!");
+				}
+				else
+				{
+					testOutput["post"] = mValue(fev.exportState());
+					BOOST_REQUIRE_MESSAGE(testOutput.at("post").type() == obj_type, testname + "fev.exportState returned something not an object.");
+
+					if (testInput.count("expect") > 0)
+					{
+						BOOST_REQUIRE_MESSAGE(testInput.count("expect") == 1, testname + " multiple expect set!");
+
+						State postState(State::Null);
+						State expectState(State::Null);
+						AccountMaskMap expectStateMap;
+						ImportTest::importState(testOutput.at("post").get_obj(), postState);
+						ImportTest::importState(testInput.at("expect").get_obj(), expectState, expectStateMap);
+						ImportTest::compareStates(expectState, postState, expectStateMap, WhenError::Throw);
+					}
+
+					BOOST_REQUIRE_MESSAGE(testOutput.count("expect") == 0, testname + " expect should never been added to the output!");
+
+					testOutput["callcreates"] = fev.exportCallCreates();
+					testOutput["out"] = output.size() > 4096 ? "#" + toString(output.size()) : toHexPrefixed(output);
+
+					// compare expected output with post output
+					if (testInput.count("expectOut") > 0)
+					{
+						BOOST_REQUIRE_MESSAGE(testInput.at("expectOut").type() == str_type, testname + " expectOut field is not a string.");
+						std::string warning = " Check State: Error! Unexpected output: " + testOutput["out"].get_str() + " Expected: " + testInput.at("expectOut").get_str();
+						BOOST_CHECK_MESSAGE(testOutput["out"].get_str() == testInput.at("expectOut").get_str(), warning);
+					}
+
+					testOutput["gas"] = toCompactHexPrefixed(fev.gas, 1);
+					testOutput["logs"] = exportLog(fev.sub.logs);
+				}
 			}
 			else
 			{
-				testOutput["post"] = mValue(fev.exportState());
-				BOOST_REQUIRE_MESSAGE(testOutput.at("post").type() == obj_type, testname + "fev.exportState returned something not an object.");
-
-				if (testInput.count("expect") > 0)
+				if (testInput.count("post") > 0)	// No exceptions expected
 				{
-					BOOST_REQUIRE_MESSAGE(testInput.count("expect") == 1, testname + " multiple expect set!");
+					BOOST_REQUIRE_MESSAGE(testInput.at("post").type() == obj_type, testname + " post field is not an object.");
+					BOOST_CHECK(!vmExceptionOccured);
+
+					BOOST_REQUIRE_MESSAGE(testInput.count("callcreates") > 0, testname + " callcreates field is missing.");
+					BOOST_REQUIRE_MESSAGE(testInput.at("callcreates").type() == array_type, testname + " callcreates field is not an array.");
+					BOOST_REQUIRE_MESSAGE(testInput.count("out") > 0, testname + " out field is missing.");
+					BOOST_REQUIRE_MESSAGE(testInput.count("gas") > 0, testname + " gas field is missing.");
+					BOOST_REQUIRE_MESSAGE(testInput.count("logs") > 0, testname + " logs field is missing.");
+					BOOST_REQUIRE_MESSAGE(testInput.at("logs").type() == str_type, testname + " logs field is not a string.");
+
+					dev::test::FakeExtVM test(eth::EnvInfo{BlockHeader{}, lastBlockHashes, 0});
+					test.importState(testInput.at("post").get_obj());
+					test.importCallCreates(testInput.at("callcreates").get_array());
+
+					checkOutput(output, testInput);
+
+					BOOST_CHECK_EQUAL(toInt(testInput.at("gas")), fev.gas);
 
 					State postState(State::Null);
 					State expectState(State::Null);
-					AccountMaskMap expectStateMap;
-					ImportTest::importState(testOutput.at("post").get_obj(), postState);
-					ImportTest::importState(testInput.at("expect").get_obj(), expectState, expectStateMap);
-					ImportTest::compareStates(expectState, postState, expectStateMap, WhenError::Throw);
+					mObject mPostState = fev.exportState();
+					ImportTest::importState(mPostState, postState);
+					ImportTest::importState(testInput.at("post").get_obj(), expectState);
+					ImportTest::compareStates(expectState, postState);
+
+					//checkAddresses<std::map<Address, std::tuple<u256, u256, std::map<u256, u256>, bytes> > >(test.addresses, fev.addresses);
+
+					checkCallCreates(fev.callcreates, test.callcreates);
+
+					BOOST_CHECK_EQUAL(exportLog(fev.sub.logs), testInput.at("logs").get_str());
 				}
-
-				BOOST_REQUIRE_MESSAGE(testOutput.count("expect") == 0, testname + " expect should never been added to the output!");
-
-				testOutput["callcreates"] = fev.exportCallCreates();
-				testOutput["out"] = output.size() > 4096 ? "#" + toString(output.size()) : toHexPrefixed(output);
-
-				// compare expected output with post output
-				if (testInput.count("expectOut") > 0)
-				{
-					BOOST_REQUIRE_MESSAGE(testInput.at("expectOut").type() == str_type, testname + " expectOut field is not a string.");
-					std::string warning = " Check State: Error! Unexpected output: " + testOutput["out"].get_str() + " Expected: " + testInput.at("expectOut").get_str();
-					BOOST_CHECK_MESSAGE(testOutput["out"].get_str() == testInput.at("expectOut").get_str(), warning);
-				}
-
-				testOutput["gas"] = toCompactHexPrefixed(fev.gas, 1);
-				testOutput["logs"] = exportLog(fev.sub.logs);
+				else	// Exception expected
+					BOOST_CHECK(vmExceptionOccured);
 			}
 		}
-		else
-		{
-			if (testInput.count("post") > 0)	// No exceptions expected
-			{
-				BOOST_REQUIRE_MESSAGE(testInput.at("post").type() == obj_type, testname + " post field is not an object.");
-				BOOST_CHECK(!vmExceptionOccured);
 
-				BOOST_REQUIRE_MESSAGE(testInput.count("callcreates") > 0, testname + " callcreates field is missing.");
-				BOOST_REQUIRE_MESSAGE(testInput.at("callcreates").type() == array_type, testname + " callcreates field is not an array.");
-				BOOST_REQUIRE_MESSAGE(testInput.count("out") > 0, testname + " out field is missing.");
-				BOOST_REQUIRE_MESSAGE(testInput.count("gas") > 0, testname + " gas field is missing.");
-				BOOST_REQUIRE_MESSAGE(testInput.count("logs") > 0, testname + " logs field is missing.");
-				BOOST_REQUIRE_MESSAGE(testInput.at("logs").type() == str_type, testname + " logs field is not a string.");
-
-				dev::test::FakeExtVM test(eth::EnvInfo{BlockHeader{}, lastBlockHashes, 0});
-				test.importState(testInput.at("post").get_obj());
-				test.importCallCreates(testInput.at("callcreates").get_array());
-
-				checkOutput(output, testInput);
-
-				BOOST_CHECK_EQUAL(toInt(testInput.at("gas")), fev.gas);
-
-				State postState(State::Null);
-				State expectState(State::Null);
-				mObject mPostState = fev.exportState();
-				ImportTest::importState(mPostState, postState);
-				ImportTest::importState(testInput.at("post").get_obj(), expectState);
-				ImportTest::compareStates(expectState, postState);
-
-				//checkAddresses<std::map<Address, std::tuple<u256, u256, std::map<u256, u256>, bytes> > >(test.addresses, fev.addresses);
-
-				checkCallCreates(fev.callcreates, test.callcreates);
-
-				BOOST_CHECK_EQUAL(exportLog(fev.sub.logs), testInput.at("logs").get_str());
-			}
-			else	// Exception expected
-				BOOST_CHECK(vmExceptionOccured);
-		}
+		return v;
 	}
 
-	return v;
-}
-
-} } // namespace close
-
+	std::string folder() const override
+	{
+		return "VMTests";
+	}
+};
 
 class VmTestFixture
 {
@@ -477,28 +481,12 @@ public:
 			cnote << "Skipping " << casename << " because --all option is not specified.\n";
 			return;
 		}
-		fillAllFilesInFolder(casename);
-	}
-
-	void fillAllFilesInFolder(string const& _folder)
-	{
-		using path = boost::filesystem::path;
-		path const fillersPath = path(test::getTestPath()) / "src/VMTestsFiller" / path(_folder);
-		string const filter = test::Options::get().singleTestName.empty() ? string() : test::Options::get().singleTestName + "Filler";
-
-		std::vector<boost::filesystem::path> const files = test::getJsonFiles(fillersPath.string(), filter);
-		size_t fileCount = files.size();
-		if (test::Options::get().filltests)
-			fileCount *= 2; //tests are checked when filled and after they been filled
-
-		auto testOutput = dev::test::TestOutputHelper(fileCount);
-		for (auto const& file: files)
-		{
-			test::TestOutputHelper::setCurrentTestFileName(file.filename().string());
-			test::executeTests(file.filename().string(), "/VMTests/"+_folder, "/VMTestsFiller/"+_folder, dev::test::doVMTests);
-		}
+		VmTestSuite suite;
+		test::runAllTestsInFolder(suite, casename);
 	}
 };
+
+} } // namespace close
 
 
 BOOST_FIXTURE_TEST_SUITE(VMTests, VmTestFixture)

--- a/test/tools/jsontests/vm.cpp
+++ b/test/tools/jsontests/vm.cpp
@@ -27,6 +27,7 @@
 #include <libevm/VMFactory.h>
 #include <libevm/ExtVMFace.h>
 #include <boost/filesystem.hpp>
+#include <test/tools/libtesteth/TestSuite.h>
 
 using namespace std;
 using namespace json_spirit;

--- a/test/tools/jsontests/vm.cpp
+++ b/test/tools/jsontests/vm.cpp
@@ -482,7 +482,7 @@ public:
 			return;
 		}
 		VmTestSuite suite;
-		test::runAllTestsInFolder(suite, casename);
+		suite.runAllTestsInFolder(casename);
 	}
 };
 

--- a/test/tools/libtesteth/TestHelper.cpp
+++ b/test/tools/libtesteth/TestHelper.cpp
@@ -404,31 +404,6 @@ void checkCallCreates(eth::Transactions const& _resultCallCreates, eth::Transact
 	}
 }
 
-void TestSute::runAllTestsInFolder(const std::string& _folder) const
-{
-	fs::path const fillersPath = fs::path(test::getTestPath()) / "src" / fs::path(folder() + "Filler") / fs::path(_folder);
-	string const filter = test::Options::get().singleTestName.empty() ? string() : test::Options::get().singleTestName + "Filler";
-	std::vector<boost::filesystem::path> const files = test::getJsonFiles(fillersPath.string(), filter);
-	size_t fileCount = files.size();
-	if (test::Options::get().filltests)
-		fileCount *= 2; //tests are checked when filled and after they been filled
-
-	fs::path const destTestFolder = fs::path(folder()) / fs::path(_folder);
-	fs::path const srcTestFolder = fs::path(folder() + "Filler") / fs::path(_folder);
-
-	auto suiteTestDo = [&](json_spirit::mValue const& _input, bool _fillin)
-	{
-		return doTests(_input, _fillin);
-	};
-
-	auto testOutput = dev::test::TestOutputHelper(fileCount);
-	for (auto const& file: files)
-	{
-		test::TestOutputHelper::setCurrentTestFileName(file.filename().string());
-		executeTests(file.filename().string(), destTestFolder.string(), srcTestFolder.string(), suiteTestDo);
-	}
-}
-
 void executeTests(const string& _name, fs::path const& _testPathAppendix, fs::path const& _fillerPathAppendix, std::function<json_spirit::mValue(json_spirit::mValue const&, bool)> doTests)
 {
 	fs::path const testPath = getTestPath() / _testPathAppendix;

--- a/test/tools/libtesteth/TestHelper.cpp
+++ b/test/tools/libtesteth/TestHelper.cpp
@@ -404,7 +404,32 @@ void checkCallCreates(eth::Transactions const& _resultCallCreates, eth::Transact
 	}
 }
 
-void executeTests(const string& _name, fs::path const& _testPathAppendix, fs::path const& _fillerPathAppendix, std::function<json_spirit::mValue(json_spirit::mValue const&, bool)> doTests, bool _addFillerSuffix)
+void runAllTestsInFolder(test::TestSute const& _suite, const std::string& _folder)
+{
+	fs::path const fillersPath = fs::path(test::getTestPath()) / "src" / fs::path(_suite.folder() + "Filler") / fs::path(_folder);
+	string const filter = test::Options::get().singleTestName.empty() ? string() : test::Options::get().singleTestName + "Filler";
+	std::vector<boost::filesystem::path> const files = test::getJsonFiles(fillersPath.string(), filter);
+	size_t fileCount = files.size();
+	if (test::Options::get().filltests)
+		fileCount *= 2; //tests are checked when filled and after they been filled
+
+	fs::path const destTestFolder = fs::path(_suite.folder()) / fs::path(_folder);
+	fs::path const srcTestFolder = fs::path(_suite.folder() + "Filler") / fs::path(_folder);
+
+	auto suiteTestDo = [&_suite](json_spirit::mValue const& _input, bool _fillin)
+	{
+		return _suite.doTests(_input, _fillin);
+	};
+
+	auto testOutput = dev::test::TestOutputHelper(fileCount);
+	for (auto const& file: files)
+	{
+		test::TestOutputHelper::setCurrentTestFileName(file.filename().string());
+		executeTests(file.filename().string(), destTestFolder.string(), srcTestFolder.string(), suiteTestDo);
+	}
+}
+
+void executeTests(const string& _name, fs::path const& _testPathAppendix, fs::path const& _fillerPathAppendix, std::function<json_spirit::mValue(json_spirit::mValue const&, bool)> doTests)
 {
 	fs::path const testPath = getTestPath() / _testPathAppendix;
 
@@ -425,7 +450,7 @@ void executeTests(const string& _name, fs::path const& _testPathAppendix, fs::pa
 		json_spirit::mValue v;
 		boost::filesystem::path p(__FILE__);
 
-		string const nameEnding = _addFillerSuffix ? "Filler.json" : ".json";
+		string const nameEnding = "Filler.json";
 		fs::path const testfileUnderTestPath = fs::path ("src") / _fillerPathAppendix / fs::path(name + nameEnding);
 		fs::path const testfilename = getTestPath() / testfileUnderTestPath;
 		string s = asString(dev::contents(testfilename));
@@ -434,7 +459,7 @@ void executeTests(const string& _name, fs::path const& _testPathAppendix, fs::pa
 		json_spirit::read_string(s, v);
 		removeComments(v);
 		json_spirit::mValue output = doTests(v, true);
-		addClientInfo(output, testfilename);
+		addClientInfo(output, testfileUnderTestPath);
 		writeFile(testPath / fs::path(name + ".json"), asBytes(json_spirit::write_string(output, true)));
 	}
 

--- a/test/tools/libtesteth/TestHelper.cpp
+++ b/test/tools/libtesteth/TestHelper.cpp
@@ -404,21 +404,21 @@ void checkCallCreates(eth::Transactions const& _resultCallCreates, eth::Transact
 	}
 }
 
-void runAllTestsInFolder(test::TestSute const& _suite, const std::string& _folder)
+void TestSute::runAllTestsInFolder(const std::string& _folder) const
 {
-	fs::path const fillersPath = fs::path(test::getTestPath()) / "src" / fs::path(_suite.folder() + "Filler") / fs::path(_folder);
+	fs::path const fillersPath = fs::path(test::getTestPath()) / "src" / fs::path(folder() + "Filler") / fs::path(_folder);
 	string const filter = test::Options::get().singleTestName.empty() ? string() : test::Options::get().singleTestName + "Filler";
 	std::vector<boost::filesystem::path> const files = test::getJsonFiles(fillersPath.string(), filter);
 	size_t fileCount = files.size();
 	if (test::Options::get().filltests)
 		fileCount *= 2; //tests are checked when filled and after they been filled
 
-	fs::path const destTestFolder = fs::path(_suite.folder()) / fs::path(_folder);
-	fs::path const srcTestFolder = fs::path(_suite.folder() + "Filler") / fs::path(_folder);
+	fs::path const destTestFolder = fs::path(folder()) / fs::path(_folder);
+	fs::path const srcTestFolder = fs::path(folder() + "Filler") / fs::path(_folder);
 
-	auto suiteTestDo = [&_suite](json_spirit::mValue const& _input, bool _fillin)
+	auto suiteTestDo = [&](json_spirit::mValue const& _input, bool _fillin)
 	{
-		return _suite.doTests(_input, _fillin);
+		return doTests(_input, _fillin);
 	};
 
 	auto testOutput = dev::test::TestOutputHelper(fileCount);

--- a/test/tools/libtesteth/TestHelper.h
+++ b/test/tools/libtesteth/TestHelper.h
@@ -105,7 +105,6 @@ dev::eth::BlockHeader constructHeader(
 	u256 const& _timestamp,
 	bytes const& _extraData);
 void updateEthashSeal(dev::eth::BlockHeader& _header, h256 const& _mixHash, dev::eth::Nonce const& _nonce);
-void runAllTestsInFolder(test::TestSute const& _testSuite, std::string const& _folder);
 void executeTests(const std::string& _name, boost::filesystem::path const& _testPathAppendix, boost::filesystem::path const& _fillerPathAppendix, std::function<json_spirit::mValue(json_spirit::mValue const&, bool)> doTests);
 RLPStream createRLPStreamFromTransactionFields(json_spirit::mObject const& _tObj);
 json_spirit::mObject fillJsonWithStateChange(eth::State const& _stateOrig, eth::State const& _statePost, eth::ChangeLog const& _changeLog);

--- a/test/tools/libtesteth/TestHelper.h
+++ b/test/tools/libtesteth/TestHelper.h
@@ -105,7 +105,8 @@ dev::eth::BlockHeader constructHeader(
 	u256 const& _timestamp,
 	bytes const& _extraData);
 void updateEthashSeal(dev::eth::BlockHeader& _header, h256 const& _mixHash, dev::eth::Nonce const& _nonce);
-void executeTests(const std::string& _name, boost::filesystem::path const& _testPathAppendix, boost::filesystem::path const& _fillerPathAppendix, std::function<json_spirit::mValue(json_spirit::mValue const&, bool)> doTests, bool _addFillerSuffix = true);
+void runAllTestsInFolder(test::TestSute const& _testSuite, std::string const& _folder);
+void executeTests(const std::string& _name, boost::filesystem::path const& _testPathAppendix, boost::filesystem::path const& _fillerPathAppendix, std::function<json_spirit::mValue(json_spirit::mValue const&, bool)> doTests);
 RLPStream createRLPStreamFromTransactionFields(json_spirit::mObject const& _tObj);
 json_spirit::mObject fillJsonWithStateChange(eth::State const& _stateOrig, eth::State const& _statePost, eth::ChangeLog const& _changeLog);
 json_spirit::mObject fillJsonWithState(eth::State const& _state);

--- a/test/tools/libtesteth/TestHelper.h
+++ b/test/tools/libtesteth/TestHelper.h
@@ -37,6 +37,7 @@
 #include <test/tools/libtesteth/Options.h>
 #include <test/tools/libtesteth/ImportTest.h>
 #include <test/tools/libtesteth/TestOutputHelper.h>
+#include <test/tools/libtesteth/TestSuite.h>
 
 namespace dev
 {

--- a/test/tools/libtesteth/TestHelper.h
+++ b/test/tools/libtesteth/TestHelper.h
@@ -37,7 +37,6 @@
 #include <test/tools/libtesteth/Options.h>
 #include <test/tools/libtesteth/ImportTest.h>
 #include <test/tools/libtesteth/TestOutputHelper.h>
-#include <test/tools/libtesteth/TestSuite.h>
 
 namespace dev
 {

--- a/test/tools/libtesteth/TestSuite.cpp
+++ b/test/tools/libtesteth/TestSuite.cpp
@@ -1,0 +1,59 @@
+/*
+	This file is part of cpp-ethereum.
+
+	cpp-ethereum is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	cpp-ethereum is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/** @file
+ */
+
+#include <test/tools/libtesteth/TestHelper.h>
+#include <test/tools/libtesteth/TestSuite.h>
+#include <test/tools/libtesteth/JsonSpiritHeaders.h>
+#include <boost/filesystem/path.hpp>
+#include <string>
+namespace fs = boost::filesystem;
+using namespace std;
+
+namespace dev
+{
+namespace test
+{
+
+void TestSute::runAllTestsInFolder(const std::string& _folder) const
+{
+	fs::path const fillersPath = fs::path(test::getTestPath()) / "src" / fs::path(folder() + "Filler") / fs::path(_folder);
+	string const filter = test::Options::get().singleTestName.empty() ? string() : test::Options::get().singleTestName + "Filler";
+	std::vector<boost::filesystem::path> const files = test::getJsonFiles(fillersPath.string(), filter);
+	size_t fileCount = files.size();
+	if (test::Options::get().filltests)
+		fileCount *= 2; //tests are checked when filled and after they been filled
+
+	fs::path const destTestFolder = fs::path(folder()) / fs::path(_folder);
+	fs::path const srcTestFolder = fs::path(folder() + "Filler") / fs::path(_folder);
+
+	auto suiteTestDo = [&](json_spirit::mValue const& _input, bool _fillin)
+	{
+		return doTests(_input, _fillin);
+	};
+
+	auto testOutput = dev::test::TestOutputHelper(fileCount);
+	for (auto const& file: files)
+	{
+		test::TestOutputHelper::setCurrentTestFileName(file.filename().string());
+		executeTests(file.filename().string(), destTestFolder.string(), srcTestFolder.string(), suiteTestDo);
+	}
+}
+
+}
+}

--- a/test/tools/libtesteth/TestSuite.cpp
+++ b/test/tools/libtesteth/TestSuite.cpp
@@ -15,6 +15,7 @@
 	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
  */
 /** @file
+ * Base functions for all test suites
  */
 
 #include <test/tools/libtesteth/TestHelper.h>
@@ -42,7 +43,7 @@ void TestSute::runAllTestsInFolder(const std::string& _folder) const
 	fs::path const destTestFolder = fs::path(folder()) / fs::path(_folder);
 	fs::path const srcTestFolder = fs::path(folder() + "Filler") / fs::path(_folder);
 
-	auto suiteTestDo = [&](json_spirit::mValue const& _input, bool _fillin)
+	auto suiteTestDo = [this](json_spirit::mValue const& _input, bool _fillin)
 	{
 		return doTests(_input, _fillin);
 	};

--- a/test/tools/libtesteth/TestSuite.h
+++ b/test/tools/libtesteth/TestSuite.h
@@ -15,6 +15,7 @@
 	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
  */
 /** @file
+ * A base class for test suites
  */
 
 #pragma once

--- a/test/tools/libtesteth/TestSuite.h
+++ b/test/tools/libtesteth/TestSuite.h
@@ -1,0 +1,38 @@
+/*
+	This file is part of cpp-ethereum.
+
+	cpp-ethereum is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	cpp-ethereum is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/** @file
+ */
+
+#pragma once
+#include <test/tools/libtesteth/JsonSpiritHeaders.h>
+
+namespace dev
+{
+namespace test
+{
+
+class TestSute
+{
+public:
+	virtual ~TestSute() {}
+	virtual json_spirit::mValue doTests(json_spirit::mValue const&, bool) const = 0;
+	virtual std::string folder() const = 0;
+	void runAllTestsInFolder(std::string const& _folder) const;
+};
+
+}
+}


### PR DESCRIPTION
the goal of this change is to make 
```void executeTests```
private and eventually simplify the logic of executeTests itself.

in this PR executeTests removed from VMTests