### PR TITLE
ecpairing final gas costs 100k base + 80k per point

### DIFF
--- a/libethcore/Precompiled.cpp
+++ b/libethcore/Precompiled.cpp
@@ -201,7 +201,7 @@ ETH_REGISTER_PRECOMPILED(alt_bn128_pairing_product)(bytesConstRef _in)
 
 ETH_REGISTER_PRECOMPILED_PRICER(alt_bn128_pairing_product)(bytesConstRef _in)
 {
-	return 40000 + (_in.size() / 192) * 60000;
+	return 100000 + (_in.size() / 192) * 80000;
 }
 
 }


### PR DESCRIPTION
See the updated https://github.com/ethereum/EIPs/pull/212 ([permalink](https://github.com/ethereum/EIPs/blob/9961da4c77659c6217eae41130c3a40d3f526ac4/EIPS/pairings.md)).