### PR TITLE
Fixes the following compilation error on Ubuntu 16.04 with clang 6.0

### DIFF
--- a/libethashseal/EthashClient.cpp
+++ b/libethashseal/EthashClient.cpp
@@ -124,14 +124,14 @@ void EthashClient::setShouldPrecomputeDAG(bool _precompute)
 
 void EthashClient::submitExternalHashrate(u256 const& _rate, h256 const& _id)
 {
-	WriteGuard(x_externalRates);
+	WriteGuard writeGuard(x_externalRates);
 	m_externalRates[_id] = make_pair(_rate, chrono::steady_clock::now());
 }
 
 u256 EthashClient::externalHashrate() const
 {
 	u256 ret = 0;
-	WriteGuard(x_externalRates);
+	WriteGuard writeGuard(x_externalRates);
 	for (auto i = m_externalRates.begin(); i != m_externalRates.end();)
 		if (chrono::steady_clock::now() - i->second.second > chrono::seconds(5))
 			i = m_externalRates.erase(i);

--- a/test/tools/libtesteth/TestUtils.h
+++ b/test/tools/libtesteth/TestUtils.h
@@ -34,9 +34,9 @@ namespace test
 
 // should be used for multithread tests
 static SharedMutex x_boostTest;
-#define ETH_CHECK_EQUAL(x, y) { dev::WriteGuard(x_boostTest); BOOST_CHECK_EQUAL(x, y); }
-#define ETH_CHECK_EQUAL_COLLECTIONS(xb, xe, yb, ye) { dev::WriteGuard(x_boostTest); BOOST_CHECK_EQUAL_COLLECTIONS(xb, xe, yb, ye); }
-#define ETH_REQUIRE(x) { dev::WriteGuard(x_boostTest); BOOST_REQUIRE(x); }
+#define ETH_CHECK_EQUAL(x, y) { dev::WriteGuard wg(x_boostTest); BOOST_CHECK_EQUAL(x, y); }
+#define ETH_CHECK_EQUAL_COLLECTIONS(xb, xe, yb, ye) { dev::WriteGuard wg(x_boostTest); BOOST_CHECK_EQUAL_COLLECTIONS(xb, xe, yb, ye); }
+#define ETH_REQUIRE(x) { dev::WriteGuard wg(x_boostTest); BOOST_REQUIRE(x); }
 
 struct LoadTestFileFixture
 {


### PR DESCRIPTION
error: parentheses were disambiguated as redundant
      parentheses around declaration of variable named ...