### PR TITLE
Avoid race condition in vptr lookup

### DIFF
--- a/eth/main.cpp
+++ b/eth/main.cpp
@@ -282,10 +282,10 @@ public:
 	bool shouldExit() const { return s_shouldExit; }
 
 private:
-	static bool s_shouldExit;
+	static std::atomic<bool> s_shouldExit;
 };
 
-bool ExitHandler::s_shouldExit = false;
+std::atomic<bool> ExitHandler::s_shouldExit = {false};
 
 int main(int argc, char** argv)
 {

--- a/libdevcore/Worker.cpp
+++ b/libdevcore/Worker.cpp
@@ -31,6 +31,7 @@ void Worker::startWorking()
 {
 //	cnote << "startWorking for thread" << m_name;
 	std::unique_lock<std::mutex> l(x_work);
+	assert (m_state != WorkerState::Constructor); // Vptr table should be ready here! Have you called allowVprAccess();?
 	if (m_work)
 	{
 		WorkerState ex = WorkerState::Stopped;
@@ -94,10 +95,9 @@ void Worker::startWorking()
 		}));
 //		cnote << "Spawning" << m_name;
 	}
-
 	DEV_TIMED_ABOVE("Start worker", 100)
 		while (m_state == WorkerState::Starting)
-			m_state_notifier.wait(l);
+			m_state_notifier.wait(l); // waiting
 }
 
 void Worker::stopWorking()
@@ -134,6 +134,7 @@ void Worker::terminate()
 
 void Worker::allowVptrAccess()
 {
+	Guard l(x_work);
 	m_state = WorkerState::Starting;
 	m_state_notifier.notify_all();
 }

--- a/libdevcore/Worker.h
+++ b/libdevcore/Worker.h
@@ -68,13 +68,19 @@ protected:
 	void setName(std::string _n) { if (!isWorking()) m_name = _n; }
 
 	/// Starts worker thread; causes startedWorking() to be called.
+	/// Should not be called until vptr table is ready.
 	void startWorking();
 	
 	/// Stop worker thread; causes call to stopWorking().
 	void stopWorking();
 
 	/// Returns if worker thread is present.
-	bool isWorking() const { Guard l(x_work); return m_state == WorkerState::Started; }
+	bool isWorking() const { return m_state == WorkerState::Started; }
+
+	/// Returns if still vptr table is in construction.
+	bool inConstructor() const { return m_state == WorkerState::Constructor; }
+	
+	bool isStarting() const { return m_state == WorkerState::Starting; }
 	
 	/// Called after thread is started from startWorking().
 	virtual void startedWorking() {}

--- a/libdevcore/Worker.h
+++ b/libdevcore/Worker.h
@@ -38,6 +38,7 @@ enum class IfRunning
 
 enum class WorkerState
 {
+	Constructor,
 	Starting,
 	Started,
 	Stopping,
@@ -95,16 +96,20 @@ protected:
 	/// This has to be called in the destructor of any derived class.  Otherwise the worker thread will try to lookup vptrs.
 	void terminate();
 
+	/// Start threads.
+	/// This has to be called in the constructor of any most-derived class, to notify that vptr is ready.
+	void allowVptrAccess();
+
 private:
 
 	std::string m_name;
 
 	unsigned m_idleWaitMs = 0;
 	
-	mutable Mutex x_work;						///< Lock for the network existance and m_state_notifier.
+	mutable Mutex x_work;						///< Lock for the network existance, m_state_notifier and vptr table.
 	std::unique_ptr<std::thread> m_work;		///< The network thread.
     mutable std::condition_variable m_state_notifier; //< Notification when m_state changes.
-	std::atomic<WorkerState> m_state = {WorkerState::Starting};
+	std::atomic<WorkerState> m_state = {WorkerState::Constructor};
 };
 
 }

--- a/libethashseal/EthashCPUMiner.cpp
+++ b/libethashseal/EthashCPUMiner.cpp
@@ -37,6 +37,7 @@ unsigned EthashCPUMiner::s_numInstances = 0;
 EthashCPUMiner::EthashCPUMiner(GenericMiner<EthashProofOfWork>::ConstructionInfo const& _ci):
 	GenericMiner<EthashProofOfWork>(_ci), Worker("miner" + toString(index()))
 {
+	allowVptrAccess();
 }
 
 EthashCPUMiner::~EthashCPUMiner()

--- a/libethashseal/EthashClient.cpp
+++ b/libethashseal/EthashClient.cpp
@@ -58,6 +58,7 @@ EthashClient::EthashClient(
 	// will throw if we're not an Ethash seal engine.
 	asEthashClient(*this);
 	allowVptrAccess();
+	startWorking();
 }
 
 Ethash* EthashClient::ethash() const

--- a/libethashseal/EthashClient.cpp
+++ b/libethashseal/EthashClient.cpp
@@ -53,7 +53,7 @@ EthashClient::EthashClient(
 	WithExisting _forceAction,
 	TransactionQueue::Limits const& _limits
 ):
-	Client(_params, _networkID, _host, _gpForAdoption, _dbPath, _forceAction, _limits)
+	Client(_params, _networkID, _host, _gpForAdoption, false, _dbPath, _forceAction, _limits)
 {
 	// will throw if we're not an Ethash seal engine.
 	asEthashClient(*this);

--- a/libethashseal/EthashClient.cpp
+++ b/libethashseal/EthashClient.cpp
@@ -57,6 +57,7 @@ EthashClient::EthashClient(
 {
 	// will throw if we're not an Ethash seal engine.
 	asEthashClient(*this);
+	allowVptrAccess();
 }
 
 Ethash* EthashClient::ethash() const

--- a/libethereum/BlockChainSync.h
+++ b/libethereum/BlockChainSync.h
@@ -140,7 +140,7 @@ private:
 	EthereumHost& m_host;
 	Handler<> m_bqRoomAvailable;				///< Triggered once block queue has space for more blocks
 	mutable RecursiveMutex x_sync;
-	SyncState m_state = SyncState::Idle;		///< Current sync state
+	std::atomic<SyncState> m_state = {SyncState::Idle};		///< Current sync state
 	h256Hash m_knownNewHashes; 					///< New hashes we know about use for logging only
 	unsigned m_chainStartBlock = 0;
 	unsigned m_startingBlock = 0;      	    	///< Last block number for the start of sync

--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -123,7 +123,6 @@ void Client::init(p2p::Host* _extNet, fs::path const& _dbPath, WithExisting _for
 	if (_dbPath.size())
 		Defaults::setDBPath(_dbPath);
 	doWork(false);
-	startWorking();
 }
 
 ImportResult Client::queueBlock(bytes const& _block, bool _isSafe)

--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -63,6 +63,7 @@ Client::Client(
 	int _networkID,
 	p2p::Host* _host,
 	std::shared_ptr<GasPricer> _gpForAdoption,
+	bool _final,
 	fs::path const& _dbPath,
 	WithExisting _forceAction,
 	TransactionQueue::Limits const& _l
@@ -76,6 +77,8 @@ Client::Client(
 	m_working(chainParams().accountStartNonce)
 {
 	init(_host, _dbPath, _forceAction, _networkID);
+	if (_final)
+		allowVptrAccess();
 }
 
 Client::~Client()

--- a/libethereum/Client.h
+++ b/libethereum/Client.h
@@ -83,6 +83,7 @@ public:
 		int _networkID,
 		p2p::Host* _host,
 		std::shared_ptr<GasPricer> _gpForAdoption,
+		bool _final, // true when no derived object is to be constructed!
 		boost::filesystem::path const& _dbPath = boost::filesystem::path(),
 		WithExisting _forceAction = WithExisting::Trust,
 		TransactionQueue::Limits const& _l = TransactionQueue::Limits{1024, 1024}

--- a/libethereum/ClientTest.cpp
+++ b/libethereum/ClientTest.cpp
@@ -49,7 +49,9 @@ ClientTest::ClientTest(
 	TransactionQueue::Limits const& _limits
 ):
 	Client(_params, _networkID, _host, _gpForAdoption, _dbPath, _forceAction, _limits)
-{}
+{
+	allowVptrAccess();
+}
 
 void ClientTest::setChainParams(string const& _genesis)
 {

--- a/libethereum/ClientTest.cpp
+++ b/libethereum/ClientTest.cpp
@@ -51,6 +51,7 @@ ClientTest::ClientTest(
 	Client(_params, _networkID, _host, _gpForAdoption, _dbPath, _forceAction, _limits)
 {
 	allowVptrAccess();
+	startWorking();
 }
 
 void ClientTest::setChainParams(string const& _genesis)

--- a/libethereum/ClientTest.cpp
+++ b/libethereum/ClientTest.cpp
@@ -48,7 +48,7 @@ ClientTest::ClientTest(
 	WithExisting _forceAction,
 	TransactionQueue::Limits const& _limits
 ):
-	Client(_params, _networkID, _host, _gpForAdoption, _dbPath, _forceAction, _limits)
+	Client(_params, _networkID, _host, _gpForAdoption, false, _dbPath, _forceAction, _limits)
 {
 	allowVptrAccess();
 	startWorking();

--- a/libethereum/EthereumHost.cpp
+++ b/libethereum/EthereumHost.cpp
@@ -390,6 +390,7 @@ EthereumHost::EthereumHost(BlockChain const& _ch, OverlayDB const& _db, Transact
 	m_peerObserver = make_shared<EthereumPeerObserver>(*m_sync, x_sync, m_tq);
 	m_latestBlockSent = _ch.currentHash();
 	m_tq.onImport([this](ImportResult _ir, h256 const& _h, h512 const& _nodeId) { onTransactionImported(_ir, _h, _nodeId); });
+	allowVptrAccess();
 }
 
 EthereumHost::~EthereumHost()

--- a/libp2p/Host.cpp
+++ b/libp2p/Host.cpp
@@ -127,7 +127,7 @@ void Host::start()
 {
 	DEV_TIMED_FUNCTION_ABOVE(500);
 	startWorking();
-	while (isWorking() && !haveNetwork())
+	while (inConstructor() || isStarting() || (isWorking() && !haveNetwork()))
 		this_thread::sleep_for(chrono::milliseconds(10));
 	
 	// network start failed!

--- a/libp2p/Host.cpp
+++ b/libp2p/Host.cpp
@@ -114,6 +114,7 @@ Host::Host(string const& _clientVersion, NetworkPreferences const& _n, bytesCons
 	Host(_clientVersion, networkAlias(_restoreNetwork), _n)
 {
 	m_restoreNetwork = _restoreNetwork.toBytes();
+	allowVptrAccess();
 }
 
 Host::~Host()

--- a/libwebthree/WebThree.cpp
+++ b/libwebthree/WebThree.cpp
@@ -60,7 +60,7 @@ WebThreeDirect::WebThreeDirect(
 		else if (_params.sealEngineName == "NoProof" && _testing)
 			m_ethereum.reset(new eth::ClientTest(_params, (int)_params.networkID, &m_net, shared_ptr<GasPricer>(), _dbPath, _we));
 		else
-			m_ethereum.reset(new eth::Client(_params, (int)_params.networkID, &m_net, shared_ptr<GasPricer>(), _dbPath, _we));
+			m_ethereum.reset(new eth::Client(_params, (int)_params.networkID, &m_net, shared_ptr<GasPricer>(), true, _dbPath, _we));
 		string bp = DEV_QUOTED(ETH_BUILD_PLATFORM);
 		vector<string> bps;
 		boost::split(bps, bp, boost::is_any_of("/"));

--- a/libwhisper/WhisperHost.cpp
+++ b/libwhisper/WhisperHost.cpp
@@ -33,6 +33,7 @@ using namespace dev::shh;
 WhisperHost::WhisperHost(bool _storeMessagesInDB): Worker("shh"), m_storeMessagesInDB(_storeMessagesInDB)
 {
 	loadMessagesFromBD();
+	allowVptrAccess();
 }
 
 WhisperHost::~WhisperHost()

--- a/test/unittests/libp2p/net.cpp
+++ b/test/unittests/libp2p/net.cpp
@@ -125,9 +125,9 @@ struct TestNodeTable: public NodeTable
 /**
  * Only used for testing. Not useful beyond tests.
  */
-struct TestNodeTableHost: public TestHost
+struct TestNodeTableHost final: public TestHost
 {
-	TestNodeTableHost(unsigned _count = 8): m_alias(KeyPair::create()), nodeTable(new TestNodeTable(m_io, m_alias, bi::address::from_string("127.0.0.1"))), testNodes(TestNodeTable::createTestNodes(_count)) {};
+	TestNodeTableHost(unsigned _count = 8): m_alias(KeyPair::create()), nodeTable(new TestNodeTable(m_io, m_alias, bi::address::from_string("127.0.0.1"))), testNodes(TestNodeTable::createTestNodes(_count)) { allowVptrAccess(); };
 	~TestNodeTableHost() { m_io.stop(); stopWorking(); }
 
 	void setup() { for (auto n: testNodes) nodeTables.push_back(make_shared<TestNodeTable>(m_io,n.first, bi::address::from_string("127.0.0.1"),n.second)); }
@@ -144,10 +144,10 @@ struct TestNodeTableHost: public TestHost
 	std::vector<shared_ptr<TestNodeTable>> nodeTables;
 };
 
-class TestUDPSocket: UDPSocketEvents, public TestHost
+class TestUDPSocket final: UDPSocketEvents, public TestHost
 {
 public:
-	TestUDPSocket(unsigned _port): m_socket(new UDPSocket<TestUDPSocket, 1024>(m_io, *this, _port)) {}
+	TestUDPSocket(unsigned _port): m_socket(new UDPSocket<TestUDPSocket, 1024>(m_io, *this, _port)) { allowVptrAccess(); }
 
 	void onDisconnected(UDPSocketFace*) {};
 	void onReceived(UDPSocketFace*, bi::udp::endpoint const&, bytesConstRef _packet) { if (_packet.toString() == "AAAA") success = true; }


### PR DESCRIPTION
This PR removes some race conditions ThreadSanitizer reported during `eth/eth` runs.

Fixes #4544 