### PR TITLE
Rename bad block error message.

### DIFF
--- a/libethcore/Common.cpp
+++ b/libethcore/Common.cpp
@@ -134,7 +134,7 @@ static void badBlockInfo(BlockHeader const& _bi, string const& _err)
 	ss << c_border + "  Import Failure     " + _err + string(max<int>(0, 53 - _err.size()), ' ') + "  " + c_border << "\n";
 	ss << c_space << "\n";
 	string bin = toString(_bi.number());
-	ss << c_border + ("                     Guru Meditation #" + string(max<int>(0, 8 - bin.size()), '0') + bin + "." + _bi.hash().abridged() + "                    ") + c_border << "\n";
+	ss << c_border + ("                     Bad Block #" + string(max<int>(0, 8 - bin.size()), '0') + bin + "." + _bi.hash().abridged() + "                    ") + c_border << "\n";
 	ss << c_space << "\n";
 	ss << c_line;
 	cwarn << "\n" + ss.str();


### PR DESCRIPTION
Discussed in Issue:  #4301. This is a more explicit error message for bad blocks. 