### PR TITLE
Update the snapcraft metadata

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,16 +9,13 @@ confinement: devmode
 apps:
   eth:
     command: eth
-  ethkey:
-    command: ethkey
   ethvm:
     command: ethvm
-  rlp:
-    command: rlp
 
 parts:
   cpp-ethereum:
     source: .
+    source-type: git
     plugin: cmake
     build-packages:
       - build-essential


### PR DESCRIPTION
With this, the snap build will succeed in build.snapcraft.io
- Add the git source-type, to get the git submodules.
- For now remove the binaries that are not installed in DESTDIR.