### PR TITLE
Download snapshot through Parity's warp protocol

### DIFF
--- a/eth/main.cpp
+++ b/eth/main.cpp
@@ -856,17 +856,9 @@ int main(int argc, char** argv)
         chainParams.allowFutureBlocks = true;
     }
 
-    dev::WebThreeDirect web3(
-        WebThreeDirect::composeClientVersion("eth"),
-        getDataDir(),
-        snapshotPath,
-        chainParams,
-        withExisting,
-        nodeMode == NodeMode::Full ? caps : set<string>(),
-        netPrefs,
-        &nodesState,
-        testingMode
-    );
+    dev::WebThreeDirect web3(WebThreeDirect::composeClientVersion("eth"), getDataDir(),
+        snapshotPath, chainParams, withExisting, nodeMode == NodeMode::Full ? caps : set<string>(),
+        netPrefs, &nodesState, testingMode);
 
     if (!extraData.empty())
         web3.ethereum()->setExtraData(extraData);

--- a/eth/main.cpp
+++ b/eth/main.cpp
@@ -342,6 +342,7 @@ int main(int argc, char** argv)
         ("only", po::value<string>()->value_name("<n>"), "Equivalent to --export-from n --export-to n.")
         ("format", po::value<string>()->value_name("<binary/hex/human>"), "Set export format.")
         ("dont-check", "Prevent checking some block aspects. Faster importing, but to apply only when the data is known to be valid.")
+        ("download-snapshot", po::value<string>()->value_name("<path>"), "Download Parity Warp Sync snapshot data to the specified path.")
         ("import-snapshot", po::value<string>()->value_name("<path>"), "Import blockchain and state data from the Parity Warp Sync snapshot.\n");
 
     po::options_description generalOptions("General Options", c_lineWidth);
@@ -382,6 +383,9 @@ int main(int argc, char** argv)
             return -1;
         }
 
+    std::string snapshotPath;
+    if (vm.count("download-snapshot"))
+        snapshotPath = vm["download-snapshot"].as<string>();
     if (vm.count("import-snapshot"))
     {
         mode = OperationMode::ImportSnapshot;
@@ -855,6 +859,7 @@ int main(int argc, char** argv)
     dev::WebThreeDirect web3(
         WebThreeDirect::composeClientVersion("eth"),
         getDataDir(),
+        snapshotPath,
         chainParams,
         withExisting,
         nodeMode == NodeMode::Full ? caps : set<string>(),

--- a/eth/main.cpp
+++ b/eth/main.cpp
@@ -333,6 +333,7 @@ int main(int argc, char** argv)
         ("no-discovery",  "Disable node discovery, implies --no-bootstrap.")
         ("pin",  "Only accept or connect to trusted peers.");
 
+    std::string snapshotPath;
     po::options_description importExportMode("Import/export modes", c_lineWidth);
     importExportMode.add_options()
         ("import,I", po::value<string>()->value_name("<file>"), "Import blocks from file.")
@@ -342,7 +343,7 @@ int main(int argc, char** argv)
         ("only", po::value<string>()->value_name("<n>"), "Equivalent to --export-from n --export-to n.")
         ("format", po::value<string>()->value_name("<binary/hex/human>"), "Set export format.")
         ("dont-check", "Prevent checking some block aspects. Faster importing, but to apply only when the data is known to be valid.")
-        ("download-snapshot", po::value<string>()->value_name("<path>"), "Download Parity Warp Sync snapshot data to the specified path.")
+        ("download-snapshot", po::value<string>(&snapshotPath)->value_name("<path>"), "Download Parity Warp Sync snapshot data to the specified path.")
         ("import-snapshot", po::value<string>()->value_name("<path>"), "Import blockchain and state data from the Parity Warp Sync snapshot.\n");
 
     po::options_description generalOptions("General Options", c_lineWidth);
@@ -383,9 +384,6 @@ int main(int argc, char** argv)
             return -1;
         }
 
-    std::string snapshotPath;
-    if (vm.count("download-snapshot"))
-        snapshotPath = vm["download-snapshot"].as<string>();
     if (vm.count("import-snapshot"))
     {
         mode = OperationMode::ImportSnapshot;

--- a/libethashseal/EthashClient.cpp
+++ b/libethashseal/EthashClient.cpp
@@ -50,10 +50,11 @@ EthashClient::EthashClient(
 	p2p::Host* _host,
 	std::shared_ptr<GasPricer> _gpForAdoption,
 	fs::path const& _dbPath,
+	fs::path const& _snapshotPath,
 	WithExisting _forceAction,
 	TransactionQueue::Limits const& _limits
 ):
-	Client(_params, _networkID, _host, _gpForAdoption, _dbPath, _forceAction, _limits)
+	Client(_params, _networkID, _host, _gpForAdoption, _dbPath, _snapshotPath, _forceAction, _limits)
 {
 	// will throw if we're not an Ethash seal engine.
 	asEthashClient(*this);

--- a/libethashseal/EthashClient.cpp
+++ b/libethashseal/EthashClient.cpp
@@ -1,18 +1,18 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file EthashClient.cpp
  * @author Gav Wood <i@gavwood.com>
@@ -30,113 +30,108 @@ namespace fs = boost::filesystem;
 
 EthashClient& dev::eth::asEthashClient(Interface& _c)
 {
-	if (dynamic_cast<Ethash*>(_c.sealEngine()))
-		return dynamic_cast<EthashClient&>(_c);
-	throw InvalidSealEngine();
+    if (dynamic_cast<Ethash*>(_c.sealEngine()))
+        return dynamic_cast<EthashClient&>(_c);
+    throw InvalidSealEngine();
 }
 
 EthashClient* dev::eth::asEthashClient(Interface* _c)
 {
-	if (dynamic_cast<Ethash*>(_c->sealEngine()))
-		return &dynamic_cast<EthashClient&>(*_c);
-	throw InvalidSealEngine();
+    if (dynamic_cast<Ethash*>(_c->sealEngine()))
+        return &dynamic_cast<EthashClient&>(*_c);
+    throw InvalidSealEngine();
 }
 
 DEV_SIMPLE_EXCEPTION(ChainParamsNotEthash);
 
-EthashClient::EthashClient(
-	ChainParams const& _params,
-	int _networkID,
-	p2p::Host* _host,
-	std::shared_ptr<GasPricer> _gpForAdoption,
-	fs::path const& _dbPath,
-	fs::path const& _snapshotPath,
-	WithExisting _forceAction,
-	TransactionQueue::Limits const& _limits
-):
-	Client(_params, _networkID, _host, _gpForAdoption, _dbPath, _snapshotPath, _forceAction, _limits)
+EthashClient::EthashClient(ChainParams const& _params, int _networkID, p2p::Host* _host,
+    std::shared_ptr<GasPricer> _gpForAdoption, fs::path const& _dbPath,
+    fs::path const& _snapshotPath, WithExisting _forceAction,
+    TransactionQueue::Limits const& _limits)
+  : Client(
+        _params, _networkID, _host, _gpForAdoption, _dbPath, _snapshotPath, _forceAction, _limits)
 {
-	// will throw if we're not an Ethash seal engine.
-	asEthashClient(*this);
+    // will throw if we're not an Ethash seal engine.
+    asEthashClient(*this);
 }
 
 EthashClient::~EthashClient()
 {
-	terminate();
+    terminate();
 }
 
 Ethash* EthashClient::ethash() const
 {
-	return dynamic_cast<Ethash*>(Client::sealEngine());
+    return dynamic_cast<Ethash*>(Client::sealEngine());
 }
 
 bool EthashClient::isMining() const
 {
-	return ethash()->farm().isMining();
+    return ethash()->farm().isMining();
 }
 
 WorkingProgress EthashClient::miningProgress() const
 {
-	if (isMining())
-		return ethash()->farm().miningProgress();
-	return WorkingProgress();
+    if (isMining())
+        return ethash()->farm().miningProgress();
+    return WorkingProgress();
 }
 
 u256 EthashClient::hashrate() const
 {
-	u256 r = externalHashrate();
-	if (isMining())
-		r += miningProgress().rate();
-	return r;
+    u256 r = externalHashrate();
+    if (isMining())
+        r += miningProgress().rate();
+    return r;
 }
 
 std::tuple<h256, h256, h256> EthashClient::getEthashWork()
 {
-	// lock the work so a later submission isn't invalidated by processing a transaction elsewhere.
-	// this will be reset as soon as a new block arrives, allowing more transactions to be processed.
-	bool oldShould = shouldServeWork();
-	m_lastGetWork = chrono::system_clock::now();
+    // lock the work so a later submission isn't invalidated by processing a transaction elsewhere.
+    // this will be reset as soon as a new block arrives, allowing more transactions to be processed.
+    bool oldShould = shouldServeWork();
+    m_lastGetWork = chrono::system_clock::now();
 
-	if (!sealEngine()->shouldSeal(this))
-		return std::tuple<h256, h256, h256>();
+    if (!sealEngine()->shouldSeal(this))
+        return std::tuple<h256, h256, h256>();
 
-	// if this request has made us bother to serve work, prep it now.
-	if (!oldShould && shouldServeWork())
-		onPostStateChanged();
-	else
-		// otherwise, set this to true so that it gets prepped next time.
-		m_remoteWorking = true;
-	ethash()->manuallySetWork(m_sealingInfo);
-	return std::tuple<h256, h256, h256>(m_sealingInfo.hash(WithoutSeal), Ethash::seedHash(m_sealingInfo), Ethash::boundary(m_sealingInfo));
+    // if this request has made us bother to serve work, prep it now.
+    if (!oldShould && shouldServeWork())
+        onPostStateChanged();
+    else
+        // otherwise, set this to true so that it gets prepped next time.
+        m_remoteWorking = true;
+    ethash()->manuallySetWork(m_sealingInfo);
+    return std::tuple<h256, h256, h256>(m_sealingInfo.hash(WithoutSeal), Ethash::seedHash(m_sealingInfo), Ethash::boundary(m_sealingInfo));
 }
 
 bool EthashClient::submitEthashWork(h256 const& _mixHash, h64 const& _nonce)
 {
-	ethash()->manuallySubmitWork(_mixHash, _nonce);
-	return true;
+    ethash()->manuallySubmitWork(_mixHash, _nonce);
+    return true;
 }
 
 void EthashClient::setShouldPrecomputeDAG(bool _precompute)
 {
-	bytes trueBytes {1};
-	bytes falseBytes {0};
-	sealEngine()->setOption("precomputeDAG", _precompute ? trueBytes: falseBytes);
+    bytes trueBytes {1};
+    bytes falseBytes {0};
+    sealEngine()->setOption("precomputeDAG", _precompute ? trueBytes: falseBytes);
 }
 
 void EthashClient::submitExternalHashrate(u256 const& _rate, h256 const& _id)
 {
-	WriteGuard writeGuard(x_externalRates);
-	m_externalRates[_id] = make_pair(_rate, chrono::steady_clock::now());
+    WriteGuard writeGuard(x_externalRates);
+    m_externalRates[_id] = make_pair(_rate, chrono::steady_clock::now());
 }
 
 u256 EthashClient::externalHashrate() const
 {
-	u256 ret = 0;
-	WriteGuard writeGuard(x_externalRates);
-	for (auto i = m_externalRates.begin(); i != m_externalRates.end();)
-		if (chrono::steady_clock::now() - i->second.second > chrono::seconds(5))
-			i = m_externalRates.erase(i);
-		else
-			ret += i++->second.first;
-	return ret;
+    u256 ret = 0;
+    WriteGuard writeGuard(x_externalRates);
+    for (auto i = m_externalRates.begin(); i != m_externalRates.end();)
+        if (chrono::steady_clock::now() - i->second.second > chrono::seconds(5))
+            i = m_externalRates.erase(i);
+        else
+            ret += i++->second.first;
+    return ret;
 }

--- a/libethashseal/EthashClient.h
+++ b/libethashseal/EthashClient.h
@@ -1,18 +1,18 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file EthashClient.h
  * @author Gav Wood <i@gavwood.com>
@@ -37,55 +37,51 @@ DEV_SIMPLE_EXCEPTION(InvalidSealEngine);
 class EthashClient: public Client
 {
 public:
-	/// Trivial forwarding constructor.
-	EthashClient(
-		ChainParams const& _params,
-		int _networkID,
-		p2p::Host* _host,
-		std::shared_ptr<GasPricer> _gpForAdoption,
-		boost::filesystem::path const& _dbPath = boost::filesystem::path(),
-		boost::filesystem::path const& _snapshotPath = boost::filesystem::path(),
-		WithExisting _forceAction = WithExisting::Trust,
-		TransactionQueue::Limits const& _l = TransactionQueue::Limits{1024, 1024}
-	);
-	~EthashClient();
+    /// Trivial forwarding constructor.
+    EthashClient(ChainParams const& _params, int _networkID, p2p::Host* _host,
+        std::shared_ptr<GasPricer> _gpForAdoption,
+        boost::filesystem::path const& _dbPath = boost::filesystem::path(),
+        boost::filesystem::path const& _snapshotPath = boost::filesystem::path(),
+        WithExisting _forceAction = WithExisting::Trust,
+        TransactionQueue::Limits const& _l = TransactionQueue::Limits{1024, 1024});
+    ~EthashClient();
 
-	Ethash* ethash() const;
+    Ethash* ethash() const;
 
-	/// Enable/disable precomputing of the DAG for next epoch
-	void setShouldPrecomputeDAG(bool _precompute);
+    /// Enable/disable precomputing of the DAG for next epoch
+    void setShouldPrecomputeDAG(bool _precompute);
 
-	/// Are we mining now?
-	bool isMining() const;
+    /// Are we mining now?
+    bool isMining() const;
 
-	/// The hashrate...
-	u256 hashrate() const;
+    /// The hashrate...
+    u256 hashrate() const;
 
-	/// Check the progress of the mining.
-	WorkingProgress miningProgress() const;
+    /// Check the progress of the mining.
+    WorkingProgress miningProgress() const;
 
-	/// @returns true only if it's worth bothering to prep the mining block.
-	bool shouldServeWork() const { return m_bq.items().first == 0 && (isMining() || remoteActive()); }
+    /// @returns true only if it's worth bothering to prep the mining block.
+    bool shouldServeWork() const { return m_bq.items().first == 0 && (isMining() || remoteActive()); }
 
-	/// Update to the latest transactions and get hash of the current block to be mined minus the
-	/// nonce (the 'work hash') and the difficulty to be met.
-	/// @returns Tuple of hash without seal, seed hash, target boundary.
-	std::tuple<h256, h256, h256> getEthashWork();
+    /// Update to the latest transactions and get hash of the current block to be mined minus the
+    /// nonce (the 'work hash') and the difficulty to be met.
+    /// @returns Tuple of hash without seal, seed hash, target boundary.
+    std::tuple<h256, h256, h256> getEthashWork();
 
-	/** @brief Submit the proof for the proof-of-work.
-	 * @param _s A valid solution.
-	 * @return true if the solution was indeed valid and accepted.
-	 */
-	bool submitEthashWork(h256 const& _mixHash, h64 const& _nonce);
+    /** @brief Submit the proof for the proof-of-work.
+     * @param _s A valid solution.
+     * @return true if the solution was indeed valid and accepted.
+     */
+    bool submitEthashWork(h256 const& _mixHash, h64 const& _nonce);
 
-	void submitExternalHashrate(u256 const& _rate, h256 const& _id);
+    void submitExternalHashrate(u256 const& _rate, h256 const& _id);
 
 protected:
-	u256 externalHashrate() const;
+    u256 externalHashrate() const;
 
-	// external hashrate
-	mutable std::unordered_map<h256, std::pair<u256, std::chrono::steady_clock::time_point>> m_externalRates;
-	mutable SharedMutex x_externalRates;
+    // external hashrate
+    mutable std::unordered_map<h256, std::pair<u256, std::chrono::steady_clock::time_point>> m_externalRates;
+    mutable SharedMutex x_externalRates;
 };
 
 EthashClient& asEthashClient(Interface& _c);

--- a/libethashseal/EthashClient.h
+++ b/libethashseal/EthashClient.h
@@ -44,6 +44,7 @@ public:
 		p2p::Host* _host,
 		std::shared_ptr<GasPricer> _gpForAdoption,
 		boost::filesystem::path const& _dbPath = boost::filesystem::path(),
+		boost::filesystem::path const& _snapshotPath = boost::filesystem::path(),
 		WithExisting _forceAction = WithExisting::Trust,
 		TransactionQueue::Limits const& _l = TransactionQueue::Limits{1024, 1024}
 	);

--- a/libethashseal/EthashClient.h
+++ b/libethashseal/EthashClient.h
@@ -39,9 +39,8 @@ class EthashClient: public Client
 public:
     /// Trivial forwarding constructor.
     EthashClient(ChainParams const& _params, int _networkID, p2p::Host* _host,
-        std::shared_ptr<GasPricer> _gpForAdoption,
-        boost::filesystem::path const& _dbPath = boost::filesystem::path(),
-        boost::filesystem::path const& _snapshotPath = boost::filesystem::path(),
+        std::shared_ptr<GasPricer> _gpForAdoption, boost::filesystem::path const& _dbPath = {},
+        boost::filesystem::path const& _snapshotPath = {},
         WithExisting _forceAction = WithExisting::Trust,
         TransactionQueue::Limits const& _l = TransactionQueue::Limits{1024, 1024});
     ~EthashClient();

--- a/libethcore/Exceptions.h
+++ b/libethcore/Exceptions.h
@@ -1,18 +1,18 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file Exceptions.h
  * @author Gav Wood <i@gavwood.com>
@@ -93,5 +93,7 @@ DEV_SIMPLE_EXCEPTION(InvalidStateChunkData);
 DEV_SIMPLE_EXCEPTION(InvalidBlockChunkData);
 DEV_SIMPLE_EXCEPTION(AccountAlreadyImported);
 DEV_SIMPLE_EXCEPTION(InvalidWarpStatusPacket);
+DEV_SIMPLE_EXCEPTION(FailedToDownloadManifest);
+DEV_SIMPLE_EXCEPTION(FailedToDownloadDaoForkBlockHeader);
 }
 }

--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -131,10 +131,11 @@ void Client::init(p2p::Host* _extNet, fs::path const& _dbPath, fs::path const& _
 
     // create Warp capability if we either download snapshot or can give out snapshot
     auto const importedSnapshot = importedSnapshotPath(_dbPath, bc().genesisHash());
-    if (!_snapshotDownloadPath.empty() || fs::exists(importedSnapshot))
+    bool const importedSnapshotExists = fs::exists(importedSnapshot);
+    if (!_snapshotDownloadPath.empty() || importedSnapshotExists)
     {
-        std::shared_ptr<SnapshotStorageFace> snapshotStorage =
-            createSnapshotStorage(importedSnapshot);
+        std::shared_ptr<SnapshotStorageFace> snapshotStorage(
+            importedSnapshotExists ? createSnapshotStorage(importedSnapshot) : nullptr);
         m_warpHost = _extNet->registerCapability(make_shared<WarpHostCapability>(
             bc(), _networkId, _snapshotDownloadPath, snapshotStorage));
     }

--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -1,18 +1,18 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file Client.cpp
  * @author Gav Wood <i@gavwood.com>
@@ -43,9 +43,9 @@ static_assert(BOOST_VERSION >= 106400, "Wrong boost headers version");
 
 std::ostream& dev::eth::operator<<(std::ostream& _out, ActivityReport const& _r)
 {
-	_out << "Since " << toString(_r.since) << " (" << std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now() - _r.since).count();
-	_out << "): " << _r.ticks << "ticks";
-	return _out;
+    _out << "Since " << toString(_r.since) << " (" << std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now() - _r.since).count();
+    _out << "): " << _r.ticks << "ticks";
+    return _out;
 }
 
 #if defined(_WIN32)
@@ -61,41 +61,42 @@ const char* ClientDetail::name() { return EthTeal "⧫" EthCoal " ●"; }
 #endif
 
 Client::Client(
-	ChainParams const& _params,
-	int _networkID,
-	p2p::Host* _host,
-	std::shared_ptr<GasPricer> _gpForAdoption,
-	fs::path const& _dbPath,
-	WithExisting _forceAction,
-	TransactionQueue::Limits const& _l
+    ChainParams const& _params,
+    int _networkID,
+    p2p::Host* _host,
+    std::shared_ptr<GasPricer> _gpForAdoption,
+    fs::path const& _dbPath,
+    fs::path const& _snapshotPath,
+    WithExisting _forceAction,
+    TransactionQueue::Limits const& _l
 ):
-	ClientBase(),
-	Worker("eth", 0),
-	m_bc(_params, _dbPath, _forceAction, [](unsigned d, unsigned t){ std::cerr << "REVISING BLOCKCHAIN: Processed " << d << " of " << t << "...\r"; }),
-	m_tq(_l),
-	m_gp(_gpForAdoption ? _gpForAdoption : make_shared<TrivialGasPricer>()),
-	m_preSeal(chainParams().accountStartNonce),
-	m_postSeal(chainParams().accountStartNonce),
-	m_working(chainParams().accountStartNonce)
+    ClientBase(),
+    Worker("eth", 0),
+    m_bc(_params, _dbPath, _forceAction, [](unsigned d, unsigned t){ std::cerr << "REVISING BLOCKCHAIN: Processed " << d << " of " << t << "...\r"; }),
+    m_tq(_l),
+    m_gp(_gpForAdoption ? _gpForAdoption : make_shared<TrivialGasPricer>()),
+    m_preSeal(chainParams().accountStartNonce),
+    m_postSeal(chainParams().accountStartNonce),
+    m_working(chainParams().accountStartNonce)
 {
-	init(_host, _dbPath, _forceAction, _networkID);
+    init(_host, _dbPath, _snapshotPath, _forceAction, _networkID);
 }
 
 Client::~Client()
 {
-	stopWorking();
-	terminate();
+    stopWorking();
+    terminate();
 }
 
-void Client::init(p2p::Host* _extNet, fs::path const& _dbPath, WithExisting _forceAction, u256 _networkId)
+void Client::init(p2p::Host* _extNet, fs::path const& _dbPath, fs::path const& _snapshotDownloadPath, WithExisting _forceAction, u256 _networkId)
 {
     DEV_TIMED_FUNCTION_ABOVE(500);
 
     // Cannot be opened until after blockchain is open, since BlockChain may upgrade the database.
-	// TODO: consider returning the upgrade mechanism here. will delaying the opening of the blockchain database
-	// until after the construction.
+    // TODO: consider returning the upgrade mechanism here. will delaying the opening of the blockchain database
+    // until after the construction.
     m_stateDB = State::openDB(_dbPath, bc().genesisHash(), _forceAction);
-	// LAZY. TODO: move genesis state construction/commiting to stateDB openning and have this just take the root from the genesis block.
+    // LAZY. TODO: move genesis state construction/commiting to stateDB openning and have this just take the root from the genesis block.
     m_preSeal = bc().genesisBlock(m_stateDB);
     m_postSeal = m_preSeal;
 
@@ -121,264 +122,269 @@ void Client::init(p2p::Host* _extNet, fs::path const& _dbPath, WithExisting _for
 
     m_gp->update(bc());
 
-	auto host = _extNet->registerCapability(make_shared<EthereumHost>(bc(), m_stateDB, m_tq, m_bq, _networkId));
-    m_host = host;
-
-	_extNet->addCapability(host, EthereumHost::staticName(), EthereumHost::c_oldProtocolVersion); //TODO: remove this once v61+ protocol is common
-
-    auto const snapshotPath = importedSnapshotPath(_dbPath, bc().genesisHash());
-    if (fs::exists(snapshotPath))
+    // create Ethereum capability only if we're not downloading the snapshot
+    if (_snapshotDownloadPath.empty())
     {
-        std::shared_ptr<SnapshotStorageFace> snapshotStorage = createSnapshotStorage(snapshotPath);
+        auto host = _extNet->registerCapability(make_shared<EthereumHost>(bc(), m_stateDB, m_tq, m_bq, _networkId));
+        m_host = host;
+
+        _extNet->addCapability(host, EthereumHost::staticName(), EthereumHost::c_oldProtocolVersion); //TODO: remove this once v61+ protocol is common
+    }
+
+    // create Warp capability if we either download snapshot or can give out snapshot
+    auto const importedSnapshot = importedSnapshotPath(_dbPath, bc().genesisHash());
+    if (!_snapshotDownloadPath.empty() || fs::exists(importedSnapshot))
+    {
+        std::shared_ptr<SnapshotStorageFace> snapshotStorage = createSnapshotStorage(importedSnapshot);
         m_warpHost = _extNet->registerCapability(
-            make_shared<WarpHostCapability>(bc(), _networkId, snapshotStorage));
+            make_shared<WarpHostCapability>(bc(), _networkId, _snapshotDownloadPath, snapshotStorage));
     }
 
     if (_dbPath.size())
-		Defaults::setDBPath(_dbPath);
-	doWork(false);
+        Defaults::setDBPath(_dbPath);
+    doWork(false);
 }
 
 ImportResult Client::queueBlock(bytes const& _block, bool _isSafe)
 {
-	if (m_bq.status().verified + m_bq.status().verifying + m_bq.status().unverified > 10000)
-		this_thread::sleep_for(std::chrono::milliseconds(500));
-	return m_bq.import(&_block, _isSafe);
+    if (m_bq.status().verified + m_bq.status().verifying + m_bq.status().unverified > 10000)
+        this_thread::sleep_for(std::chrono::milliseconds(500));
+    return m_bq.import(&_block, _isSafe);
 }
 
 tuple<ImportRoute, bool, unsigned> Client::syncQueue(unsigned _max)
 {
-	stopWorking();
-	return bc().sync(m_bq, m_stateDB, _max);
+    stopWorking();
+    return bc().sync(m_bq, m_stateDB, _max);
 }
 
 void Client::onBadBlock(Exception& _ex) const
 {
-	// BAD BLOCK!!!
-	bytes const* block = boost::get_error_info<errinfo_block>(_ex);
-	if (!block)
-	{
-		cwarn << "ODD: onBadBlock called but exception (" << _ex.what() << ") has no block in it.";
-		cwarn << boost::diagnostic_information(_ex);
-		return;
-	}
+    // BAD BLOCK!!!
+    bytes const* block = boost::get_error_info<errinfo_block>(_ex);
+    if (!block)
+    {
+        cwarn << "ODD: onBadBlock called but exception (" << _ex.what() << ") has no block in it.";
+        cwarn << boost::diagnostic_information(_ex);
+        return;
+    }
 
-	badBlock(*block, _ex.what());
+    badBlock(*block, _ex.what());
 }
 
 void Client::callQueuedFunctions()
 {
-	while (true)
-	{
-		function<void()> f;
-		DEV_WRITE_GUARDED(x_functionQueue)
-			if (!m_functionQueue.empty())
-			{
-				f = m_functionQueue.front();
-				m_functionQueue.pop();
-			}
-		if (f)
-			f();
-		else
-			break;
-	}
+    while (true)
+    {
+        function<void()> f;
+        DEV_WRITE_GUARDED(x_functionQueue)
+            if (!m_functionQueue.empty())
+            {
+                f = m_functionQueue.front();
+                m_functionQueue.pop();
+            }
+        if (f)
+            f();
+        else
+            break;
+    }
 }
 
 u256 Client::networkId() const
 {
-	if (auto h = m_host.lock())
-		return h->networkId();
-	return 0;
+    if (auto h = m_host.lock())
+        return h->networkId();
+    return 0;
 }
 
 void Client::setNetworkId(u256 const& _n)
 {
-	if (auto h = m_host.lock())
-		h->setNetworkId(_n);
+    if (auto h = m_host.lock())
+        h->setNetworkId(_n);
 }
 
 bool Client::isSyncing() const
 {
-	if (auto h = m_host.lock())
-		return h->isSyncing();
-	return false;
+    if (auto h = m_host.lock())
+        return h->isSyncing();
+    return false;
 }
 
 bool Client::isMajorSyncing() const
 {
-	if (auto h = m_host.lock())
-	{
-		SyncState state = h->status().state;
-		return state != SyncState::Idle || h->bq().items().first > 10;
-	}
-	return false;
+    if (auto h = m_host.lock())
+    {
+        SyncState state = h->status().state;
+        return state != SyncState::Idle || h->bq().items().first > 10;
+    }
+    return false;
 }
 
 void Client::startedWorking()
 {
-	// Synchronise the state according to the head of the block chain.
-	// TODO: currently it contains keys for *all* blocks. Make it remove old ones.
-	clog(ClientTrace) << "startedWorking()";
+    // Synchronise the state according to the head of the block chain.
+    // TODO: currently it contains keys for *all* blocks. Make it remove old ones.
+    clog(ClientTrace) << "startedWorking()";
 
-	DEV_WRITE_GUARDED(x_preSeal)
-		m_preSeal.sync(bc());
-	DEV_READ_GUARDED(x_preSeal)
-	{
-		DEV_WRITE_GUARDED(x_working)
-			m_working = m_preSeal;
-		DEV_WRITE_GUARDED(x_postSeal)
-			m_postSeal = m_preSeal;
-	}
+    DEV_WRITE_GUARDED(x_preSeal)
+        m_preSeal.sync(bc());
+    DEV_READ_GUARDED(x_preSeal)
+    {
+        DEV_WRITE_GUARDED(x_working)
+            m_working = m_preSeal;
+        DEV_WRITE_GUARDED(x_postSeal)
+            m_postSeal = m_preSeal;
+    }
 }
 
 void Client::doneWorking()
 {
-	// Synchronise the state according to the head of the block chain.
-	// TODO: currently it contains keys for *all* blocks. Make it remove old ones.
-	DEV_WRITE_GUARDED(x_preSeal)
-		m_preSeal.sync(bc());
-	DEV_READ_GUARDED(x_preSeal)
-	{
-		DEV_WRITE_GUARDED(x_working)
-			m_working = m_preSeal;
-		DEV_WRITE_GUARDED(x_postSeal)
-			m_postSeal = m_preSeal;
-	}
+    // Synchronise the state according to the head of the block chain.
+    // TODO: currently it contains keys for *all* blocks. Make it remove old ones.
+    DEV_WRITE_GUARDED(x_preSeal)
+        m_preSeal.sync(bc());
+    DEV_READ_GUARDED(x_preSeal)
+    {
+        DEV_WRITE_GUARDED(x_working)
+            m_working = m_preSeal;
+        DEV_WRITE_GUARDED(x_postSeal)
+            m_postSeal = m_preSeal;
+    }
 }
 
 void Client::reopenChain(WithExisting _we)
 {
-	reopenChain(bc().chainParams(), _we);
+    reopenChain(bc().chainParams(), _we);
 }
 
 void Client::reopenChain(ChainParams const& _p, WithExisting _we)
 {
-	bool wasSealing = wouldSeal();
-	if (wasSealing)
-		stopSealing();
-	stopWorking();
+    bool wasSealing = wouldSeal();
+    if (wasSealing)
+        stopSealing();
+    stopWorking();
 
-	m_tq.clear();
-	m_bq.clear();
-	sealEngine()->cancelGeneration();
+    m_tq.clear();
+    m_bq.clear();
+    sealEngine()->cancelGeneration();
 
-	{
-		WriteGuard l(x_postSeal);
-		WriteGuard l2(x_preSeal);
-		WriteGuard l3(x_working);
+    {
+        WriteGuard l(x_postSeal);
+        WriteGuard l2(x_preSeal);
+        WriteGuard l3(x_working);
 
-		auto author = m_preSeal.author();	// backup and restore author.
-		m_preSeal = Block(chainParams().accountStartNonce);
-		m_postSeal = Block(chainParams().accountStartNonce);
-		m_working = Block(chainParams().accountStartNonce);
+        auto author = m_preSeal.author();   // backup and restore author.
+        m_preSeal = Block(chainParams().accountStartNonce);
+        m_postSeal = Block(chainParams().accountStartNonce);
+        m_working = Block(chainParams().accountStartNonce);
 
-		m_stateDB = OverlayDB();
-		bc().reopen(_p, _we);
-		m_stateDB = State::openDB(Defaults::dbPath(), bc().genesisHash(), _we);
+        m_stateDB = OverlayDB();
+        bc().reopen(_p, _we);
+        m_stateDB = State::openDB(Defaults::dbPath(), bc().genesisHash(), _we);
 
-		m_preSeal = bc().genesisBlock(m_stateDB);
-		m_preSeal.setAuthor(author);
-		m_postSeal = m_preSeal;
-		m_working = Block(chainParams().accountStartNonce);
-	}
+        m_preSeal = bc().genesisBlock(m_stateDB);
+        m_preSeal.setAuthor(author);
+        m_postSeal = m_preSeal;
+        m_working = Block(chainParams().accountStartNonce);
+    }
 
-	if (auto h = m_host.lock())
-		h->reset();
+    if (auto h = m_host.lock())
+        h->reset();
 
-	startedWorking();
-	doWork();
+    startedWorking();
+    doWork();
 
-	startWorking();
-	if (wasSealing)
-		startSealing();
+    startWorking();
+    if (wasSealing)
+        startSealing();
 }
 
 void Client::executeInMainThread(function<void ()> const& _function)
 {
-	DEV_WRITE_GUARDED(x_functionQueue)
-		m_functionQueue.push(_function);
-	m_signalled.notify_all();
+    DEV_WRITE_GUARDED(x_functionQueue)
+        m_functionQueue.push(_function);
+    m_signalled.notify_all();
 }
 
 void Client::clearPending()
 {
-	DEV_WRITE_GUARDED(x_postSeal)
-	{
-		if (!m_postSeal.pending().size())
-			return;
-		m_tq.clear();
-		DEV_READ_GUARDED(x_preSeal)
-			m_postSeal = m_preSeal;
-	}
+    DEV_WRITE_GUARDED(x_postSeal)
+    {
+        if (!m_postSeal.pending().size())
+            return;
+        m_tq.clear();
+        DEV_READ_GUARDED(x_preSeal)
+            m_postSeal = m_preSeal;
+    }
 
-	startSealing();
-	h256Hash changeds;
-	noteChanged(changeds);
+    startSealing();
+    h256Hash changeds;
+    noteChanged(changeds);
 }
 
 template <class S, class T>
 static S& filtersStreamOut(S& _out, T const& _fs)
 {
-	_out << "{";
-	unsigned i = 0;
-	for (h256 const& f: _fs)
-	{
-		_out << (i++ ? ", " : "");
-		if (f == PendingChangedFilter)
-			_out << LogTag::Special << "pending";
-		else if (f == ChainChangedFilter)
-			_out << LogTag::Special << "chain";
-		else
-			_out << f;
-	}
-	_out << "}";
-	return _out;
+    _out << "{";
+    unsigned i = 0;
+    for (h256 const& f: _fs)
+    {
+        _out << (i++ ? ", " : "");
+        if (f == PendingChangedFilter)
+            _out << LogTag::Special << "pending";
+        else if (f == ChainChangedFilter)
+            _out << LogTag::Special << "chain";
+        else
+            _out << f;
+    }
+    _out << "}";
+    return _out;
 }
 
 void Client::appendFromNewPending(TransactionReceipt const& _receipt, h256Hash& io_changed, h256 _sha3)
 {
-	Guard l(x_filtersWatches);
-	io_changed.insert(PendingChangedFilter);
-	m_specialFilters.at(PendingChangedFilter).push_back(_sha3);
-	for (pair<h256 const, InstalledFilter>& i: m_filters)
-	{
-		// acceptable number.
-		auto m = i.second.filter.matches(_receipt);
-		if (m.size())
-		{
-			// filter catches them
-			for (LogEntry const& l: m)
-				i.second.changes.push_back(LocalisedLogEntry(l));
-			io_changed.insert(i.first);
-		}
-	}
+    Guard l(x_filtersWatches);
+    io_changed.insert(PendingChangedFilter);
+    m_specialFilters.at(PendingChangedFilter).push_back(_sha3);
+    for (pair<h256 const, InstalledFilter>& i: m_filters)
+    {
+        // acceptable number.
+        auto m = i.second.filter.matches(_receipt);
+        if (m.size())
+        {
+            // filter catches them
+            for (LogEntry const& l: m)
+                i.second.changes.push_back(LocalisedLogEntry(l));
+            io_changed.insert(i.first);
+        }
+    }
 }
 
 void Client::appendFromBlock(h256 const& _block, BlockPolarity _polarity, h256Hash& io_changed)
 {
-	// TODO: more precise check on whether the txs match.
-	auto receipts = bc().receipts(_block).receipts;
+    // TODO: more precise check on whether the txs match.
+    auto receipts = bc().receipts(_block).receipts;
 
-	Guard l(x_filtersWatches);
-	io_changed.insert(ChainChangedFilter);
-	m_specialFilters.at(ChainChangedFilter).push_back(_block);
-	for (pair<h256 const, InstalledFilter>& i: m_filters)
-	{
-		// acceptable number & looks like block may contain a matching log entry.
-		for (size_t j = 0; j < receipts.size(); j++)
-		{
-			auto tr = receipts[j];
-			auto m = i.second.filter.matches(tr);
-			if (m.size())
-			{
-				auto transactionHash = transaction(_block, j).sha3();
-				// filter catches them
-				for (LogEntry const& l: m)
-					i.second.changes.push_back(LocalisedLogEntry(l, _block, (BlockNumber)bc().number(_block), transactionHash, j, 0, _polarity));
-				io_changed.insert(i.first);
-			}
-		}
-	}
+    Guard l(x_filtersWatches);
+    io_changed.insert(ChainChangedFilter);
+    m_specialFilters.at(ChainChangedFilter).push_back(_block);
+    for (pair<h256 const, InstalledFilter>& i: m_filters)
+    {
+        // acceptable number & looks like block may contain a matching log entry.
+        for (size_t j = 0; j < receipts.size(); j++)
+        {
+            auto tr = receipts[j];
+            auto m = i.second.filter.matches(tr);
+            if (m.size())
+            {
+                auto transactionHash = transaction(_block, j).sha3();
+                // filter catches them
+                for (LogEntry const& l: m)
+                    i.second.changes.push_back(LocalisedLogEntry(l, _block, (BlockNumber)bc().number(_block), transactionHash, j, 0, _polarity));
+                io_changed.insert(i.first);
+            }
+        }
+    }
 }
 
 unsigned static const c_syncMin = 1;
@@ -387,481 +393,481 @@ double static const c_targetDuration = 1;
 
 void Client::syncBlockQueue()
 {
-//	cdebug << "syncBlockQueue()";
+//  cdebug << "syncBlockQueue()";
 
-	ImportRoute ir;
-	unsigned count;
-	Timer t;
-	tie(ir, m_syncBlockQueue, count) = bc().sync(m_bq, m_stateDB, m_syncAmount);
-	double elapsed = t.elapsed();
+    ImportRoute ir;
+    unsigned count;
+    Timer t;
+    tie(ir, m_syncBlockQueue, count) = bc().sync(m_bq, m_stateDB, m_syncAmount);
+    double elapsed = t.elapsed();
 
-	if (count)
-	{
-		clog(ClientNote) << count << "blocks imported in" << unsigned(elapsed * 1000) << "ms (" << (count / elapsed) << "blocks/s) in #" << bc().number();
-	}
+    if (count)
+    {
+        clog(ClientNote) << count << "blocks imported in" << unsigned(elapsed * 1000) << "ms (" << (count / elapsed) << "blocks/s) in #" << bc().number();
+    }
 
-	if (elapsed > c_targetDuration * 1.1 && count > c_syncMin)
-		m_syncAmount = max(c_syncMin, count * 9 / 10);
-	else if (count == m_syncAmount && elapsed < c_targetDuration * 0.9 && m_syncAmount < c_syncMax)
-		m_syncAmount = min(c_syncMax, m_syncAmount * 11 / 10 + 1);
-	if (ir.liveBlocks.empty())
-		return;
-	onChainChanged(ir);
+    if (elapsed > c_targetDuration * 1.1 && count > c_syncMin)
+        m_syncAmount = max(c_syncMin, count * 9 / 10);
+    else if (count == m_syncAmount && elapsed < c_targetDuration * 0.9 && m_syncAmount < c_syncMax)
+        m_syncAmount = min(c_syncMax, m_syncAmount * 11 / 10 + 1);
+    if (ir.liveBlocks.empty())
+        return;
+    onChainChanged(ir);
 }
 
 void Client::syncTransactionQueue()
 {
-	resyncStateFromChain();
+    resyncStateFromChain();
 
-	Timer timer;
+    Timer timer;
 
-	h256Hash changeds;
-	TransactionReceipts newPendingReceipts;
+    h256Hash changeds;
+    TransactionReceipts newPendingReceipts;
 
-	DEV_WRITE_GUARDED(x_working)
-	{
-		if (m_working.isSealed())
-		{
-			ctrace << "Skipping txq sync for a sealed block.";
-			return;
-		}
+    DEV_WRITE_GUARDED(x_working)
+    {
+        if (m_working.isSealed())
+        {
+            ctrace << "Skipping txq sync for a sealed block.";
+            return;
+        }
 
-		tie(newPendingReceipts, m_syncTransactionQueue) = m_working.sync(bc(), m_tq, *m_gp);
-	}
+        tie(newPendingReceipts, m_syncTransactionQueue) = m_working.sync(bc(), m_tq, *m_gp);
+    }
 
-	if (newPendingReceipts.empty())
-	{
-		auto s = m_tq.status();
-		ctrace << "No transactions to process. " << m_working.pending().size() << " pending, " << s.current << " queued, " << s.future << " future, " << s.unverified << " unverified";
-		return;
-	}
+    if (newPendingReceipts.empty())
+    {
+        auto s = m_tq.status();
+        ctrace << "No transactions to process. " << m_working.pending().size() << " pending, " << s.current << " queued, " << s.future << " future, " << s.unverified << " unverified";
+        return;
+    }
 
-	DEV_READ_GUARDED(x_working)
-		DEV_WRITE_GUARDED(x_postSeal)
-			m_postSeal = m_working;
+    DEV_READ_GUARDED(x_working)
+        DEV_WRITE_GUARDED(x_postSeal)
+            m_postSeal = m_working;
 
-	DEV_READ_GUARDED(x_postSeal)
-		for (size_t i = 0; i < newPendingReceipts.size(); i++)
-			appendFromNewPending(newPendingReceipts[i], changeds, m_postSeal.pending()[i].sha3());
+    DEV_READ_GUARDED(x_postSeal)
+        for (size_t i = 0; i < newPendingReceipts.size(); i++)
+            appendFromNewPending(newPendingReceipts[i], changeds, m_postSeal.pending()[i].sha3());
 
-	// Tell farm about new transaction (i.e. restart mining).
-	onPostStateChanged();
+    // Tell farm about new transaction (i.e. restart mining).
+    onPostStateChanged();
 
-	// Tell watches about the new transactions.
-	noteChanged(changeds);
+    // Tell watches about the new transactions.
+    noteChanged(changeds);
 
-	// Tell network about the new transactions.
-	if (auto h = m_host.lock())
-		h->noteNewTransactions();
+    // Tell network about the new transactions.
+    if (auto h = m_host.lock())
+        h->noteNewTransactions();
 
-	ctrace << "Processed " << newPendingReceipts.size() << " transactions in" << (timer.elapsed() * 1000) << "(" << (bool)m_syncTransactionQueue << ")";
+    ctrace << "Processed " << newPendingReceipts.size() << " transactions in" << (timer.elapsed() * 1000) << "(" << (bool)m_syncTransactionQueue << ")";
 }
 
 void Client::onDeadBlocks(h256s const& _blocks, h256Hash& io_changed)
 {
-	// insert transactions that we are declaring the dead part of the chain
-	for (auto const& h: _blocks)
-	{
-		clog(ClientTrace) << "Dead block:" << h;
-		for (auto const& t: bc().transactions(h))
-		{
-			clog(ClientTrace) << "Resubmitting dead-block transaction " << Transaction(t, CheckTransaction::None);
-			ctrace << "Resubmitting dead-block transaction " << Transaction(t, CheckTransaction::None);
-			m_tq.import(t, IfDropped::Retry);
-		}
-	}
+    // insert transactions that we are declaring the dead part of the chain
+    for (auto const& h: _blocks)
+    {
+        clog(ClientTrace) << "Dead block:" << h;
+        for (auto const& t: bc().transactions(h))
+        {
+            clog(ClientTrace) << "Resubmitting dead-block transaction " << Transaction(t, CheckTransaction::None);
+            ctrace << "Resubmitting dead-block transaction " << Transaction(t, CheckTransaction::None);
+            m_tq.import(t, IfDropped::Retry);
+        }
+    }
 
-	for (auto const& h: _blocks)
-		appendFromBlock(h, BlockPolarity::Dead, io_changed);
+    for (auto const& h: _blocks)
+        appendFromBlock(h, BlockPolarity::Dead, io_changed);
 }
 
 void Client::onNewBlocks(h256s const& _blocks, h256Hash& io_changed)
 {
-	// remove transactions from m_tq nicely rather than relying on out of date nonce later on.
-	for (auto const& h: _blocks)
-		clog(ClientTrace) << "Live block:" << h;
+    // remove transactions from m_tq nicely rather than relying on out of date nonce later on.
+    for (auto const& h: _blocks)
+        clog(ClientTrace) << "Live block:" << h;
 
-	if (auto h = m_host.lock())
-		h->noteNewBlocks();
+    if (auto h = m_host.lock())
+        h->noteNewBlocks();
 
-	for (auto const& h: _blocks)
-		appendFromBlock(h, BlockPolarity::Live, io_changed);
+    for (auto const& h: _blocks)
+        appendFromBlock(h, BlockPolarity::Live, io_changed);
 }
 
 void Client::resyncStateFromChain()
 {
-	DEV_READ_GUARDED(x_working)
-		if (bc().currentHash() == m_working.info().parentHash())
-			return;
-		
-	// RESTART MINING
+    DEV_READ_GUARDED(x_working)
+        if (bc().currentHash() == m_working.info().parentHash())
+            return;
+        
+    // RESTART MINING
 
-	bool preChanged = false;
-	Block newPreMine(chainParams().accountStartNonce);
-	DEV_READ_GUARDED(x_preSeal)
-		newPreMine = m_preSeal;
+    bool preChanged = false;
+    Block newPreMine(chainParams().accountStartNonce);
+    DEV_READ_GUARDED(x_preSeal)
+        newPreMine = m_preSeal;
 
-	// TODO: use m_postSeal to avoid re-evaluating our own blocks.
-	preChanged = newPreMine.sync(bc());
+    // TODO: use m_postSeal to avoid re-evaluating our own blocks.
+    preChanged = newPreMine.sync(bc());
 
-	if (preChanged || m_postSeal.author() != m_preSeal.author())
-	{
-		DEV_WRITE_GUARDED(x_preSeal)
-			m_preSeal = newPreMine;
-		DEV_WRITE_GUARDED(x_working)
-			m_working = newPreMine;
-		DEV_READ_GUARDED(x_postSeal)
-			if (!m_postSeal.isSealed() || m_postSeal.info().hash() != newPreMine.info().parentHash())
-				for (auto const& t: m_postSeal.pending())
-				{
-					clog(ClientTrace) << "Resubmitting post-seal transaction " << t;
-//						ctrace << "Resubmitting post-seal transaction " << t;
-					auto ir = m_tq.import(t, IfDropped::Retry);
-					if (ir != ImportResult::Success)
-						onTransactionQueueReady();
-				}
-		DEV_READ_GUARDED(x_working) DEV_WRITE_GUARDED(x_postSeal)
-			m_postSeal = m_working;
+    if (preChanged || m_postSeal.author() != m_preSeal.author())
+    {
+        DEV_WRITE_GUARDED(x_preSeal)
+            m_preSeal = newPreMine;
+        DEV_WRITE_GUARDED(x_working)
+            m_working = newPreMine;
+        DEV_READ_GUARDED(x_postSeal)
+            if (!m_postSeal.isSealed() || m_postSeal.info().hash() != newPreMine.info().parentHash())
+                for (auto const& t: m_postSeal.pending())
+                {
+                    clog(ClientTrace) << "Resubmitting post-seal transaction " << t;
+//                      ctrace << "Resubmitting post-seal transaction " << t;
+                    auto ir = m_tq.import(t, IfDropped::Retry);
+                    if (ir != ImportResult::Success)
+                        onTransactionQueueReady();
+                }
+        DEV_READ_GUARDED(x_working) DEV_WRITE_GUARDED(x_postSeal)
+            m_postSeal = m_working;
 
-		onPostStateChanged();
-	}
+        onPostStateChanged();
+    }
 
-	// Quick hack for now - the TQ at this point already has the prior pending transactions in it;
-	// we should resync with it manually until we are stricter about what constitutes "knowing".
-	onTransactionQueueReady();
+    // Quick hack for now - the TQ at this point already has the prior pending transactions in it;
+    // we should resync with it manually until we are stricter about what constitutes "knowing".
+    onTransactionQueueReady();
 }
 
 void Client::resetState()
 {
-	Block newPreMine(chainParams().accountStartNonce);
-	DEV_READ_GUARDED(x_preSeal)
-		newPreMine = m_preSeal;
+    Block newPreMine(chainParams().accountStartNonce);
+    DEV_READ_GUARDED(x_preSeal)
+        newPreMine = m_preSeal;
 
-	DEV_WRITE_GUARDED(x_working)
-		m_working = newPreMine;
-	DEV_READ_GUARDED(x_working) DEV_WRITE_GUARDED(x_postSeal)
-		m_postSeal = m_working;
+    DEV_WRITE_GUARDED(x_working)
+        m_working = newPreMine;
+    DEV_READ_GUARDED(x_working) DEV_WRITE_GUARDED(x_postSeal)
+        m_postSeal = m_working;
 
-	onPostStateChanged();
-	onTransactionQueueReady();
+    onPostStateChanged();
+    onTransactionQueueReady();
 }
 
 void Client::onChainChanged(ImportRoute const& _ir)
 {
-//	ctrace << "onChainChanged()";
-	h256Hash changeds;
-	onDeadBlocks(_ir.deadBlocks, changeds);
-	for (auto const& t: _ir.goodTranactions)
-	{
-		clog(ClientTrace) << "Safely dropping transaction " << t.sha3();
-		m_tq.dropGood(t);
-	}
-	onNewBlocks(_ir.liveBlocks, changeds);
-	if (!isMajorSyncing())
-		resyncStateFromChain();
-	noteChanged(changeds);
+//  ctrace << "onChainChanged()";
+    h256Hash changeds;
+    onDeadBlocks(_ir.deadBlocks, changeds);
+    for (auto const& t: _ir.goodTranactions)
+    {
+        clog(ClientTrace) << "Safely dropping transaction " << t.sha3();
+        m_tq.dropGood(t);
+    }
+    onNewBlocks(_ir.liveBlocks, changeds);
+    if (!isMajorSyncing())
+        resyncStateFromChain();
+    noteChanged(changeds);
 }
 
 bool Client::remoteActive() const
 {
-	return chrono::system_clock::now() - m_lastGetWork < chrono::seconds(30);
+    return chrono::system_clock::now() - m_lastGetWork < chrono::seconds(30);
 }
 
 void Client::onPostStateChanged()
 {
-	clog(ClientTrace) << "Post state changed.";
-	m_signalled.notify_all();
-	m_remoteWorking = false;
+    clog(ClientTrace) << "Post state changed.";
+    m_signalled.notify_all();
+    m_remoteWorking = false;
 }
 
 void Client::startSealing()
 {
-	if (m_wouldSeal == true)
-		return;
-	clog(ClientNote) << "Mining Beneficiary: " << author();
-	if (author())
-	{
-		m_wouldSeal = true;
-		m_signalled.notify_all();
-	}
-	else
-		clog(ClientNote) << "You need to set an author in order to seal!";
+    if (m_wouldSeal == true)
+        return;
+    clog(ClientNote) << "Mining Beneficiary: " << author();
+    if (author())
+    {
+        m_wouldSeal = true;
+        m_signalled.notify_all();
+    }
+    else
+        clog(ClientNote) << "You need to set an author in order to seal!";
 }
 
 void Client::rejigSealing()
 {
-	if ((wouldSeal() || remoteActive()) && !isMajorSyncing())
-	{
-		if (sealEngine()->shouldSeal(this))
-		{
-			m_wouldButShouldnot = false;
+    if ((wouldSeal() || remoteActive()) && !isMajorSyncing())
+    {
+        if (sealEngine()->shouldSeal(this))
+        {
+            m_wouldButShouldnot = false;
 
-			clog(ClientTrace) << "Rejigging seal engine...";
-			DEV_WRITE_GUARDED(x_working)
-			{
-				if (m_working.isSealed())
-				{
-					clog(ClientNote) << "Tried to seal sealed block...";
-					return;
-				}
-				m_working.commitToSeal(bc(), m_extraData);
-			}
-			DEV_READ_GUARDED(x_working)
-			{
-				DEV_WRITE_GUARDED(x_postSeal)
-					m_postSeal = m_working;
-				m_sealingInfo = m_working.info();
-			}
+            clog(ClientTrace) << "Rejigging seal engine...";
+            DEV_WRITE_GUARDED(x_working)
+            {
+                if (m_working.isSealed())
+                {
+                    clog(ClientNote) << "Tried to seal sealed block...";
+                    return;
+                }
+                m_working.commitToSeal(bc(), m_extraData);
+            }
+            DEV_READ_GUARDED(x_working)
+            {
+                DEV_WRITE_GUARDED(x_postSeal)
+                    m_postSeal = m_working;
+                m_sealingInfo = m_working.info();
+            }
 
-			if (wouldSeal())
-			{
-				sealEngine()->onSealGenerated([=](bytes const& header){
-					if (!this->submitSealed(header))
-						clog(ClientNote) << "Submitting block failed...";
-				});
-				ctrace << "Generating seal on" << m_sealingInfo.hash(WithoutSeal) << "#" << m_sealingInfo.number();
-				sealEngine()->generateSeal(m_sealingInfo);
-			}
-		}
-		else
-			m_wouldButShouldnot = true;
-	}
-	if (!m_wouldSeal)
-		sealEngine()->cancelGeneration();
+            if (wouldSeal())
+            {
+                sealEngine()->onSealGenerated([=](bytes const& header){
+                    if (!this->submitSealed(header))
+                        clog(ClientNote) << "Submitting block failed...";
+                });
+                ctrace << "Generating seal on" << m_sealingInfo.hash(WithoutSeal) << "#" << m_sealingInfo.number();
+                sealEngine()->generateSeal(m_sealingInfo);
+            }
+        }
+        else
+            m_wouldButShouldnot = true;
+    }
+    if (!m_wouldSeal)
+        sealEngine()->cancelGeneration();
 }
 
 void Client::noteChanged(h256Hash const& _filters)
 {
-	Guard l(x_filtersWatches);
-	if (_filters.size())
-		filtersStreamOut(cwatch << "noteChanged:", _filters);
-	// accrue all changes left in each filter into the watches.
-	for (auto& w: m_watches)
-		if (_filters.count(w.second.id))
-		{
-			if (m_filters.count(w.second.id))
-			{
-				cwatch << "!!!" << w.first << w.second.id.abridged();
-				w.second.changes += m_filters.at(w.second.id).changes;
-			}
-			else if (m_specialFilters.count(w.second.id))
-				for (h256 const& hash: m_specialFilters.at(w.second.id))
-				{
-					cwatch << "!!!" << w.first << LogTag::Special << (w.second.id == PendingChangedFilter ? "pending" : w.second.id == ChainChangedFilter ? "chain" : "???");
-					w.second.changes.push_back(LocalisedLogEntry(SpecialLogEntry, hash));
-				}
-		}
-	// clear the filters now.
-	for (auto& i: m_filters)
-		i.second.changes.clear();
-	for (auto& i: m_specialFilters)
-		i.second.clear();
+    Guard l(x_filtersWatches);
+    if (_filters.size())
+        filtersStreamOut(cwatch << "noteChanged:", _filters);
+    // accrue all changes left in each filter into the watches.
+    for (auto& w: m_watches)
+        if (_filters.count(w.second.id))
+        {
+            if (m_filters.count(w.second.id))
+            {
+                cwatch << "!!!" << w.first << w.second.id.abridged();
+                w.second.changes += m_filters.at(w.second.id).changes;
+            }
+            else if (m_specialFilters.count(w.second.id))
+                for (h256 const& hash: m_specialFilters.at(w.second.id))
+                {
+                    cwatch << "!!!" << w.first << LogTag::Special << (w.second.id == PendingChangedFilter ? "pending" : w.second.id == ChainChangedFilter ? "chain" : "???");
+                    w.second.changes.push_back(LocalisedLogEntry(SpecialLogEntry, hash));
+                }
+        }
+    // clear the filters now.
+    for (auto& i: m_filters)
+        i.second.changes.clear();
+    for (auto& i: m_specialFilters)
+        i.second.clear();
 }
 
 void Client::doWork(bool _doWait)
 {
-	bool t = true;
-	if (m_syncBlockQueue.compare_exchange_strong(t, false))
-		syncBlockQueue();
+    bool t = true;
+    if (m_syncBlockQueue.compare_exchange_strong(t, false))
+        syncBlockQueue();
 
-	if (m_needStateReset)
-	{
-		resetState();
-		m_needStateReset = false;
-	}
+    if (m_needStateReset)
+    {
+        resetState();
+        m_needStateReset = false;
+    }
 
-	t = true;
-	bool isSealed = false;
-	DEV_READ_GUARDED(x_working)
-		isSealed = m_working.isSealed();
-	if (!isSealed && !isMajorSyncing() && !m_remoteWorking && m_syncTransactionQueue.compare_exchange_strong(t, false))
-		syncTransactionQueue();
+    t = true;
+    bool isSealed = false;
+    DEV_READ_GUARDED(x_working)
+        isSealed = m_working.isSealed();
+    if (!isSealed && !isMajorSyncing() && !m_remoteWorking && m_syncTransactionQueue.compare_exchange_strong(t, false))
+        syncTransactionQueue();
 
-	tick();
+    tick();
 
-	rejigSealing();
+    rejigSealing();
 
-	callQueuedFunctions();
+    callQueuedFunctions();
 
-	DEV_READ_GUARDED(x_working)
-		isSealed = m_working.isSealed();
-	// If the block is sealed, we have to wait for it to tickle through the block queue
-	// (which only signals as wanting to be synced if it is ready).
-	if (!m_syncBlockQueue && !m_syncTransactionQueue && (_doWait || isSealed))
-	{
-		std::unique_lock<std::mutex> l(x_signalled);
-		m_signalled.wait_for(l, chrono::seconds(1));
-	}
+    DEV_READ_GUARDED(x_working)
+        isSealed = m_working.isSealed();
+    // If the block is sealed, we have to wait for it to tickle through the block queue
+    // (which only signals as wanting to be synced if it is ready).
+    if (!m_syncBlockQueue && !m_syncTransactionQueue && (_doWait || isSealed))
+    {
+        std::unique_lock<std::mutex> l(x_signalled);
+        m_signalled.wait_for(l, chrono::seconds(1));
+    }
 }
 
 void Client::tick()
 {
-	if (chrono::system_clock::now() - m_lastTick > chrono::seconds(1))
-	{
-		m_report.ticks++;
-		checkWatchGarbage();
-		m_bq.tick();
-		m_lastTick = chrono::system_clock::now();
-		if (m_report.ticks == 15)
-			clog(ClientTrace) << activityReport();
-	}
+    if (chrono::system_clock::now() - m_lastTick > chrono::seconds(1))
+    {
+        m_report.ticks++;
+        checkWatchGarbage();
+        m_bq.tick();
+        m_lastTick = chrono::system_clock::now();
+        if (m_report.ticks == 15)
+            clog(ClientTrace) << activityReport();
+    }
 }
 
 void Client::checkWatchGarbage()
 {
-	if (chrono::system_clock::now() - m_lastGarbageCollection > chrono::seconds(5))
-	{
-		// watches garbage collection
-		vector<unsigned> toUninstall;
-		DEV_GUARDED(x_filtersWatches)
-			for (auto key: keysOf(m_watches))
-				if (m_watches[key].lastPoll != chrono::system_clock::time_point::max() && chrono::system_clock::now() - m_watches[key].lastPoll > chrono::seconds(20))
-				{
-					toUninstall.push_back(key);
-					clog(ClientTrace) << "GC: Uninstall" << key << "(" << chrono::duration_cast<chrono::seconds>(chrono::system_clock::now() - m_watches[key].lastPoll).count() << "s old)";
-				}
-		for (auto i: toUninstall)
-			uninstallWatch(i);
+    if (chrono::system_clock::now() - m_lastGarbageCollection > chrono::seconds(5))
+    {
+        // watches garbage collection
+        vector<unsigned> toUninstall;
+        DEV_GUARDED(x_filtersWatches)
+            for (auto key: keysOf(m_watches))
+                if (m_watches[key].lastPoll != chrono::system_clock::time_point::max() && chrono::system_clock::now() - m_watches[key].lastPoll > chrono::seconds(20))
+                {
+                    toUninstall.push_back(key);
+                    clog(ClientTrace) << "GC: Uninstall" << key << "(" << chrono::duration_cast<chrono::seconds>(chrono::system_clock::now() - m_watches[key].lastPoll).count() << "s old)";
+                }
+        for (auto i: toUninstall)
+            uninstallWatch(i);
 
-		// blockchain GC
-		bc().garbageCollect();
+        // blockchain GC
+        bc().garbageCollect();
 
-		m_lastGarbageCollection = chrono::system_clock::now();
-	}
+        m_lastGarbageCollection = chrono::system_clock::now();
+    }
 }
 
 void Client::prepareForTransaction()
 {
-	startWorking();
+    startWorking();
 }
 
 Block Client::block(h256 const& _block) const
 {
-	try
-	{
-		Block ret(bc(), m_stateDB);
-		ret.populateFromChain(bc(), _block);
-		return ret;
-	}
-	catch (Exception& ex)
-	{
-		ex << errinfo_block(bc().block(_block));
-		onBadBlock(ex);
-		return Block(bc());
-	}
+    try
+    {
+        Block ret(bc(), m_stateDB);
+        ret.populateFromChain(bc(), _block);
+        return ret;
+    }
+    catch (Exception& ex)
+    {
+        ex << errinfo_block(bc().block(_block));
+        onBadBlock(ex);
+        return Block(bc());
+    }
 }
 
 Block Client::block(h256 const& _blockHash, PopulationStatistics* o_stats) const
 {
-	try
-	{
-		Block ret(bc(), m_stateDB);
-		PopulationStatistics s = ret.populateFromChain(bc(), _blockHash);
-		if (o_stats)
-			swap(s, *o_stats);
-		return ret;
-	}
-	catch (Exception& ex)
-	{
-		ex << errinfo_block(bc().block(_blockHash));
-		onBadBlock(ex);
-		return Block(bc());
-	}
+    try
+    {
+        Block ret(bc(), m_stateDB);
+        PopulationStatistics s = ret.populateFromChain(bc(), _blockHash);
+        if (o_stats)
+            swap(s, *o_stats);
+        return ret;
+    }
+    catch (Exception& ex)
+    {
+        ex << errinfo_block(bc().block(_blockHash));
+        onBadBlock(ex);
+        return Block(bc());
+    }
 }
 
 void Client::flushTransactions()
 {
-	doWork();
+    doWork();
 }
 
 SyncStatus Client::syncStatus() const
 {
-	auto h = m_host.lock();
-	if (!h)
-		return SyncStatus();
-	SyncStatus status = h->status();
-	status.majorSyncing = isMajorSyncing();
-	return status;
+    auto h = m_host.lock();
+    if (!h)
+        return SyncStatus();
+    SyncStatus status = h->status();
+    status.majorSyncing = isMajorSyncing();
+    return status;
 }
 
 bool Client::submitSealed(bytes const& _header)
 {
-	bytes newBlock;
-	{
-		UpgradableGuard l(x_working);
-		{
-			UpgradeGuard l2(l);
-			if (!m_working.sealBlock(_header))
-				return false;
-		}
-		DEV_WRITE_GUARDED(x_postSeal)
-			m_postSeal = m_working;
-		newBlock = m_working.blockData();
-	}
+    bytes newBlock;
+    {
+        UpgradableGuard l(x_working);
+        {
+            UpgradeGuard l2(l);
+            if (!m_working.sealBlock(_header))
+                return false;
+        }
+        DEV_WRITE_GUARDED(x_postSeal)
+            m_postSeal = m_working;
+        newBlock = m_working.blockData();
+    }
 
-	// OPTIMISE: very inefficient to not utilise the existing OverlayDB in m_postSeal that contains all trie changes.
-	return m_bq.import(&newBlock, true) == ImportResult::Success;
+    // OPTIMISE: very inefficient to not utilise the existing OverlayDB in m_postSeal that contains all trie changes.
+    return m_bq.import(&newBlock, true) == ImportResult::Success;
 }
 
 void Client::rewind(unsigned _n)
 {
-	executeInMainThread([=]() {
-		bc().rewind(_n);
-		onChainChanged(ImportRoute());
-	});
+    executeInMainThread([=]() {
+        bc().rewind(_n);
+        onChainChanged(ImportRoute());
+    });
 
-	for (unsigned i = 0; i < 10; ++i)
-	{
-		u256 n;
-		DEV_READ_GUARDED(x_working)
-			n = m_working.info().number();
-		if (n == _n + 1)
-			break;
-		this_thread::sleep_for(std::chrono::milliseconds(50));
-	}
-	auto h = m_host.lock();
-	if (h)
-		h->reset();
+    for (unsigned i = 0; i < 10; ++i)
+    {
+        u256 n;
+        DEV_READ_GUARDED(x_working)
+            n = m_working.info().number();
+        if (n == _n + 1)
+            break;
+        this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+    auto h = m_host.lock();
+    if (h)
+        h->reset();
 }
 
 pair<h256, Address> Client::submitTransaction(TransactionSkeleton const& _t, Secret const& _secret)
 {
-	prepareForTransaction();
+    prepareForTransaction();
 
-	TransactionSkeleton ts(_t);
-	ts.from = toAddress(_secret);
-	if (_t.nonce == Invalid256)
-		ts.nonce = max<u256>(postSeal().transactionsFrom(ts.from), m_tq.maxNonce(ts.from));
-	if (ts.gasPrice == Invalid256)
-		ts.gasPrice = gasBidPrice();
-	if (ts.gas == Invalid256)
-		ts.gas = min<u256>(gasLimitRemaining() / 5, balanceAt(ts.from) / ts.gasPrice);
+    TransactionSkeleton ts(_t);
+    ts.from = toAddress(_secret);
+    if (_t.nonce == Invalid256)
+        ts.nonce = max<u256>(postSeal().transactionsFrom(ts.from), m_tq.maxNonce(ts.from));
+    if (ts.gasPrice == Invalid256)
+        ts.gasPrice = gasBidPrice();
+    if (ts.gas == Invalid256)
+        ts.gas = min<u256>(gasLimitRemaining() / 5, balanceAt(ts.from) / ts.gasPrice);
 
-	Transaction t(ts, _secret);
-	m_tq.import(t.rlp());
+    Transaction t(ts, _secret);
+    m_tq.import(t.rlp());
 
-	return make_pair(t.sha3(), toAddress(ts.from, ts.nonce));
+    return make_pair(t.sha3(), toAddress(ts.from, ts.nonce));
 }
 
 // TODO: remove try/catch, allow exceptions
 ExecutionResult Client::call(Address const& _from, u256 _value, Address _dest, bytes const& _data, u256 _gas, u256 _gasPrice, BlockNumber _blockNumber, FudgeFactor _ff)
 {
-	ExecutionResult ret;
-	try
-	{
-		Block temp = block(_blockNumber);
-		u256 nonce = max<u256>(temp.transactionsFrom(_from), m_tq.maxNonce(_from));
-		u256 gas = _gas == Invalid256 ? gasLimitRemaining() : _gas;
-		u256 gasPrice = _gasPrice == Invalid256 ? gasBidPrice() : _gasPrice;
-		Transaction t(_value, gasPrice, gas, _dest, _data, nonce);
-		t.forceSender(_from);
-		if (_ff == FudgeFactor::Lenient)
-			temp.mutableState().addBalance(_from, (u256)(t.gas() * t.gasPrice() + t.value()));
-		ret = temp.execute(bc().lastBlockHashes(), t, Permanence::Reverted);
-	}
-	catch (...)
-	{
-		// TODO: Some sort of notification of failure.
-	}
-	return ret;
+    ExecutionResult ret;
+    try
+    {
+        Block temp = block(_blockNumber);
+        u256 nonce = max<u256>(temp.transactionsFrom(_from), m_tq.maxNonce(_from));
+        u256 gas = _gas == Invalid256 ? gasLimitRemaining() : _gas;
+        u256 gasPrice = _gasPrice == Invalid256 ? gasBidPrice() : _gasPrice;
+        Transaction t(_value, gasPrice, gas, _dest, _data, nonce);
+        t.forceSender(_from);
+        if (_ff == FudgeFactor::Lenient)
+            temp.mutableState().addBalance(_from, (u256)(t.gas() * t.gasPrice() + t.value()));
+        ret = temp.execute(bc().lastBlockHashes(), t, Permanence::Reverted);
+    }
+    catch (...)
+    {
+        // TODO: Some sort of notification of failure.
+    }
+    return ret;
 }

--- a/libethereum/Client.h
+++ b/libethereum/Client.h
@@ -216,7 +216,8 @@ public:
 protected:
     /// Perform critical setup functions.
     /// Must be called in the constructor of the finally derived class.
-    void init(p2p::Host* _extNet, boost::filesystem::path const& _dbPath, boost::filesystem::path const& _snapshotPath, WithExisting _forceAction, u256 _networkId);
+    void init(p2p::Host* _extNet, boost::filesystem::path const& _dbPath,
+        boost::filesystem::path const& _snapshotPath, WithExisting _forceAction, u256 _networkId);
 
     /// InterfaceStub methods
     BlockChain& bc() override { return m_bc; }

--- a/libethereum/Client.h
+++ b/libethereum/Client.h
@@ -1,18 +1,18 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file Client.h
  * @author Gav Wood <i@gavwood.com>
@@ -45,6 +45,7 @@
 
 #include <boost/filesystem/path.hpp>
 
+
 namespace dev
 {
 namespace eth
@@ -55,9 +56,9 @@ class DownloadMan;
 
 enum ClientWorkState
 {
-	Active = 0,
-	Deleting,
-	Deleted
+    Active = 0,
+    Deleting,
+    Deleted
 };
 
 struct ClientNote: public LogChannel { static const char* name(); static const int verbosity = 2; };
@@ -67,8 +68,8 @@ struct ClientDetail: public LogChannel { static const char* name(); static const
 
 struct ActivityReport
 {
-	unsigned ticks = 0;
-	std::chrono::system_clock::time_point since = std::chrono::system_clock::now();
+    unsigned ticks = 0;
+    std::chrono::system_clock::time_point since = std::chrono::system_clock::now();
 };
 
 std::ostream& operator<<(std::ostream& _out, ActivityReport const& _r);
@@ -79,275 +80,276 @@ std::ostream& operator<<(std::ostream& _out, ActivityReport const& _r);
 class Client: public ClientBase, protected Worker
 {
 public:
-	Client(
-		ChainParams const& _params,
-		int _networkID,
-		p2p::Host* _host,
-		std::shared_ptr<GasPricer> _gpForAdoption,
-		boost::filesystem::path const& _dbPath = boost::filesystem::path(),
-		WithExisting _forceAction = WithExisting::Trust,
-		TransactionQueue::Limits const& _l = TransactionQueue::Limits{1024, 1024}
-	);
-	/// Destructor.
-	virtual ~Client();
+    Client(
+        ChainParams const& _params,
+        int _networkID,
+        p2p::Host* _host,
+        std::shared_ptr<GasPricer> _gpForAdoption,
+        boost::filesystem::path const& _dbPath = boost::filesystem::path(),
+        boost::filesystem::path const& _snapshotPath = boost::filesystem::path(),
+        WithExisting _forceAction = WithExisting::Trust,
+        TransactionQueue::Limits const& _l = TransactionQueue::Limits{1024, 1024}
+    );
+    /// Destructor.
+    virtual ~Client();
 
-	/// Get information on this chain.
-	ChainParams const& chainParams() const { return bc().chainParams(); }
+    /// Get information on this chain.
+    ChainParams const& chainParams() const { return bc().chainParams(); }
 
-	virtual ImportResult injectTransaction(bytes const& _rlp, IfDropped _id = IfDropped::Ignore) override { prepareForTransaction(); return m_tq.import(_rlp, _id); }
+    virtual ImportResult injectTransaction(bytes const& _rlp, IfDropped _id = IfDropped::Ignore) override { prepareForTransaction(); return m_tq.import(_rlp, _id); }
 
-	/// Resets the gas pricer to some other object.
-	void setGasPricer(std::shared_ptr<GasPricer> _gp) { m_gp = _gp; }
-	std::shared_ptr<GasPricer> gasPricer() const { return m_gp; }
+    /// Resets the gas pricer to some other object.
+    void setGasPricer(std::shared_ptr<GasPricer> _gp) { m_gp = _gp; }
+    std::shared_ptr<GasPricer> gasPricer() const { return m_gp; }
 
-	/// Submits the given transaction.
-	/// @returns the new transaction's hash.
-	virtual std::pair<h256, Address> submitTransaction(TransactionSkeleton const& _t, Secret const& _secret) override;
+    /// Submits the given transaction.
+    /// @returns the new transaction's hash.
+    virtual std::pair<h256, Address> submitTransaction(TransactionSkeleton const& _t, Secret const& _secret) override;
 
-	/// Makes the given call. Nothing is recorded into the state.
-	virtual ExecutionResult call(Address const& _secret, u256 _value, Address _dest, bytes const& _data, u256 _gas, u256 _gasPrice, BlockNumber _blockNumber, FudgeFactor _ff = FudgeFactor::Strict) override;
+    /// Makes the given call. Nothing is recorded into the state.
+    virtual ExecutionResult call(Address const& _secret, u256 _value, Address _dest, bytes const& _data, u256 _gas, u256 _gasPrice, BlockNumber _blockNumber, FudgeFactor _ff = FudgeFactor::Strict) override;
 
-	/// Blocks until all pending transactions have been processed.
-	virtual void flushTransactions() override;
+    /// Blocks until all pending transactions have been processed.
+    virtual void flushTransactions() override;
 
-	/// Queues a block for import.
-	ImportResult queueBlock(bytes const& _block, bool _isSafe = false);
+    /// Queues a block for import.
+    ImportResult queueBlock(bytes const& _block, bool _isSafe = false);
 
-	/// Get the remaining gas limit in this block.
-	virtual u256 gasLimitRemaining() const override { return m_postSeal.gasLimitRemaining(); }
-	/// Get the gas bid price
-	virtual u256 gasBidPrice() const override { return m_gp->bid(); }
+    /// Get the remaining gas limit in this block.
+    virtual u256 gasLimitRemaining() const override { return m_postSeal.gasLimitRemaining(); }
+    /// Get the gas bid price
+    virtual u256 gasBidPrice() const override { return m_gp->bid(); }
 
-	// [PRIVATE API - only relevant for base clients, not available in general]
-	/// Get the block.
-	dev::eth::Block block(h256 const& _blockHash, PopulationStatistics* o_stats) const;
+    // [PRIVATE API - only relevant for base clients, not available in general]
+    /// Get the block.
+    dev::eth::Block block(h256 const& _blockHash, PopulationStatistics* o_stats) const;
 
-	/// Get the object representing the current state of Ethereum.
-	dev::eth::Block postState() const { ReadGuard l(x_postSeal); return m_postSeal; }
-	/// Get the object representing the current canonical blockchain.
-	BlockChain const& blockChain() const { return bc(); }
-	/// Get some information on the block queue.
-	BlockQueueStatus blockQueueStatus() const { return m_bq.status(); }
-	/// Get some information on the block syncing.
-	SyncStatus syncStatus() const override;
-	/// Get the block queue.
-	BlockQueue const& blockQueue() const { return m_bq; }
-	/// Get the block queue.
-	OverlayDB const& stateDB() const { return m_stateDB; }
-	/// Get some information on the transaction queue.
-	TransactionQueue::Status transactionQueueStatus() const { return m_tq.status(); }
-	TransactionQueue::Limits transactionQueueLimits() const { return m_tq.limits(); }
+    /// Get the object representing the current state of Ethereum.
+    dev::eth::Block postState() const { ReadGuard l(x_postSeal); return m_postSeal; }
+    /// Get the object representing the current canonical blockchain.
+    BlockChain const& blockChain() const { return bc(); }
+    /// Get some information on the block queue.
+    BlockQueueStatus blockQueueStatus() const { return m_bq.status(); }
+    /// Get some information on the block syncing.
+    SyncStatus syncStatus() const override;
+    /// Get the block queue.
+    BlockQueue const& blockQueue() const { return m_bq; }
+    /// Get the block queue.
+    OverlayDB const& stateDB() const { return m_stateDB; }
+    /// Get some information on the transaction queue.
+    TransactionQueue::Status transactionQueueStatus() const { return m_tq.status(); }
+    TransactionQueue::Limits transactionQueueLimits() const { return m_tq.limits(); }
 
-	/// Freeze worker thread and sync some of the block queue.
-	std::tuple<ImportRoute, bool, unsigned> syncQueue(unsigned _max = 1);
+    /// Freeze worker thread and sync some of the block queue.
+    std::tuple<ImportRoute, bool, unsigned> syncQueue(unsigned _max = 1);
 
-	// Sealing stuff:
-	// Note: "mining"/"miner" is deprecated. Use "sealing"/"sealer".
+    // Sealing stuff:
+    // Note: "mining"/"miner" is deprecated. Use "sealing"/"sealer".
 
-	virtual Address author() const override { ReadGuard l(x_preSeal); return m_preSeal.author(); }
-	virtual void setAuthor(Address const& _us) override { WriteGuard l(x_preSeal); m_preSeal.setAuthor(_us); }
+    virtual Address author() const override { ReadGuard l(x_preSeal); return m_preSeal.author(); }
+    virtual void setAuthor(Address const& _us) override { WriteGuard l(x_preSeal); m_preSeal.setAuthor(_us); }
 
-	/// Type of sealers available for this seal engine.
-	strings sealers() const { return sealEngine()->sealers(); }
-	/// Current sealer in use.
-	std::string sealer() const { return sealEngine()->sealer(); }
-	/// Change sealer.
-	void setSealer(std::string const& _id) { sealEngine()->setSealer(_id); if (wouldSeal()) startSealing(); }
-	/// Review option for the sealer.
-	bytes sealOption(std::string const& _name) const { return sealEngine()->option(_name); }
-	/// Set option for the sealer.
-	bool setSealOption(std::string const& _name, bytes const& _value) { auto ret = sealEngine()->setOption(_name, _value); if (wouldSeal()) startSealing(); return ret; }
+    /// Type of sealers available for this seal engine.
+    strings sealers() const { return sealEngine()->sealers(); }
+    /// Current sealer in use.
+    std::string sealer() const { return sealEngine()->sealer(); }
+    /// Change sealer.
+    void setSealer(std::string const& _id) { sealEngine()->setSealer(_id); if (wouldSeal()) startSealing(); }
+    /// Review option for the sealer.
+    bytes sealOption(std::string const& _name) const { return sealEngine()->option(_name); }
+    /// Set option for the sealer.
+    bool setSealOption(std::string const& _name, bytes const& _value) { auto ret = sealEngine()->setOption(_name, _value); if (wouldSeal()) startSealing(); return ret; }
 
-	/// Start sealing.
-	void startSealing() override;
-	/// Stop sealing.
-	void stopSealing() override { m_wouldSeal = false; }
-	/// Are we sealing now?
-	bool wouldSeal() const override { return m_wouldSeal; }
+    /// Start sealing.
+    void startSealing() override;
+    /// Stop sealing.
+    void stopSealing() override { m_wouldSeal = false; }
+    /// Are we sealing now?
+    bool wouldSeal() const override { return m_wouldSeal; }
 
-	/// Are we updating the chain (syncing or importing a new block)?
-	bool isSyncing() const override;
-	/// Are we syncing the chain?
-	bool isMajorSyncing() const override;
+    /// Are we updating the chain (syncing or importing a new block)?
+    bool isSyncing() const override;
+    /// Are we syncing the chain?
+    bool isMajorSyncing() const override;
 
-	/// Gets the network id.
-	u256 networkId() const override;
-	/// Sets the network id.
-	void setNetworkId(u256 const& _n) override;
+    /// Gets the network id.
+    u256 networkId() const override;
+    /// Sets the network id.
+    void setNetworkId(u256 const& _n) override;
 
-	/// Get the seal engine.
-	SealEngineFace* sealEngine() const override { return bc().sealEngine(); }
+    /// Get the seal engine.
+    SealEngineFace* sealEngine() const override { return bc().sealEngine(); }
 
-	// Debug stuff:
+    // Debug stuff:
 
-	DownloadMan const* downloadMan() const;
-	/// Clears pending transactions. Just for debug use.
-	void clearPending();
-	/// Kills the blockchain. Just for debug use.
-	void killChain() { reopenChain(WithExisting::Kill); }
-	/// Reloads the blockchain. Just for debug use.
-	void reopenChain(ChainParams const& _p, WithExisting _we = WithExisting::Trust);
-	void reopenChain(WithExisting _we);
-	/// Retries all blocks with unknown parents.
-	void retryUnknown() { m_bq.retryAllUnknown(); }
-	/// Get a report of activity.
-	ActivityReport activityReport() { ActivityReport ret; std::swap(m_report, ret); return ret; }
-	/// Set the extra data that goes into sealed blocks.
-	void setExtraData(bytes const& _extraData) { m_extraData = _extraData; }
-	/// Rewind to a prior head.
-	void rewind(unsigned _n);
-	/// Rescue the chain.
-	void rescue() { bc().rescue(m_stateDB); }
+    DownloadMan const* downloadMan() const;
+    /// Clears pending transactions. Just for debug use.
+    void clearPending();
+    /// Kills the blockchain. Just for debug use.
+    void killChain() { reopenChain(WithExisting::Kill); }
+    /// Reloads the blockchain. Just for debug use.
+    void reopenChain(ChainParams const& _p, WithExisting _we = WithExisting::Trust);
+    void reopenChain(WithExisting _we);
+    /// Retries all blocks with unknown parents.
+    void retryUnknown() { m_bq.retryAllUnknown(); }
+    /// Get a report of activity.
+    ActivityReport activityReport() { ActivityReport ret; std::swap(m_report, ret); return ret; }
+    /// Set the extra data that goes into sealed blocks.
+    void setExtraData(bytes const& _extraData) { m_extraData = _extraData; }
+    /// Rewind to a prior head.
+    void rewind(unsigned _n);
+    /// Rescue the chain.
+    void rescue() { bc().rescue(m_stateDB); }
 
-	std::unique_ptr<StateImporterFace> createStateImporter() { return dev::eth::createStateImporter(m_stateDB); }
-	std::unique_ptr<BlockChainImporterFace> createBlockChainImporter() { return dev::eth::createBlockChainImporter(m_bc); }
+    std::unique_ptr<StateImporterFace> createStateImporter() { return dev::eth::createStateImporter(m_stateDB); }
+    std::unique_ptr<BlockChainImporterFace> createBlockChainImporter() { return dev::eth::createBlockChainImporter(m_bc); }
 
-	/// Queues a function to be executed in the main thread (that owns the blockchain, etc).
-	void executeInMainThread(std::function<void()> const& _function);
+    /// Queues a function to be executed in the main thread (that owns the blockchain, etc).
+    void executeInMainThread(std::function<void()> const& _function);
 
-	virtual Block block(h256 const& _block) const override;
-	using ClientBase::block;
+    virtual Block block(h256 const& _block) const override;
+    using ClientBase::block;
 
-	/// should be called after the constructor of the most derived class finishes.
-	void startWorking() { Worker::startWorking(); };
-
-protected:
-	/// Perform critical setup functions.
-	/// Must be called in the constructor of the finally derived class.
-	void init(p2p::Host* _extNet, boost::filesystem::path const& _dbPath, WithExisting _forceAction, u256 _networkId);
-
-	/// InterfaceStub methods
-	BlockChain& bc() override { return m_bc; }
-	BlockChain const& bc() const override { return m_bc; }
-
-	/// Returns the state object for the full block (i.e. the terminal state) for index _h.
-	/// Works properly with LatestBlock and PendingBlock.
-	virtual Block preSeal() const override { ReadGuard l(x_preSeal); return m_preSeal; }
-	virtual Block postSeal() const override { ReadGuard l(x_postSeal); return m_postSeal; }
-	virtual void prepareForTransaction() override;
-
-	/// Collate the changed filters for the bloom filter of the given pending transaction.
-	/// Insert any filters that are activated into @a o_changed.
-	void appendFromNewPending(TransactionReceipt const& _receipt, h256Hash& io_changed, h256 _sha3);
-
-	/// Collate the changed filters for the hash of the given block.
-	/// Insert any filters that are activated into @a o_changed.
-	void appendFromBlock(h256 const& _blockHash, BlockPolarity _polarity, h256Hash& io_changed);
-
-	/// Record that the set of filters @a _filters have changed.
-	/// This doesn't actually make any callbacks, but incrememnts some counters in m_watches.
-	void noteChanged(h256Hash const& _filters);
-
-	/// Submit
-	virtual bool submitSealed(bytes const& _s);
+    /// should be called after the constructor of the most derived class finishes.
+    void startWorking() { Worker::startWorking(); };
 
 protected:
-	/// Called when Worker is starting.
-	void startedWorking() override;
+    /// Perform critical setup functions.
+    /// Must be called in the constructor of the finally derived class.
+    void init(p2p::Host* _extNet, boost::filesystem::path const& _dbPath, boost::filesystem::path const& _snapshotPath, WithExisting _forceAction, u256 _networkId);
 
-	/// Do some work. Handles blockchain maintenance and sealing.
-	void doWork(bool _doWait);
-	void doWork() override { doWork(true); }
+    /// InterfaceStub methods
+    BlockChain& bc() override { return m_bc; }
+    BlockChain const& bc() const override { return m_bc; }
 
-	/// Called when Worker is exiting.
-	void doneWorking() override;
+    /// Returns the state object for the full block (i.e. the terminal state) for index _h.
+    /// Works properly with LatestBlock and PendingBlock.
+    virtual Block preSeal() const override { ReadGuard l(x_preSeal); return m_preSeal; }
+    virtual Block postSeal() const override { ReadGuard l(x_postSeal); return m_postSeal; }
+    virtual void prepareForTransaction() override;
 
-	/// Called when wouldSeal(), pendingTransactions() have changed.
-	void rejigSealing();
+    /// Collate the changed filters for the bloom filter of the given pending transaction.
+    /// Insert any filters that are activated into @a o_changed.
+    void appendFromNewPending(TransactionReceipt const& _receipt, h256Hash& io_changed, h256 _sha3);
 
-	/// Called on chain changes
-	void onDeadBlocks(h256s const& _blocks, h256Hash& io_changed);
+    /// Collate the changed filters for the hash of the given block.
+    /// Insert any filters that are activated into @a o_changed.
+    void appendFromBlock(h256 const& _blockHash, BlockPolarity _polarity, h256Hash& io_changed);
 
-	/// Called on chain changes
-	virtual void onNewBlocks(h256s const& _blocks, h256Hash& io_changed);
+    /// Record that the set of filters @a _filters have changed.
+    /// This doesn't actually make any callbacks, but incrememnts some counters in m_watches.
+    void noteChanged(h256Hash const& _filters);
 
-	/// Called after processing blocks by onChainChanged(_ir)
-	void resyncStateFromChain();
+    /// Submit
+    virtual bool submitSealed(bytes const& _s);
 
-	/// Clear working state of transactions
-	void resetState();
+protected:
+    /// Called when Worker is starting.
+    void startedWorking() override;
 
-	/// Magically called when the chain has changed. An import route is provided.
-	/// Called by either submitWork() or in our main thread through syncBlockQueue().
-	void onChainChanged(ImportRoute const& _ir);
+    /// Do some work. Handles blockchain maintenance and sealing.
+    void doWork(bool _doWait);
+    void doWork() override { doWork(true); }
 
-	/// Signal handler for when the block queue needs processing.
-	void syncBlockQueue();
+    /// Called when Worker is exiting.
+    void doneWorking() override;
 
-	/// Signal handler for when the block queue needs processing.
-	void syncTransactionQueue();
+    /// Called when wouldSeal(), pendingTransactions() have changed.
+    void rejigSealing();
 
-	/// Magically called when m_tq needs syncing. Be nice and don't block.
-	void onTransactionQueueReady() { m_syncTransactionQueue = true; m_signalled.notify_all(); }
+    /// Called on chain changes
+    void onDeadBlocks(h256s const& _blocks, h256Hash& io_changed);
 
-	/// Magically called when m_bq needs syncing. Be nice and don't block.
-	void onBlockQueueReady() { m_syncBlockQueue = true; m_signalled.notify_all(); }
+    /// Called on chain changes
+    virtual void onNewBlocks(h256s const& _blocks, h256Hash& io_changed);
 
-	/// Called when the post state has changed (i.e. when more transactions are in it or we're sealing on a new block).
-	/// This updates m_sealingInfo.
-	void onPostStateChanged();
+    /// Called after processing blocks by onChainChanged(_ir)
+    void resyncStateFromChain();
 
-	/// Does garbage collection on watches.
-	void checkWatchGarbage();
+    /// Clear working state of transactions
+    void resetState();
 
-	/// Ticks various system-level objects.
-	void tick();
+    /// Magically called when the chain has changed. An import route is provided.
+    /// Called by either submitWork() or in our main thread through syncBlockQueue().
+    void onChainChanged(ImportRoute const& _ir);
 
-	/// Called when we have attempted to import a bad block.
-	/// @warning May be called from any thread.
-	void onBadBlock(Exception& _ex) const;
+    /// Signal handler for when the block queue needs processing.
+    void syncBlockQueue();
 
-	/// Executes the pending functions in m_functionQueue
-	void callQueuedFunctions();
+    /// Signal handler for when the block queue needs processing.
+    void syncTransactionQueue();
 
-	BlockChain m_bc;						///< Maintains block database and owns the seal engine.
-	BlockQueue m_bq;						///< Maintains a list of incoming blocks not yet on the blockchain (to be imported).
-	TransactionQueue m_tq;					///< Maintains a list of incoming transactions not yet in a block on the blockchain.
+    /// Magically called when m_tq needs syncing. Be nice and don't block.
+    void onTransactionQueueReady() { m_syncTransactionQueue = true; m_signalled.notify_all(); }
 
-	std::shared_ptr<GasPricer> m_gp;		///< The gas pricer.
+    /// Magically called when m_bq needs syncing. Be nice and don't block.
+    void onBlockQueueReady() { m_syncBlockQueue = true; m_signalled.notify_all(); }
 
-	OverlayDB m_stateDB;					///< Acts as the central point for the state database, so multiple States can share it.
-	mutable SharedMutex x_preSeal;			///< Lock on m_preSeal.
-	Block m_preSeal;						///< The present state of the client.
-	mutable SharedMutex x_postSeal;			///< Lock on m_postSeal.
-	Block m_postSeal;						///< The state of the client which we're sealing (i.e. it'll have all the rewards added).
-	mutable SharedMutex x_working;			///< Lock on m_working.
-	Block m_working;						///< The state of the client which we're sealing (i.e. it'll have all the rewards added), while we're actually working on it.
-	BlockHeader m_sealingInfo;				///< The header we're attempting to seal on (derived from m_postSeal).
-	bool remoteActive() const;				///< Is there an active and valid remote worker?
-	bool m_remoteWorking = false;			///< Has the remote worker recently been reset?
-	std::atomic<bool> m_needStateReset = { false };			///< Need reset working state to premin on next sync
-	std::chrono::system_clock::time_point m_lastGetWork;	///< Is there an active and valid remote worker?
+    /// Called when the post state has changed (i.e. when more transactions are in it or we're sealing on a new block).
+    /// This updates m_sealingInfo.
+    void onPostStateChanged();
 
-	std::weak_ptr<EthereumHost> m_host;		///< Our Ethereum Host. Don't do anything if we can't lock.
+    /// Does garbage collection on watches.
+    void checkWatchGarbage();
+
+    /// Ticks various system-level objects.
+    void tick();
+
+    /// Called when we have attempted to import a bad block.
+    /// @warning May be called from any thread.
+    void onBadBlock(Exception& _ex) const;
+
+    /// Executes the pending functions in m_functionQueue
+    void callQueuedFunctions();
+
+    BlockChain m_bc;                        ///< Maintains block database and owns the seal engine.
+    BlockQueue m_bq;                        ///< Maintains a list of incoming blocks not yet on the blockchain (to be imported).
+    TransactionQueue m_tq;                  ///< Maintains a list of incoming transactions not yet in a block on the blockchain.
+
+    std::shared_ptr<GasPricer> m_gp;        ///< The gas pricer.
+
+    OverlayDB m_stateDB;                    ///< Acts as the central point for the state database, so multiple States can share it.
+    mutable SharedMutex x_preSeal;          ///< Lock on m_preSeal.
+    Block m_preSeal;                        ///< The present state of the client.
+    mutable SharedMutex x_postSeal;         ///< Lock on m_postSeal.
+    Block m_postSeal;                       ///< The state of the client which we're sealing (i.e. it'll have all the rewards added).
+    mutable SharedMutex x_working;          ///< Lock on m_working.
+    Block m_working;                        ///< The state of the client which we're sealing (i.e. it'll have all the rewards added), while we're actually working on it.
+    BlockHeader m_sealingInfo;              ///< The header we're attempting to seal on (derived from m_postSeal).
+    bool remoteActive() const;              ///< Is there an active and valid remote worker?
+    bool m_remoteWorking = false;           ///< Has the remote worker recently been reset?
+    std::atomic<bool> m_needStateReset = { false };         ///< Need reset working state to premin on next sync
+    std::chrono::system_clock::time_point m_lastGetWork;    ///< Is there an active and valid remote worker?
+
+    std::weak_ptr<EthereumHost> m_host;     ///< Our Ethereum Host. Don't do anything if we can't lock.
     std::weak_ptr<WarpHostCapability> m_warpHost;
 
     std::condition_variable m_signalled;
-	Mutex x_signalled;
+    Mutex x_signalled;
 
-	Handler<> m_tqReady;
-	Handler<h256 const&> m_tqReplaced;
-	Handler<> m_bqReady;
+    Handler<> m_tqReady;
+    Handler<h256 const&> m_tqReplaced;
+    Handler<> m_bqReady;
 
-	bool m_wouldSeal = false;				///< True if we /should/ be sealing.
-	bool m_wouldButShouldnot = false;		///< True if the last time we called rejigSealing wouldSeal() was true but sealer's shouldSeal() was false.
+    bool m_wouldSeal = false;               ///< True if we /should/ be sealing.
+    bool m_wouldButShouldnot = false;       ///< True if the last time we called rejigSealing wouldSeal() was true but sealer's shouldSeal() was false.
 
-	mutable std::chrono::system_clock::time_point m_lastGarbageCollection;
-											///< When did we last both doing GC on the watches?
-	mutable std::chrono::system_clock::time_point m_lastTick = std::chrono::system_clock::now();
-											///< When did we last tick()?
+    mutable std::chrono::system_clock::time_point m_lastGarbageCollection;
+                                            ///< When did we last both doing GC on the watches?
+    mutable std::chrono::system_clock::time_point m_lastTick = std::chrono::system_clock::now();
+                                            ///< When did we last tick()?
 
-	unsigned m_syncAmount = 50;				///< Number of blocks to sync in each go.
+    unsigned m_syncAmount = 50;             ///< Number of blocks to sync in each go.
 
-	ActivityReport m_report;
+    ActivityReport m_report;
 
-	SharedMutex x_functionQueue;
-	std::queue<std::function<void()>> m_functionQueue;	///< Functions waiting to be executed in the main thread.
+    SharedMutex x_functionQueue;
+    std::queue<std::function<void()>> m_functionQueue;  ///< Functions waiting to be executed in the main thread.
 
-	std::atomic<bool> m_syncTransactionQueue = {false};
-	std::atomic<bool> m_syncBlockQueue = {false};
+    std::atomic<bool> m_syncTransactionQueue = {false};
+    std::atomic<bool> m_syncBlockQueue = {false};
 
-	bytes m_extraData;
+    bytes m_extraData;
 };
 
 }

--- a/libethereum/ClientTest.cpp
+++ b/libethereum/ClientTest.cpp
@@ -48,7 +48,7 @@ ClientTest::ClientTest(
 	WithExisting _forceAction,
 	TransactionQueue::Limits const& _limits
 ):
-	Client(_params, _networkID, _host, _gpForAdoption, _dbPath, _forceAction, _limits)
+	Client(_params, _networkID, _host, _gpForAdoption, _dbPath, std::string(), _forceAction, _limits)
 {}
 
 ClientTest::~ClientTest()

--- a/libethereum/ClientTest.cpp
+++ b/libethereum/ClientTest.cpp
@@ -1,18 +1,18 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file ClientTest.cpp
  * @author Dimitry Khokhlov <dimitry@ethdev.com>
@@ -31,106 +31,101 @@ namespace fs = boost::filesystem;
 
 ClientTest& dev::eth::asClientTest(Interface& _c)
 {
-	return dynamic_cast<ClientTest&>(_c);
+    return dynamic_cast<ClientTest&>(_c);
 }
 
 ClientTest* dev::eth::asClientTest(Interface* _c)
 {
-	return &dynamic_cast<ClientTest&>(*_c);
+    return &dynamic_cast<ClientTest&>(*_c);
 }
 
-ClientTest::ClientTest(
-	ChainParams const& _params,
-	int _networkID,
-	p2p::Host* _host,
-	std::shared_ptr<GasPricer> _gpForAdoption,
-	fs::path const& _dbPath,
-	WithExisting _forceAction,
-	TransactionQueue::Limits const& _limits
-):
-	Client(_params, _networkID, _host, _gpForAdoption, _dbPath, std::string(), _forceAction, _limits)
+ClientTest::ClientTest(ChainParams const& _params, int _networkID, p2p::Host* _host,
+    std::shared_ptr<GasPricer> _gpForAdoption, fs::path const& _dbPath, WithExisting _forceAction,
+    TransactionQueue::Limits const& _limits)
+  : Client(
+        _params, _networkID, _host, _gpForAdoption, _dbPath, std::string(), _forceAction, _limits)
 {}
 
 ClientTest::~ClientTest()
 {
-	terminate();
+    terminate();
 }
 
 void ClientTest::setChainParams(string const& _genesis)
 {
-	ChainParams params;
-	try
-	{
-		params = params.loadConfig(_genesis);
-		if (params.sealEngineName != "NoProof")
-			BOOST_THROW_EXCEPTION(ChainParamsNotNoProof() << errinfo_comment("Provided configuration is not well formatted."));
+    ChainParams params;
+    try
+    {
+        params = params.loadConfig(_genesis);
+        if (params.sealEngineName != "NoProof")
+            BOOST_THROW_EXCEPTION(ChainParamsNotNoProof() << errinfo_comment("Provided configuration is not well formatted."));
 
-		reopenChain(params, WithExisting::Kill);
-		setAuthor(params.author); //for some reason author is not being set
-	}
-	catch (...)
-	{
-		BOOST_THROW_EXCEPTION(ChainParamsInvalid() << errinfo_comment("Provided configuration is not well formatted."));
-	}
+        reopenChain(params, WithExisting::Kill);
+        setAuthor(params.author); //for some reason author is not being set
+    }
+    catch (...)
+    {
+        BOOST_THROW_EXCEPTION(ChainParamsInvalid() << errinfo_comment("Provided configuration is not well formatted."));
+    }
 }
 
 bool ClientTest::addBlock(string const& _rlp)
 {
-	if (auto h = m_host.lock())
-		h->noteNewBlocks();
+    if (auto h = m_host.lock())
+        h->noteNewBlocks();
 
-	bytes rlpBytes = fromHex(_rlp, WhenError::Throw);
-	RLP blockRLP(rlpBytes);
-	return (m_bq.import(blockRLP.data(), true) == ImportResult::Success);
+    bytes rlpBytes = fromHex(_rlp, WhenError::Throw);
+    RLP blockRLP(rlpBytes);
+    return (m_bq.import(blockRLP.data(), true) == ImportResult::Success);
 }
 
 void ClientTest::modifyTimestamp(u256 const& _timestamp)
 {
-	Block block(chainParams().accountStartNonce);
-	DEV_READ_GUARDED(x_preSeal)
-		block = m_preSeal;
+    Block block(chainParams().accountStartNonce);
+    DEV_READ_GUARDED(x_preSeal)
+        block = m_preSeal;
 
-	Transactions transactions;
-	DEV_READ_GUARDED(x_postSeal)
-		transactions = m_postSeal.pending();
-	block.resetCurrent(_timestamp);
+    Transactions transactions;
+    DEV_READ_GUARDED(x_postSeal)
+        transactions = m_postSeal.pending();
+    block.resetCurrent(_timestamp);
 
-	DEV_WRITE_GUARDED(x_preSeal)
-		m_preSeal = block;
+    DEV_WRITE_GUARDED(x_preSeal)
+        m_preSeal = block;
 
-	auto& lastHashes = bc().lastBlockHashes();
-	assert(bc().currentHash() == block.info().parentHash());
-	for (auto const& t: transactions)
-		block.execute(lastHashes, t);
+    auto& lastHashes = bc().lastBlockHashes();
+    assert(bc().currentHash() == block.info().parentHash());
+    for (auto const& t: transactions)
+        block.execute(lastHashes, t);
 
-	DEV_WRITE_GUARDED(x_working)
-		m_working = block;
-	DEV_READ_GUARDED(x_postSeal)
-		m_postSeal = block;
+    DEV_WRITE_GUARDED(x_working)
+        m_working = block;
+    DEV_READ_GUARDED(x_postSeal)
+        m_postSeal = block;
 
-	onPostStateChanged();
+    onPostStateChanged();
 }
 
 void ClientTest::mineBlocks(unsigned _count)
 {
-	m_blocksToMine = _count;
-	startSealing();
+    m_blocksToMine = _count;
+    startSealing();
 }
 
 void ClientTest::onNewBlocks(h256s const& _blocks, h256Hash& io_changed)
 {
-	Client::onNewBlocks(_blocks, io_changed);
+    Client::onNewBlocks(_blocks, io_changed);
 
-	if(--m_blocksToMine <= 0)
-		stopSealing();
+    if(--m_blocksToMine <= 0)
+        stopSealing();
 }
 
 bool ClientTest::completeSync()
 {
-	auto h = m_host.lock();
-	if (!h)
-		return false;
+    auto h = m_host.lock();
+    if (!h)
+        return false;
 
-	h->completeSync();
-	return true;
+    h->completeSync();
+    return true;
 }

--- a/libethereum/CommonNet.h
+++ b/libethereum/CommonNet.h
@@ -75,6 +75,8 @@ enum class Asking
 	BlockBodies,
 	NodeData,
 	Receipts,
+	WarpManifest,
+	WarpData,
 	Nothing
 };
 

--- a/libethereum/CommonNet.h
+++ b/libethereum/CommonNet.h
@@ -1,18 +1,18 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file CommonNet.h
  * @author Gav Wood <i@gavwood.com>
@@ -36,11 +36,11 @@ class OverlayDB;
 namespace eth
 {
 
-static const unsigned c_maxHeaders = 2048;		///< Maximum number of hashes BlockHashes will ever send.
-static const unsigned c_maxHeadersAsk = 2048;	///< Maximum number of hashes GetBlockHashes will ever ask for.
-static const unsigned c_maxBlocks = 128;		///< Maximum number of blocks Blocks will ever send.
-static const unsigned c_maxBlocksAsk = 128;		///< Maximum number of blocks we ask to receive in Blocks (when using GetChain).
-static const unsigned c_maxPayload = 262144;	///< Maximum size of packet for us to send.
+static const unsigned c_maxHeaders = 2048;      ///< Maximum number of hashes BlockHashes will ever send.
+static const unsigned c_maxHeadersAsk = 2048;   ///< Maximum number of hashes GetBlockHashes will ever ask for.
+static const unsigned c_maxBlocks = 128;        ///< Maximum number of blocks Blocks will ever send.
+static const unsigned c_maxBlocksAsk = 128;     ///< Maximum number of blocks we ask to receive in Blocks (when using GetChain).
+static const unsigned c_maxPayload = 262144;    ///< Maximum size of packet for us to send.
 static const unsigned c_maxNodes = c_maxBlocks; ///< Maximum number of nodes will ever send.
 static const unsigned c_maxReceipts = c_maxBlocks; ///< Maximum number of receipts will ever send.
 
@@ -51,54 +51,54 @@ class EthereumPeer;
 
 enum SubprotocolPacketType: byte
 {
-	StatusPacket = 0x00,
-	NewBlockHashesPacket = 0x01,
-	TransactionsPacket = 0x02,
-	GetBlockHeadersPacket = 0x03,
-	BlockHeadersPacket = 0x04,
-	GetBlockBodiesPacket = 0x05,
-	BlockBodiesPacket = 0x06,
-	NewBlockPacket = 0x07,
+    StatusPacket = 0x00,
+    NewBlockHashesPacket = 0x01,
+    TransactionsPacket = 0x02,
+    GetBlockHeadersPacket = 0x03,
+    BlockHeadersPacket = 0x04,
+    GetBlockBodiesPacket = 0x05,
+    BlockBodiesPacket = 0x06,
+    NewBlockPacket = 0x07,
 
-	GetNodeDataPacket = 0x0d,
-	NodeDataPacket = 0x0e,
-	GetReceiptsPacket = 0x0f,
-	ReceiptsPacket = 0x10,
+    GetNodeDataPacket = 0x0d,
+    NodeDataPacket = 0x0e,
+    GetReceiptsPacket = 0x0f,
+    ReceiptsPacket = 0x10,
 
-	PacketCount
+    PacketCount
 };
 
 enum class Asking
 {
-	State,
-	BlockHeaders,
-	BlockBodies,
-	NodeData,
-	Receipts,
-	WarpManifest,
-	WarpData,
-	Nothing
+    State,
+    BlockHeaders,
+    BlockBodies,
+    NodeData,
+    Receipts,
+    WarpManifest,
+    WarpData,
+    Nothing
 };
 
 enum class SyncState
 {
-	NotSynced,			///< Initial chain sync has not started yet
-	Idle,				///< Initial chain sync complete. Waiting for new packets
-	Waiting,			///< Block downloading paused. Waiting for block queue to process blocks and free space
-	Blocks,				///< Downloading blocks
-	State,				///< Downloading state
+    NotSynced,          ///< Initial chain sync has not started yet
+    Idle,               ///< Initial chain sync complete. Waiting for new packets
+    Waiting,            ///< Block downloading paused. Waiting for block queue to process blocks and free space
+    Blocks,             ///< Downloading blocks
+    State,              ///< Downloading state
 
-	Size		/// Must be kept last
+    Size        /// Must be kept last
 };
 
 struct SyncStatus
 {
-	SyncState state = SyncState::Idle;
-	unsigned protocolVersion = 0;
-	unsigned startBlockNumber;
-	unsigned currentBlockNumber;
-	unsigned highestBlockNumber;
-	bool majorSyncing = false;
+    SyncState state = SyncState::Idle;
+    unsigned protocolVersion = 0;
+    unsigned startBlockNumber;
+    unsigned currentBlockNumber;
+    unsigned highestBlockNumber;
+    bool majorSyncing = false;
 };
 
 }

--- a/libethereum/EthereumPeer.cpp
+++ b/libethereum/EthereumPeer.cpp
@@ -46,6 +46,8 @@ static string toString(Asking _a)
 	case Asking::Receipts: return "Receipts";
 	case Asking::Nothing: return "Nothing";
 	case Asking::State: return "State";
+	case Asking::WarpManifest: return "WarpManifest";
+	case Asking::WarpData: return "WarpData";
 	}
 	return "?";
 }

--- a/libethereum/EthereumPeer.cpp
+++ b/libethereum/EthereumPeer.cpp
@@ -1,18 +1,18 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file EthereumPeer.cpp
  * @author Gav Wood <i@gavwood.com>
@@ -38,81 +38,83 @@ static const unsigned c_maxHeadersToSend = 1024;
 
 static string toString(Asking _a)
 {
-	switch (_a)
-	{
-	case Asking::BlockHeaders: return "BlockHeaders";
-	case Asking::BlockBodies: return "BlockBodies";
-	case Asking::NodeData: return "NodeData";
-	case Asking::Receipts: return "Receipts";
-	case Asking::Nothing: return "Nothing";
-	case Asking::State: return "State";
-	case Asking::WarpManifest: return "WarpManifest";
-	case Asking::WarpData: return "WarpData";
-	}
-	return "?";
+    switch (_a)
+    {
+    case Asking::BlockHeaders: return "BlockHeaders";
+    case Asking::BlockBodies: return "BlockBodies";
+    case Asking::NodeData: return "NodeData";
+    case Asking::Receipts: return "Receipts";
+    case Asking::Nothing: return "Nothing";
+    case Asking::State: return "State";
+    case Asking::WarpManifest:
+        return "WarpManifest";
+    case Asking::WarpData:
+        return "WarpData";
+    }
+    return "?";
 }
 
 EthereumPeer::EthereumPeer(std::shared_ptr<SessionFace> _s, HostCapabilityFace* _h, unsigned _i, CapDesc const& _cap):
-	Capability(_s, _h, _i),
-	m_peerCapabilityVersion(_cap.second)
+    Capability(_s, _h, _i),
+    m_peerCapabilityVersion(_cap.second)
 {
-	session()->addNote("manners", isRude() ? "RUDE" : "nice");
+    session()->addNote("manners", isRude() ? "RUDE" : "nice");
 }
 
 EthereumPeer::~EthereumPeer()
 {
-	if (m_asking != Asking::Nothing)
-	{
-		clog(NetAllDetail) << "Peer aborting while being asked for " << ::toString(m_asking);
-		setRude();
-	}
-	abortSync();
+    if (m_asking != Asking::Nothing)
+    {
+        clog(NetAllDetail) << "Peer aborting while being asked for " << ::toString(m_asking);
+        setRude();
+    }
+    abortSync();
 }
 
 void EthereumPeer::init(unsigned _hostProtocolVersion, u256 _hostNetworkId, u256 _chainTotalDifficulty, h256 _chainCurrentHash, h256 _chainGenesisHash, shared_ptr<EthereumHostDataFace> _hostData, shared_ptr<EthereumPeerObserverFace> _observer)
 {
-	m_hostData = _hostData;
-	m_observer = _observer;
-	m_hostProtocolVersion = _hostProtocolVersion;
-	requestStatus(_hostNetworkId, _chainTotalDifficulty, _chainCurrentHash, _chainGenesisHash);
+    m_hostData = _hostData;
+    m_observer = _observer;
+    m_hostProtocolVersion = _hostProtocolVersion;
+    requestStatus(_hostNetworkId, _chainTotalDifficulty, _chainCurrentHash, _chainGenesisHash);
 }
 
 bool EthereumPeer::isRude() const
 {
-	auto s = session();
-	if (s)
-		return s->repMan().isRude(*s, name());
-	return false;
+    auto s = session();
+    if (s)
+        return s->repMan().isRude(*s, name());
+    return false;
 }
 
 unsigned EthereumPeer::askOverride() const
 {
-	std::string static const badGeth = "Geth/v0.9.27";
-	auto s = session();
-	if (!s)
-		return c_maxBlocksAsk;
-	if (s->info().clientVersion.substr(0, badGeth.size()) == badGeth)
-		return 1;
-	bytes const& d = s->repMan().data(*s, name());
-	return d.empty() ? c_maxBlocksAsk : RLP(d).toInt<unsigned>(RLP::LaissezFaire);
+    std::string static const badGeth = "Geth/v0.9.27";
+    auto s = session();
+    if (!s)
+        return c_maxBlocksAsk;
+    if (s->info().clientVersion.substr(0, badGeth.size()) == badGeth)
+        return 1;
+    bytes const& d = s->repMan().data(*s, name());
+    return d.empty() ? c_maxBlocksAsk : RLP(d).toInt<unsigned>(RLP::LaissezFaire);
 }
 
 void EthereumPeer::setRude()
 {
-	auto s = session();
-	if (!s)
-		return;
-	auto old = askOverride();
-	s->repMan().setData(*s, name(), rlp(askOverride() / 2 + 1));
-	cnote << "Rude behaviour; askOverride now" << askOverride() << ", was" << old;
-	s->repMan().noteRude(*s, name());
-	session()->addNote("manners", "RUDE");
+    auto s = session();
+    if (!s)
+        return;
+    auto old = askOverride();
+    s->repMan().setData(*s, name(), rlp(askOverride() / 2 + 1));
+    cnote << "Rude behaviour; askOverride now" << askOverride() << ", was" << old;
+    s->repMan().noteRude(*s, name());
+    session()->addNote("manners", "RUDE");
 }
 
 void EthereumPeer::abortSync()
 {
-	if (auto observer = m_observer.lock())
-		observer->onPeerAborting();
+    if (auto observer = m_observer.lock())
+        observer->onPeerAborting();
 }
 
 
@@ -122,317 +124,317 @@ void EthereumPeer::abortSync()
 
 void EthereumPeer::setIdle()
 {
-	setAsking(Asking::Nothing);
+    setAsking(Asking::Nothing);
 }
 
 void EthereumPeer::requestStatus(u256 _hostNetworkId, u256 _chainTotalDifficulty, h256 _chainCurrentHash, h256 _chainGenesisHash)
 {
-	assert(m_asking == Asking::Nothing);
-	setAsking(Asking::State);
-	m_requireTransactions = true;
-	RLPStream s;
-	bool latest = m_peerCapabilityVersion == m_hostProtocolVersion;
-	prep(s, StatusPacket, 5)
-					<< (latest ? m_hostProtocolVersion : EthereumHost::c_oldProtocolVersion)
-					<< _hostNetworkId
-					<< _chainTotalDifficulty
-					<< _chainCurrentHash
-					<< _chainGenesisHash;
-	sealAndSend(s);
+    assert(m_asking == Asking::Nothing);
+    setAsking(Asking::State);
+    m_requireTransactions = true;
+    RLPStream s;
+    bool latest = m_peerCapabilityVersion == m_hostProtocolVersion;
+    prep(s, StatusPacket, 5)
+                    << (latest ? m_hostProtocolVersion : EthereumHost::c_oldProtocolVersion)
+                    << _hostNetworkId
+                    << _chainTotalDifficulty
+                    << _chainCurrentHash
+                    << _chainGenesisHash;
+    sealAndSend(s);
 }
 
 void EthereumPeer::requestBlockHeaders(unsigned _startNumber, unsigned _count, unsigned _skip, bool _reverse)
 {
-	if (m_asking != Asking::Nothing)
-	{
-		clog(NetWarn) << "Asking headers while requesting " << ::toString(m_asking);
-	}
-	setAsking(Asking::BlockHeaders);
-	RLPStream s;
-	prep(s, GetBlockHeadersPacket, 4) << _startNumber << _count << _skip << (_reverse ? 1 : 0);
-	clog(NetMessageDetail) << "Requesting " << _count << " block headers starting from " << _startNumber << (_reverse ? " in reverse" : "");
-	m_lastAskedHeaders = _count;
-	sealAndSend(s);
+    if (m_asking != Asking::Nothing)
+    {
+        clog(NetWarn) << "Asking headers while requesting " << ::toString(m_asking);
+    }
+    setAsking(Asking::BlockHeaders);
+    RLPStream s;
+    prep(s, GetBlockHeadersPacket, 4) << _startNumber << _count << _skip << (_reverse ? 1 : 0);
+    clog(NetMessageDetail) << "Requesting " << _count << " block headers starting from " << _startNumber << (_reverse ? " in reverse" : "");
+    m_lastAskedHeaders = _count;
+    sealAndSend(s);
 }
 
 void EthereumPeer::requestBlockHeaders(h256 const& _startHash, unsigned _count, unsigned _skip, bool _reverse)
 {
-	if (m_asking != Asking::Nothing)
-	{
-		clog(NetWarn) << "Asking headers while requesting " << ::toString(m_asking);
-	}
-	setAsking(Asking::BlockHeaders);
-	RLPStream s;
-	prep(s, GetBlockHeadersPacket, 4) << _startHash << _count << _skip << (_reverse ? 1 : 0);
-	clog(NetMessageDetail) << "Requesting " << _count << " block headers starting from " << _startHash << (_reverse ? " in reverse" : "");
-	m_lastAskedHeaders = _count;
-	sealAndSend(s);
+    if (m_asking != Asking::Nothing)
+    {
+        clog(NetWarn) << "Asking headers while requesting " << ::toString(m_asking);
+    }
+    setAsking(Asking::BlockHeaders);
+    RLPStream s;
+    prep(s, GetBlockHeadersPacket, 4) << _startHash << _count << _skip << (_reverse ? 1 : 0);
+    clog(NetMessageDetail) << "Requesting " << _count << " block headers starting from " << _startHash << (_reverse ? " in reverse" : "");
+    m_lastAskedHeaders = _count;
+    sealAndSend(s);
 }
 
 
 void EthereumPeer::requestBlockBodies(h256s const& _blocks)
 {
-	requestByHashes(_blocks, Asking::BlockBodies, GetBlockBodiesPacket);
+    requestByHashes(_blocks, Asking::BlockBodies, GetBlockBodiesPacket);
 }
 
 void EthereumPeer::requestNodeData(h256s const& _hashes)
 {
-	requestByHashes(_hashes, Asking::NodeData, GetNodeDataPacket);
+    requestByHashes(_hashes, Asking::NodeData, GetNodeDataPacket);
 }
 
 void EthereumPeer::requestReceipts(h256s const& _blocks)
 {
-	requestByHashes(_blocks, Asking::Receipts, GetReceiptsPacket);
+    requestByHashes(_blocks, Asking::Receipts, GetReceiptsPacket);
 }
 
 void EthereumPeer::requestByHashes(h256s const& _hashes, Asking _asking, SubprotocolPacketType _packetType)
 {
-	if (m_asking != Asking::Nothing)
-	{
-		clog(NetWarn) << "Asking "<< ::toString(_asking) << " while requesting " << ::toString(m_asking);
-	}
-	setAsking(_asking);
-	if (_hashes.size())
-	{
-		RLPStream s;
-		prep(s, _packetType, _hashes.size());
-		for (auto const& i: _hashes)
-			s << i;
-		sealAndSend(s);
-	}
-	else
-		setIdle();
+    if (m_asking != Asking::Nothing)
+    {
+        clog(NetWarn) << "Asking "<< ::toString(_asking) << " while requesting " << ::toString(m_asking);
+    }
+    setAsking(_asking);
+    if (_hashes.size())
+    {
+        RLPStream s;
+        prep(s, _packetType, _hashes.size());
+        for (auto const& i: _hashes)
+            s << i;
+        sealAndSend(s);
+    }
+    else
+        setIdle();
 }
 
 void EthereumPeer::setAsking(Asking _a)
 {
-	m_asking = _a;
-	m_lastAsk = std::chrono::system_clock::to_time_t(chrono::system_clock::now());
+    m_asking = _a;
+    m_lastAsk = std::chrono::system_clock::to_time_t(chrono::system_clock::now());
 
-	auto s = session();
-	if (s)
-	{
-		s->addNote("ask", ::toString(_a));
-		s->addNote("sync", string(isCriticalSyncing() ? "ONGOING" : "holding") + (needsSyncing() ? " & needed" : ""));
-	}
+    auto s = session();
+    if (s)
+    {
+        s->addNote("ask", ::toString(_a));
+        s->addNote("sync", string(isCriticalSyncing() ? "ONGOING" : "holding") + (needsSyncing() ? " & needed" : ""));
+    }
 }
 
 void EthereumPeer::tick()
 {
-	auto s = session();
-	time_t  now = std::chrono::system_clock::to_time_t(chrono::system_clock::now());
-	if (s && (now - m_lastAsk > 10 && m_asking != Asking::Nothing))
-		// timeout
-		s->disconnect(PingTimeout);
+    auto s = session();
+    time_t  now = std::chrono::system_clock::to_time_t(chrono::system_clock::now());
+    if (s && (now - m_lastAsk > 10 && m_asking != Asking::Nothing))
+        // timeout
+        s->disconnect(PingTimeout);
 }
 
 bool EthereumPeer::isConversing() const
 {
-	return m_asking != Asking::Nothing;
+    return m_asking != Asking::Nothing;
 }
 
 bool EthereumPeer::isCriticalSyncing() const
 {
-	return m_asking == Asking::BlockHeaders || m_asking == Asking::State || (m_asking == Asking::BlockBodies && m_protocolVersion == 62);
+    return m_asking == Asking::BlockHeaders || m_asking == Asking::State || (m_asking == Asking::BlockBodies && m_protocolVersion == 62);
 }
 
 bool EthereumPeer::interpret(unsigned _id, RLP const& _r)
 {
-	auto observer = m_observer.lock();
-	auto hostData = m_hostData.lock();
-	if (!observer || !hostData)
-		return false;
+    auto observer = m_observer.lock();
+    auto hostData = m_hostData.lock();
+    if (!observer || !hostData)
+        return false;
 
-	m_lastAsk = std::chrono::system_clock::to_time_t(chrono::system_clock::now());
-	try
-	{
-	switch (_id)
-	{
-	case StatusPacket:
-	{
-		m_protocolVersion = _r[0].toInt<unsigned>();
-		m_networkId = _r[1].toInt<u256>();
-		m_totalDifficulty = _r[2].toInt<u256>();
-		m_latestHash = _r[3].toHash<h256>();
-		m_genesisHash = _r[4].toHash<h256>();
-		if (m_peerCapabilityVersion == m_hostProtocolVersion)
-			m_protocolVersion = m_hostProtocolVersion;
+    m_lastAsk = std::chrono::system_clock::to_time_t(chrono::system_clock::now());
+    try
+    {
+    switch (_id)
+    {
+    case StatusPacket:
+    {
+        m_protocolVersion = _r[0].toInt<unsigned>();
+        m_networkId = _r[1].toInt<u256>();
+        m_totalDifficulty = _r[2].toInt<u256>();
+        m_latestHash = _r[3].toHash<h256>();
+        m_genesisHash = _r[4].toHash<h256>();
+        if (m_peerCapabilityVersion == m_hostProtocolVersion)
+            m_protocolVersion = m_hostProtocolVersion;
 
-		clog(NetMessageSummary) << "Status:" << m_protocolVersion << "/" << m_networkId << "/" << m_genesisHash << ", TD:" << m_totalDifficulty << "=" << m_latestHash;
-		setIdle();
-		observer->onPeerStatus(dynamic_pointer_cast<EthereumPeer>(dynamic_pointer_cast<EthereumPeer>(shared_from_this())));
-		break;
-	}
-	case TransactionsPacket:
-	{
-		observer->onPeerTransactions(dynamic_pointer_cast<EthereumPeer>(dynamic_pointer_cast<EthereumPeer>(shared_from_this())), _r);
-		break;
-	}
-	case GetBlockHeadersPacket:
-	{
-		/// Packet layout:
-		/// [ block: { P , B_32 }, maxHeaders: P, skip: P, reverse: P in { 0 , 1 } ]
-		const auto blockId = _r[0];
-		const auto maxHeaders = _r[1].toInt<u256>();
-		const auto skip = _r[2].toInt<u256>();
-		const auto reverse = _r[3].toInt<bool>();
+        clog(NetMessageSummary) << "Status:" << m_protocolVersion << "/" << m_networkId << "/" << m_genesisHash << ", TD:" << m_totalDifficulty << "=" << m_latestHash;
+        setIdle();
+        observer->onPeerStatus(dynamic_pointer_cast<EthereumPeer>(dynamic_pointer_cast<EthereumPeer>(shared_from_this())));
+        break;
+    }
+    case TransactionsPacket:
+    {
+        observer->onPeerTransactions(dynamic_pointer_cast<EthereumPeer>(dynamic_pointer_cast<EthereumPeer>(shared_from_this())), _r);
+        break;
+    }
+    case GetBlockHeadersPacket:
+    {
+        /// Packet layout:
+        /// [ block: { P , B_32 }, maxHeaders: P, skip: P, reverse: P in { 0 , 1 } ]
+        const auto blockId = _r[0];
+        const auto maxHeaders = _r[1].toInt<u256>();
+        const auto skip = _r[2].toInt<u256>();
+        const auto reverse = _r[3].toInt<bool>();
 
-		auto numHeadersToSend = maxHeaders <= c_maxHeadersToSend ? static_cast<unsigned>(maxHeaders) : c_maxHeadersToSend;
+        auto numHeadersToSend = maxHeaders <= c_maxHeadersToSend ? static_cast<unsigned>(maxHeaders) : c_maxHeadersToSend;
 
-		if (skip > std::numeric_limits<unsigned>::max() - 1)
-		{
-			clog(NetAllDetail) << "Requested block skip is too big: " << skip;
-			break;
-		}
+        if (skip > std::numeric_limits<unsigned>::max() - 1)
+        {
+            clog(NetAllDetail) << "Requested block skip is too big: " << skip;
+            break;
+        }
 
-		pair<bytes, unsigned> const rlpAndItemCount = hostData->blockHeaders(blockId, numHeadersToSend, skip, reverse);
+        pair<bytes, unsigned> const rlpAndItemCount = hostData->blockHeaders(blockId, numHeadersToSend, skip, reverse);
 
-		RLPStream s;
-		prep(s, BlockHeadersPacket, rlpAndItemCount.second).appendRaw(rlpAndItemCount.first, rlpAndItemCount.second);
-		sealAndSend(s);
-		addRating(0);
-		break;
-	}
-	case BlockHeadersPacket:
-	{
-		if (m_asking != Asking::BlockHeaders)
-			clog(NetImpolite) << "Peer giving us block headers when we didn't ask for them.";
-		else
-		{
-			setIdle();
-			observer->onPeerBlockHeaders(dynamic_pointer_cast<EthereumPeer>(shared_from_this()), _r);
-		}
-		break;
-	}
-	case GetBlockBodiesPacket:
-	{
-		unsigned count = static_cast<unsigned>(_r.itemCount());
-		clog(NetMessageSummary) << "GetBlockBodies (" << dec << count << "entries)";
+        RLPStream s;
+        prep(s, BlockHeadersPacket, rlpAndItemCount.second).appendRaw(rlpAndItemCount.first, rlpAndItemCount.second);
+        sealAndSend(s);
+        addRating(0);
+        break;
+    }
+    case BlockHeadersPacket:
+    {
+        if (m_asking != Asking::BlockHeaders)
+            clog(NetImpolite) << "Peer giving us block headers when we didn't ask for them.";
+        else
+        {
+            setIdle();
+            observer->onPeerBlockHeaders(dynamic_pointer_cast<EthereumPeer>(shared_from_this()), _r);
+        }
+        break;
+    }
+    case GetBlockBodiesPacket:
+    {
+        unsigned count = static_cast<unsigned>(_r.itemCount());
+        clog(NetMessageSummary) << "GetBlockBodies (" << dec << count << "entries)";
 
-		if (!count)
-		{
-			clog(NetImpolite) << "Zero-entry GetBlockBodies: Not replying.";
-			addRating(-10);
-			break;
-		}
+        if (!count)
+        {
+            clog(NetImpolite) << "Zero-entry GetBlockBodies: Not replying.";
+            addRating(-10);
+            break;
+        }
 
-		pair<bytes, unsigned> const rlpAndItemCount = hostData->blockBodies(_r);
+        pair<bytes, unsigned> const rlpAndItemCount = hostData->blockBodies(_r);
 
-		addRating(0);
-		RLPStream s;
-		prep(s, BlockBodiesPacket, rlpAndItemCount.second).appendRaw(rlpAndItemCount.first, rlpAndItemCount.second);
-		sealAndSend(s);
-		break;
-	}
-	case BlockBodiesPacket:
-	{
-		if (m_asking != Asking::BlockBodies)
-			clog(NetImpolite) << "Peer giving us block bodies when we didn't ask for them.";
-		else
-		{
-			setIdle();
-			observer->onPeerBlockBodies(dynamic_pointer_cast<EthereumPeer>(shared_from_this()), _r);
-		}
-		break;
-	}
-	case NewBlockPacket:
-	{
-		observer->onPeerNewBlock(dynamic_pointer_cast<EthereumPeer>(shared_from_this()), _r);
-		break;
-	}
-	case NewBlockHashesPacket:
-	{
-		unsigned itemCount = _r.itemCount();
+        addRating(0);
+        RLPStream s;
+        prep(s, BlockBodiesPacket, rlpAndItemCount.second).appendRaw(rlpAndItemCount.first, rlpAndItemCount.second);
+        sealAndSend(s);
+        break;
+    }
+    case BlockBodiesPacket:
+    {
+        if (m_asking != Asking::BlockBodies)
+            clog(NetImpolite) << "Peer giving us block bodies when we didn't ask for them.";
+        else
+        {
+            setIdle();
+            observer->onPeerBlockBodies(dynamic_pointer_cast<EthereumPeer>(shared_from_this()), _r);
+        }
+        break;
+    }
+    case NewBlockPacket:
+    {
+        observer->onPeerNewBlock(dynamic_pointer_cast<EthereumPeer>(shared_from_this()), _r);
+        break;
+    }
+    case NewBlockHashesPacket:
+    {
+        unsigned itemCount = _r.itemCount();
 
-		clog(NetMessageSummary) << "BlockHashes (" << dec << itemCount << "entries)" << (itemCount ? "" : ": NoMoreHashes");
+        clog(NetMessageSummary) << "BlockHashes (" << dec << itemCount << "entries)" << (itemCount ? "" : ": NoMoreHashes");
 
-		if (itemCount > c_maxIncomingNewHashes)
-		{
-			disable("Too many new hashes");
-			break;
-		}
+        if (itemCount > c_maxIncomingNewHashes)
+        {
+            disable("Too many new hashes");
+            break;
+        }
 
-		vector<pair<h256, u256>> hashes(itemCount);
-		for (unsigned i = 0; i < itemCount; ++i)
-			hashes[i] = std::make_pair(_r[i][0].toHash<h256>(), _r[i][1].toInt<u256>());
+        vector<pair<h256, u256>> hashes(itemCount);
+        for (unsigned i = 0; i < itemCount; ++i)
+            hashes[i] = std::make_pair(_r[i][0].toHash<h256>(), _r[i][1].toInt<u256>());
 
-		observer->onPeerNewHashes(dynamic_pointer_cast<EthereumPeer>(shared_from_this()), hashes);
-		break;
-	}
-	case GetNodeDataPacket:
-	{
-		unsigned count = static_cast<unsigned>(_r.itemCount());
-		if (!count)
-		{
-			clog(NetImpolite) << "Zero-entry GetNodeData: Not replying.";
-			addRating(-10);
-			break;
-		}
-		clog(NetMessageSummary) << "GetNodeData (" << dec << count << " entries)";
+        observer->onPeerNewHashes(dynamic_pointer_cast<EthereumPeer>(shared_from_this()), hashes);
+        break;
+    }
+    case GetNodeDataPacket:
+    {
+        unsigned count = static_cast<unsigned>(_r.itemCount());
+        if (!count)
+        {
+            clog(NetImpolite) << "Zero-entry GetNodeData: Not replying.";
+            addRating(-10);
+            break;
+        }
+        clog(NetMessageSummary) << "GetNodeData (" << dec << count << " entries)";
 
-		strings const data = hostData->nodeData(_r);
+        strings const data = hostData->nodeData(_r);
 
-		addRating(0);
-		RLPStream s;
-		prep(s, NodeDataPacket, data.size());
-		for (auto const& element: data)
-			s.append(element);
-		sealAndSend(s);
-		break;
-	}
-	case GetReceiptsPacket:
-	{
-		unsigned count = static_cast<unsigned>(_r.itemCount());
-		if (!count)
-		{
-			clog(NetImpolite) << "Zero-entry GetReceipts: Not replying.";
-			addRating(-10);
-			break;
-		}
-		clog(NetMessageSummary) << "GetReceipts (" << dec << count << " entries)";
+        addRating(0);
+        RLPStream s;
+        prep(s, NodeDataPacket, data.size());
+        for (auto const& element: data)
+            s.append(element);
+        sealAndSend(s);
+        break;
+    }
+    case GetReceiptsPacket:
+    {
+        unsigned count = static_cast<unsigned>(_r.itemCount());
+        if (!count)
+        {
+            clog(NetImpolite) << "Zero-entry GetReceipts: Not replying.";
+            addRating(-10);
+            break;
+        }
+        clog(NetMessageSummary) << "GetReceipts (" << dec << count << " entries)";
 
-		pair<bytes, unsigned> const rlpAndItemCount = hostData->receipts(_r);
+        pair<bytes, unsigned> const rlpAndItemCount = hostData->receipts(_r);
 
-		addRating(0);
-		RLPStream s;
-		prep(s, ReceiptsPacket, rlpAndItemCount.second).appendRaw(rlpAndItemCount.first, rlpAndItemCount.second);
-		sealAndSend(s);
-		break;
-	}
-	case NodeDataPacket:
-	{
-		if (m_asking != Asking::NodeData)
-			clog(NetImpolite) << "Peer giving us node data when we didn't ask for them.";
-		else
-		{
-			setIdle();
-			observer->onPeerNodeData(dynamic_pointer_cast<EthereumPeer>(shared_from_this()), _r);
-		}
-		break;
-	}
-	case ReceiptsPacket:
-	{
-		if (m_asking != Asking::Receipts)
-			clog(NetImpolite) << "Peer giving us receipts when we didn't ask for them.";
-		else
-		{
-			setIdle();
-			observer->onPeerReceipts(dynamic_pointer_cast<EthereumPeer>(shared_from_this()), _r);
-		}
-		break;
-	}
-	default:
-		return false;
-	}
-	}
-	catch (Exception const&)
-	{
-		clog(NetWarn) << "Peer causing an Exception:" << boost::current_exception_diagnostic_information() << _r;
-	}
-	catch (std::exception const& _e)
-	{
-		clog(NetWarn) << "Peer causing an exception:" << _e.what() << _r;
-	}
+        addRating(0);
+        RLPStream s;
+        prep(s, ReceiptsPacket, rlpAndItemCount.second).appendRaw(rlpAndItemCount.first, rlpAndItemCount.second);
+        sealAndSend(s);
+        break;
+    }
+    case NodeDataPacket:
+    {
+        if (m_asking != Asking::NodeData)
+            clog(NetImpolite) << "Peer giving us node data when we didn't ask for them.";
+        else
+        {
+            setIdle();
+            observer->onPeerNodeData(dynamic_pointer_cast<EthereumPeer>(shared_from_this()), _r);
+        }
+        break;
+    }
+    case ReceiptsPacket:
+    {
+        if (m_asking != Asking::Receipts)
+            clog(NetImpolite) << "Peer giving us receipts when we didn't ask for them.";
+        else
+        {
+            setIdle();
+            observer->onPeerReceipts(dynamic_pointer_cast<EthereumPeer>(shared_from_this()), _r);
+        }
+        break;
+    }
+    default:
+        return false;
+    }
+    }
+    catch (Exception const&)
+    {
+        clog(NetWarn) << "Peer causing an Exception:" << boost::current_exception_diagnostic_information() << _r;
+    }
+    catch (std::exception const& _e)
+    {
+        clog(NetWarn) << "Peer causing an exception:" << _e.what() << _r;
+    }
 
-	return true;
+    return true;
 }

--- a/libethereum/WarpHostCapability.cpp
+++ b/libethereum/WarpHostCapability.cpp
@@ -130,7 +130,7 @@ public:
         boost::this_fiber::yield();
     }
 
-    void onPeerDisconnect(std::shared_ptr<WarpPeerCapability> _peer, Asking _asking)
+    void onPeerDisconnect(std::shared_ptr<WarpPeerCapability> _peer, Asking _asking) override
     {
         if (_asking == Asking::WarpManifest)
         {
@@ -172,6 +172,7 @@ private:
         RLP manifestRlp(manifestBytes);
         if (!validateManifest(manifestRlp))
         {
+            // TODO try disconnecting instead of disabling; disabled peer still occupies the peer slot
             _peer->disable("Invalid snapshot manifest.");
             return;
         }
@@ -322,6 +323,7 @@ WarpHostCapability::WarpHostCapability(BlockChain const& _blockChain, u256 const
     m_peerObserver(std::make_shared<WarpPeerObserver>(*this, m_blockChain, _snapshotDownloadPath)),
     m_lastTick(0)
 {
+    (void)SnapshotLog::debug; // override "unused variable" error on macOS
 }
 
 WarpHostCapability::~WarpHostCapability()

--- a/libethereum/WarpHostCapability.cpp
+++ b/libethereum/WarpHostCapability.cpp
@@ -19,11 +19,7 @@
 #include "BlockChain.h"
 #include "SnapshotStorage.h"
 
-#include <boost/fiber/fiber.hpp>
-#include <boost/fiber/future/future.hpp>
-#include <boost/fiber/future/promise.hpp>
-#include <boost/fiber/operations.hpp>
-#include <boost/fiber/unbuffered_channel.hpp>
+#include <boost/fiber/all.hpp>
 
 namespace dev
 {
@@ -31,6 +27,8 @@ namespace eth
 {
 namespace
 {
+
+static size_t const c_freePeerBufferSize = 32;
 
 struct SnapshotLog: public LogChannel
 {
@@ -59,19 +57,22 @@ h256 snapshotBlockHash(RLP const& _manifestRlp)
 class WarpPeerObserver: public WarpPeerObserverFace
 {
 public:
-    WarpPeerObserver(WarpHostCapability& _host,
-        BlockChain const& _blockChain,
-        boost::filesystem::path const&  _snapshotPath):
-        m_hostProtocolVersion(_host.protocolVersion()), 
-        m_hostNetworkId(_host.networkId()), 
-        m_hostGenesisHash(_blockChain.genesisHash()), 
-        m_snapshotDir(_snapshotPath) 
-    {}
+	WarpPeerObserver(WarpHostCapability& _host,
+		BlockChain const& _blockChain,
+		boost::filesystem::path const&  _snapshotPath):
+		m_hostProtocolVersion(_host.protocolVersion()), 
+		m_hostNetworkId(_host.networkId()), 
+		m_hostGenesisHash(_blockChain.genesisHash()), 
+		m_freePeers(c_freePeerBufferSize),
+		m_snapshotDir(_snapshotPath) 
+	{}
     ~WarpPeerObserver()
     {
         if (m_downloadFiber)
             m_downloadFiber->join();
     }
+
+    // TODO somehow handle peer disconnecting
 
     void onPeerStatus(std::shared_ptr<WarpPeerCapability> _peer) override
     {
@@ -112,8 +113,6 @@ public:
         if (!_r.isList() || _r.itemCount() != 1)
             return;
 
-        // TODO handle timeouts
-
         RLP const data = _r[0];
 
         h256 const hash = sha3(data.toBytesConstRef());
@@ -124,13 +123,15 @@ public:
 
         h256 const askedHash = it->second;
         m_requestedChunks.erase(it);
-            
+
         if (hash == askedHash)
         {
             // TODO handle writeFile failure
             writeFile((boost::filesystem::path(m_snapshotDir) / toHex(hash)).string(), data.toBytesConstRef());
 
-            clog(SnapshotLog) << "Saved chunk" << hash << " Chunks left: " << m_neededChunks.size();
+            clog(SnapshotLog) << "Saved chunk" << hash << " Chunks left: " << m_neededChunks.size() << " Requested chunks: " << m_requestedChunks.size();
+            if (m_neededChunks.empty() && m_requestedChunks.empty())
+                clog(SnapshotLog) << "Snapshot download complete!";
         }
         else
             m_neededChunks.push_back(askedHash);
@@ -139,9 +140,16 @@ public:
         boost::this_fiber::yield();
     }
 
-    void onPeerRequestTimeout(std::shared_ptr<WarpPeerCapability> /*_peer*/, Asking /*_asking*/) override
+    void onPeerRequestTimeout(std::shared_ptr<WarpPeerCapability> _peer, Asking /*_asking*/) override
     {
-        // TODO
+        clog(SnapshotLog) << "Peer timed out";
+
+        auto it = m_requestedChunks.find(_peer);
+        if (it == m_requestedChunks.end())
+            return;
+
+        m_neededChunks.push_back(it->second);
+        m_requestedChunks.erase(it);
     }
 
 private:
@@ -185,9 +193,7 @@ private:
             m_requestedChunks[peer] = chunkHash;
             m_neededChunks.pop_front();
         }
-        clog(SnapshotLog) << "Snapshot download complete!";
     }
-
 
     unsigned const m_hostProtocolVersion;
     u256 const m_hostNetworkId;
@@ -195,7 +201,7 @@ private:
     boost::fibers::promise<bytes> m_manifest;
     h256 m_syncingSnapshotHash;
     std::deque<h256> m_neededChunks;
-    boost::fibers::unbuffered_channel<std::weak_ptr<WarpPeerCapability>> m_freePeers;
+    boost::fibers::buffered_channel<std::weak_ptr<WarpPeerCapability>> m_freePeers;
     boost::filesystem::path const m_snapshotDir;
     std::map<std::weak_ptr<WarpPeerCapability>, h256, std::owner_less<std::weak_ptr<WarpPeerCapability>>> m_requestedChunks;
 
@@ -208,7 +214,8 @@ private:
 WarpHostCapability::WarpHostCapability(BlockChain const& _blockChain, u256 const& _networkId,
     boost::filesystem::path const& _snapshotDownloadPath, std::shared_ptr<SnapshotStorageFace> _snapshotStorage)
   : m_blockChain(_blockChain), m_networkId(_networkId), m_snapshot(_snapshotStorage), 
-  m_peerObserver(std::make_shared<WarpPeerObserver>(*this, m_blockChain, _snapshotDownloadPath))
+    m_peerObserver(std::make_shared<WarpPeerObserver>(*this, m_blockChain, _snapshotDownloadPath)),
+    m_lastTick(0)
 {
 }
 
@@ -239,7 +246,19 @@ std::shared_ptr<p2p::Capability> WarpHostCapability::newPeerCapability(
 
 void WarpHostCapability::doWork()
 {
-    // TODO call tick() on peers similar to EthereumHost
+	time_t const now = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+	if (now - m_lastTick >= 1)
+	{
+		m_lastTick = now;
+
+		auto sessions = peerSessions();
+		for (auto s : sessions)
+		{
+			auto cap = p2p::capabilityFromSession<WarpPeerCapability>(*s.first);
+			assert(cap);
+			cap->tick();
+		}
+	}
 }
 
 }  // namespace eth

--- a/libethereum/WarpHostCapability.cpp
+++ b/libethereum/WarpHostCapability.cpp
@@ -17,7 +17,6 @@
 
 #include "WarpHostCapability.h"
 #include "BlockChain.h"
-#include "SnapshotStorage.h"
 
 #include <boost/fiber/all.hpp>
 

--- a/libethereum/WarpHostCapability.h
+++ b/libethereum/WarpHostCapability.h
@@ -1,5 +1,4 @@
 /*
-<<<<<<< HEAD
     This file is part of cpp-ethereum.
 
     cpp-ethereum is free software: you can redistribute it and/or modify
@@ -48,7 +47,8 @@ private:
     u256 const m_networkId;
 
     std::shared_ptr<SnapshotStorageFace> m_snapshot;
-    std::shared_ptr<WarpPeerObserverFace> m_peerObserver;
+	std::shared_ptr<WarpPeerObserverFace> m_peerObserver;
+	time_t m_lastTick;
 };
 
 }  // namespace eth

--- a/libethereum/WarpHostCapability.h
+++ b/libethereum/WarpHostCapability.h
@@ -25,12 +25,12 @@ namespace dev
 {
 namespace eth
 {
-
 class WarpHostCapability : public p2p::HostCapability<WarpPeerCapability>, Worker
 {
 public:
     WarpHostCapability(BlockChain const& _blockChain, u256 const& _networkId,
-        boost::filesystem::path const& _snapshotDownloadPath, std::shared_ptr<SnapshotStorageFace> _snapshotStorage);
+        boost::filesystem::path const& _snapshotDownloadPath,
+        std::shared_ptr<SnapshotStorageFace> _snapshotStorage);
     ~WarpHostCapability();
 
     unsigned protocolVersion() const { return c_WarpProtocolVersion; }
@@ -47,8 +47,8 @@ private:
     u256 const m_networkId;
 
     std::shared_ptr<SnapshotStorageFace> m_snapshot;
-	std::shared_ptr<WarpPeerObserverFace> m_peerObserver;
-	time_t m_lastTick;
+    std::shared_ptr<WarpPeerObserverFace> m_peerObserver;
+    time_t m_lastTick;
 };
 
 }  // namespace eth

--- a/libethereum/WarpHostCapability.h
+++ b/libethereum/WarpHostCapability.h
@@ -1,4 +1,5 @@
 /*
+<<<<<<< HEAD
     This file is part of cpp-ethereum.
 
     cpp-ethereum is free software: you can redistribute it and/or modify
@@ -25,21 +26,29 @@ namespace dev
 {
 namespace eth
 {
-class WarpHostCapability : public p2p::HostCapability<WarpPeerCapability>
+
+class WarpHostCapability : public p2p::HostCapability<WarpPeerCapability>, Worker
 {
 public:
     WarpHostCapability(BlockChain const& _blockChain, u256 const& _networkId,
-        std::shared_ptr<SnapshotStorageFace> _snapshotStorage);
+        boost::filesystem::path const& _snapshotDownloadPath, std::shared_ptr<SnapshotStorageFace> _snapshotStorage);
+    ~WarpHostCapability();
+
+    unsigned protocolVersion() const { return c_WarpProtocolVersion; }
+    u256 networkId() const { return m_networkId; }
 
 protected:
     std::shared_ptr<p2p::Capability> newPeerCapability(std::shared_ptr<p2p::SessionFace> const& _s,
         unsigned _idOffset, p2p::CapDesc const& _cap) override;
 
 private:
+    void doWork() override;
+
     BlockChain const& m_blockChain;
     u256 const m_networkId;
 
     std::shared_ptr<SnapshotStorageFace> m_snapshot;
+    std::shared_ptr<WarpPeerObserverFace> m_peerObserver;
 };
 
 }  // namespace eth

--- a/libethereum/WarpPeerCapability.h
+++ b/libethereum/WarpPeerCapability.h
@@ -83,6 +83,9 @@ public:
     void requestManifest();
     void requestData(h256 const& _chunkHash);
 
+    /// Host runs this periodically to check up on the peer.
+    void tick();
+
     u256 snapshotNumber() const { return m_snapshotNumber; }
 
     using p2p::Capability::disable;

--- a/libethereum/WarpPeerCapability.h
+++ b/libethereum/WarpPeerCapability.h
@@ -51,10 +51,11 @@ public:
 
     virtual void onPeerManifest(std::shared_ptr<WarpPeerCapability> _peer, RLP const& _r) = 0;
 
+    virtual void onPeerBlockHeaders(std::shared_ptr<WarpPeerCapability> _peer, RLP const& _r) = 0;
+
     virtual void onPeerData(std::shared_ptr<WarpPeerCapability> _peer, RLP const& _r) = 0;
 
-    virtual void onPeerRequestTimeout(
-        std::shared_ptr<WarpPeerCapability> _peer, Asking _asking) = 0;
+    virtual void onPeerDisconnect(std::shared_ptr<WarpPeerCapability> _peer, Asking _asking) = 0;
 };
 
 class WarpPeerCapability : public p2p::Capability
@@ -82,6 +83,7 @@ public:
         u256 const& _chainTotalDifficulty, h256 const& _chainCurrentHash,
         h256 const& _chainGenesisHash, h256 const& _snapshotBlockHash,
         u256 const& _snapshotBlockNumber);
+    void requestBlockHeaders(unsigned _startNumber, unsigned _count, unsigned _skip, bool _reverse);
     void requestManifest();
     void requestData(h256 const& _chunkHash);
 
@@ -96,6 +98,8 @@ private:
     using p2p::Capability::sealAndSend;
 
     bool interpret(unsigned _id, RLP const& _r) override;
+
+    void onDisconnect() override;
 
     void setAsking(Asking _a);
 

--- a/libethereum/WarpPeerCapability.h
+++ b/libethereum/WarpPeerCapability.h
@@ -53,7 +53,8 @@ public:
 
     virtual void onPeerData(std::shared_ptr<WarpPeerCapability> _peer, RLP const& _r) = 0;
 
-    virtual void onPeerRequestTimeout(std::shared_ptr<WarpPeerCapability> _peer, Asking _asking) = 0;
+    virtual void onPeerRequestTimeout(
+        std::shared_ptr<WarpPeerCapability> _peer, Asking _asking) = 0;
 };
 
 class WarpPeerCapability : public p2p::Capability
@@ -74,7 +75,8 @@ public:
         std::weak_ptr<WarpPeerObserverFace> _observer);
 
     /// Validates whether peer is able to communicate with the host, disables peer if not
-    bool validateStatus(h256 const& _genesisHash, std::vector<unsigned> const& _protocolVersions, u256 const& _networkId);
+    bool validateStatus(h256 const& _genesisHash, std::vector<unsigned> const& _protocolVersions,
+        u256 const& _networkId);
 
     void requestStatus(unsigned _hostProtocolVersion, u256 const& _hostNetworkId,
         u256 const& _chainTotalDifficulty, h256 const& _chainCurrentHash,
@@ -113,9 +115,9 @@ private:
     std::atomic<time_t> m_lastAsk;
 
     /// These are determined through either a Status message.
-    h256 m_latestHash;                      ///< Peer's latest block's hash.
-    u256 m_totalDifficulty;                 ///< Peer's latest block's total difficulty.
-    h256 m_genesisHash;                     ///< Peer's genesis hash
+    h256 m_latestHash;       ///< Peer's latest block's hash.
+    u256 m_totalDifficulty;  ///< Peer's latest block's total difficulty.
+    h256 m_genesisHash;      ///< Peer's genesis hash
     h256 m_snapshotHash;
     u256 m_snapshotNumber;
 

--- a/libethereum/WarpPeerCapability.h
+++ b/libethereum/WarpPeerCapability.h
@@ -105,8 +105,6 @@ private:
 
     void setIdle() { setAsking(Asking::Nothing); }
 
-    unsigned m_hostProtocolVersion = 0;
-
     /// Peer's protocol version.
     unsigned m_protocolVersion = 0;
 

--- a/libp2p/Capability.h
+++ b/libp2p/Capability.h
@@ -1,18 +1,18 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file Capability.h
  * @author Gav Wood <i@gavwood.com>
@@ -33,34 +33,35 @@ class ReputationManager;
 
 class Capability: public std::enable_shared_from_this<Capability>
 {
-	friend class Session;
+    friend class Session;
 
 public:
-	Capability(std::shared_ptr<SessionFace> _s, HostCapabilityFace* _h, unsigned _idOffset);
-	virtual ~Capability() {}
+    Capability(std::shared_ptr<SessionFace> _s, HostCapabilityFace* _h, unsigned _idOffset);
+    virtual ~Capability() {}
 
-	// Implement these in the derived class.
-/*	static std::string name() { return ""; }
-	static u256 version() { return 0; }
-	static unsigned messageCount() { return 0; }
+    // Implement these in the derived class.
+/*  static std::string name() { return ""; }
+    static u256 version() { return 0; }
+    static unsigned messageCount() { return 0; }
 */
 protected:
-	std::shared_ptr<SessionFace> session() const { return m_session.lock(); }
-	HostCapabilityFace* hostCapability() const { return m_hostCap; }
+    std::shared_ptr<SessionFace> session() const { return m_session.lock(); }
+    HostCapabilityFace* hostCapability() const { return m_hostCap; }
 
-	virtual bool interpret(unsigned _id, RLP const&) = 0;
+    virtual bool interpret(unsigned _id, RLP const&) = 0;
+    virtual void onDisconnect() {}
 
-	void disable(std::string const& _problem);
+    void disable(std::string const& _problem);
 
-	RLPStream& prep(RLPStream& _s, unsigned _id, unsigned _args = 0);
-	void sealAndSend(RLPStream& _s);
-	void addRating(int _r);
+    RLPStream& prep(RLPStream& _s, unsigned _id, unsigned _args = 0);
+    void sealAndSend(RLPStream& _s);
+    void addRating(int _r);
 
 private:
-	std::weak_ptr<SessionFace> m_session;
-	HostCapabilityFace* m_hostCap;
-	bool m_enabled = true;
-	unsigned m_idOffset;
+    std::weak_ptr<SessionFace> m_session;
+    HostCapabilityFace* m_hostCap;
+    bool m_enabled = true;
+    unsigned m_idOffset;
 };
 
 }

--- a/libp2p/Session.cpp
+++ b/libp2p/Session.cpp
@@ -1,18 +1,18 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file Session.cpp
  * @author Gav Wood <i@gavwood.com>
@@ -33,394 +33,397 @@ using namespace dev;
 using namespace dev::p2p;
 
 Session::Session(Host* _h, unique_ptr<RLPXFrameCoder>&& _io, std::shared_ptr<RLPXSocket> const& _s, std::shared_ptr<Peer> const& _n, PeerSessionInfo _info):
-	m_server(_h),
-	m_io(move(_io)),
-	m_socket(_s),
-	m_peer(_n),
-	m_info(_info),
-	m_ping(chrono::steady_clock::time_point::max())
+    m_server(_h),
+    m_io(move(_io)),
+    m_socket(_s),
+    m_peer(_n),
+    m_info(_info),
+    m_ping(chrono::steady_clock::time_point::max())
 {
-	m_peer->m_lastDisconnect = NoDisconnect;
-	m_lastReceived = m_connect = chrono::steady_clock::now();
-	DEV_GUARDED(x_info)
-		m_info.socketId = m_socket->ref().native_handle();
+    m_peer->m_lastDisconnect = NoDisconnect;
+    m_lastReceived = m_connect = chrono::steady_clock::now();
+    DEV_GUARDED(x_info)
+        m_info.socketId = m_socket->ref().native_handle();
 }
 
 Session::~Session()
 {
-	ThreadContext tc(info().id.abridged());
-	ThreadContext tc2(info().clientVersion);
-	clog(NetMessageSummary) << "Closing peer session :-(";
-	m_peer->m_lastConnected = m_peer->m_lastAttempted - chrono::seconds(1);
+    ThreadContext tc(info().id.abridged());
+    ThreadContext tc2(info().clientVersion);
+    clog(NetMessageSummary) << "Closing peer session :-(";
+    m_peer->m_lastConnected = m_peer->m_lastAttempted - chrono::seconds(1);
 
-	// Read-chain finished for one reason or another.
-	for (auto& i: m_capabilities)
-		i.second.reset();
+    // Read-chain finished for one reason or another.
+    for (auto& i : m_capabilities)
+    {
+        i.second->onDisconnect();
+        i.second.reset();
+    }
 
-	try
-	{
-		bi::tcp::socket& socket = m_socket->ref();
-		if (socket.is_open())
-		{
-			boost::system::error_code ec;
-			socket.shutdown(boost::asio::ip::tcp::socket::shutdown_both, ec);
-			socket.close();
-		}
-	}
-	catch (...){}
+    try
+    {
+        bi::tcp::socket& socket = m_socket->ref();
+        if (socket.is_open())
+        {
+            boost::system::error_code ec;
+            socket.shutdown(boost::asio::ip::tcp::socket::shutdown_both, ec);
+            socket.close();
+        }
+    }
+    catch (...){}
 }
 
 ReputationManager& Session::repMan()
 {
-	return m_server->repMan();
+    return m_server->repMan();
 }
 
 NodeID Session::id() const
 {
-	return m_peer ? m_peer->id : NodeID();
+    return m_peer ? m_peer->id : NodeID();
 }
 
 void Session::addRating(int _r)
 {
-	if (m_peer)
-	{
-		m_peer->m_rating += _r;
-		m_peer->m_score += _r;
-		if (_r >= 0)
-			m_peer->noteSessionGood();
-	}
+    if (m_peer)
+    {
+        m_peer->m_rating += _r;
+        m_peer->m_score += _r;
+        if (_r >= 0)
+            m_peer->noteSessionGood();
+    }
 }
 
 int Session::rating() const
 {
-	return m_peer->m_rating;
+    return m_peer->m_rating;
 }
 
 template <class T> vector<T> randomSelection(vector<T> const& _t, unsigned _n)
 {
-	if (_t.size() <= _n)
-		return _t;
-	vector<T> ret = _t;
-	while (ret.size() > _n)
-	{
-		auto i = ret.begin();
-		advance(i, rand() % ret.size());
-		ret.erase(i);
-	}
-	return ret;
+    if (_t.size() <= _n)
+        return _t;
+    vector<T> ret = _t;
+    while (ret.size() > _n)
+    {
+        auto i = ret.begin();
+        advance(i, rand() % ret.size());
+        ret.erase(i);
+    }
+    return ret;
 }
 
 bool Session::readPacket(uint16_t _capId, PacketType _t, RLP const& _r)
 {
-	m_lastReceived = chrono::steady_clock::now();
-	clog(NetRight) << _t << _r;
-	try // Generic try-catch block designed to capture RLP format errors - TODO: give decent diagnostics, make a bit more specific over what is caught.
-	{
-		// v4 frame headers are useless, offset packet type used
-		// v5 protocol type is in header, packet type not offset
-		if (_capId == 0 && _t < UserPacket)
-			return interpret(_t, _r);
+    m_lastReceived = chrono::steady_clock::now();
+    clog(NetRight) << _t << _r;
+    try // Generic try-catch block designed to capture RLP format errors - TODO: give decent diagnostics, make a bit more specific over what is caught.
+    {
+        // v4 frame headers are useless, offset packet type used
+        // v5 protocol type is in header, packet type not offset
+        if (_capId == 0 && _t < UserPacket)
+            return interpret(_t, _r);
 
-		for (auto const& i: m_capabilities)
-			if (_t >= (int)i.second->m_idOffset && _t - i.second->m_idOffset < i.second->hostCapability()->messageCount())
-				return i.second->m_enabled ? i.second->interpret(_t - i.second->m_idOffset, _r) : true;
+        for (auto const& i: m_capabilities)
+            if (_t >= (int)i.second->m_idOffset && _t - i.second->m_idOffset < i.second->hostCapability()->messageCount())
+                return i.second->m_enabled ? i.second->interpret(_t - i.second->m_idOffset, _r) : true;
 
-		return false;
-	}
-	catch (std::exception const& _e)
-	{
-		clog(NetWarn) << "Exception caught in p2p::Session::interpret(): " << _e.what() << ". PacketType: " << _t << ". RLP: " << _r;
-		disconnect(BadProtocol);
-		return true;
-	}
-	return true;
+        return false;
+    }
+    catch (std::exception const& _e)
+    {
+        clog(NetWarn) << "Exception caught in p2p::Session::interpret(): " << _e.what() << ". PacketType: " << _t << ". RLP: " << _r;
+        disconnect(BadProtocol);
+        return true;
+    }
+    return true;
 }
 
 bool Session::interpret(PacketType _t, RLP const& _r)
 {
-	switch (_t)
-	{
-	case DisconnectPacket:
-	{
-		string reason = "Unspecified";
-		auto r = (DisconnectReason)_r[0].toInt<int>();
-		if (!_r[0].isInt())
-			drop(BadProtocol);
-		else
-		{
-			reason = reasonOf(r);
-			clog(NetMessageSummary) << "Disconnect (reason: " << reason << ")";
-			drop(DisconnectRequested);
-		}
-		break;
-	}
-	case PingPacket:
-	{
-		clog(NetTriviaSummary) << "Ping" << m_info.id;
-		RLPStream s;
-		sealAndSend(prep(s, PongPacket));
-		break;
-	}
-	case PongPacket:
-		DEV_GUARDED(x_info)
-		{
-			m_info.lastPing = std::chrono::steady_clock::now() - m_ping;
-			clog(NetTriviaSummary) << "Latency: " << chrono::duration_cast<chrono::milliseconds>(m_info.lastPing).count() << " ms";
-		}
-		break;
-	case GetPeersPacket:
-	case PeersPacket:
-		break;
-	default:
-		return false;
-	}
-	return true;
+    switch (_t)
+    {
+    case DisconnectPacket:
+    {
+        string reason = "Unspecified";
+        auto r = (DisconnectReason)_r[0].toInt<int>();
+        if (!_r[0].isInt())
+            drop(BadProtocol);
+        else
+        {
+            reason = reasonOf(r);
+            clog(NetMessageSummary) << "Disconnect (reason: " << reason << ")";
+            drop(DisconnectRequested);
+        }
+        break;
+    }
+    case PingPacket:
+    {
+        clog(NetTriviaSummary) << "Ping" << m_info.id;
+        RLPStream s;
+        sealAndSend(prep(s, PongPacket));
+        break;
+    }
+    case PongPacket:
+        DEV_GUARDED(x_info)
+        {
+            m_info.lastPing = std::chrono::steady_clock::now() - m_ping;
+            clog(NetTriviaSummary) << "Latency: " << chrono::duration_cast<chrono::milliseconds>(m_info.lastPing).count() << " ms";
+        }
+        break;
+    case GetPeersPacket:
+    case PeersPacket:
+        break;
+    default:
+        return false;
+    }
+    return true;
 }
 
 void Session::ping()
 {
-	RLPStream s;
-	sealAndSend(prep(s, PingPacket));
-	m_ping = std::chrono::steady_clock::now();
+    RLPStream s;
+    sealAndSend(prep(s, PingPacket));
+    m_ping = std::chrono::steady_clock::now();
 }
 
 RLPStream& Session::prep(RLPStream& _s, PacketType _id, unsigned _args)
 {
-	return _s.append((unsigned)_id).appendList(_args);
+    return _s.append((unsigned)_id).appendList(_args);
 }
 
 void Session::sealAndSend(RLPStream& _s)
 {
-	bytes b;
-	_s.swapOut(b);
-	send(move(b));
+    bytes b;
+    _s.swapOut(b);
+    send(move(b));
 }
 
 bool Session::checkPacket(bytesConstRef _msg)
 {
-	if (_msg[0] > 0x7f || _msg.size() < 2)
-		return false;
-	if (RLP(_msg.cropped(1)).actualSize() + 1 != _msg.size())
-		return false;
-	return true;
+    if (_msg[0] > 0x7f || _msg.size() < 2)
+        return false;
+    if (RLP(_msg.cropped(1)).actualSize() + 1 != _msg.size())
+        return false;
+    return true;
 }
 
 void Session::send(bytes&& _msg)
 {
-	bytesConstRef msg(&_msg);
-	clog(NetLeft) << RLP(msg.cropped(1));
-	if (!checkPacket(msg))
-		clog(NetWarn) << "INVALID PACKET CONSTRUCTED!";
+    bytesConstRef msg(&_msg);
+    clog(NetLeft) << RLP(msg.cropped(1));
+    if (!checkPacket(msg))
+        clog(NetWarn) << "INVALID PACKET CONSTRUCTED!";
 
-	if (!m_socket->ref().is_open())
-		return;
+    if (!m_socket->ref().is_open())
+        return;
 
-	bool doWrite = false;
-	DEV_GUARDED(x_framing)
-	{
-		m_writeQueue.push_back(std::move(_msg));
-		doWrite = (m_writeQueue.size() == 1);
-	}
+    bool doWrite = false;
+    DEV_GUARDED(x_framing)
+    {
+        m_writeQueue.push_back(std::move(_msg));
+        doWrite = (m_writeQueue.size() == 1);
+    }
 
-	if (doWrite)
-		write();
+    if (doWrite)
+        write();
 }
 
 void Session::write()
 {
-	bytes const* out = nullptr;
-	DEV_GUARDED(x_framing)
-	{
-		m_io->writeSingleFramePacket(&m_writeQueue[0], m_writeQueue[0]);
-		out = &m_writeQueue[0];
-	}
-	auto self(shared_from_this());
-	ba::async_write(m_socket->ref(), ba::buffer(*out), [this, self](boost::system::error_code ec, std::size_t /*length*/)
-	{
-		ThreadContext tc(info().id.abridged());
-		ThreadContext tc2(info().clientVersion);
-		// must check queue, as write callback can occur following dropped()
-		if (ec)
-		{
-			clog(NetWarn) << "Error sending: " << ec.message();
-			drop(TCPError);
-			return;
-		}
+    bytes const* out = nullptr;
+    DEV_GUARDED(x_framing)
+    {
+        m_io->writeSingleFramePacket(&m_writeQueue[0], m_writeQueue[0]);
+        out = &m_writeQueue[0];
+    }
+    auto self(shared_from_this());
+    ba::async_write(m_socket->ref(), ba::buffer(*out), [this, self](boost::system::error_code ec, std::size_t /*length*/)
+    {
+        ThreadContext tc(info().id.abridged());
+        ThreadContext tc2(info().clientVersion);
+        // must check queue, as write callback can occur following dropped()
+        if (ec)
+        {
+            clog(NetWarn) << "Error sending: " << ec.message();
+            drop(TCPError);
+            return;
+        }
 
-		DEV_GUARDED(x_framing)
-		{
-			m_writeQueue.pop_front();
-			if (m_writeQueue.empty())
-				return;
-		}
-		write();
-	});
+        DEV_GUARDED(x_framing)
+        {
+            m_writeQueue.pop_front();
+            if (m_writeQueue.empty())
+                return;
+        }
+        write();
+    });
 }
 
 namespace
 {
-	void halveAtomicInt(atomic<int>& i)
-	{
-		int oldInt = 0;
-		int newInt = 0;
-		do
-		{
-			oldInt = i;
-			newInt = oldInt / 2;
-		}
-		while (i.atomic::compare_exchange_weak(oldInt, newInt));
-	}
+    void halveAtomicInt(atomic<int>& i)
+    {
+        int oldInt = 0;
+        int newInt = 0;
+        do
+        {
+            oldInt = i;
+            newInt = oldInt / 2;
+        }
+        while (i.atomic::compare_exchange_weak(oldInt, newInt));
+    }
 }
 
 void Session::drop(DisconnectReason _reason)
 {
-	if (m_dropped)
-		return;
-	bi::tcp::socket& socket = m_socket->ref();
-	if (socket.is_open())
-		try
-		{
-			boost::system::error_code ec;
-			clog(NetConnect) << "Closing " << socket.remote_endpoint(ec) << "(" << reasonOf(_reason) << ")";
-			socket.shutdown(boost::asio::ip::tcp::socket::shutdown_both, ec);
-			socket.close();
-		}
-		catch (...) {}
+    if (m_dropped)
+        return;
+    bi::tcp::socket& socket = m_socket->ref();
+    if (socket.is_open())
+        try
+        {
+            boost::system::error_code ec;
+            clog(NetConnect) << "Closing " << socket.remote_endpoint(ec) << "(" << reasonOf(_reason) << ")";
+            socket.shutdown(boost::asio::ip::tcp::socket::shutdown_both, ec);
+            socket.close();
+        }
+        catch (...) {}
 
-	m_peer->m_lastDisconnect = _reason;
-	if (_reason == BadProtocol)
-	{
-		halveAtomicInt(m_peer->m_rating);
-		halveAtomicInt(m_peer->m_score);
-	}
-	m_dropped = true;
+    m_peer->m_lastDisconnect = _reason;
+    if (_reason == BadProtocol)
+    {
+        halveAtomicInt(m_peer->m_rating);
+        halveAtomicInt(m_peer->m_score);
+    }
+    m_dropped = true;
 }
 
 void Session::disconnect(DisconnectReason _reason)
 {
-	clog(NetConnect) << "Disconnecting (our reason:" << reasonOf(_reason) << ")";
+    clog(NetConnect) << "Disconnecting (our reason:" << reasonOf(_reason) << ")";
 
-	if (m_socket->ref().is_open())
-	{
-		RLPStream s;
-		prep(s, DisconnectPacket, 1) << (int)_reason;
-		sealAndSend(s);
-	}
-	drop(_reason);
+    if (m_socket->ref().is_open())
+    {
+        RLPStream s;
+        prep(s, DisconnectPacket, 1) << (int)_reason;
+        sealAndSend(s);
+    }
+    drop(_reason);
 }
 
 void Session::start()
 {
-	ping();
-	doRead();
+    ping();
+    doRead();
 }
 
 void Session::doRead()
 {
-	// ignore packets received while waiting to disconnect.
-	if (m_dropped)
-		return;
+    // ignore packets received while waiting to disconnect.
+    if (m_dropped)
+        return;
 
-	auto self(shared_from_this());
-	m_data.resize(h256::size);
-	ba::async_read(m_socket->ref(), boost::asio::buffer(m_data, h256::size), [this,self](boost::system::error_code ec, std::size_t length)
-	{
-		ThreadContext tc(info().id.abridged());
-		ThreadContext tc2(info().clientVersion);
-		if (!checkRead(h256::size, ec, length))
-			return;
-		else if (!m_io->authAndDecryptHeader(bytesRef(m_data.data(), length)))
-		{
-			clog(NetWarn) << "header decrypt failed";
-			drop(BadProtocol); // todo: better error
-			return;
-		}
-		
-		uint16_t hProtocolId;
-		uint32_t hLength;
-		uint8_t hPadding;
-		try
-		{
-			RLPXFrameInfo header(bytesConstRef(m_data.data(), length));
-			hProtocolId = header.protocolId;
-			hLength = header.length;
-			hPadding = header.padding;
-		}
-		catch (std::exception const& _e)
-		{
-			clog(NetWarn) << "Exception decoding frame header RLP:" << _e.what() << bytesConstRef(m_data.data(), h128::size).cropped(3);
-			drop(BadProtocol);
-			return;
-		}
+    auto self(shared_from_this());
+    m_data.resize(h256::size);
+    ba::async_read(m_socket->ref(), boost::asio::buffer(m_data, h256::size), [this,self](boost::system::error_code ec, std::size_t length)
+    {
+        ThreadContext tc(info().id.abridged());
+        ThreadContext tc2(info().clientVersion);
+        if (!checkRead(h256::size, ec, length))
+            return;
+        else if (!m_io->authAndDecryptHeader(bytesRef(m_data.data(), length)))
+        {
+            clog(NetWarn) << "header decrypt failed";
+            drop(BadProtocol); // todo: better error
+            return;
+        }
+        
+        uint16_t hProtocolId;
+        uint32_t hLength;
+        uint8_t hPadding;
+        try
+        {
+            RLPXFrameInfo header(bytesConstRef(m_data.data(), length));
+            hProtocolId = header.protocolId;
+            hLength = header.length;
+            hPadding = header.padding;
+        }
+        catch (std::exception const& _e)
+        {
+            clog(NetWarn) << "Exception decoding frame header RLP:" << _e.what() << bytesConstRef(m_data.data(), h128::size).cropped(3);
+            drop(BadProtocol);
+            return;
+        }
 
-		/// read padded frame and mac
-		auto tlen = hLength + hPadding + h128::size;
-		m_data.resize(tlen);
-		ba::async_read(m_socket->ref(), boost::asio::buffer(m_data, tlen), [this, self, hLength, hProtocolId, tlen](boost::system::error_code ec, std::size_t length)
-		{
-			ThreadContext tc(info().id.abridged());
-			ThreadContext tc2(info().clientVersion);
-			if (!checkRead(tlen, ec, length))
-				return;
-			else if (!m_io->authAndDecryptFrame(bytesRef(m_data.data(), tlen)))
-			{
-				clog(NetWarn) << "frame decrypt failed";
-				drop(BadProtocol); // todo: better error
-				return;
-			}
+        /// read padded frame and mac
+        auto tlen = hLength + hPadding + h128::size;
+        m_data.resize(tlen);
+        ba::async_read(m_socket->ref(), boost::asio::buffer(m_data, tlen), [this, self, hLength, hProtocolId, tlen](boost::system::error_code ec, std::size_t length)
+        {
+            ThreadContext tc(info().id.abridged());
+            ThreadContext tc2(info().clientVersion);
+            if (!checkRead(tlen, ec, length))
+                return;
+            else if (!m_io->authAndDecryptFrame(bytesRef(m_data.data(), tlen)))
+            {
+                clog(NetWarn) << "frame decrypt failed";
+                drop(BadProtocol); // todo: better error
+                return;
+            }
 
-			bytesConstRef frame(m_data.data(), hLength);
-			if (!checkPacket(frame))
-			{
-				cerr << "Received " << frame.size() << ": " << toHex(frame) << endl;
-				clog(NetWarn) << "INVALID MESSAGE RECEIVED";
-				disconnect(BadProtocol);
-				return;
-			}
-			else
-			{
-				auto packetType = (PacketType)RLP(frame.cropped(0, 1)).toInt<unsigned>();
-				RLP r(frame.cropped(1));
-				bool ok = readPacket(hProtocolId, packetType, r);
-				if (!ok)
-					clog(NetWarn) << "Couldn't interpret packet." << RLP(r);
-			}
-			doRead();
-		});
-	});
+            bytesConstRef frame(m_data.data(), hLength);
+            if (!checkPacket(frame))
+            {
+                cerr << "Received " << frame.size() << ": " << toHex(frame) << endl;
+                clog(NetWarn) << "INVALID MESSAGE RECEIVED";
+                disconnect(BadProtocol);
+                return;
+            }
+            else
+            {
+                auto packetType = (PacketType)RLP(frame.cropped(0, 1)).toInt<unsigned>();
+                RLP r(frame.cropped(1));
+                bool ok = readPacket(hProtocolId, packetType, r);
+                if (!ok)
+                    clog(NetWarn) << "Couldn't interpret packet." << RLP(r);
+            }
+            doRead();
+        });
+    });
 }
 
 bool Session::checkRead(std::size_t _expected, boost::system::error_code _ec, std::size_t _length)
 {
-	if (_ec && _ec.category() != boost::asio::error::get_misc_category() && _ec.value() != boost::asio::error::eof)
-	{
-		clog(NetConnect) << "Error reading: " << _ec.message();
-		drop(TCPError);
-		return false;
-	}
-	else if (_ec && _length < _expected)
-	{
-		clog(NetWarn) << "Error reading - Abrupt peer disconnect: " << _ec.message();
-		repMan().noteRude(*this);
-		drop(TCPError);
-		return false;
-	}
-	else if (_length != _expected)
-	{
-		// with static m_data-sized buffer this shouldn't happen unless there's a regression
-		// sec recommends checking anyways (instead of assert)
-		clog(NetWarn) << "Error reading - TCP read buffer length differs from expected frame size.";
-		disconnect(UserReason);
-		return false;
-	}
+    if (_ec && _ec.category() != boost::asio::error::get_misc_category() && _ec.value() != boost::asio::error::eof)
+    {
+        clog(NetConnect) << "Error reading: " << _ec.message();
+        drop(TCPError);
+        return false;
+    }
+    else if (_ec && _length < _expected)
+    {
+        clog(NetWarn) << "Error reading - Abrupt peer disconnect: " << _ec.message();
+        repMan().noteRude(*this);
+        drop(TCPError);
+        return false;
+    }
+    else if (_length != _expected)
+    {
+        // with static m_data-sized buffer this shouldn't happen unless there's a regression
+        // sec recommends checking anyways (instead of assert)
+        clog(NetWarn) << "Error reading - TCP read buffer length differs from expected frame size.";
+        disconnect(UserReason);
+        return false;
+    }
 
-	return true;
+    return true;
 }
 
 void Session::registerCapability(CapDesc const& _desc, std::shared_ptr<Capability> _p)
 {
-	DEV_GUARDED(x_framing)
-	{
-		m_capabilities[_desc] = _p;
-	}
+    DEV_GUARDED(x_framing)
+    {
+        m_capabilities[_desc] = _p;
+    }
 }

--- a/libwebthree/WebThree.cpp
+++ b/libwebthree/WebThree.cpp
@@ -39,6 +39,7 @@ static_assert(BOOST_VERSION >= 106400, "Wrong boost headers version");
 WebThreeDirect::WebThreeDirect(
 	std::string const& _clientVersion,
 	boost::filesystem::path const& _dbPath,
+	boost::filesystem::path const& _snapshotPath,
 	eth::ChainParams const& _params,
 	WithExisting _we,
 	std::set<std::string> const& _interfaces,
@@ -56,12 +57,13 @@ WebThreeDirect::WebThreeDirect(
 		Ethash::init();
 		NoProof::init();
 		if (_params.sealEngineName == "Ethash")
-			m_ethereum.reset(new eth::EthashClient(_params, (int)_params.networkID, &m_net, shared_ptr<GasPricer>(), _dbPath, _we));
+			m_ethereum.reset(new eth::EthashClient(_params, (int)_params.networkID, &m_net, shared_ptr<GasPricer>(), _dbPath, _snapshotPath, _we));
 		else if (_params.sealEngineName == "NoProof" && _testing)
 			m_ethereum.reset(new eth::ClientTest(_params, (int)_params.networkID, &m_net, shared_ptr<GasPricer>(), _dbPath, _we));
 		else
-			m_ethereum.reset(new eth::Client(_params, (int)_params.networkID, &m_net, shared_ptr<GasPricer>(), _dbPath, _we));
+			m_ethereum.reset(new eth::Client(_params, (int)_params.networkID, &m_net, shared_ptr<GasPricer>(), _dbPath, _snapshotPath, _we));
 		m_ethereum->startWorking();
+
 		string bp = DEV_QUOTED(ETH_BUILD_PLATFORM);
 		vector<string> bps;
 		boost::split(bps, bp, boost::is_any_of("/"));

--- a/libwebthree/WebThree.cpp
+++ b/libwebthree/WebThree.cpp
@@ -1,18 +1,18 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file WebThree.cpp
  * @author Gav Wood <i@gavwood.com>
@@ -36,124 +36,116 @@ using namespace dev::shh;
 
 static_assert(BOOST_VERSION >= 106400, "Wrong boost headers version");
 
-WebThreeDirect::WebThreeDirect(
-	std::string const& _clientVersion,
-	boost::filesystem::path const& _dbPath,
-	boost::filesystem::path const& _snapshotPath,
-	eth::ChainParams const& _params,
-	WithExisting _we,
-	std::set<std::string> const& _interfaces,
-	NetworkPreferences const& _n,
-	bytesConstRef _network,
-	bool _testing
-):
-	m_clientVersion(_clientVersion),
-	m_net(_clientVersion, _n, _network)
+WebThreeDirect::WebThreeDirect(std::string const& _clientVersion,
+    boost::filesystem::path const& _dbPath, boost::filesystem::path const& _snapshotPath,
+    eth::ChainParams const& _params, WithExisting _we, std::set<std::string> const& _interfaces,
+    NetworkPreferences const& _n, bytesConstRef _network, bool _testing)
+  : m_clientVersion(_clientVersion), m_net(_clientVersion, _n, _network)
 {
-	if (_dbPath.size())
-		Defaults::setDBPath(_dbPath);
-	if (_interfaces.count("eth"))
-	{
-		Ethash::init();
-		NoProof::init();
-		if (_params.sealEngineName == "Ethash")
-			m_ethereum.reset(new eth::EthashClient(_params, (int)_params.networkID, &m_net, shared_ptr<GasPricer>(), _dbPath, _snapshotPath, _we));
-		else if (_params.sealEngineName == "NoProof" && _testing)
-			m_ethereum.reset(new eth::ClientTest(_params, (int)_params.networkID, &m_net, shared_ptr<GasPricer>(), _dbPath, _we));
-		else
-			m_ethereum.reset(new eth::Client(_params, (int)_params.networkID, &m_net, shared_ptr<GasPricer>(), _dbPath, _snapshotPath, _we));
-		m_ethereum->startWorking();
+    if (_dbPath.size())
+        Defaults::setDBPath(_dbPath);
+    if (_interfaces.count("eth"))
+    {
+        Ethash::init();
+        NoProof::init();
+        if (_params.sealEngineName == "Ethash")
+            m_ethereum.reset(new eth::EthashClient(_params, (int)_params.networkID, &m_net, shared_ptr<GasPricer>(), _dbPath, _snapshotPath, _we));
+        else if (_params.sealEngineName == "NoProof" && _testing)
+            m_ethereum.reset(new eth::ClientTest(_params, (int)_params.networkID, &m_net, shared_ptr<GasPricer>(), _dbPath, _we));
+        else
+            m_ethereum.reset(new eth::Client(_params, (int)_params.networkID, &m_net, shared_ptr<GasPricer>(), _dbPath, _snapshotPath, _we));
+        m_ethereum->startWorking();
 
-		string bp = DEV_QUOTED(ETH_BUILD_PLATFORM);
-		vector<string> bps;
-		boost::split(bps, bp, boost::is_any_of("/"));
-		bps[0] = bps[0].substr(0, 5);
-		bps[1] = bps[1].substr(0, 3);
-		bps.back() = bps.back().substr(0, 3);
-		m_ethereum->setExtraData(rlpList(0, string(dev::Version) + "++" + string(DEV_QUOTED(ETH_COMMIT_HASH)).substr(0, 4) + (ETH_CLEAN_REPO ? "-" : "*") + string(DEV_QUOTED(ETH_BUILD_TYPE)).substr(0, 1) + boost::join(bps, "/")));
-	}
+        string bp = DEV_QUOTED(ETH_BUILD_PLATFORM);
+        vector<string> bps;
+        boost::split(bps, bp, boost::is_any_of("/"));
+        bps[0] = bps[0].substr(0, 5);
+        bps[1] = bps[1].substr(0, 3);
+        bps.back() = bps.back().substr(0, 3);
+        m_ethereum->setExtraData(rlpList(0, string(dev::Version) + "++" + string(DEV_QUOTED(ETH_COMMIT_HASH)).substr(0, 4) + (ETH_CLEAN_REPO ? "-" : "*") + string(DEV_QUOTED(ETH_BUILD_TYPE)).substr(0, 1) + boost::join(bps, "/")));
+    }
 }
 
 WebThreeDirect::~WebThreeDirect()
 {
-	// Utterly horrible right now - WebThree owns everything (good), but:
-	// m_net (Host) owns the eth::EthereumHost via a shared_ptr.
-	// The eth::EthereumHost depends on eth::Client (it maintains a reference to the BlockChain field of Client).
-	// eth::Client (owned by us via a unique_ptr) uses eth::EthereumHost (via a weak_ptr).
-	// Really need to work out a clean way of organising ownership and guaranteeing startup/shutdown is perfect.
+    // Utterly horrible right now - WebThree owns everything (good), but:
+    // m_net (Host) owns the eth::EthereumHost via a shared_ptr.
+    // The eth::EthereumHost depends on eth::Client (it maintains a reference to the BlockChain field of Client).
+    // eth::Client (owned by us via a unique_ptr) uses eth::EthereumHost (via a weak_ptr).
+    // Really need to work out a clean way of organising ownership and guaranteeing startup/shutdown is perfect.
 
-	// Have to call stop here to get the Host to kill its io_service otherwise we end up with left-over reads,
-	// still referencing Sessions getting deleted *after* m_ethereum is reset, causing bad things to happen, since
-	// the guarantee is that m_ethereum is only reset *after* all sessions have ended (sessions are allowed to
-	// use bits of data owned by m_ethereum).
-	m_net.stop();
-	m_ethereum.reset();
+    // Have to call stop here to get the Host to kill its io_service otherwise we end up with left-over reads,
+    // still referencing Sessions getting deleted *after* m_ethereum is reset, causing bad things to happen, since
+    // the guarantee is that m_ethereum is only reset *after* all sessions have ended (sessions are allowed to
+    // use bits of data owned by m_ethereum).
+    m_net.stop();
+    m_ethereum.reset();
 }
 
 std::string WebThreeDirect::composeClientVersion(std::string const& _client)
 {
-	return _client + "/" + \
-		"v" + dev::Version + "/" + \
-		DEV_QUOTED(ETH_BUILD_OS) + "/" + \
-		DEV_QUOTED(ETH_BUILD_COMPILER) + "/" + \
-		DEV_QUOTED(ETH_BUILD_JIT_MODE) + "/" + \
-		DEV_QUOTED(ETH_BUILD_TYPE) + "/" + \
-		string(DEV_QUOTED(ETH_COMMIT_HASH)).substr(0, 8) + \
-		(ETH_CLEAN_REPO ? "" : "*") + "/";
+    return _client + "/" + \
+        "v" + dev::Version + "/" + \
+        DEV_QUOTED(ETH_BUILD_OS) + "/" + \
+        DEV_QUOTED(ETH_BUILD_COMPILER) + "/" + \
+        DEV_QUOTED(ETH_BUILD_JIT_MODE) + "/" + \
+        DEV_QUOTED(ETH_BUILD_TYPE) + "/" + \
+        string(DEV_QUOTED(ETH_COMMIT_HASH)).substr(0, 8) + \
+        (ETH_CLEAN_REPO ? "" : "*") + "/";
 }
 
 p2p::NetworkPreferences const& WebThreeDirect::networkPreferences() const
 {
-	return m_net.networkPreferences();
+    return m_net.networkPreferences();
 }
 
 void WebThreeDirect::setNetworkPreferences(p2p::NetworkPreferences const& _n, bool _dropPeers)
 {
-	auto had = isNetworkStarted();
-	if (had)
-		stopNetwork();
-	m_net.setNetworkPreferences(_n, _dropPeers);
-	if (had)
-		startNetwork();
+    auto had = isNetworkStarted();
+    if (had)
+        stopNetwork();
+    m_net.setNetworkPreferences(_n, _dropPeers);
+    if (had)
+        startNetwork();
 }
 
 std::vector<PeerSessionInfo> WebThreeDirect::peers()
 {
-	return m_net.peerSessionInfo();
+    return m_net.peerSessionInfo();
 }
 
 size_t WebThreeDirect::peerCount() const
 {
-	return m_net.peerCount();
+    return m_net.peerCount();
 }
 
 void WebThreeDirect::setIdealPeerCount(size_t _n)
 {
-	return m_net.setIdealPeerCount(_n);
+    return m_net.setIdealPeerCount(_n);
 }
 
 void WebThreeDirect::setPeerStretch(size_t _n)
 {
-	return m_net.setPeerStretch(_n);
+    return m_net.setPeerStretch(_n);
 }
 
 bytes WebThreeDirect::saveNetwork()
 {
-	return m_net.saveNetwork();
+    return m_net.saveNetwork();
 }
 
 void WebThreeDirect::addNode(NodeID const& _node, bi::tcp::endpoint const& _host)
 {
-	m_net.addNode(_node, NodeIPEndpoint(_host.address(), _host.port(), _host.port()));
+    m_net.addNode(_node, NodeIPEndpoint(_host.address(), _host.port(), _host.port()));
 }
 
 void WebThreeDirect::requirePeer(NodeID const& _node, bi::tcp::endpoint const& _host)
 {
-	m_net.requirePeer(_node, NodeIPEndpoint(_host.address(), _host.port(), _host.port()));
+    m_net.requirePeer(_node, NodeIPEndpoint(_host.address(), _host.port(), _host.port()));
 }
 
 void WebThreeDirect::addPeer(NodeSpec const& _s, PeerType _t)
 {
-	m_net.addPeer(_s, _t);
+    m_net.addPeer(_s, _t);
 }
 

--- a/libwebthree/WebThree.h
+++ b/libwebthree/WebThree.h
@@ -1,18 +1,18 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file WebThree.h
  * @author Gav Wood <i@gavwood.com>
@@ -40,9 +40,9 @@ namespace dev
 
 enum WorkState
 {
-	Active = 0,
-	Deleting,
-	Deleted
+    Active = 0,
+    Deleting,
+    Deleted
 };
 
 namespace eth { class Interface; }
@@ -54,54 +54,54 @@ class Support;
 class NetworkFace
 {
 public:
-	/// Get information concerning this node.
-	virtual p2p::NodeInfo nodeInfo() const = 0;
+    /// Get information concerning this node.
+    virtual p2p::NodeInfo nodeInfo() const = 0;
 
-	/// Get information on the current peer set.
-	virtual std::vector<p2p::PeerSessionInfo> peers() = 0;
+    /// Get information on the current peer set.
+    virtual std::vector<p2p::PeerSessionInfo> peers() = 0;
 
-	/// Same as peers().size(), but more efficient.
-	virtual size_t peerCount() const = 0;
+    /// Same as peers().size(), but more efficient.
+    virtual size_t peerCount() const = 0;
 
-	/// Generalised peer addition.
-	virtual void addPeer(p2p::NodeSpec const& _node, p2p::PeerType _t) = 0;
+    /// Generalised peer addition.
+    virtual void addPeer(p2p::NodeSpec const& _node, p2p::PeerType _t) = 0;
 
-	/// Add node to connect to.
-	virtual void addNode(p2p::NodeID const& _node, bi::tcp::endpoint const& _hostEndpoint) = 0;
-	
-	/// Require connection to peer.
-	virtual void requirePeer(p2p::NodeID const& _node, bi::tcp::endpoint const& _endpoint) = 0;
-	
-	/// Save peers
-	virtual dev::bytes saveNetwork() = 0;
+    /// Add node to connect to.
+    virtual void addNode(p2p::NodeID const& _node, bi::tcp::endpoint const& _hostEndpoint) = 0;
+    
+    /// Require connection to peer.
+    virtual void requirePeer(p2p::NodeID const& _node, bi::tcp::endpoint const& _endpoint) = 0;
+    
+    /// Save peers
+    virtual dev::bytes saveNetwork() = 0;
 
-	/// Sets the ideal number of peers.
-	virtual void setIdealPeerCount(size_t _n) = 0;
+    /// Sets the ideal number of peers.
+    virtual void setIdealPeerCount(size_t _n) = 0;
 
-	virtual bool haveNetwork() const = 0;
+    virtual bool haveNetwork() const = 0;
 
-	virtual p2p::NetworkPreferences const& networkPreferences() const = 0;
-	virtual void setNetworkPreferences(p2p::NetworkPreferences const& _n, bool _dropPeers) = 0;
+    virtual p2p::NetworkPreferences const& networkPreferences() const = 0;
+    virtual void setNetworkPreferences(p2p::NetworkPreferences const& _n, bool _dropPeers) = 0;
 
-	virtual p2p::NodeID id() const = 0;
+    virtual p2p::NodeID id() const = 0;
 
-	/// Get network id
-	virtual u256 networkId() const = 0;
+    /// Get network id
+    virtual u256 networkId() const = 0;
 
-	/// Gets the nodes.
-	virtual p2p::Peers nodes() const = 0;
+    /// Gets the nodes.
+    virtual p2p::Peers nodes() const = 0;
 
-	/// Start the network subsystem.
-	virtual void startNetwork() = 0;
+    /// Start the network subsystem.
+    virtual void startNetwork() = 0;
 
-	/// Stop the network subsystem.
-	virtual void stopNetwork() = 0;
+    /// Stop the network subsystem.
+    virtual void stopNetwork() = 0;
 
-	/// Is network working? there may not be any peers yet.
-	virtual bool isNetworkStarted() const = 0;
+    /// Is network working? there may not be any peers yet.
+    virtual bool isNetworkStarted() const = 0;
 
-	/// Get enode string.
-	virtual std::string enode() const = 0;
+    /// Get enode string.
+    virtual std::string enode() const = 0;
 };
 
 
@@ -118,102 +118,97 @@ public:
 class WebThreeDirect: public NetworkFace
 {
 public:
-	/// Constructor for private instance. If there is already another process on the machine using @a _dbPath, then this will throw an exception.
-	/// ethereum() may be safely static_cast()ed to a eth::Client*.
-	WebThreeDirect(
-		std::string const& _clientVersion,
-		boost::filesystem::path const& _dbPath,
-		boost::filesystem::path const& _snapshotPath,
-		eth::ChainParams const& _params,
-		WithExisting _we = WithExisting::Trust,
-		std::set<std::string> const& _interfaces = {"eth", "shh", "bzz"},
-		p2p::NetworkPreferences const& _n = p2p::NetworkPreferences(),
-		bytesConstRef _network = bytesConstRef(),
-		bool _testing = false
-	);
+    /// Constructor for private instance. If there is already another process on the machine using @a _dbPath, then this will throw an exception.
+    /// ethereum() may be safely static_cast()ed to a eth::Client*.
+    WebThreeDirect(std::string const& _clientVersion, boost::filesystem::path const& _dbPath,
+        boost::filesystem::path const& _snapshotPath, eth::ChainParams const& _params,
+        WithExisting _we = WithExisting::Trust,
+        std::set<std::string> const& _interfaces = {"eth", "shh", "bzz"},
+        p2p::NetworkPreferences const& _n = p2p::NetworkPreferences(),
+        bytesConstRef _network = bytesConstRef(), bool _testing = false);
 
-	/// Destructor.
-	~WebThreeDirect();
+    /// Destructor.
+    ~WebThreeDirect();
 
-	// The mainline interfaces:
+    // The mainline interfaces:
 
-	eth::Client* ethereum() const { if (!m_ethereum) BOOST_THROW_EXCEPTION(InterfaceNotSupported("eth")); return m_ethereum.get(); }
+    eth::Client* ethereum() const { if (!m_ethereum) BOOST_THROW_EXCEPTION(InterfaceNotSupported("eth")); return m_ethereum.get(); }
 
-	// Misc stuff:
+    // Misc stuff:
 
-	static std::string composeClientVersion(std::string const& _client);
-	std::string const& clientVersion() const { return m_clientVersion; }
+    static std::string composeClientVersion(std::string const& _client);
+    std::string const& clientVersion() const { return m_clientVersion; }
 
-	// Network stuff:
+    // Network stuff:
 
-	/// Get information on the current peer set.
-	std::vector<p2p::PeerSessionInfo> peers() override;
+    /// Get information on the current peer set.
+    std::vector<p2p::PeerSessionInfo> peers() override;
 
-	/// Same as peers().size(), but more efficient.
-	size_t peerCount() const override;
-	
-	/// Generalised peer addition.
-	virtual void addPeer(p2p::NodeSpec const& _node, p2p::PeerType _t) override;
+    /// Same as peers().size(), but more efficient.
+    size_t peerCount() const override;
+    
+    /// Generalised peer addition.
+    virtual void addPeer(p2p::NodeSpec const& _node, p2p::PeerType _t) override;
 
-	/// Add node to connect to.
-	virtual void addNode(p2p::NodeID const& _node, bi::tcp::endpoint const& _hostEndpoint) override;
+    /// Add node to connect to.
+    virtual void addNode(p2p::NodeID const& _node, bi::tcp::endpoint const& _hostEndpoint) override;
 
-	/// Add node to connect to.
-	void addNode(p2p::NodeID const& _node, std::string const& _hostString) { addNode(_node, p2p::Network::resolveHost(_hostString)); }
-	
-	/// Add node to connect to.
-	void addNode(bi::tcp::endpoint const& _endpoint) { addNode(p2p::NodeID(), _endpoint); }
+    /// Add node to connect to.
+    void addNode(p2p::NodeID const& _node, std::string const& _hostString) { addNode(_node, p2p::Network::resolveHost(_hostString)); }
+    
+    /// Add node to connect to.
+    void addNode(bi::tcp::endpoint const& _endpoint) { addNode(p2p::NodeID(), _endpoint); }
 
-	/// Add node to connect to.
-	void addNode(std::string const& _hostString) { addNode(p2p::NodeID(), _hostString); }
-	
-	/// Require connection to peer.
-	void requirePeer(p2p::NodeID const& _node, bi::tcp::endpoint const& _endpoint) override;
+    /// Add node to connect to.
+    void addNode(std::string const& _hostString) { addNode(p2p::NodeID(), _hostString); }
+    
+    /// Require connection to peer.
+    void requirePeer(p2p::NodeID const& _node, bi::tcp::endpoint const& _endpoint) override;
 
-	/// Require connection to peer.
-	void requirePeer(p2p::NodeID const& _node, std::string const& _hostString) { requirePeer(_node, p2p::Network::resolveHost(_hostString)); }
+    /// Require connection to peer.
+    void requirePeer(p2p::NodeID const& _node, std::string const& _hostString) { requirePeer(_node, p2p::Network::resolveHost(_hostString)); }
 
-	/// Save peers
-	dev::bytes saveNetwork() override;
+    /// Save peers
+    dev::bytes saveNetwork() override;
 
-	/// Sets the ideal number of peers.
-	void setIdealPeerCount(size_t _n) override;
+    /// Sets the ideal number of peers.
+    void setIdealPeerCount(size_t _n) override;
 
-	/// Experimental. Sets ceiling for incoming connections to multiple of ideal peer count.
-	void setPeerStretch(size_t _n);
-	
-	bool haveNetwork() const override { return m_net.haveNetwork(); }
+    /// Experimental. Sets ceiling for incoming connections to multiple of ideal peer count.
+    void setPeerStretch(size_t _n);
+    
+    bool haveNetwork() const override { return m_net.haveNetwork(); }
 
-	p2p::NetworkPreferences const& networkPreferences() const override;
+    p2p::NetworkPreferences const& networkPreferences() const override;
 
-	void setNetworkPreferences(p2p::NetworkPreferences const& _n, bool _dropPeers = false) override;
+    void setNetworkPreferences(p2p::NetworkPreferences const& _n, bool _dropPeers = false) override;
 
-	p2p::NodeInfo nodeInfo() const override { return m_net.nodeInfo(); }
+    p2p::NodeInfo nodeInfo() const override { return m_net.nodeInfo(); }
 
-	p2p::NodeID id() const override { return m_net.id(); }
+    p2p::NodeID id() const override { return m_net.id(); }
 
-	u256 networkId() const override { return m_ethereum.get()->networkId(); }
+    u256 networkId() const override { return m_ethereum.get()->networkId(); }
 
-	std::string enode() const override { return m_net.enode(); }
+    std::string enode() const override { return m_net.enode(); }
 
-	/// Gets the nodes.
-	p2p::Peers nodes() const override { return m_net.getPeers(); }
+    /// Gets the nodes.
+    p2p::Peers nodes() const override { return m_net.getPeers(); }
 
-	/// Start the network subsystem.
-	void startNetwork() override { m_net.start(); }
+    /// Start the network subsystem.
+    void startNetwork() override { m_net.start(); }
 
-	/// Stop the network subsystem.
-	void stopNetwork() override { m_net.stop(); }
+    /// Stop the network subsystem.
+    void stopNetwork() override { m_net.stop(); }
 
-	/// Is network working? there may not be any peers yet.
-	bool isNetworkStarted() const override { return m_net.isStarted(); }
+    /// Is network working? there may not be any peers yet.
+    bool isNetworkStarted() const override { return m_net.isStarted(); }
 
 private:
-	std::string m_clientVersion;					///< Our end-application client's name/version.
+    std::string m_clientVersion;                    ///< Our end-application client's name/version.
 
-	p2p::Host m_net;								///< Should run in background and send us events when blocks found and allow us to send blocks as required.
+    p2p::Host m_net;                                ///< Should run in background and send us events when blocks found and allow us to send blocks as required.
 
-	std::unique_ptr<eth::Client> m_ethereum;		///< Client for Ethereum ("eth") protocol.
+    std::unique_ptr<eth::Client> m_ethereum;        ///< Client for Ethereum ("eth") protocol.
 };
 
 

--- a/libwebthree/WebThree.h
+++ b/libwebthree/WebThree.h
@@ -123,6 +123,7 @@ public:
 	WebThreeDirect(
 		std::string const& _clientVersion,
 		boost::filesystem::path const& _dbPath,
+		boost::filesystem::path const& _snapshotPath,
 		eth::ChainParams const& _params,
 		WithExisting _we = WithExisting::Trust,
 		std::set<std::string> const& _interfaces = {"eth", "shh", "bzz"},

--- a/test/unittests/libweb3jsonrpc/Client.cpp
+++ b/test/unittests/libweb3jsonrpc/Client.cpp
@@ -60,6 +60,7 @@ BOOST_AUTO_TEST_CASE(Personal)
 	dev::WebThreeDirect web3(
 		WebThreeDirect::composeClientVersion("eth"),
 		getDataDir(),
+		string(),
 		ChainParams(),
 		WithExisting::Kill,
 		set<string>{"eth"},

--- a/test/unittests/libweb3jsonrpc/Client.cpp
+++ b/test/unittests/libweb3jsonrpc/Client.cpp
@@ -1,19 +1,19 @@
 
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
  */
 /**
  * @author Christian <chris@ethereum.org>
@@ -51,92 +51,85 @@ BOOST_FIXTURE_TEST_SUITE(ClientTests, TestOutputHelperFixture)
 
 BOOST_AUTO_TEST_CASE(Personal)
 {
-	TransientDirectory tempDir;
-	boost::filesystem::create_directories(tempDir.path() + "/keys");
+    TransientDirectory tempDir;
+    boost::filesystem::create_directories(tempDir.path() + "/keys");
 
-	KeyManager keyManager(tempDir.path(), tempDir.path() + "/keys");
-	setDataDir(tempDir.path());
+    KeyManager keyManager(tempDir.path(), tempDir.path() + "/keys");
+    setDataDir(tempDir.path());
 
-	dev::WebThreeDirect web3(
-		WebThreeDirect::composeClientVersion("eth"),
-		getDataDir(),
-		string(),
-		ChainParams(),
-		WithExisting::Kill,
-		set<string>{"eth"},
-		p2p::NetworkPreferences(0)
-	);
-	web3.stopNetwork();
-	web3.ethereum()->stopSealing();
+    dev::WebThreeDirect web3(WebThreeDirect::composeClientVersion("eth"), getDataDir(), string(),
+        ChainParams(), WithExisting::Kill, set<string>{"eth"}, p2p::NetworkPreferences(0));
+    web3.stopNetwork();
+    web3.ethereum()->stopSealing();
 
-	bool userShouldEnterPassword = false;
-	string passwordUserWillEnter;
+    bool userShouldEnterPassword = false;
+    string passwordUserWillEnter;
 
-	SimpleAccountHolder accountHolder(
-		[&](){ return web3.ethereum(); },
-		[&](Address) { if (!userShouldEnterPassword) BOOST_FAIL("Password input requested"); return passwordUserWillEnter; },
-		keyManager,
-		[](TransactionSkeleton const&, bool) -> bool {
-			return false; // user input goes here
-		}
-	);
-	rpc::Personal personal(keyManager, accountHolder, *web3.ethereum());
-	rpc::Eth eth(*web3.ethereum(), accountHolder);
+    SimpleAccountHolder accountHolder(
+        [&](){ return web3.ethereum(); },
+        [&](Address) { if (!userShouldEnterPassword) BOOST_FAIL("Password input requested"); return passwordUserWillEnter; },
+        keyManager,
+        [](TransactionSkeleton const&, bool) -> bool {
+            return false; // user input goes here
+        }
+    );
+    rpc::Personal personal(keyManager, accountHolder, *web3.ethereum());
+    rpc::Eth eth(*web3.ethereum(), accountHolder);
 
-	// Create account
+    // Create account
 
-	string password = "12345";
-	string address = personal.personal_newAccount(password);
+    string password = "12345";
+    string address = personal.personal_newAccount(password);
 
-	// Try to send transaction
+    // Try to send transaction
 
-	Json::Value tx;
-	tx["from"] = address;
-	tx["to"] = string("0x0000000000000000000000000000000000000000");
-	tx["value"] = string("0x10000");
-	tx["value"] = string("0x5208");
-	auto sendingShouldFail = [&]() -> string
-	{
-		try
-		{
-			eth.eth_sendTransaction(tx);
-			BOOST_FAIL("Exception expected.");
-		}
-		catch (jsonrpc::JsonRpcException const& _e)
-		{
-			return _e.GetMessage();
-		}
-		return string();
-	};
-	auto sendingShouldSucceed = [&]()
-	{
-		BOOST_CHECK(!eth.eth_sendTransaction(tx).empty());
-	};
+    Json::Value tx;
+    tx["from"] = address;
+    tx["to"] = string("0x0000000000000000000000000000000000000000");
+    tx["value"] = string("0x10000");
+    tx["value"] = string("0x5208");
+    auto sendingShouldFail = [&]() -> string
+    {
+        try
+        {
+            eth.eth_sendTransaction(tx);
+            BOOST_FAIL("Exception expected.");
+        }
+        catch (jsonrpc::JsonRpcException const& _e)
+        {
+            return _e.GetMessage();
+        }
+        return string();
+    };
+    auto sendingShouldSucceed = [&]()
+    {
+        BOOST_CHECK(!eth.eth_sendTransaction(tx).empty());
+    };
 
-	BOOST_TEST_CHECKPOINT("Account is locked at the start.");
-	BOOST_CHECK_EQUAL(sendingShouldFail(), "Transaction rejected by user.");
+    BOOST_TEST_CHECKPOINT("Account is locked at the start.");
+    BOOST_CHECK_EQUAL(sendingShouldFail(), "Transaction rejected by user.");
 
-	BOOST_TEST_CHECKPOINT("Unlocking without password should not work.");
-	BOOST_CHECK(!personal.personal_unlockAccount(address, string(), 2));
-	BOOST_CHECK_EQUAL(sendingShouldFail(), "Transaction rejected by user.");
+    BOOST_TEST_CHECKPOINT("Unlocking without password should not work.");
+    BOOST_CHECK(!personal.personal_unlockAccount(address, string(), 2));
+    BOOST_CHECK_EQUAL(sendingShouldFail(), "Transaction rejected by user.");
 
-	BOOST_TEST_CHECKPOINT("Unlocking with wrong password should not work.");
-	BOOST_CHECK(!personal.personal_unlockAccount(address, "abcd", 2));
-	BOOST_CHECK_EQUAL(sendingShouldFail(), "Transaction rejected by user.");
+    BOOST_TEST_CHECKPOINT("Unlocking with wrong password should not work.");
+    BOOST_CHECK(!personal.personal_unlockAccount(address, "abcd", 2));
+    BOOST_CHECK_EQUAL(sendingShouldFail(), "Transaction rejected by user.");
 
-	BOOST_TEST_CHECKPOINT("Unlocking with correct password should work.");
-	BOOST_CHECK(personal.personal_unlockAccount(address, password, 2));
-	sendingShouldSucceed();
-	BOOST_TEST_CHECKPOINT("Transaction should be sendable multiple times in unlocked mode.");
-	sendingShouldSucceed();
+    BOOST_TEST_CHECKPOINT("Unlocking with correct password should work.");
+    BOOST_CHECK(personal.personal_unlockAccount(address, password, 2));
+    sendingShouldSucceed();
+    BOOST_TEST_CHECKPOINT("Transaction should be sendable multiple times in unlocked mode.");
+    sendingShouldSucceed();
 
-	this_thread::sleep_for(chrono::seconds(2));
-	BOOST_TEST_CHECKPOINT("After unlock time, account should be locked again.");
-	BOOST_CHECK_EQUAL(sendingShouldFail(), "Transaction rejected by user.");
+    this_thread::sleep_for(chrono::seconds(2));
+    BOOST_TEST_CHECKPOINT("After unlock time, account should be locked again.");
+    BOOST_CHECK_EQUAL(sendingShouldFail(), "Transaction rejected by user.");
 
-	BOOST_TEST_CHECKPOINT("Unlocking again with empty password should not work.");
-	BOOST_CHECK(!personal.personal_unlockAccount(address, string(), 2));
-	BOOST_CHECK_EQUAL(sendingShouldFail(), "Transaction rejected by user.");
+    BOOST_TEST_CHECKPOINT("Unlocking again with empty password should not work.");
+    BOOST_CHECK(!personal.personal_unlockAccount(address, string(), 2));
+    BOOST_CHECK_EQUAL(sendingShouldFail(), "Transaction rejected by user.");
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This is the solution using boost.fiber

### Motivation for using boost.fiber

The approach that `BlockChainSync` class takes to deal with asynchronous p2p nature of the sync looks like an anti-pattern that led to it becoming utterly unmaintainable. That approach could be described as having several network message handlers in one class, saving info about current stage of the sync in a bunch of member variables in the class, branching a lot in each handler depending on the current state of member variables. This way the essence of the sync algorithm itself gets spread out over a lot of different parts of the class, it's hard to keep track of what's currently going on and what should happen next. 

I am looking for a better approach that can elegantly express what we want to achieve. Fibers allow us here to have a "main algorithm" in one fiber that gets interrupted each time we need to get some data asynchronously, then gets resumed from the place we left off when we have data already. So the main algorithm looks like it's synchronous. 
The data itself is sent to fiber through `buffered_channel` - producers/consumers-kind of data structure, where the fiber gets "blocked" if it tries to get the data not pushed yet to the channel. 
To some extent I think this is similar to goroutines and channels of golang.

Also switching context between the fibers is very cheap unlike with threads, and it all happens in the single thread, therefore no need to deal with thread-safety/possible races/mutexes etc.

This is still kind of experiment to see where it goes, I myself am not fully convinced that fibers are the best solution for this. 

### Current status:
- It is able to download the snapshot from from several peers at once (this is the improvement over the version in https://github.com/ethereum/cpp-ethereum/pull/4227)
- It starts downloading from the first peer found that supports warp protocol (this probably should be changed to better strategy in later PRs) It's better currently to run it giving the peer address from the needed network with `--peerset required:`
- Peer not responding to request should be handled correctly, but I haven't seen this in practice and still need to test if this works.

### Still to be done:
- [x] Probably peer disconnecting should be handled better - if it happens after we reqested a chunk, I think chunk will stay marked as being downloaded forever.
- [x] Without `--peerset` we connect to Ethereum Classic nodes very often and happily download the snapshot for classic chain. To deal with this probably we need to do DAO challenge first similar to full sync.
- [x] Need to add boost.fiber to hunter's boost to be able to link at all (no idea yet how to do it)
- [x] ~~fix macOS build failure because of unused `SnapshotLog::debug` - this doesn't make sense to me yet~~ looks like I've already found a workaround doing import https://github.com/ethereum/cpp-ethereum/blob/04e8ca5afe785cafe18905d6f0f032cb1d869c7a/libethereum/SnapshotImporter.cpp#L45
- [ ] tests