### PR TITLE
split large test suites

### DIFF
--- a/test/tools/jsontests/BlockChainTests.cpp
+++ b/test/tools/jsontests/BlockChainTests.cpp
@@ -1041,7 +1041,9 @@ BOOST_AUTO_TEST_CASE(stInitCodeTest){}
 BOOST_AUTO_TEST_CASE(stLogTests){}
 BOOST_AUTO_TEST_CASE(stMemoryTest){}
 BOOST_AUTO_TEST_CASE(stPreCompiledContracts){}
+BOOST_AUTO_TEST_CASE(stPreCompiledContracts2){}
 BOOST_AUTO_TEST_CASE(stRandom){}
+BOOST_AUTO_TEST_CASE(stRandom2){}
 BOOST_AUTO_TEST_CASE(stRecursiveCreate){}
 BOOST_AUTO_TEST_CASE(stRefundTest){}
 BOOST_AUTO_TEST_CASE(stSolidityTest){}
@@ -1077,6 +1079,7 @@ BOOST_AUTO_TEST_CASE(stStackTests){}
 BOOST_AUTO_TEST_CASE(stStaticCall){}
 BOOST_AUTO_TEST_CASE(stReturnDataTest){}
 BOOST_AUTO_TEST_CASE(stZeroKnowledge){}
+BOOST_AUTO_TEST_CASE(stZeroKnowledge2){}
 
 //Stress Tests
 BOOST_AUTO_TEST_CASE(stAttackTest){}

--- a/test/tools/jsontests/StateTests.cpp
+++ b/test/tools/jsontests/StateTests.cpp
@@ -153,7 +153,9 @@ BOOST_AUTO_TEST_CASE(stInitCodeTest){}
 BOOST_AUTO_TEST_CASE(stLogTests){}
 BOOST_AUTO_TEST_CASE(stMemoryTest){}
 BOOST_AUTO_TEST_CASE(stPreCompiledContracts){}
+BOOST_AUTO_TEST_CASE(stPreCompiledContracts2){}
 BOOST_AUTO_TEST_CASE(stRandom){}
+BOOST_AUTO_TEST_CASE(stRandom2){}
 BOOST_AUTO_TEST_CASE(stRecursiveCreate){}
 BOOST_AUTO_TEST_CASE(stRefundTest){}
 BOOST_AUTO_TEST_CASE(stSolidityTest){}
@@ -189,6 +191,7 @@ BOOST_AUTO_TEST_CASE(stStackTests){}
 BOOST_AUTO_TEST_CASE(stStaticCall){}
 BOOST_AUTO_TEST_CASE(stReturnDataTest){}
 BOOST_AUTO_TEST_CASE(stZeroKnowledge){}
+BOOST_AUTO_TEST_CASE(stZeroKnowledge2){}
 BOOST_AUTO_TEST_CASE(stCodeCopyTest){}
 
 //Stress Tests


### PR DESCRIPTION
for faster test execution and regeneration of the tests on threads
this PR split large test suites into smaller ones

tests: https://github.com/ethereum/tests/pull/353