### PR TITLE
options for createRandomTest from file

### DIFF
--- a/test/tools/fuzzTesting/RandomCode.h
+++ b/test/tools/fuzzTesting/RandomCode.h
@@ -18,6 +18,7 @@
  * @date 2017
  */
 
+#pragma once
 #include <string>
 #include <random>
 #include <boost/filesystem/path.hpp>
@@ -27,8 +28,6 @@
 #include <libdevcore/CommonData.h>
 #include <libevm/Instruction.h>
 #include <test/tools/libtesteth/TestSuite.h>
-
-#pragma once
 
 namespace dev
 {
@@ -56,6 +55,7 @@ public:
 	RandomCodeOptions();
 	void setWeight(dev::eth::Instruction _opCode, int _weight);
 	void addAddress(dev::Address const& _address, AddressType _type);
+	void loadFromFile(boost::filesystem::path const& _file);
 	dev::Address getRandomAddress(AddressType _type = AddressType::All) const;
 	int getWeightedRandomOpcode() const;
 

--- a/test/tools/fuzzTesting/createRandomTest.cpp
+++ b/test/tools/fuzzTesting/createRandomTest.cpp
@@ -45,8 +45,10 @@ bool createRandomTest()
 	}
 	else
 	{
-		RandomCodeOptions options;
-		std::string test = test::RandomCode::get().fillRandomTest(suite, c_testExampleStateTest, options);
+		RandomCodeOptions codeOptions;
+		if (options.randomCodeOptionsPath.is_initialized())
+			codeOptions.loadFromFile(options.randomCodeOptionsPath.get());
+		std::string test = test::RandomCode::get().fillRandomTest(suite, c_testExampleStateTest, codeOptions);
 		std::cout << test << "\n";
 		return test.empty() ? false : true;
 	}

--- a/test/tools/fuzzTesting/fuzzHelper.cpp
+++ b/test/tools/fuzzTesting/fuzzHelper.cpp
@@ -487,10 +487,17 @@ RandomCodeOptions::RandomCodeOptions() :
 	addAddress(Address("0x0000000000000000000000000000000000000008"), AddressType::ByzantiumPrecompiled);
 }
 
-void boost_require_range(int _value, int a, int b)
+void boost_require_range(int _value, int _min, int _max)
 {
-	BOOST_REQUIRE(_value >= a);
-	BOOST_REQUIRE(_value <= b);
+	BOOST_REQUIRE(_value >= _min);
+	BOOST_REQUIRE(_value <= _max);
+}
+
+int getProbability(json_spirit::mValue const& _obj)
+{
+	int probability = _obj.get_int();
+	boost_require_range(probability, 0, 100);
+	return probability;
 }
 
 void RandomCodeOptions::loadFromFile(boost::filesystem::path const& _jsonFileName)
@@ -509,22 +516,14 @@ void RandomCodeOptions::loadFromFile(boost::filesystem::path const& _jsonFileNam
 	//Parse Probabilities
 	json_spirit::mObject probObj = obj.at("probabilities").get_obj();
 	useUndefinedOpCodes = probObj.at("useUndefinedOpCodes").get_bool();
-	smartCodeProbability = probObj.at("smartCodeProbability").get_int();
-	boost_require_range(smartCodeProbability, 0, 100);
-	randomAddressProbability = probObj.at("randomAddressProbability").get_int();
-	boost_require_range(randomAddressProbability, 0, 100);
-	emptyCodeProbability = probObj.at("emptyCodeProbability").get_int();
-	boost_require_range(emptyCodeProbability, 0, 100);
-	emptyAddressProbability = probObj.at("emptyAddressProbability").get_int();
-	boost_require_range(emptyAddressProbability, 0, 100);
-	precompiledAddressProbability = probObj.at("precompiledAddressProbability").get_int();
-	boost_require_range(precompiledAddressProbability, 0, 100);
-	byzPrecompiledAddressProbability = probObj.at("byzPrecompiledAddressProbability").get_int();
-	boost_require_range(byzPrecompiledAddressProbability, 0, 100);
-	precompiledDestProbability = probObj.at("precompiledDestProbability").get_int();
-	boost_require_range(precompiledDestProbability, 0, 100);
-	sendingAddressProbability = probObj.at("sendingAddressProbability").get_int();
-	boost_require_range(sendingAddressProbability, 0, 100);
+	smartCodeProbability = getProbability(probObj.at("smartCodeProbability"));
+	randomAddressProbability = getProbability(probObj.at("randomAddressProbability"));
+	emptyCodeProbability = getProbability(probObj.at("emptyCodeProbability"));
+	emptyAddressProbability = getProbability(probObj.at("emptyAddressProbability"));
+	precompiledAddressProbability = getProbability(probObj.at("precompiledAddressProbability"));
+	byzPrecompiledAddressProbability = getProbability(probObj.at("byzPrecompiledAddressProbability"));
+	precompiledDestProbability = getProbability(probObj.at("precompiledDestProbability"));
+	sendingAddressProbability = getProbability(probObj.at("sendingAddressProbability"));
 }
 
 void RandomCodeOptions::setWeight(eth::Instruction _opCode, int _weight)

--- a/test/tools/libtesteth/Options.cpp
+++ b/test/tools/libtesteth/Options.cpp
@@ -58,6 +58,7 @@ void printHelp()
 	cout << setw(30) << "--fillchain" << setw(25) << "When filling the state tests, fill tests as blockchain instead\n";
 	cout << setw(30) << "--randomcode <MaxOpcodeNum>" << setw(25) << "Generate smart random EVM code\n";
 	cout << setw(30) << "--createRandomTest" << setw(25) << "Create random test and output it to the console\n";
+	cout << setw(30) << "--createRandomTest <PathToOptions.json>" << setw(25) << "Use following options file for random code generation\n";
 	cout << setw(30) << "--seed <uint>" << setw(25) << "Define a seed for random test\n";
 	cout << setw(30) << "--options <PathTo.json>" << setw(25) << "Use following options file for random code generation\n";
 	//cout << setw(30) << "--fulloutput" << setw(25) << "Disable address compression in the output field\n";
@@ -261,7 +262,26 @@ Options::Options(int argc, char** argv)
 			exit(0);
 		}
 		else if (arg == "--createRandomTest")
+		{
 			createRandomTest = true;
+			if (i + 1 < argc) // two params
+			{
+				auto options = std::string{argv[++i]};
+				if (options[0] == '-') // not param, another option
+					i--;
+				else
+				{
+					boost::filesystem::path file(options);
+					if (boost::filesystem::exists(file))
+						randomCodeOptionsPath = file;
+					else
+					{
+						std::cerr << "Options file not found! Default options at: tests/src/randomCodeOptions.json\n";
+						exit(0);
+					}
+				}
+			}
+		}
 		else if (arg == "--seed")
 		{
 			throwIfNoArgumentFollows();

--- a/test/tools/libtesteth/Options.cpp
+++ b/test/tools/libtesteth/Options.cpp
@@ -296,6 +296,11 @@ Options::Options(int argc, char** argv)
 			cerr << "--seed <uint> could be used only with --createRandomTest \n";
 			exit(1);
 		}
+		if (randomCodeOptionsPath.is_initialized())
+		{
+			cerr << "--options <pathToOptions.json> could be used only with --createRandomTest \n";
+			exit(1);
+		}
 	}
 
 	//Default option

--- a/test/tools/libtesteth/Options.cpp
+++ b/test/tools/libtesteth/Options.cpp
@@ -59,6 +59,7 @@ void printHelp()
 	cout << setw(30) << "--randomcode <MaxOpcodeNum>" << setw(25) << "Generate smart random EVM code\n";
 	cout << setw(30) << "--createRandomTest" << setw(25) << "Create random test and output it to the console\n";
 	cout << setw(30) << "--seed <uint>" << setw(25) << "Define a seed for random test\n";
+	cout << setw(30) << "--options <PathTo.json>" << setw(25) << "Use following options file for random code generation\n";
 	//cout << setw(30) << "--fulloutput" << setw(25) << "Disable address compression in the output field\n";
 
 	cout << setw(30) << "--help" << setw(25) << "Display list of command arguments\n";
@@ -203,6 +204,18 @@ Options::Options(int argc, char** argv)
 			int indentLevelInt = atoi(argv[i]);
 			if (indentLevelInt > g_logVerbosity)
 				g_logVerbosity = indentLevelInt;
+		}
+		else if (arg == "--options")
+		{
+			throwIfNoArgumentFollows();
+			boost::filesystem::path file(std::string{argv[++i]});
+			if (boost::filesystem::exists(file))
+				randomCodeOptionsPath = file;
+			else
+			{
+				std::cerr << "Options file not found! Default options at: tests/src/randomCodeOptions.json\n";
+				exit(0);
+			}
 		}
 		else if (arg == "-t")
 		{

--- a/test/tools/libtesteth/Options.cpp
+++ b/test/tools/libtesteth/Options.cpp
@@ -275,10 +275,7 @@ Options::Options(int argc, char** argv)
 					if (boost::filesystem::exists(file))
 						randomCodeOptionsPath = file;
 					else
-					{
-						std::cerr << "Options file not found! Default options at: tests/src/randomCodeOptions.json\n";
-						exit(0);
-					}
+						BOOST_THROW_EXCEPTION(InvalidOption("Options file not found! Default options at: tests/src/randomCodeOptions.json\n"));
 				}
 			}
 		}
@@ -312,15 +309,7 @@ Options::Options(int argc, char** argv)
 	else
 	{
 		if (randomTestSeed.is_initialized())
-		{
-			cerr << "--seed <uint> could be used only with --createRandomTest \n";
-			exit(1);
-		}
-		if (randomCodeOptionsPath.is_initialized())
-		{
-			cerr << "--options <pathToOptions.json> could be used only with --createRandomTest \n";
-			exit(1);
-		}
+			BOOST_THROW_EXCEPTION(InvalidOption("--seed <uint> could be used only with --createRandomTest \n"));
 	}
 
 	//Default option

--- a/test/tools/libtesteth/Options.h
+++ b/test/tools/libtesteth/Options.h
@@ -59,6 +59,7 @@ public:
 	eth::StandardTrace::DebugOptions jsontraceOptions; ///< output config for jsontrace
 	std::string testpath;	///< Custom test folder path
 	Verbosity logVerbosity = Verbosity::NiceReport;
+	boost::optional<boost::filesystem::path> randomCodeOptionsPath; ///< Options for random code generation in fuzz tests
 
 	/// Test selection
 	/// @{


### PR DESCRIPTION
Load some options for generating a random test from file.

Usage
`./testeth -t GeneralStateTests -- --createRandomTest ` 
`./testeth -t GeneralStateTests -- --createRandomTest <pathToOptions.json>`


Options file format:

```
{
	"probabilities" : 
	{
		"//comment" : "spawn undefined bytecodes in code",
		"useUndefinedOpCodes" : false,

		"//comment" : "spawn correct opcodes (with correct argument stack and reasonable arguments)",
		"smartCodeProbability" : 99,

		"//comment" : "probability of generating a random address instead of defined from list",
		"randomAddressProbability" : 3,

		"//comment" : "probability of code being empty (empty code mean empty account)",
		"emptyCodeProbability" : 2,

		"//comment" : "probability of generating an empty address for transaction creation",
		"emptyAddressProbability" : 15,

		"//comment" : "probability of generating a precompiled address for calls",
		"precompiledAddressProbability" : 5,

		"//comment" : "probability of generating a precompiled address for calls",
		"byzPrecompiledAddressProbability" : 10,

		"//comment" : "probability of generating a precompiled address as tx destination",
		"precompiledDestProbability" : 2,

		"//comment" : "probability of calling to the tx sending account",
		"sendingAddressProbability" : 3	
	}
}
```