### PR TITLE
--fillchain --filltests should not write the (broken) GeneralStateTest

### DIFF
--- a/test/tools/jsontests/BlockChainTests.cpp
+++ b/test/tools/jsontests/BlockChainTests.cpp
@@ -976,7 +976,8 @@ class bcTestFixture {
 			return;
 		}
 
-		suite.runAllTestsInFolder(casename);
+		test::AccessSwitch accessSwitch = test::Options::get().filltests ? test::AccessSwitch::Writable : test::AccessSwitch::ReadOnly;
+		suite.runAllTestsInFolder(casename, accessSwitch);
 	}
 };
 
@@ -986,7 +987,8 @@ class bcTransitionFixture {
 	{
 		string const& casename = boost::unit_test::framework::current_test_case().p_name;
 		test::TransitionTestsSuite suite;
-		suite.runAllTestsInFolder(casename);
+		test::AccessSwitch accessSwitch = test::Options::get().filltests ? test::AccessSwitch::Writable : test::AccessSwitch::ReadOnly;
+		suite.runAllTestsInFolder(casename, accessSwitch);
 	}
 };
 
@@ -1006,7 +1008,7 @@ class bcGeneralTestsFixture
 			cnote << "Skipping hive test " << casename << ". Use --all to run it.\n";
 
 		test::BCGeneralStateTestsSuite suite;
-		suite.runAllTestsInFolder(casename);
+		suite.runAllTestsInFolder(casename, test::AccessSwitch::ReadOnly);
 	}
 };
 

--- a/test/tools/jsontests/StateTests.cpp
+++ b/test/tools/jsontests/StateTests.cpp
@@ -139,8 +139,9 @@ public:
 			std::cout << "Skipping " << casename << " because --all option is not specified.\n";
 			return;
 		}
+		test::AccessSwitch const accessSwitch = test::Options::get().filltests && !test::Options::get().fillchain ? test::AccessSwitch::Writable : test::AccessSwitch::ReadOnly;
 		test::StateTestSuite suite;
-		suite.runAllTestsInFolder(casename);
+		suite.runAllTestsInFolder(casename, accessSwitch);
 	}
 };
 

--- a/test/tools/jsontests/TransactionTests.cpp
+++ b/test/tools/jsontests/TransactionTests.cpp
@@ -27,12 +27,15 @@
 #include <test/tools/libtesteth/TestHelper.h>
 #include <test/tools/fuzzTesting/fuzzHelper.h>
 #include <test/tools/libtesteth/TestSuite.h>
+#include <boost/filesystem/path.hpp>
 #include <string>
 
 using namespace std;
 using namespace json_spirit;
 using namespace dev;
 using namespace dev::eth;
+
+namespace fs = boost::filesystem;
 
 namespace dev {  namespace test {
 
@@ -192,7 +195,8 @@ public:
 			return;
 		}
 
-		suite.runAllTestsInFolder(casename);
+		dev::test::AccessSwitch const accessSwitch = test::Options::get().filltests ? dev::test::AccessSwitch::Writable : dev::test::AccessSwitch::ReadOnly;
+		suite.runAllTestsInFolder(casename, accessSwitch);
 	}
 };
 

--- a/test/tools/jsontests/vm.cpp
+++ b/test/tools/jsontests/vm.cpp
@@ -488,8 +488,9 @@ public:
 			std::cout << "Skipping " << casename << " because --all option is not specified.\n";
 			return;
 		}
+		test::AccessSwitch const accessSwitch = test::Options::get().filltests ? test::AccessSwitch::Writable : test::AccessSwitch::ReadOnly;
 		test::VmTestSuite suite;
-		suite.runAllTestsInFolder(casename);
+		suite.runAllTestsInFolder(casename, accessSwitch);
 	}
 };
 

--- a/test/tools/libtesteth/TestHelper.h
+++ b/test/tools/libtesteth/TestHelper.h
@@ -104,6 +104,11 @@ dev::eth::BlockHeader constructHeader(
 	u256 const& _timestamp,
 	bytes const& _extraData);
 void updateEthashSeal(dev::eth::BlockHeader& _header, h256 const& _mixHash, dev::eth::Nonce const& _nonce);
+enum class AccessSwitch
+{
+	ReadOnly,
+	Writable
+};
 RLPStream createRLPStreamFromTransactionFields(json_spirit::mObject const& _tObj);
 json_spirit::mObject fillJsonWithStateChange(eth::State const& _stateOrig, eth::State const& _statePost, eth::ChangeLog const& _changeLog);
 json_spirit::mObject fillJsonWithState(eth::State const& _state);

--- a/test/tools/libtesteth/TestSuite.cpp
+++ b/test/tools/libtesteth/TestSuite.cpp
@@ -101,7 +101,7 @@ void TestSuite::runAllTestsInFolder(string const& _testFolder, test::AccessSwitc
 	{
 		testOutput.showProgress();
 		test::TestOutputHelper::setCurrentTestFileName(file.filename().string());
-		executeTests(file.filename().string(), {destTestFolder.string(), _accessSwitch}, srcTestFolder.string(), suiteTestDo);
+		executeTests(file.filename().string(), {destTestFolder, _accessSwitch}, srcTestFolder, suiteTestDo);
 	}
 }
 

--- a/test/tools/libtesteth/TestSuite.cpp
+++ b/test/tools/libtesteth/TestSuite.cpp
@@ -80,7 +80,7 @@ void addClientInfo(json_spirit::mValue& _v, fs::path const& _testSource)
 	}
 }
 
-void TestSuite::runAllTestsInFolder(string const& _testFolder) const
+void TestSuite::runAllTestsInFolder(string const& _testFolder, test::AccessSwitch _accessSwitch) const
 {
 	string const filter = test::Options::get().singleTestName.empty() ? string() : test::Options::get().singleTestName + "Filler";
 	std::vector<boost::filesystem::path> const files = test::getJsonFiles(getFullPathFiller(_testFolder).string(), filter);
@@ -101,7 +101,7 @@ void TestSuite::runAllTestsInFolder(string const& _testFolder) const
 	{
 		testOutput.showProgress();
 		test::TestOutputHelper::setCurrentTestFileName(file.filename().string());
-		executeTests(file.filename().string(), destTestFolder.string(), srcTestFolder.string(), suiteTestDo);
+		executeTests(file.filename().string(), {destTestFolder.string(), _accessSwitch}, srcTestFolder.string(), suiteTestDo);
 	}
 }
 
@@ -120,7 +120,7 @@ void TestSuite::copyAllTestsFromFolder(string const& _testFolder) const
 		dev::test::copyFile(srcFile.string(), destFile.string());
 		BOOST_REQUIRE_MESSAGE(boost::filesystem::exists(destFile.string()), "Error when copying the test file!");
 	}
-	runAllTestsInFolder(_testFolder); //check that copied tests are valid
+	runAllTestsInFolder(_testFolder, AccessSwitch::ReadOnly); //check that copied tests are valid
 }
 
 fs::path TestSuite::getFullPathFiller(string const& _testFolder) const
@@ -133,9 +133,9 @@ fs::path TestSuite::getFullPath(string const& _testFolder) const
 	return fs::path(test::getTestPath()) / suiteFolder() / _testFolder;
 }
 
-void TestSuite::executeTests(const string& _name, fs::path const& _testPathAppendix, fs::path const& _fillerPathAppendix, std::function<json_spirit::mValue(json_spirit::mValue const&, bool)> doTests) const
+void TestSuite::executeTests(const string& _name, std::pair<fs::path const&, AccessSwitch> _testPathAppendix, fs::path const& _fillerPathAppendix, std::function<json_spirit::mValue(json_spirit::mValue const&, bool)> doTests) const
 {
-	fs::path const testPath = getTestPath() / _testPathAppendix;
+	fs::path const testPath = getTestPath() / _testPathAppendix.first;
 
 	if (Options::get().stats)
 		Listener::registerListener(Stats::get());
@@ -163,6 +163,8 @@ void TestSuite::executeTests(const string& _name, fs::path const& _testPathAppen
 		json_spirit::read_string(s, v);
 		removeComments(v);
 		json_spirit::mValue output = doTests(v, true);
+		if (_testPathAppendix.second != AccessSwitch::Writable)
+			return; // This happens in -t StateTestsGeneral -- --fillchain --filltests, where the GeneralStateTest should not be updated.
 		addClientInfo(output, testfileUnderTestPath);
 		writeFile(testPath / fs::path(name + ".json"), asBytes(json_spirit::write_string(output, true)));
 	}

--- a/test/tools/libtesteth/TestSuite.h
+++ b/test/tools/libtesteth/TestSuite.h
@@ -43,7 +43,7 @@ public:
 	virtual json_spirit::mValue doTests(json_spirit::mValue const&, bool) const = 0;
 
 	// Execute all tests from _folder
-	void runAllTestsInFolder(std::string const& _testFolder) const;
+	void runAllTestsInFolder(std::string const& _testFolder, test::AccessSwitch _accessSwitch) const;
 
 	// Copy .json tests from the src folder to the dest folder because such test is crafted manually and could not be filled.
 	// Used in bcForgedTest, ttWrongRLP tests and such.
@@ -55,7 +55,7 @@ public:
 	// Structure  <suiteFolder>/<testFolder>/<test>.json
 	boost::filesystem::path getFullPath(std::string const& _testFolder) const;
 
-	void executeTests(const std::string& _name, boost::filesystem::path const& _testPathAppendix, boost::filesystem::path const& _fillerPathAppendix, std::function<json_spirit::mValue(json_spirit::mValue const&, bool)> doTests) const;
+	void executeTests(const std::string& _name, std::pair<boost::filesystem::path const&, AccessSwitch> _testPathAppendix, boost::filesystem::path const& _fillerPathAppendix, std::function<json_spirit::mValue(json_spirit::mValue const&, bool)> doTests) const;
 };
 
 }


### PR DESCRIPTION
Before this PR, running `testeth -t StateTestsGeneral -- --filltests --fillchain` modified the GeneralStateTest in addition to the desired file in `BlockchainTests/GeneralStateTest`.  Moreover, the written `GeneralStateTest` was corrupt.  This PR stops `testeth -- --filltests --fillchain` from writing to the GeneralStateTest file.

Fixes #4258 