### PR TITLE
More boost::filesystem::path instead of std::string

### DIFF
--- a/test/tools/jsontests/BlockChainTests.cpp
+++ b/test/tools/jsontests/BlockChainTests.cpp
@@ -123,20 +123,19 @@ json_spirit::mValue BlockchainTestSuite::doTests(json_spirit::mValue const& _inp
 
 	return tests;
 }
-std::string BlockchainTestSuite::suiteFolder() const
+fs::path BlockchainTestSuite::suiteFolder() const
 {
 	return "BlockchainTests";
 }
-std::string BlockchainTestSuite::suiteFillerFolder() const
+fs::path BlockchainTestSuite::suiteFillerFolder() const
 {
 	return "BlockchainTestsFiller";
 }
-std::string BCGeneralStateTestsSuite::suiteFolder() const
+fs::path BCGeneralStateTestsSuite::suiteFolder() const
 {
-	fs::path folder = fs::path("BlockchainTests") / "GeneralStateTests";
-	return folder.string();
+	return fs::path("BlockchainTests") / "GeneralStateTests";
 }
-std::string BCGeneralStateTestsSuite::suiteFillerFolder() const
+fs::path BCGeneralStateTestsSuite::suiteFillerFolder() const
 {
 	return "GenStateTestAsBcTemp";
 }
@@ -170,14 +169,12 @@ json_spirit::mValue TransitionTestsSuite::doTests(json_spirit::mValue const& _in
 	return output;
 }
 
-std::string TransitionTestsSuite::suiteFolder() const {
-	fs::path folder = fs::path("BlockchainTests") / "TransitionTests";
-	return folder.string();
+fs::path TransitionTestsSuite::suiteFolder() const {
+	return fs::path("BlockchainTests") / "TransitionTests";
 }
 
-std::string TransitionTestsSuite::suiteFillerFolder() const {
-	fs::path folder = fs::path("BlockchainTestsFiller") / "TransitionTests";
-	return folder.string();
+fs::path TransitionTestsSuite::suiteFillerFolder() const {
+	return fs::path("BlockchainTestsFiller") / "TransitionTests";
 }
 
 ChainBranch::ChainBranch(TestBlock const& _genesis): blockchain(_genesis)

--- a/test/tools/jsontests/BlockChainTests.h
+++ b/test/tools/jsontests/BlockChainTests.h
@@ -23,6 +23,7 @@ along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 #include <libethashseal/GenesisInfo.h>
 #include <test/tools/libtesteth/TestSuite.h>
 #include <test/tools/libtesteth/BlockChainHelper.h>
+#include <boost/filesystem/path.hpp>
 
 using namespace dev;
 
@@ -35,21 +36,21 @@ class BlockchainTestSuite: public TestSuite
 {
 public:
 	json_spirit::mValue doTests(json_spirit::mValue const& _input, bool _fillin) const override;
-	std::string suiteFolder() const override;
-	std::string suiteFillerFolder() const override;
+	boost::filesystem::path suiteFolder() const override;
+	boost::filesystem::path suiteFillerFolder() const override;
 };
 
 class BCGeneralStateTestsSuite: public BlockchainTestSuite
 {
-	std::string suiteFolder() const override;
-	std::string suiteFillerFolder() const override;
+	boost::filesystem::path suiteFolder() const override;
+	boost::filesystem::path suiteFillerFolder() const override;
 };
 
 class TransitionTestsSuite: public TestSuite
 {
 	json_spirit::mValue doTests(json_spirit::mValue const& _input, bool _fillin) const override;
-	std::string suiteFolder() const override;
-	std::string suiteFillerFolder() const override;
+	boost::filesystem::path suiteFolder() const override;
+	boost::filesystem::path suiteFillerFolder() const override;
 };
 
 struct ChainBranch

--- a/test/tools/jsontests/StateTests.cpp
+++ b/test/tools/jsontests/StateTests.cpp
@@ -116,12 +116,12 @@ json_spirit::mValue StateTestSuite::doTests(json_spirit::mValue const& _input, b
 	return v;
 }
 
-std::string StateTestSuite::suiteFolder() const
+fs::path StateTestSuite::suiteFolder() const
 {
 	return "GeneralStateTests";
 }
 
-std::string StateTestSuite::suiteFillerFolder() const
+fs::path StateTestSuite::suiteFillerFolder() const
 {
 	return "GeneralStateTestsFiller";
 }

--- a/test/tools/jsontests/StateTests.h
+++ b/test/tools/jsontests/StateTests.h
@@ -20,6 +20,7 @@ along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 
 #pragma once
 #include <test/tools/libtesteth/TestSuite.h>
+#include <boost/filesystem/path.hpp>
 
 namespace dev
 {
@@ -30,8 +31,8 @@ class StateTestSuite: public TestSuite
 {
 public:
 	json_spirit::mValue doTests(json_spirit::mValue const& _input, bool _fillin) const override;
-	std::string suiteFolder() const override;
-	std::string suiteFillerFolder() const override;
+	boost::filesystem::path suiteFolder() const override;
+	boost::filesystem::path suiteFillerFolder() const override;
 };
 
 }

--- a/test/tools/jsontests/TransactionTests.cpp
+++ b/test/tools/jsontests/TransactionTests.cpp
@@ -27,12 +27,14 @@
 #include <test/tools/libtesteth/TestHelper.h>
 #include <test/tools/fuzzTesting/fuzzHelper.h>
 #include <test/tools/libtesteth/TestSuite.h>
+#include <boost/filesystem/path.hpp>
 #include <string>
 
 using namespace std;
 using namespace json_spirit;
 using namespace dev;
 using namespace dev::eth;
+namespace fs = boost::filesystem;
 
 namespace dev {  namespace test {
 
@@ -165,12 +167,12 @@ class TransactionTestSuite: public TestSuite
 		return v;
 	}//doTransactionTests
 
-	std::string suiteFolder() const override
+	fs::path suiteFolder() const override
 	{
 		return "TransactionTests";
 	}
 
-	std::string suiteFillerFolder() const override
+	fs::path suiteFillerFolder() const override
 	{
 		return "TransactionTestsFiller";
 	}

--- a/test/tools/jsontests/vm.cpp
+++ b/test/tools/jsontests/vm.cpp
@@ -464,12 +464,12 @@ class VmTestSuite: public TestSuite
 		return v;
 	}
 
-	std::string suiteFolder() const override
+	fs::path suiteFolder() const override
 	{
 		return "VMTests";
 	}
 
-	std::string suiteFillerFolder() const override
+	fs::path suiteFillerFolder() const override
 	{
 		return "VMTestsFiller";
 	}

--- a/test/tools/libtesteth/TestSuite.h
+++ b/test/tools/libtesteth/TestSuite.h
@@ -31,10 +31,10 @@ class TestSuite
 {
 protected:
 	// A folder of the test suite. like "VMTests". should be implemented for each test suite.
-	virtual std::string suiteFolder() const = 0;
+	virtual boost::filesystem::path suiteFolder() const = 0;
 
 	// A folder of the test suite in src folder. like "VMTestsFiller". should be implemented for each test suite.
-	virtual std::string suiteFillerFolder() const = 0;
+	virtual boost::filesystem::path suiteFillerFolder() const = 0;
 
 public:
 	virtual ~TestSuite() {}


### PR DESCRIPTION
This is something I demanded when I was reviewing #4527 