### PR TITLE
Tracis CI: Disable macOS builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,11 +46,11 @@ matrix:
           env:
               - ZIP_SUFFIX=ubuntu-trusty
 
-        - os: osx
-          osx_image: xcode9
-          env:
-              - TRAVIS_TESTS=Off
-              - ZIP_SUFFIX=macos-sierra
+#        - os: osx
+#          osx_image: xcode9
+#          env:
+#              - TRAVIS_TESTS=Off
+#              - ZIP_SUFFIX=macos-sierra
 git:
     depth: 2
 cache:


### PR DESCRIPTION
Builds without tests are useless. Circle CI is building and testing the same XCode 9 environment.