### PR TITLE
Remove some ThreadSanitizer warnings

### DIFF
--- a/libdevcore/Worker.cpp
+++ b/libdevcore/Worker.cpp
@@ -103,7 +103,8 @@ void Worker::stopWorking()
 	if (m_work)
 	{
 		WorkerState ex = WorkerState::Started;
-		m_state.compare_exchange_strong(ex, WorkerState::Stopping);
+		if (!m_state.compare_exchange_strong(ex, WorkerState::Stopping))
+			return;
 		m_state_notifier.notify_all();
 
 		DEV_TIMED_ABOVE("Stop worker", 100)

--- a/libdevcore/Worker.cpp
+++ b/libdevcore/Worker.cpp
@@ -118,7 +118,8 @@ void Worker::terminate()
 	std::unique_lock<Mutex> l(x_work);
 	if (m_work)
 	{
-		m_state.exchange(WorkerState::Killing);
+		if (m_state.exchange(WorkerState::Killing) == WorkerState::Killing)
+			return; // Somebody else is doing this
 		l.unlock();
 		m_state_notifier.notify_all();
 		DEV_TIMED_ABOVE("Terminate worker", 100)

--- a/libdevcore/Worker.h
+++ b/libdevcore/Worker.h
@@ -92,7 +92,8 @@ protected:
 //	void join() const { Guard l(x_work); try { if (m_work) m_work->join(); } catch (...) {} }
 
 	/// Stop and never start again.
-	/// This has to be called in the destructor of any derived class.  Otherwise the worker thread will try to lookup vptrs.
+	/// This has to be called in the destructor of any most derived class.  Otherwise the worker thread will try to lookup vptrs.
+	/// It's OK to call terminate() in destructors of multiple derived classes.
 	void terminate();
 
 private:

--- a/libethashseal/EthashClient.cpp
+++ b/libethashseal/EthashClient.cpp
@@ -59,6 +59,11 @@ EthashClient::EthashClient(
 	asEthashClient(*this);
 }
 
+EthashClient::~EthashClient()
+{
+	terminate();
+}
+
 Ethash* EthashClient::ethash() const
 {
 	return dynamic_cast<Ethash*>(Client::sealEngine());

--- a/libethashseal/EthashClient.h
+++ b/libethashseal/EthashClient.h
@@ -47,6 +47,7 @@ public:
 		WithExisting _forceAction = WithExisting::Trust,
 		TransactionQueue::Limits const& _l = TransactionQueue::Limits{1024, 1024}
 	);
+	~EthashClient();
 
 	Ethash* ethash() const;
 

--- a/libethereum/BlockChain.cpp
+++ b/libethereum/BlockChain.cpp
@@ -334,8 +334,11 @@ void BlockChain::close()
 	// Not thread safe...
 	delete m_extrasDB;
 	delete m_blocksDB;
-	m_lastBlockHash = m_genesisHash;
-	m_lastBlockNumber = 0;
+	DEV_WRITE_GUARDED(x_lastBlockHash)
+	{
+		m_lastBlockHash = m_genesisHash;
+		m_lastBlockNumber = 0;
+	}
 	m_details.clear();
 	m_blocks.clear();
 	m_logBlooms.clear();

--- a/libethereum/BlockChain.h
+++ b/libethereum/BlockChain.h
@@ -227,7 +227,7 @@ public:
 
 	/// Get a number for the given hash (or the most recent mined if none given). Thread-safe.
 	unsigned number(h256 const& _hash) const { return details(_hash).number; }
-	unsigned number() const { return m_lastBlockNumber; }
+	unsigned number() const { ReadGuard l(x_lastBlockHash); return m_lastBlockNumber; }
 
 	/// Get a given block (RLP format). Thread-safe.
 	h256 currentHash() const { ReadGuard l(x_lastBlockHash); return m_lastBlockHash; }
@@ -403,7 +403,7 @@ private:
 	ldb::DB* m_extrasDB;
 
 	/// Hash of the last (valid) block on the longest chain.
-	mutable boost::shared_mutex x_lastBlockHash;
+	mutable boost::shared_mutex x_lastBlockHash; // should protect both m_lastBlockHash and m_lastBlockNumber
 	h256 m_lastBlockHash;
 	unsigned m_lastBlockNumber = 0;
 

--- a/libethereum/BlockChainSync.h
+++ b/libethereum/BlockChainSync.h
@@ -143,7 +143,7 @@ private:
 	Handler<> m_bqRoomAvailable;				///< Triggered once block queue has space for more blocks
 	mutable RecursiveMutex x_sync;
 	std::set<std::weak_ptr<EthereumPeer>, std::owner_less<std::weak_ptr<EthereumPeer>>> m_daoChallengedPeers; ///> Peers to which we've sent DAO challenge request
-	SyncState m_state = SyncState::Idle;		///< Current sync state
+	std::atomic<SyncState> m_state{SyncState::Idle};		///< Current sync state
 	h256Hash m_knownNewHashes; 					///< New hashes we know about use for logging only
 	unsigned m_chainStartBlock = 0;
 	unsigned m_startingBlock = 0;      	    	///< Last block number for the start of sync

--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -123,7 +123,6 @@ void Client::init(p2p::Host* _extNet, fs::path const& _dbPath, WithExisting _for
 	if (_dbPath.size())
 		Defaults::setDBPath(_dbPath);
 	doWork(false);
-	startWorking();
 }
 
 ImportResult Client::queueBlock(bytes const& _block, bool _isSafe)

--- a/libethereum/Client.h
+++ b/libethereum/Client.h
@@ -198,6 +198,9 @@ public:
 	virtual Block block(h256 const& _block) const override;
 	using ClientBase::block;
 
+	/// should be called after the constructor of the most derived class finishes.
+	void startWorking() { Worker::startWorking(); };
+
 protected:
 	/// Perform critical setup functions.
 	/// Must be called in the constructor of the finally derived class.

--- a/libethereum/ClientTest.cpp
+++ b/libethereum/ClientTest.cpp
@@ -51,6 +51,11 @@ ClientTest::ClientTest(
 	Client(_params, _networkID, _host, _gpForAdoption, _dbPath, _forceAction, _limits)
 {}
 
+ClientTest::~ClientTest()
+{
+	terminate();
+}
+
 void ClientTest::setChainParams(string const& _genesis)
 {
 	ChainParams params;

--- a/libethereum/ClientTest.h
+++ b/libethereum/ClientTest.h
@@ -46,6 +46,7 @@ public:
 		WithExisting _forceAction = WithExisting::Trust,
 		TransactionQueue::Limits const& _l = TransactionQueue::Limits{1024, 1024}
 	);
+	~ClientTest();
 
 	void setChainParams(std::string const& _genesis);
 	void mineBlocks(unsigned _count);

--- a/libethereum/EthereumHost.cpp
+++ b/libethereum/EthereumHost.cpp
@@ -606,7 +606,6 @@ bool EthereumHost::isSyncing() const
 
 SyncStatus EthereumHost::status() const
 {
-	RecursiveGuard l(x_sync);
 	return m_sync->status();
 }
 

--- a/libethereum/EthereumHost.cpp
+++ b/libethereum/EthereumHost.cpp
@@ -80,7 +80,6 @@ public:
 
 	void onPeerAborting() override
 	{
-		RecursiveGuard l(m_syncMutex);
 		try
 		{
 			m_sync.onPeerAborting();

--- a/libethereum/EthereumHost.cpp
+++ b/libethereum/EthereumHost.cpp
@@ -54,11 +54,10 @@ namespace
 class EthereumPeerObserver: public EthereumPeerObserverFace
 {
 public:
-	EthereumPeerObserver(BlockChainSync& _sync, RecursiveMutex& _syncMutex, TransactionQueue& _tq): m_sync(_sync), m_syncMutex(_syncMutex), m_tq(_tq) {}
+	EthereumPeerObserver(BlockChainSync& _sync, TransactionQueue& _tq): m_sync(_sync), m_tq(_tq) {}
 
 	void onPeerStatus(std::shared_ptr<EthereumPeer> _peer) override
 	{
-		RecursiveGuard l(m_syncMutex);
 		try
 		{
 			m_sync.onPeerStatus(_peer);
@@ -92,7 +91,6 @@ public:
 
 	void onPeerBlockHeaders(std::shared_ptr<EthereumPeer> _peer, RLP const& _headers) override
 	{
-		RecursiveGuard l(m_syncMutex);
 		try
 		{
 			m_sync.onPeerBlockHeaders(_peer, _headers);
@@ -107,7 +105,6 @@ public:
 
 	void onPeerBlockBodies(std::shared_ptr<EthereumPeer> _peer, RLP const& _r) override
 	{
-		RecursiveGuard l(m_syncMutex);
 		try
 		{
 			m_sync.onPeerBlockBodies(_peer, _r);
@@ -122,7 +119,6 @@ public:
 
 	void onPeerNewHashes(std::shared_ptr<EthereumPeer> _peer, std::vector<std::pair<h256, u256>> const& _hashes) override
 	{
-		RecursiveGuard l(m_syncMutex);
 		try
 		{
 			m_sync.onPeerNewHashes(_peer, _hashes);
@@ -137,7 +133,6 @@ public:
 
 	void onPeerNewBlock(std::shared_ptr<EthereumPeer> _peer, RLP const& _r) override
 	{
-		RecursiveGuard l(m_syncMutex);
 		try
 		{
 			m_sync.onPeerNewBlock(_peer, _r);
@@ -164,7 +159,6 @@ public:
 
 private:
 	BlockChainSync& m_sync;
-	RecursiveMutex& m_syncMutex;
 	TransactionQueue& m_tq;
 };
 
@@ -386,7 +380,7 @@ EthereumHost::EthereumHost(BlockChain const& _ch, OverlayDB const& _db, Transact
 	// TODO: Composition would be better. Left like that to avoid initialization
 	//       issues as BlockChainSync accesses other EthereumHost members.
 	m_sync.reset(new BlockChainSync(*this));
-	m_peerObserver = make_shared<EthereumPeerObserver>(*m_sync, x_sync, m_tq);
+	m_peerObserver = make_shared<EthereumPeerObserver>(*m_sync, m_tq);
 	m_latestBlockSent = _ch.currentHash();
 	m_tq.onImport([this](ImportResult _ir, h256 const& _h, h512 const& _nodeId) { onTransactionImported(_ir, _h, _nodeId); });
 }
@@ -413,7 +407,6 @@ bool EthereumHost::ensureInitialised()
 
 void EthereumHost::reset()
 {
-	RecursiveGuard l(x_sync);
 	m_sync->abortSync();
 
 	m_latestBlockSent = h256();
@@ -423,7 +416,6 @@ void EthereumHost::reset()
 
 void EthereumHost::completeSync()
 {
-	RecursiveGuard l(x_sync);
 	m_sync->completeSync();
 }
 

--- a/libethereum/EthereumHost.h
+++ b/libethereum/EthereumHost.h
@@ -132,7 +132,6 @@ private:
 	bool m_newTransactions = false;
 	bool m_newBlocks = false;
 
-	mutable RecursiveMutex x_sync;
 	mutable Mutex x_transactions;
 	std::unique_ptr<BlockChainSync> m_sync;
 	std::atomic<time_t> m_lastTick = { 0 };

--- a/libp2p/Common.cpp
+++ b/libp2p/Common.cpp
@@ -200,6 +200,12 @@ void DeadlineOps::reap()
 	});
 }
 
+Node::Node(Node const& _original):
+	id(_original.id),
+	endpoint(_original.endpoint),
+	peerType(_original.peerType.load())
+{}
+
 Node::Node(NodeSpec const& _s, PeerType _p):
 	id(_s.id()),
 	endpoint(_s.nodeIPEndpoint()),

--- a/libp2p/Common.h
+++ b/libp2p/Common.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <string>
 #include <set>
 #include <vector>
@@ -243,7 +244,7 @@ class Node
 {
 public:
 	Node() = default;
-	Node(Node const&) = default;
+	Node(Node const&);
 	Node(Public _publicKey, NodeIPEndpoint const& _ip, PeerType _peerType = PeerType::Optional): id(_publicKey), endpoint(_ip), peerType(_peerType) {}
 	Node(NodeSpec const& _s, PeerType _peerType = PeerType::Optional);
 
@@ -260,7 +261,7 @@ public:
 	NodeIPEndpoint endpoint;
 
 	// TODO: p2p implement
-	PeerType peerType = PeerType::Optional;
+	std::atomic<PeerType> peerType{PeerType::Optional};
 };
 
 class DeadlineOps

--- a/libp2p/Host.h
+++ b/libp2p/Host.h
@@ -285,6 +285,9 @@ private:
 	/// Get or create host identifier (KeyPair).
 	static KeyPair networkAlias(bytesConstRef _b);
 
+	/// returns true if a member of m_requiredPeers
+	bool isRequiredPeer(NodeID const&) const;
+
 	bytes m_restoreNetwork;										///< Set by constructor and used to set Host key and restore network peers & nodes.
 
 	std::atomic<bool> m_run{false};													///< Whether network is running.
@@ -317,7 +320,7 @@ private:
 	
 	/// Peers we try to connect regardless of p2p network.
 	std::set<NodeID> m_requiredPeers;
-	Mutex x_requiredPeers;
+	mutable Mutex x_requiredPeers;
 
 	/// The nodes to which we are currently connected. Used by host to service peer requests and keepAlivePeers and for shutdown. (see run())
 	/// Mutable because we flush zombie entries (null-weakptrs) as regular maintenance from a const method.

--- a/libweb3jsonrpc/IpcServerBase.cpp
+++ b/libweb3jsonrpc/IpcServerBase.cpp
@@ -45,9 +45,9 @@ template <class S> IpcServerBase<S>::IpcServerBase(string const& _path):
 
 template <class S> bool IpcServerBase<S>::StartListening()
 {
-	if (!m_running)
+	bool wasRunning = m_running.exchange(true);
+	if (!wasRunning)
 	{
-		m_running = true;
 		m_listeningThread = std::thread([this](){ Listen(); });
 		return true;
 	}
@@ -56,9 +56,9 @@ template <class S> bool IpcServerBase<S>::StartListening()
 
 template <class S> bool IpcServerBase<S>::StopListening()
 {
-	if (m_running)
+	bool wasRunning = m_running.exchange(false);
+	if (wasRunning)
 	{
-		m_running = false;
 		DEV_GUARDED(x_sockets)
 		{
 			for (S s : m_sockets)

--- a/libweb3jsonrpc/IpcServerBase.h
+++ b/libweb3jsonrpc/IpcServerBase.h
@@ -22,6 +22,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <string>
 #include <thread>
 #include <mutex>
@@ -46,7 +47,7 @@ protected:
 	void GenerateResponse(S _connection);
 
 protected:
-	bool m_running = false;
+	std::atomic<bool> m_running{false};
 	std::string m_path;
 	std::unordered_set<S> m_sockets;
 	std::mutex x_sockets;

--- a/libwebthree/WebThree.cpp
+++ b/libwebthree/WebThree.cpp
@@ -61,6 +61,7 @@ WebThreeDirect::WebThreeDirect(
 			m_ethereum.reset(new eth::ClientTest(_params, (int)_params.networkID, &m_net, shared_ptr<GasPricer>(), _dbPath, _we));
 		else
 			m_ethereum.reset(new eth::Client(_params, (int)_params.networkID, &m_net, shared_ptr<GasPricer>(), _dbPath, _we));
+		m_ethereum->startWorking();
 		string bp = DEV_QUOTED(ETH_BUILD_PLATFORM);
 		vector<string> bps;
 		boost::split(bps, bp, boost::is_any_of("/"));


### PR DESCRIPTION
This should be the easier part of #4579.  Adding mutex or atomic, avoiding deadlocks, or stopping threads before vptr table is destroyed.