### PR TITLE
Circle CI: Add macOS and refactor config

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -42,6 +42,13 @@ defaults:
           export TMPDIR=/dev/shm
         fi
         export ETHEREUM_TEST_PATH=~/project/test/jsontests
+
+        # If the DAG file does not exist, we have to run a single test with mining
+        # to create it before we can run tests in parallel.
+        if [ ! -f ~/.ethash/full-R23-0000000000000000 ]; then
+          test/testeth -t BlockChainSuite/updateStats
+        fi
+
         ctest --output-on-failure -j $TEST_PARALLEL_JOBS
 
   store-eth: &store-eth
@@ -139,7 +146,7 @@ jobs:
       - run:
           name: "Install macOS dependencies"
           command: |
-            pip install -q requests &
+            pip install -q requests codecov &
             HOMEBREW_NO_AUTO_UPDATE=1 brew install -q cmake ninja leveldb libmicrohttpd &
             wait
       - *restore-deps-cache

--- a/circle.yml
+++ b/circle.yml
@@ -1,102 +1,165 @@
-default-steps: &default-steps
-  - checkout
+defaults:
 
-  - run:
-      name: "Init submodules"
-      command: git submodule update --init
+  update-submodules: &update-submodules
+    run:
+      name: "Update git submodules"
+      command: git submodule update --init --depth 20
 
-  - run:
+  upload-hunter-cache: &upload-hunter-cache
+    run:
+      name: "Upload Hunter cache"
+      command: |  # Upload Hunter cache if not PR build.
+        if [ ! "$CIRCLE_PR_NUMBER" ]; then
+          cmake --build build --target hunter_upload_cache
+        fi
+
+  environment-info: &environment-info
+    run:
       name: "Environment info"
       command: |
         echo CXX: $CXX
         $CXX --version
         $CXX --version > compiler.version
 
-  - cache-restore:
-      name: "Restore dependencies cache"
-      key: &deps-cache-key deps-1-{{arch}}-{{checksum "compiler.version"}}-{{checksum "cmake/ProjectJsonRpcCpp.cmake"}}
-
-  - run:
+  configure: &configure
+    run:
       name: "Configure"
       command: |
         mkdir -p build && cd build
-        cmake .. -G "${GENERATOR}" -DCOVERAGE=ON
+        cmake .. -G "$GENERATOR" -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCOVERAGE=ON $CMAKE_OPTIONS
 
-  - run:
-      name: "Upload Hunter cache"
-      command: |
-        if [ ! "$CIRCLE_PR_NUMBER" ]; then  # Skip forked PRs.
-          cmake --build build --target hunter_upload_cache
-        fi
-
-  - run:
+  build: &build
+    run:
       name: "Build"
+      command: cmake --build build -- -j $BUILD_PARALLEL_JOBS
+
+  test: &test
+    run:
+      name: "Test"
+      pwd: build
       command: |
-        cmake --build build -- -j $BUILD_PARALLEL_JOBS
+        if [ $(uname) = Linux ]; then
+          export TMPDIR=/dev/shm
+        fi
+        export ETHEREUM_TEST_PATH=~/project/test/jsontests
+        ctest --output-on-failure -j $TEST_PARALLEL_JOBS
 
-  - cache-save:
-      name: "Save dependencies cache"
-      key: *deps-cache-key
-      paths:
-        - ~/cpp-ethereum/build/deps
-
-  - store_artifacts:
+  store-eth: &store-eth
+    store_artifacts:
       path: build/eth/eth
       destination: eth
 
-  - cache-restore:
-      name: "Restore Ethash DAG file"
-      key: ethash-dag0
+  save-deps-cache: &save-deps-cache
+    cache-save:
+      name: "Save dependencies cache"
+      key: &deps-cache-key deps-2-{{arch}}-{{checksum "compiler.version"}}-{{checksum "cmake/ProjectJsonRpcCpp.cmake"}}
+      paths:
+        - build/deps
 
-  - run:
-      name: "Test"
-      pwd: ~/cpp-ethereum/build
-      command: |
-        export ETHEREUM_TEST_PATH=~/cpp-ethereum/test/jsontests
-        export TMPDIR=/dev/shm
-        CTEST_OUTPUT_ON_FAILURE=1 ctest -j8
+  restore-deps-cache: &restore-deps-cache
+    cache-restore:
+      name: "Restore dependencies cache"
+      key: *deps-cache-key
 
-  - cache-save:
+  save-ethash-dag: &save-ethash-dag
+    cache-save:
       name: "Save Ethash DAG file"
-      key: ethash-dag0
+      key: &ethash-dag-key ethash-dag0-{{arch}}
       paths:
         - ~/.ethash/full-R23-0000000000000000
 
-  - run:
-      name: "Code coverage"
-      pwd: ~/cpp-ethereum/build
-      command: |
-        bash <(curl -s https://codecov.io/bash) -X fix
+  restore-ethash-dag: &restore-ethash-dag
+    cache-restore:
+      name: "Restore Ethash DAG file"
+      key: *ethash-dag-key
+
+  upload-coverage-data: &upload-coverage-data
+    run:
+      name: "Upload coverage data"
+      pwd: build
+      command: codecov
+
+  linux-steps: &linux-steps
+    - checkout
+    - *update-submodules
+    - *environment-info
+    - *restore-deps-cache
+    - *configure
+    - *upload-hunter-cache
+    - *build
+    - *save-deps-cache
+    - *store-eth
+    - *restore-ethash-dag
+    - *test
+    - *save-ethash-dag
+    - *upload-coverage-data
+
 
 version: 2
 jobs:
 
-  default-clang5-ninja:
+  Linux-Clang5:
     environment:
       - CXX: clang++-5.0
       - CC:  clang-5.0
       - GENERATOR: Ninja
       - BUILD_PARALLEL_JOBS: 8
+      - TEST_PARALLEL_JOBS: 8
     docker:
       - image: ethereum/cpp-build-env
-    working_directory: ~/cpp-ethereum
-    steps: *default-steps
+    steps: *linux-steps
 
-  debug-gcc6-ninja:
+  Linux-GCC6-Debug:
     environment:
       - BUILD_TYPE: Debug
       - CXX: g++-6
       - CC:  gcc-6
       - GENERATOR: Ninja
       - BUILD_PARALLEL_JOBS: 4
+      - TEST_PARALLEL_JOBS: 4
+      # TODO: Fix memory leaks reported in leveldb.
+      # - CMAKE_OPTIONS: -DSANITIZE=address
+      # - ASAN_OPTIONS: detect_leaks=0
     docker:
       - image: ethereum/cpp-build-env
-    working_directory: ~/cpp-ethereum
-    steps: *default-steps
+    steps: *linux-steps
 
+  macOS-XCode9:
+    environment:
+      - CXX: clang++
+      - GENERATOR: Ninja
+      - BUILD_PARALLEL_JOBS: 8
+      - TEST_PARALLEL_JOBS: 8
+    macos:
+      xcode: "9.0"
+    steps:
+      - checkout
+      - *update-submodules
+      - *environment-info
+      - run:
+          name: "Install macOS dependencies"
+          command: |
+            pip install -q requests &
+            HOMEBREW_NO_AUTO_UPDATE=1 brew install -q cmake ninja leveldb libmicrohttpd &
+            wait
+      - *restore-deps-cache
+      - *configure
+      - *upload-hunter-cache
+      - *build
+      - *save-deps-cache
+      - *store-eth
+      - *restore-ethash-dag
+      - *test
+      - *save-ethash-dag
+      - *upload-coverage-data
+
+# TODO: Run GCC6 build only in develop branch.
+# TODO: Enabled nightly builds and add more configs.
+# TODO: Separate builds from testing jobs.
 workflows:
   version: 2
   cpp-ethereum:
     jobs:
-      - default-clang5-ninja
-      - debug-gcc6-ninja
+      - macOS-XCode9
+      - Linux-Clang5
+      - Linux-GCC6-Debug


### PR DESCRIPTION
1. This adds macOS build on Circle CI. This is experimental feature of Circle CI (we have beta access to it). The macOS build sometimes fails to start. Circle CI should restart such builds automatically.
2. ctest seems to be nice testing frontend. It outputs nice logs for remove CI services. Pay attentions to timings there -- some tests are running a long time.
3. The "updateStats" test is unstable and sometimes crashes.
4. Because of (3) I added also ASan build with GCC6. It shows other issues in tests.
5. Read also the TODO list in circle.yml file.