### PR TITLE
CMake: Map imported configs with only single entry

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,8 +45,8 @@ if(CMAKE_CONFIGURATION_TYPES)
 endif()
 
 # Map current configuration to congigurations of imported targets.
-set(CMAKE_MAP_IMPORTED_CONFIG_DEBUG RelWithDebInfo Release)
-set(CMAKE_MAP_IMPORTED_CONFIG_RELWITHDEBINFO RelWithDebInfo Release)
+set(CMAKE_MAP_IMPORTED_CONFIG_DEBUG Release)
+set(CMAKE_MAP_IMPORTED_CONFIG_RELWITHDEBINFO Release)
 
 set(HUNTER_CONFIGURATION_TYPES Release)
 set(HUNTER_JOBS_NUMBER 4)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,10 +44,6 @@ if(CMAKE_CONFIGURATION_TYPES)
     set(CMAKE_CONFIGURATION_TYPES "Debug;Release;RelWithDebInfo" CACHE STRING "" FORCE)
 endif()
 
-# Map current configuration to congigurations of imported targets.
-set(CMAKE_MAP_IMPORTED_CONFIG_DEBUG Release)
-set(CMAKE_MAP_IMPORTED_CONFIG_RELWITHDEBINFO Release)
-
 set(HUNTER_CONFIGURATION_TYPES Release)
 set(HUNTER_JOBS_NUMBER 4)
 set(HUNTER_CACHE_SERVERS "https://github.com/ethereum/hunter-cache")


### PR DESCRIPTION
This should fix CMake 3.9 generator for Visual Studio.