### PR TITLE
Fix an assertion that sometimes fails

### DIFF
--- a/test/tools/fuzzTesting/fuzzHelper.cpp
+++ b/test/tools/fuzzTesting/fuzzHelper.cpp
@@ -249,7 +249,7 @@ std::string RandomCodeBase::generate(int _maxOpNumber, RandomCodeOptions const& 
 
 	//random opCode amount
 	int size = (int)(test::RandomCode::get().randomPercent() * _maxOpNumber / 100);
-	assert(size < _maxOpNumber);
+	assert(size <= _maxOpNumber);
 
 	for (auto i = 0; i < size; i++)
 	{


### PR DESCRIPTION
Since `randomPercent()` can be 100, the computed `size` can be identical to `_maxOpNumber`.