### PR TITLE
tweak createRandomTest params

### DIFF
--- a/test/tools/fuzzTesting/createRandomTest.cpp
+++ b/test/tools/fuzzTesting/createRandomTest.cpp
@@ -34,8 +34,7 @@ namespace dev { namespace test {
 bool createRandomTest()
 {
 	StateTestSuite suite;
-	dev::test::Options& optionsConst = const_cast<dev::test::Options&>(dev::test::Options::get());
-	dev::test::Options& options = optionsConst;
+	dev::test::Options const& options = dev::test::Options::get();
 	if (options.rCurrentTestSuite != suite.suiteFolder())
 	{
 		std::cerr << "Error! Test suite '" + options.rCurrentTestSuite + "' not supported! (Usage -t <TestSuite>)\n";
@@ -53,7 +52,7 @@ bool createRandomTest()
 }} //namespaces
 
 //Prints a generated test Json into std::out
-std::string dev::test::RandomCode::fillRandomTest(dev::test::TestSuite const& _testSuite, std::string const& _testString, dev::test::RandomCodeOptions& _options)
+std::string dev::test::RandomCode::fillRandomTest(dev::test::TestSuite const& _testSuite, std::string const& _testString, dev::test::RandomCodeOptions const& _options)
 {
 	bool wasError = false;
 	json_spirit::mValue v;
@@ -89,7 +88,7 @@ std::string dev::test::RandomCode::fillRandomTest(dev::test::TestSuite const& _t
 }
 
 /// Parse Test string replacing keywords to fuzzed values
-void dev::test::RandomCode::parseTestWithTypes(std::string& _test, std::map<std::string, std::string> const& _varMap, RandomCodeOptions& _options)
+void dev::test::RandomCode::parseTestWithTypes(std::string& _test, std::map<std::string, std::string> const& _varMap, RandomCodeOptions const& _options)
 {
 	std::vector<std::string> types = getTypes();
 
@@ -135,13 +134,15 @@ void dev::test::RandomCode::parseTestWithTypes(std::string& _test, std::map<std:
 				replace = test::RandomCode::randomUniIntHex(dev::u256("100000"), dev::u256("36028797018963967"));
 			else if (type == "[DESTADDRESS]")
 			{
-				Address address = _options.getRandomAddress(RandomCodeOptions::AddressType::DestinationAccount);
-				if (address != ZeroAddress) //else transaction creation
+				Address address = _options.getRandomAddress(RandomCodeOptions::AddressType::PrecompiledOrStateOrCreate);
+				if (address != ZeroAddress)
 					replace = "0x" + toString(address);
+				else
+					replace = std::string(); // transaction creation
 			}
-			else if (type == "[ADDRESS]") {
-				Address destAddress = _options.getRandomAddress(RandomCodeOptions::AddressType::StateAccount);
-				_options.addAddress(destAddress, RandomCodeOptions::AddressType::DestinationAccount);
+			else if (type == "[ADDRESS]")
+			{
+				Address destAddress = _options.getRandomAddress(RandomCodeOptions::AddressType::PrecompiledOrState);
 				replace = toString(destAddress);
 			}
 			else if (type == "[0xADDRESS]") {
@@ -220,28 +221,35 @@ std::string const c_testExampleStateTest = R"(
 		"previousHash" : "[HASH32]"
 		},
 	"pre" : {
-		"[ADDRESS]" : {
+		"ffffffffffffffffffffffffffffffffffffffff" : {
 			"balance" : "[HEX]",
 			"code" : "[CODE]",
 			"nonce" : "[V]",
 			"storage" : {
 			}
 		},
-		"[ADDRESS]" : {
+		"1000000000000000000000000000000000000000" : {
 			"balance" : "[HEX]",
 			"code" : "[CODE]",
 			"nonce" : "[V]",
 			"storage" : {
 			}
 		},
-		"[ADDRESS]" : {
+		"b94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
 			"balance" : "[HEX]",
 			"code" : "[CODE]",
 			"nonce" : "[V]",
 			"storage" : {
 			}
 		},
-		"[ADDRESS]" : {
+		"c94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+			"balance" : "[HEX]",
+			"code" : "[CODE]",
+			"nonce" : "[V]",
+			"storage" : {
+			}
+		},
+		"d94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
 			"balance" : "[HEX]",
 			"code" : "[CODE]",
 			"nonce" : "[V]",

--- a/test/tools/fuzzTesting/fuzzHelper.h
+++ b/test/tools/fuzzTesting/fuzzHelper.h
@@ -52,8 +52,12 @@ struct RandomCodeOptions
 public:
 	enum AddressType{
 		Precompiled,
+		ByzantiumPrecompiled,
 		StateAccount,
+		SendingAccount,
 		PrecompiledOrStateOrCreate,
+		DestinationAccount,
+		CallAccount,
 		All
 	};
 	RandomCodeOptions();
@@ -68,11 +72,17 @@ public:
 	int emptyCodeProbability;
 	int emptyAddressProbability;
 	int precompiledAddressProbability;
+	int byzPrecompiledAddressProbability;
+	int precompiledDestProbability;
+	int sendingAddressProbability;
 
 private:
 	std::map<int, int> mapWeights;
 	std::vector<dev::Address> precompiledAddressList;
+	std::vector<dev::Address> byzPrecompiledAddressList;
 	std::vector<dev::Address> stateAddressList;
+	std::vector<dev::Address> sendingAddressList;
+	std::vector<dev::Address> destinationAddressList;
 };
 
 enum class SizeStrictness
@@ -91,10 +101,10 @@ class RandomCode
 {
 public:
 	/// Generate random vm code
-	static std::string generate(int _maxOpNumber, RandomCodeOptions const& _options);
+	static std::string generate(int _maxOpNumber, RandomCodeOptions& _options);
 
 	/// Replace keywords in given string with values
-	static void parseTestWithTypes(std::string& _test, std::map<std::string, std::string> const& _varMap, RandomCodeOptions const& _options);
+	static void parseTestWithTypes(std::string& _test, std::map<std::string, std::string> const& _varMap, RandomCodeOptions& _options);
 	static void parseTestWithTypes(std::string& _test, std::map<std::string, std::string> const& _varMap)
 	{
 		RandomCodeOptions defaultOptions;
@@ -103,7 +113,8 @@ public:
 
 	// Returns empty string if there was an error, a filled test otherwise.
 	// prints test to the std::out or std::error if error when filling
-	static std::string fillRandomTest(dev::test::TestSuite const& _testSuite, std::string const& _testFillerTemplate, dev::test::RandomCodeOptions const& _options);
+	static std::string fillRandomTest(dev::test::TestSuite const& _testSuite, std::string const& _testFillerTemplate, dev::test::RandomCodeOptions& _options);
+
 
 	/// Generate random byte string of a given length
 	static std::string rndByteSequence(int _length = 1, SizeStrictness _sizeType = SizeStrictness::Strict);
@@ -125,7 +136,7 @@ public:
 	static int weightedOpcode(std::vector<int>& _weights);
 
 private:
-	static std::string fillArguments(dev::eth::Instruction _opcode, RandomCodeOptions const& _options);
+	static std::string fillArguments(dev::eth::Instruction _opcode, RandomCodeOptions& _options);
 	static std::string getPushCode(int _value);
 	static std::string getPushCode(std::string const& _hex);
 	static int recursiveRLP(std::string& _result, int _depth, std::string& _debug);
@@ -137,12 +148,14 @@ private:
 	static IntDistrib percentDist;			///< 0..100 percent
 	static IntDistrib opLengDist;			///< 1..32  byte string
 	static IntDistrib opMemrDist;			///< 1..10MB  byte string
+	static IntDistrib opSmallMemrDist; // 0..1kb
 	static IntDistrib uniIntDist;			///< 0..0x7fffffff
 
 	static IntGenerator randUniIntGen;		///< Generate random UniformInt from uniIntDist
 	static IntGenerator randOpCodeGen;		///< Generate random value from opCodeDist
 	static IntGenerator randOpLengGen;		///< Generate random length from opLengDist
 	static IntGenerator randOpMemrGen;		///< Generate random length from opMemrDist
+	static IntGenerator randoOpSmallMemrGen;		///< Generate random length from opSmallMemrDist
 };
 
 }

--- a/test/tools/fuzzTesting/fuzzHelper.h
+++ b/test/tools/fuzzTesting/fuzzHelper.h
@@ -56,8 +56,7 @@ public:
 		StateAccount,
 		SendingAccount,
 		PrecompiledOrStateOrCreate,
-		DestinationAccount,
-		CallAccount,
+		PrecompiledOrState,
 		All
 	};
 	RandomCodeOptions();
@@ -78,11 +77,9 @@ public:
 
 private:
 	std::map<int, int> mapWeights;
-	std::vector<dev::Address> precompiledAddressList;
-	std::vector<dev::Address> byzPrecompiledAddressList;
-	std::vector<dev::Address> stateAddressList;
-	std::vector<dev::Address> sendingAddressList;
-	std::vector<dev::Address> destinationAddressList;
+	typedef std::pair<dev::Address, AddressType> accountRecord;
+	std::vector<accountRecord> testAccounts;
+	dev::Address getRandomAddressPriv(AddressType _type) const;
 };
 
 enum class SizeStrictness
@@ -101,10 +98,10 @@ class RandomCode
 {
 public:
 	/// Generate random vm code
-	static std::string generate(int _maxOpNumber, RandomCodeOptions& _options);
+	static std::string generate(int _maxOpNumber, RandomCodeOptions const& _options);
 
 	/// Replace keywords in given string with values
-	static void parseTestWithTypes(std::string& _test, std::map<std::string, std::string> const& _varMap, RandomCodeOptions& _options);
+	static void parseTestWithTypes(std::string& _test, std::map<std::string, std::string> const& _varMap, RandomCodeOptions const& _options);
 	static void parseTestWithTypes(std::string& _test, std::map<std::string, std::string> const& _varMap)
 	{
 		RandomCodeOptions defaultOptions;
@@ -113,7 +110,7 @@ public:
 
 	// Returns empty string if there was an error, a filled test otherwise.
 	// prints test to the std::out or std::error if error when filling
-	static std::string fillRandomTest(dev::test::TestSuite const& _testSuite, std::string const& _testFillerTemplate, dev::test::RandomCodeOptions& _options);
+	static std::string fillRandomTest(dev::test::TestSuite const& _testSuite, std::string const& _testFillerTemplate, dev::test::RandomCodeOptions const& _options);
 
 
 	/// Generate random byte string of a given length
@@ -136,7 +133,7 @@ public:
 	static int weightedOpcode(std::vector<int>& _weights);
 
 private:
-	static std::string fillArguments(dev::eth::Instruction _opcode, RandomCodeOptions& _options);
+	static std::string fillArguments(dev::eth::Instruction _opcode, RandomCodeOptions const& _options);
 	static std::string getPushCode(int _value);
 	static std::string getPushCode(std::string const& _hex);
 	static int recursiveRLP(std::string& _result, int _depth, std::string& _debug);


### PR DESCRIPTION
A bit rough, but these params work well to generate interesting traces, with many CALLs succeeding so that the call depth increases. Also the Byzantium opcodes and precompiles are weighted heavier (sampled more frequently).