### PR TITLE
Fix delete-non-virtual-dtor warnings for more recent compilers

### DIFF
--- a/libethereum/BlockChainSync.h
+++ b/libethereum/BlockChainSync.h
@@ -46,7 +46,7 @@ class EthereumPeer;
  * @brief Base BlockChain synchronization strategy class.
  * Syncs to peers and keeps up to date. Base class handles blocks downloading but does not contain any details on state transfer logic.
  */
-class BlockChainSync: public HasInvariants
+class BlockChainSync final: public HasInvariants
 {
 public:
 	BlockChainSync(EthereumHost& _host);

--- a/libp2p/Common.h
+++ b/libp2p/Common.h
@@ -244,6 +244,7 @@ class Node
 {
 public:
 	Node() = default;
+	virtual ~Node() = default;
 	Node(Node const&);
 	Node(Public _publicKey, NodeIPEndpoint const& _ip, PeerType _peerType = PeerType::Optional): id(_publicKey), endpoint(_ip), peerType(_peerType) {}
 	Node(NodeSpec const& _s, PeerType _peerType = PeerType::Optional);

--- a/libp2p/UDP.h
+++ b/libp2p/UDP.h
@@ -93,6 +93,7 @@ struct UDPSocketFace
  */
 struct UDPSocketEvents
 {
+	virtual ~UDPSocketEvents() = default;
 	virtual void onDisconnected(UDPSocketFace*) {}
 	virtual void onReceived(UDPSocketFace*, bi::udp::endpoint const& _from, bytesConstRef _packetData) = 0;
 };

--- a/libweb3jsonrpc/AccountHolder.h
+++ b/libweb3jsonrpc/AccountHolder.h
@@ -64,6 +64,7 @@ class AccountHolder
 {
 public:
 	explicit AccountHolder(std::function<Interface*()> const& _client): m_client(_client) {}
+	virtual ~AccountHolder() = default;
 
 	virtual AddressHash realAccounts() const = 0;
 	// use m_web3's submitTransaction


### PR DESCRIPTION
This pull request adds virtual destructors with default implementations for several base classes to fix warnings due to deleting objects with non-virtual destructors.

I was unable to build cpp-ethereum without warnings using Clang 6 (nightly) or GCC 8 because the [delete-non-virtual-destructor](https://gcc.gnu.org/wiki/VerboseDiagnostics#delete-non-virtual-dtor) warning is emitted more aggressively than GCC 4.8, the compiler used on Travis. To fix it, I added virtual destructors to Node, UDPSocketEvents, and AccountHolder. I made BlockChainSync final instead of adding a virtual destructor to it, since it doesn't have any virtual functions or derived classes within the project, and I don't know enough about this project to know if it is intended to be derived from in the future.

As a side note, if the maintainers are interested in testing with higher releases of Clang than the default in Ubuntu 14.04, I recommend the [LLVM nightly packages](http://apt.llvm.org/) for deployment.