### PR TITLE
Avoid holding multiple locks for updating stats

### DIFF
--- a/libdevcore/vector_ref.h
+++ b/libdevcore/vector_ref.h
@@ -7,6 +7,7 @@
 #include <type_traits>
 #include <vector>
 #include <string>
+#include <atomic>
 
 #ifdef __INTEL_COMPILER
 #pragma warning(disable:597) //will not be called for implicit or explicit conversions
@@ -75,7 +76,7 @@ public:
 	/// @note adapted from OpenSSL's implementation.
 	void cleanse()
 	{
-		static unsigned char s_cleanseCounter = 0;
+		static std::atomic<unsigned char> s_cleanseCounter{0u};
 		uint8_t* p = (uint8_t*)begin();
 		size_t const len = (uint8_t*)end() - p;
 		size_t loop = len;

--- a/libethereum/BlockChain.cpp
+++ b/libethereum/BlockChain.cpp
@@ -1165,9 +1165,13 @@ void BlockChain::updateStats() const
 			m_lastStats.memBlocks += i.second.size() + 64;
 	DEV_READ_GUARDED(x_details)
 		m_lastStats.memDetails = getHashSize(m_details);
+	size_t logBloomsSize = 0;
+	size_t blocksBloomsSize = 0;
 	DEV_READ_GUARDED(x_logBlooms)
-		DEV_READ_GUARDED(x_blocksBlooms)
-			m_lastStats.memLogBlooms = getHashSize(m_logBlooms) + getHashSize(m_blocksBlooms);
+		logBloomsSize = getHashSize(m_logBlooms);
+	DEV_READ_GUARDED(x_blocksBlooms)
+		blocksBloomsSize = getHashSize(m_blocksBlooms);
+	m_lastStats.memLogBlooms = logBloomsSize + blocksBloomsSize;
 	DEV_READ_GUARDED(x_receipts)
 		m_lastStats.memReceipts = getHashSize(m_receipts);
 	DEV_READ_GUARDED(x_blockHashes)
@@ -1188,13 +1192,6 @@ void BlockChain::garbageCollect(bool _force)
 	m_lastCollection = chrono::system_clock::now();
 
 	Guard l(x_cacheUsage);
-	WriteGuard l1(x_blocks);
-	WriteGuard l2(x_details);
-	WriteGuard l3(x_blockHashes);
-	WriteGuard l4(x_receipts);
-	WriteGuard l5(x_logBlooms);
-	WriteGuard l6(x_transactionAddresses);
-	WriteGuard l7(x_blocksBlooms);
 	for (CacheID const& id: m_cacheUsage.back())
 	{
 		m_inUse.erase(id);
@@ -1202,23 +1199,44 @@ void BlockChain::garbageCollect(bool _force)
 		switch (id.second)
 		{
 		case (unsigned)-1:
+		{
+			WriteGuard l(x_blocks);
 			m_blocks.erase(id.first);
 			break;
+		}
 		case ExtraDetails:
+		{
+			WriteGuard l(x_details);
 			m_details.erase(id.first);
 			break;
+		}
+		case ExtraBlockHash:
+
+		// TODO: ExtraBlockHash seems missing.
 		case ExtraReceipts:
+		{
+			WriteGuard l(x_receipts);
 			m_receipts.erase(id.first);
 			break;
+		}
 		case ExtraLogBlooms:
+		{
+			WriteGuard l(x_logBlooms);
 			m_logBlooms.erase(id.first);
 			break;
+		}
 		case ExtraTransactionAddress:
+		{
+			WriteGuard l(x_transactionAddresses);
 			m_transactionAddresses.erase(id.first);
 			break;
+		}
 		case ExtraBlocksBlooms:
+		{
+			WriteGuard l(x_blocksBlooms);
 			m_blocksBlooms.erase(id.first);
 			break;
+		}
 		}
 	}
 	m_cacheUsage.pop_back();

--- a/libethereum/BlockChain.cpp
+++ b/libethereum/BlockChain.cpp
@@ -31,6 +31,7 @@
 #include <libdevcore/RLP.h>
 #include <libdevcore/TrieHash.h>
 #include <libdevcore/FileSystem.h>
+#include <libdevcore/FixedHash.h>
 #include <libethcore/Exceptions.h>
 #include <libethcore/BlockHeader.h>
 
@@ -1211,8 +1212,11 @@ void BlockChain::garbageCollect(bool _force)
 			break;
 		}
 		case ExtraBlockHash:
-
-		// TODO: ExtraBlockHash seems missing.
+		{
+			// m_cacheUsage should not contain ExtraBlockHash elements currently.  See the second noteUsed() in BlockChain.h, which is a no-op.
+			assert(false);
+			break;
+		}
 		case ExtraReceipts:
 		{
 			WriteGuard l(x_receipts);

--- a/libp2p/Host.cpp
+++ b/libp2p/Host.cpp
@@ -143,16 +143,10 @@ void Host::stop()
 	// such tasks may involve socket reads from Capabilities that maintain references
 	// to resources we're about to free.
 
-	{
-		// Although m_run is set by stop() or start(), it effects m_runTimer so x_runTimer is used instead of a mutex for m_run.
-		Guard l(x_runTimer);
-		// ignore if already stopped/stopping
-		if (!m_run)
-			return;
-		
-		// signal run() to prepare for shutdown and reset m_timer
-		m_run = false;
-	}
+	// ignore if already stopped/stopping, at the same time,
+	// signal run() to prepare for shutdown and reset m_timer
+	if (!m_run.exchange(false))
+		return;
 
 	// wait for m_timer to reset (indicating network scheduler has stopped)
 	while (!!m_timer)

--- a/libp2p/Host.cpp
+++ b/libp2p/Host.cpp
@@ -942,6 +942,16 @@ void Host::restoreNetwork(bytesConstRef _b)
 	}
 }
 
+bool Host::peerSlotsAvailable(Host::PeerSlotType _type)
+{
+	size_t peerNodeConns = 0;
+	{
+		Guard l(x_pendingNodeConns);
+		peerNodeConns = m_pendingPeerConns.size();
+	}
+	return peerCount() + peerNodeConns < peerSlots(_type);
+}
+
 KeyPair Host::networkAlias(bytesConstRef _b)
 {
 	RLP r(_b);

--- a/libp2p/Host.h
+++ b/libp2p/Host.h
@@ -29,6 +29,7 @@
 #include <memory>
 #include <utility>
 #include <thread>
+#include <atomic>
 #include <chrono>
 
 #include <libdevcore/Guards.h>
@@ -194,7 +195,7 @@ public:
 	std::string listenAddress() const { return m_tcpPublic.address().is_unspecified() ? "0.0.0.0" : m_tcpPublic.address().to_string(); }
 
 	/// Get the port we're listening on currently.
-	unsigned short listenPort() const { return std::max(0, m_listenPort); }
+	unsigned short listenPort() const { return std::max(0, m_listenPort.load()); }
 
 	/// Serialise the set of known peers.
 	bytes saveNetwork() const;
@@ -296,7 +297,7 @@ private:
 	/// Interface addresses (private, public)
 	std::set<bi::address> m_ifAddresses;								///< Interface addresses.
 
-	int m_listenPort = -1;												///< What port are we listening on. -1 means binding failed or acceptor hasn't been initialized.
+	std::atomic<int> m_listenPort{-1};												///< What port are we listening on. -1 means binding failed or acceptor hasn't been initialized.
 
 	ba::io_service m_ioService;											///< IOService for network stuff.
 	bi::tcp::acceptor m_tcp4Acceptor;										///< Listening acceptor.

--- a/libp2p/Host.h
+++ b/libp2p/Host.h
@@ -287,8 +287,7 @@ private:
 
 	bytes m_restoreNetwork;										///< Set by constructor and used to set Host key and restore network peers & nodes.
 
-	bool m_run = false;													///< Whether network is running.
-	mutable std::mutex x_runTimer;	///< Start/stop mutex.
+	std::atomic<bool> m_run{false};													///< Whether network is running.
 
 	std::string m_clientVersion;											///< Our version string.
 
@@ -303,6 +302,7 @@ private:
 	bi::tcp::acceptor m_tcp4Acceptor;										///< Listening acceptor.
 
 	std::unique_ptr<boost::asio::deadline_timer> m_timer;					///< Timer which, when network is running, calls scheduler() every c_timerInterval ms.
+	mutable std::mutex x_runTimer;	///< Start/stop mutex.
 	static const unsigned c_timerInterval = 100;							///< Interval which m_timer is run when network is connected.
 
 	std::set<Peer*> m_pendingPeerConns;									/// Used only by connect(Peer&) to limit concurrently connecting to same node. See connect(shared_ptr<Peer>const&).

--- a/libp2p/Host.h
+++ b/libp2p/Host.h
@@ -260,7 +260,7 @@ private:
 	void connect(std::shared_ptr<Peer> const& _p);
 
 	/// Returns true if pending and connected peer count is less than maximum
-	bool peerSlotsAvailable(PeerSlotType _type = Ingress) { Guard l(x_pendingNodeConns); return peerCount() + m_pendingPeerConns.size() < peerSlots(_type); }
+	bool peerSlotsAvailable(PeerSlotType _type = Ingress);
 	
 	/// Ping the peers to update the latency information and disconnect peers which have timed out.
 	void keepAlivePeers();


### PR DESCRIPTION
This might fix the frequent deadlocks seen in AppVeyor.

It didn't look important to update all fields at once.