### PR TITLE
update precompiled gasPrice

### DIFF
--- a/libethashseal/genesis/test/EIP158ToByzantiumAt5Test.cpp
+++ b/libethashseal/genesis/test/EIP158ToByzantiumAt5Test.cpp
@@ -55,7 +55,11 @@ R"E(
 "0000000000000000000000000000000000000001": { "wei": "1", "precompiled": { "name": "ecrecover", "linear": { "base": 3000, "word": 0 } } },
 "0000000000000000000000000000000000000002": { "wei": "1", "precompiled": { "name": "sha256", "linear": { "base": 60, "word": 12 } } },
 "0000000000000000000000000000000000000003": { "wei": "1", "precompiled": { "name": "ripemd160", "linear": { "base": 600, "word": 120 } } },
-"0000000000000000000000000000000000000004": { "wei": "1", "precompiled": { "name": "identity", "linear": { "base": 15, "word": 3 } } }
+"0000000000000000000000000000000000000004": { "wei": "1", "precompiled": { "name": "identity", "linear": { "base": 15, "word": 3 } } },
+"0000000000000000000000000000000000000005": { "wei": "1", "precompiled": { "name": "modexp", "startBlock": "0x05" } },
+"0000000000000000000000000000000000000006": { "wei": "1", "precompiled": { "name": "alt_bn128_G1_add", "startBlock": "0x05", "linear": { "base": 500, "word": 0 } } },
+"0000000000000000000000000000000000000007": { "wei": "1", "precompiled": { "name": "alt_bn128_G1_mul", "startBlock": "0x05", "linear": { "base": 40000, "word": 0 } } },
+"0000000000000000000000000000000000000008": { "wei": "1", "precompiled": { "name": "alt_bn128_pairing_product", "startBlock": "0x05" } }
 	}
 }
 )E";

--- a/libethashseal/genesis/test/byzantiumTest.cpp
+++ b/libethashseal/genesis/test/byzantiumTest.cpp
@@ -58,7 +58,7 @@ R"E(
 		"0000000000000000000000000000000000000004": { "wei": "1", "precompiled": { "name": "identity", "linear": { "base": 15, "word": 3 } } },
 		"0000000000000000000000000000000000000005": { "wei": "1", "precompiled": { "name": "modexp" } },
 		"0000000000000000000000000000000000000006": { "wei": "1", "precompiled": { "name": "alt_bn128_G1_add", "linear": { "base": 500, "word": 0 } } },
-		"0000000000000000000000000000000000000007": { "wei": "1", "precompiled": { "name": "alt_bn128_G1_mul", "linear": { "base": 2000, "word": 0 } } },
+		"0000000000000000000000000000000000000007": { "wei": "1", "precompiled": { "name": "alt_bn128_G1_mul", "linear": { "base": 40000, "word": 0 } } },
 		"0000000000000000000000000000000000000008": { "wei": "1", "precompiled": { "name": "alt_bn128_pairing_product" } }
 	}
 }

--- a/libethashseal/genesis/test/byzantiumTransitionTest.cpp
+++ b/libethashseal/genesis/test/byzantiumTransitionTest.cpp
@@ -56,9 +56,9 @@ R"E(
 		"0000000000000000000000000000000000000002": { "wei": "1", "precompiled": { "name": "sha256", "linear": { "base": 60, "word": 12 } } },
 		"0000000000000000000000000000000000000003": { "wei": "1", "precompiled": { "name": "ripemd160", "linear": { "base": 600, "word": 120 } } },
 		"0000000000000000000000000000000000000004": { "wei": "1", "precompiled": { "name": "identity", "linear": { "base": 15, "word": 3 } } },
-		"0000000000000000000000000000000000000005": { "wei": "1", "precompiled": { "name": "modexp", "startBlock": "0x02" } }
+		"0000000000000000000000000000000000000005": { "wei": "1", "precompiled": { "name": "modexp", "startBlock": "0x02" } },
 		"0000000000000000000000000000000000000006": { "wei": "1", "precompiled": { "name": "alt_bn128_G1_add", "startBlock": "0x02", "linear": { "base": 500, "word": 0 } } },
-		"0000000000000000000000000000000000000007": { "wei": "1", "precompiled": { "name": "alt_bn128_G1_mul", "startBlock": "0x02", "linear": { "base": 2000, "word": 0 } } },
+		"0000000000000000000000000000000000000007": { "wei": "1", "precompiled": { "name": "alt_bn128_G1_mul", "startBlock": "0x02", "linear": { "base": 40000, "word": 0 } } },
 		"0000000000000000000000000000000000000008": { "wei": "1", "precompiled": { "name": "alt_bn128_pairing_product", "startBlock": "0x02" } }
 	}
 }

--- a/libethcore/Precompiled.cpp
+++ b/libethcore/Precompiled.cpp
@@ -181,7 +181,7 @@ ETH_REGISTER_PRECOMPILED_PRICER(modexp)(bytesConstRef _in)
 	bigint const maxLength(max(modLength, baseLength));
 	bigint const adjustedExpLength(expLengthAdjust(baseLength + 96, expLength, _in));
 
-	return multComplexity(maxLength) * max<bigint>(adjustedExpLength, 1) / 100;
+	return multComplexity(maxLength) * max<bigint>(adjustedExpLength, 1) / 20;
 }
 
 ETH_REGISTER_PRECOMPILED(alt_bn128_G1_add)(bytesConstRef _in)
@@ -201,7 +201,7 @@ ETH_REGISTER_PRECOMPILED(alt_bn128_pairing_product)(bytesConstRef _in)
 
 ETH_REGISTER_PRECOMPILED_PRICER(alt_bn128_pairing_product)(bytesConstRef _in)
 {
-	return 100000 + (_in.size() / 192) * 80000;
+	return 40000 + (_in.size() / 192) * 60000;
 }
 
 }

--- a/test/unittests/libethcore/PrecompiledTest.cpp
+++ b/test/unittests/libethcore/PrecompiledTest.cpp
@@ -200,7 +200,7 @@ BOOST_AUTO_TEST_CASE(modexpCostFermatTheorem)
 		"fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f");
 	auto res = cost(bytesConstRef(in.data(), in.size()));
 
-	BOOST_REQUIRE_EQUAL(static_cast<int>(res), 2611);
+	BOOST_REQUIRE_EQUAL(static_cast<int>(res), 13056);
 }
 
 BOOST_AUTO_TEST_CASE(modexpCostTooLarge)
@@ -215,7 +215,7 @@ BOOST_AUTO_TEST_CASE(modexpCostTooLarge)
 		"fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd");
 	auto res = cost(bytesConstRef(in.data(), in.size()));
 
-	BOOST_REQUIRE(res == bigint{"9485687950320942729098935091911713411339877143809275006112365281928243580103464"});
+	BOOST_REQUIRE_MESSAGE(res == bigint{"47428439751604713645494675459558567056699385719046375030561826409641217900517324"}, "Got: " + toString(res));
 }
 
 BOOST_AUTO_TEST_CASE(modexpCostEmptyExponent)
@@ -233,7 +233,7 @@ BOOST_AUTO_TEST_CASE(modexpCostEmptyExponent)
 	);
 	auto res = cost(bytesConstRef(in.data(), in.size()));
 
-	BOOST_REQUIRE(res == bigint{"2"});
+	BOOST_REQUIRE_MESSAGE(res == bigint{"12"}, "Got: " + toString(res));
 }
 
 BOOST_AUTO_TEST_CASE(modexpCostZeroExponent)
@@ -250,7 +250,7 @@ BOOST_AUTO_TEST_CASE(modexpCostZeroExponent)
 	);
 	auto res = cost(bytesConstRef(in.data(), in.size()));
 
-	BOOST_REQUIRE(res == bigint{"1"});
+	BOOST_REQUIRE_MESSAGE(res == bigint{"5"}, "Got: " + toString(res));
 }
 
 BOOST_AUTO_TEST_CASE(modexpCostApproximated)
@@ -267,7 +267,7 @@ BOOST_AUTO_TEST_CASE(modexpCostApproximated)
 	);
 	auto res = cost(bytesConstRef(in.data(), in.size()));
 
-	BOOST_REQUIRE(res == bigint{"263"});
+	BOOST_REQUIRE_MESSAGE(res == bigint{"1315"}, "Got: " + toString(res));
 }
 
 BOOST_AUTO_TEST_CASE(modexpCostApproximatedPartialByte)
@@ -284,7 +284,7 @@ BOOST_AUTO_TEST_CASE(modexpCostApproximatedPartialByte)
 	);
 	auto res = cost(bytesConstRef(in.data(), in.size()));
 
-	BOOST_REQUIRE(res == bigint{"257"});
+	BOOST_REQUIRE_MESSAGE(res == bigint{"1285"}, "Got: " + toString(res));
 }
 
 BOOST_AUTO_TEST_CASE(modexpCostApproximatedGhost)
@@ -301,7 +301,7 @@ BOOST_AUTO_TEST_CASE(modexpCostApproximatedGhost)
 	);
 	auto res = cost(bytesConstRef(in.data(), in.size()));
 
-	BOOST_REQUIRE(res == bigint{"8"});
+	BOOST_REQUIRE_MESSAGE(res == bigint{"40"}, "Got: " + toString(res));
 }
 
 BOOST_AUTO_TEST_CASE(modexpCostMidRange)
@@ -318,7 +318,7 @@ BOOST_AUTO_TEST_CASE(modexpCostMidRange)
 	);
 	auto res = cost(bytesConstRef(in.data(), in.size()));
 
-	BOOST_REQUIRE(res == ((74 * 74 / 4 + 96 * 74 - 3072) * 8) / 100);
+	BOOST_REQUIRE_MESSAGE(res == ((74 * 74 / 4 + 96 * 74 - 3072) * 8) / 20, "Got: " + toString(res));
 }
 
 BOOST_AUTO_TEST_CASE(modexpCostHighRange)
@@ -335,7 +335,7 @@ BOOST_AUTO_TEST_CASE(modexpCostHighRange)
 	);
 	auto res = cost(bytesConstRef(in.data(), in.size()));
 
-	BOOST_REQUIRE(res == ((1025 * 1025 / 16 + 480 * 1025 - 199680) * 8) / 100);
+	BOOST_REQUIRE_MESSAGE(res == ((1025 * 1025 / 16 + 480 * 1025 - 199680) * 8) / 20, "Got: " + toString(res));
 }
 
 /// @defgroup PrecompiledTests Test cases for precompiled contracts.


### PR DESCRIPTION
update precompiles gas price according to

Pairings:
https://github.com/ethereum/EIPs/blob/470c61bed3b94d67815557aca224641742badb56/EIPS/pairings.md#gas-costs

Modexp:
https://github.com/ethereum/EIPs/blob/vbuterin-patch-2/EIPS/bigint_modexp.md

Add/mul:
https://github.com/ethereum/EIPs/blob/ecopts/EIPS/ecopts.md

Tests https://github.com/ethereum/tests/pull/319

