### PR TITLE
Support high CHAIN_ID encoded in Transaction's v value

### DIFF
--- a/libethcore/TransactionBase.cpp
+++ b/libethcore/TransactionBase.cpp
@@ -70,13 +70,13 @@ TransactionBase::TransactionBase(bytesConstRef _rlpData, CheckTransaction _check
 
 		if (isZeroSignature(r, s))
 		{
-			m_chainId = static_cast<int>(v);
+			m_chainId = v;
 			m_vrs = SignatureStruct{r, s, 0};
 		}
 		else
 		{
 			if (v > 36)
-				m_chainId = static_cast<int>((v - 35) / 2); 
+				m_chainId = (v - 35) / 2; 
 			else if (v == 27 || v == 28)
 				m_chainId = -4;
 			else

--- a/libethcore/TransactionBase.cpp
+++ b/libethcore/TransactionBase.cpp
@@ -76,7 +76,7 @@ TransactionBase::TransactionBase(bytesConstRef _rlpData, CheckTransaction _check
 		else
 		{
 			if (v > 36)
-				m_chainId = static_cast<int>((v - 35) / 2);
+				m_chainId = static_cast<int>((v - 35) / 2); 
 			else if (v == 27 || v == 28)
 				m_chainId = -4;
 			else
@@ -167,8 +167,14 @@ void TransactionBase::streamRLP(RLPStream& _s, IncludeSignature _sig, bool _forE
 		if (!m_vrs)
 			BOOST_THROW_EXCEPTION(TransactionIsUnsigned());
 
-		int vOffset = m_chainId*2 + 35;
-		_s << (m_vrs->v + vOffset) << (u256)m_vrs->r << (u256)m_vrs->s;
+		if (hasZeroSignature())
+			_s << m_chainId;
+		else
+		{
+			int const vOffset = m_chainId * 2 + 35;
+			_s << (m_vrs->v + vOffset);
+		}
+		_s << (u256)m_vrs->r << (u256)m_vrs->s;
 	}
 	else if (_forEip155hash)
 		_s << m_chainId << 0 << 0;

--- a/libethcore/TransactionBase.cpp
+++ b/libethcore/TransactionBase.cpp
@@ -64,23 +64,25 @@ TransactionBase::TransactionBase(bytesConstRef _rlpData, CheckTransaction _check
 
 		m_data = rlp[5].toBytes();
 
-		byte v = rlp[6].toInt<byte>();
-		h256 r = rlp[7].toInt<u256>();
-		h256 s = rlp[8].toInt<u256>();
+		int const v = rlp[6].toInt<int>();
+		h256 const r = rlp[7].toInt<u256>();
+		h256 const s = rlp[8].toInt<u256>();
 
-		m_vrs = SignatureStruct{ r, s, v };
-
-		if (hasZeroSignature())
-			m_chainId = m_vrs->v;
+		if (isZeroSignature(r, s))
+		{
+			m_chainId = static_cast<int>(v);
+			m_vrs = SignatureStruct{r, s, 0};
+		}
 		else
 		{
 			if (v > 36)
-				m_chainId = (v - 35) / 2;
+				m_chainId = static_cast<int>((v - 35) / 2);
 			else if (v == 27 || v == 28)
 				m_chainId = -4;
 			else
 				BOOST_THROW_EXCEPTION(InvalidSignature());
-			m_vrs->v = v - (m_chainId * 2 + 35);
+
+			m_vrs = SignatureStruct{r, s, static_cast<byte>(v - (m_chainId * 2 + 35))};
 
 			if (_checkSig >= CheckTransaction::Cheap && !m_vrs->isValid())
 				BOOST_THROW_EXCEPTION(InvalidSignature());

--- a/libethcore/TransactionBase.h
+++ b/libethcore/TransactionBase.h
@@ -142,7 +142,7 @@ public:
 	bool hasSignature() const { return m_vrs.is_initialized(); }
 
 	/// @returns true if the transaction was signed with zero signature
-	bool hasZeroSignature() const { return m_vrs && !m_vrs->s && !m_vrs->r; }
+	bool hasZeroSignature() const { return m_vrs && isZeroSignature(m_vrs->r, m_vrs->s); }
 
 	/// @returns true if the transaction uses EIP155 replay protection
 	bool isReplayProtected() const { return m_chainId != -4; }
@@ -167,6 +167,8 @@ protected:
 		ContractCreation,				///< Transaction to create contracts - receiveAddress() is ignored.
 		MessageCall						///< Transaction to invoke a message call - receiveAddress() is used.
 	};
+
+	static bool isZeroSignature(u256 const& _r, u256 const& _s) { return !_r && !_s; }
 
 	/// Clears the signature.
 	void clearSignature() { m_vrs = SignatureStruct(); }

--- a/test/tools/jsontests/TransactionTests.cpp
+++ b/test/tools/jsontests/TransactionTests.cpp
@@ -203,6 +203,5 @@ BOOST_AUTO_TEST_CASE(ttSpecConstantinople){}
 BOOST_AUTO_TEST_CASE(ttVRuleEip158){}
 BOOST_AUTO_TEST_CASE(ttWrongRLPFrontier){}
 BOOST_AUTO_TEST_CASE(ttWrongRLPHomestead){}
-BOOST_AUTO_TEST_CASE(ttZeroSigConstantinople){}
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
EIP155 is not clear about the possible ranges of `v` 
https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md

But other clients support high values, so we should, too.