### PR TITLE
add known genesis fields for blockchain tests

### DIFF
--- a/libethereum/ChainParams.cpp
+++ b/libethereum/ChainParams.cpp
@@ -164,10 +164,18 @@ string const c_timestamp = "timestamp";
 string const c_extraData = "extraData";
 string const c_mixHash = "mixHash";
 string const c_nonce = "nonce";
+string const c_number = "number";
+string const c_bloom = "bloom";
+string const c_hash = "hash";
+string const c_receiptTrie = "receiptTrie";
+string const c_stateRoot = "stateRoot";
+string const c_transactionsTrie = "transactionsTrie";
+string const c_uncleHash = "uncleHash";
 
 set<string> const c_knownGenesisFields = {
 	c_parentHash, c_coinbase, c_author, c_difficulty, c_gasLimit, c_gasUsed, c_timestamp,
-	c_extraData, c_mixHash, c_nonce
+	c_extraData, c_mixHash, c_nonce, c_number, c_bloom, c_hash, c_receiptTrie, c_stateRoot,
+	c_transactionsTrie, c_uncleHash
 };
 }
 


### PR DESCRIPTION
Fixes a side effect of https://github.com/ethereum/cpp-ethereum/issues/4514 that was causing Hive tests to fail. Blockchain tests have several [fields](https://github.com/ethereum/tests/blob/f62fab43837de07183b8d1a7dcdd5d0c0d4fb794/BlockchainTests/GeneralStateTests/stCallCodes/call_OOG_additionalGasCosts1_d0g0v0.json#L47) that were causing errors like:

```
[0a69c520] Running cpp-ethereum...
[0a69c520] Unknown field in config: bloom
[0a69c520] provided configuration is not well formatted
[0a69c520] sample: 
[0a69c520] 
[0a69c520] {    
[0a69c520]      "sealEngine": "Ethash",
[0a69c520]      "params": {
[0a69c520]              "accountStartNonce": "0x00",
[0a69c520]              "homesteadForkBlock": "0x118c30",
[0a69c520]              "daoHardforkBlock": "0x1d4c00",
[0a69c520]              "EIP150ForkBlock": "0x259518",
[0a69c520]              "EIP158ForkBlock": "0x28d138",
[0a69c520]              "byzantiumForkBlock": "0x42ae50",
[0a69c520]              "constantinopleForkBlock": "0x500000",
[0a69c520]              "networkID" : "0x01",
[0a69c520]              "chainID": "0x01",
[0a69c520]              "maximumExtraDataSize": "0x20",
[0a69c520]              "tieBreakingGas": false,
[0a69c520]              "minGasLimit": "0x1388",
[0a69c520]              "maxGasLimit": "7fffffffffffffff",
[0a69c520]              "gasLimitBoundDivisor": "0x0400",
[0a69c520]              "minimumDifficulty": "0x020000",
[0a69c520]              "difficultyBoundDivisor": "0x0800",
[0a69c520]              "durationLimit": "0x0d",
[0a69c520]              "blockReward": "0x4563918244F40000"
[0a69c520]      },      
[0a69c520]      "genesis": {
[0a69c520]              "nonce": "0x0000000000000042",
[0a69c520]              "difficulty": "0x400000000",
[0a69c520]              "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
[0a69c520]              "author": "0x0000000000000000000000000000000000000000",
[0a69c520]              "timestamp": "0x00",
[0a69c520]              "parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
[0a69c520]              "extraData": "0x11bbe8db4e347b4e8c937c1c8370e4b5ed33adb3db69cbdb7a38e1e50b1b82fa",
[0a69c520]              "gasLimit": "0x1388"
[0a69c520]      },      
[0a69c520]      "accounts": {
[0a69c520]              "0000000000000000000000000000000000000001": { "precompiled": { "name": "ecrecover", "linear": { "base": 3000, "word": 0 } } },
[0a69c520]              "0000000000000000000000000000000000000002": { "precompiled": { "name": "sha256", "linear": { "base": 60, "word": 12 } } },
[0a69c520]              "0000000000000000000000000000000000000003": { "precompiled": { "name": "ripemd160", "linear": { "base": 600, "word": 120 } } },
[0a69c520]              "0000000000000000000000000000000000000004": { "precompiled": { "name": "identity", "linear": { "base": 15, "word": 3 } } },
[0a69c520]              "0000000000000000000000000000000000000005": { "precompiled": { "name": "modexp", "startingBlock" : "0x2dc6c0" } },
[0a69c520]              "0000000000000000000000000000000000000006": { "precompiled": { "name": "alt_bn128_G1_add", "startingBlock" : "0x2dc6c0", "linear": { "base": 500, "word": 0 } } },
[0a69c520]              "0000000000000000000000000000000000000007": { "precompiled": { "name": "alt_bn128_G1_mul", "startingBlock" : "0x2dc6c0", "linear": { "base": 2000, "word": 0 } } },
[0a69c520]              "0000000000000000000000000000000000000008": { "precompiled": { "name": "alt_bn128_pairing_product", "startingBlock" : "0x2dc6c0" } }
[0a69c520]      }       
[0a69c520] }    
[0a69c520] 
```