### PR TITLE
Fix hang during sync with Ropsten

### DIFF
--- a/libethereum/BlockChainSync.cpp
+++ b/libethereum/BlockChainSync.cpp
@@ -465,6 +465,16 @@ void BlockChainSync::onPeerBlockHeaders(std::shared_ptr<EthereumPeer> _peer, RLP
 			m_haveCommonHeader = true;
 			m_lastImportedBlock = (unsigned)info.number();
 			m_lastImportedBlockHash = info.hash();
+		
+			if (!m_headers.empty() && m_headers.begin()->first == m_lastImportedBlock + 1 && 
+				m_headers.begin()->second[0].parent != m_lastImportedBlockHash)
+			{
+				// Start of the header chain in m_headers doesn't match our known chain,
+				// probably we've downloaded other fork
+				clog(NetWarn) << "Unknown parent of the downloaded headers, restarting sync";
+				restartSync();
+				return;
+			}
 		}
 		else
 		{


### PR DESCRIPTION
What was happening: 
- while being already synced, the node received some hashes or blocks from the pre-Byzantium ropsten fork node, 
- started downloading this other fork backwards (this is intended behaivior),
- then at some point received (old) headers from the Byzantium node, 
- set `m_haveCommonHeader = true` (we found the common block) here https://github.com/ethereum/cpp-ethereum/pull/4570/files#diff-9f5b8b62d8ddf0597e54e7c46e236653R465 going into the mode "fork block found, downloading bodies from there onward and pushing into BlockQueue".

This doesn't seem right because we haven't really found the fork block but in fact found that our downloaded chain doesn't match the existing chain in db. 

So the easy fix is to restart downloading at this point.

(actually the idea of having one `m_haveCommonHeader` flag for the whole sync process seems very confusing and probably wrong, when we have at one moment several peers belonging to different forks)