### PR TITLE
Perform input validation on the G1 element even when the G2 element is zero

### DIFF
--- a/libdevcrypto/LibSnark.cpp
+++ b/libdevcrypto/LibSnark.cpp
@@ -146,16 +146,20 @@ pair<bool, bytes> dev::crypto::alt_bn128_pairing_product(dev::bytesConstRef _in)
 		for (size_t i = 0; i < pairs; ++i)
 		{
 			bytesConstRef const pair = _in.cropped(i * pairSize, pairSize);
+			libff::alt_bn128_G1 const g1 = decodePointG1(pair);
 			libff::alt_bn128_G2 const p = decodePointG2(pair.cropped(2 * 32));
 			if (-libff::alt_bn128_G2::scalar_field::one() * p + p != libff::alt_bn128_G2::zero())
 				// p is not an element of the group (has wrong order)
 				return {false, bytes()};
+			if (-libff::alt_bn128_G1::scalar_field::one() * g1 + g1 != libff::alt_bn128_G1::zero())
+				// g1 is not an element of the group (has wrong order)
+				return {false, bytes()};
 			if (p.is_zero())
 				continue; // the pairing is one
-			if (decodePointG1(pair).is_zero())
+			if (g1.is_zero())
 				continue; // the pairing is one
 			x = x * libff::alt_bn128_miller_loop(
-				libff::alt_bn128_precompute_G1(decodePointG1(pair)),
+				libff::alt_bn128_precompute_G1(g1),
 				libff::alt_bn128_precompute_G2(p)
 			);
 		}

--- a/libdevcrypto/LibSnark.cpp
+++ b/libdevcrypto/LibSnark.cpp
@@ -151,12 +151,7 @@ pair<bool, bytes> dev::crypto::alt_bn128_pairing_product(dev::bytesConstRef _in)
 			if (-libff::alt_bn128_G2::scalar_field::one() * p + p != libff::alt_bn128_G2::zero())
 				// p is not an element of the group (has wrong order)
 				return {false, bytes()};
-			if (-libff::alt_bn128_G1::scalar_field::one() * g1 + g1 != libff::alt_bn128_G1::zero())
-				// g1 is not an element of the group (has wrong order)
-				return {false, bytes()};
-			if (p.is_zero())
-				continue; // the pairing is one
-			if (g1.is_zero())
+			if (p.is_zero() || g1.is_zero())
 				continue; // the pairing is one
 			x = x * libff::alt_bn128_miller_loop(
 				libff::alt_bn128_precompute_G1(g1),


### PR DESCRIPTION
A test case about this should be added https://github.com/ethereum/tests/issues/314.  @arkpar pointed out the problem to me.