### PR TITLE
cpp-ethereum#4598 1)Switch to C++17 style byte. 2)Fixed all compiler …

### DIFF
--- a/libdevcore/Base64.cpp
+++ b/libdevcore/Base64.cpp
@@ -33,17 +33,17 @@ using namespace dev;
 
 static inline bool is_base64(byte c)
 {
-	return (isalnum(c) || (c == '+') || (c == '/'));
+	return (isalnum(as_unsigned_char(c)) || (c == '+') || (c == '/'));
 }
 
 static inline byte find_base64_char_index(byte c)
 {
 	if ('A' <= c && c <= 'Z') return c - 'A';
-	else if ('a' <= c && c <= 'z') return c - 'a' + 1 + find_base64_char_index('Z');
-	else if ('0' <= c && c <= '9') return c - '0' + 1 + find_base64_char_index('z');
-	else if (c == '+') return 1 + find_base64_char_index('9');
-	else if (c == '/') return 1 + find_base64_char_index('+');
-	else return 1 + find_base64_char_index('/');
+	else if ('a' <= c && c <= 'z') return c - 'a' + 1 + find_base64_char_index((byte)'Z');
+	else if ('0' <= c && c <= '9') return c - '0' + 1 + find_base64_char_index((byte)'z');
+	else if (c == '+') return 1 + find_base64_char_index((byte)'9');
+	else if (c == '/') return 1 + find_base64_char_index((byte)'+');
+	else return 1 + find_base64_char_index((byte)'/');
 }
 
 string dev::toBase64(bytesConstRef _in)
@@ -73,7 +73,7 @@ string dev::toBase64(bytesConstRef _in)
 			char_array_4[3] = char_array_3[2] & 0x3f;
 
 			for (i = 0; i < 4; i++)
-				ret += base64_chars[char_array_4[i]];
+				ret += base64_chars[as_unsigned_char(char_array_4[i])];
 			i = 0;
 		}
 	}
@@ -81,7 +81,7 @@ string dev::toBase64(bytesConstRef _in)
 	if (i)
 	{
 		for (j = i; j < 3; j++)
-			char_array_3[j] = '\0';
+			char_array_3[j] = (byte)('\0');
 
 		char_array_4[0] = (char_array_3[0] & 0xfc) >> 2;
 		char_array_4[1] = ((char_array_3[0] & 0x03) << 4) + ((char_array_3[1] & 0xf0) >> 4);
@@ -89,7 +89,7 @@ string dev::toBase64(bytesConstRef _in)
 		char_array_4[3] = char_array_3[2] & 0x3f;
 
 		for (j = 0; j < i + 1; j++)
-			ret += base64_chars[char_array_4[j]];
+			ret += base64_chars[as_unsigned_char(char_array_4[j])];
 
 		while (i++ < 3)
 			ret += '=';
@@ -108,9 +108,9 @@ bytes dev::fromBase64(string const& encoded_string)
 	byte char_array_4[4];
 	bytes ret;
 
-	while (in_len-- && encoded_string[in_] != '=' && is_base64(encoded_string[in_]))
+	while (in_len-- && encoded_string[in_] != '=' && is_base64((byte)encoded_string[in_]))
 	{
-		char_array_4[i++] = encoded_string[in_]; in_++;
+		char_array_4[i++] = static_cast<byte>(encoded_string[in_]); in_++;
 		if (i == 4)
 		{
 			for (i = 0; i < 4; i++)
@@ -119,7 +119,6 @@ bytes dev::fromBase64(string const& encoded_string)
 			char_array_3[0] = (char_array_4[0] << 2) + ((char_array_4[1] & 0x30) >> 4);
 			char_array_3[1] = ((char_array_4[1] & 0xf) << 4) + ((char_array_4[2] & 0x3c) >> 2);
 			char_array_3[2] = ((char_array_4[2] & 0x3) << 6) + char_array_4[3];
-
 			for (i = 0; (i < 3); i++)
 				ret.push_back(char_array_3[i]);
 			i = 0;
@@ -129,7 +128,7 @@ bytes dev::fromBase64(string const& encoded_string)
 	if (i)
 	{
 		for (j = i; j < 4; j++)
-			char_array_4[j] = 0;
+			char_array_4[j] = static_cast<byte>(0);
 
 		for (j = 0; j < 4; j++)
 		char_array_4[j] = find_base64_char_index(char_array_4[j]);
@@ -137,7 +136,6 @@ bytes dev::fromBase64(string const& encoded_string)
 		char_array_3[0] = (char_array_4[0] << 2) + ((char_array_4[1] & 0x30) >> 4);
 		char_array_3[1] = ((char_array_4[1] & 0xf) << 4) + ((char_array_4[2] & 0x3c) >> 2);
 		char_array_3[2] = ((char_array_4[2] & 0x3) << 6) + char_array_4[3];
-
 		for (j = 0; j < i - 1; j++)
 			ret.push_back(char_array_3[j]);
 	}

--- a/libdevcore/Common.h
+++ b/libdevcore/Common.h
@@ -54,7 +54,6 @@
 #include "vector_ref.h"
 
 // CryptoPP defines byte in the global namespace, so must we.
-using byte = uint8_t;
 
 // Quote a given token stream to turn it into a string.
 #define DEV_QUOTED_HELPER(s) #s
@@ -75,6 +74,13 @@ extern std::string const EmptyString;
 using bytes = std::vector<byte>;
 using bytesRef = vector_ref<byte>;
 using bytesConstRef = vector_ref<byte const>;
+
+/// @returns the int value of a byte
+template <typename byte>
+auto as_unsigned_char(byte const value) -> typename std::underlying_type<byte>::type
+{
+	return static_cast<typename std::underlying_type<byte>::type>(value);
+};
 
 template <class T>
 class secure_vector
@@ -199,6 +205,66 @@ inline N diff(N const& _a, N const& _b)
 {
 	return std::max(_a, _b) - std::min(_a, _b);
 }
+
+template<class A>
+A foo(A bar) { return bar; }
+
+inline bool operator ==(byte b1, byte b2) { return as_unsigned_char(b1) == as_unsigned_char(b2); }
+inline bool operator ==(byte b1, unsigned int b2) { return as_unsigned_char(b1) == b2; }
+inline bool operator ==(unsigned int b1, byte b2) { return b1 == as_unsigned_char(b2); }
+inline bool operator !=(byte b1, byte b2) { return as_unsigned_char(b1) != as_unsigned_char(b2); }
+inline bool operator !=(byte b1, unsigned int b2) { return as_unsigned_char(b1) != b2; }
+inline bool operator !=(unsigned int b1, byte b2) { return b1 != as_unsigned_char(b2); }
+inline byte operator +(byte b1, byte b2) { return static_cast<byte>(as_unsigned_char(b1) + as_unsigned_char(b2)); }
+inline byte operator +(byte b1, unsigned int b2) { return static_cast<byte>(as_unsigned_char(b1) + b2); }
+inline byte operator +(unsigned int b1, byte b2) { return static_cast<byte>(b1 + as_unsigned_char(b2)); }
+inline byte operator -(byte b1, byte b2) { return static_cast<byte>(as_unsigned_char(b1) - as_unsigned_char(b2)); }
+inline byte operator -(unsigned int b1, byte b2) { return static_cast<byte>(b1 - as_unsigned_char(b2)); }
+inline byte operator -(byte b1, unsigned int b2) { return static_cast<byte>(as_unsigned_char(b1) - b2); }
+inline byte operator *(byte b1, byte b2) { return static_cast<byte>(as_unsigned_char(b1) * as_unsigned_char(b2)); }
+inline byte operator *(unsigned int b1, byte b2) { return static_cast<byte>(b1 * as_unsigned_char(b2)); }
+inline byte operator *(byte b1, unsigned int b2) { return static_cast<byte>(as_unsigned_char(b1) * b2); }
+inline byte operator /(byte b1, byte b2) { return static_cast<byte>(as_unsigned_char(b1) / as_unsigned_char(b2)); }
+inline byte operator /(unsigned int b1, byte b2) { return static_cast<byte>(b1 / as_unsigned_char(b2)); }
+inline byte operator /(byte b1, unsigned int b2) { return static_cast<byte>(as_unsigned_char(b1) / b2); }
+inline byte operator %(byte b1, byte b2) { return static_cast<byte>(as_unsigned_char(b1) % as_unsigned_char(b2)); }
+inline byte operator %(unsigned int b1, byte b2) { return static_cast<byte>(b1 % as_unsigned_char(b2)); }
+inline byte operator %(byte b1, unsigned int b2) { return static_cast<byte>(as_unsigned_char(b1) % b2); }
+inline byte operator |(byte b1, byte b2) { return static_cast<byte>(as_unsigned_char(b1) | as_unsigned_char(b2)); }
+inline byte operator |(unsigned int b1, byte b2) { return static_cast<byte>(b1 | as_unsigned_char(b2)); }
+inline byte operator |(byte b1, unsigned int b2) { return static_cast<byte>(as_unsigned_char(b1) | b2); }
+inline byte operator |(int b1, byte b2) { return static_cast<byte>(b1 | as_unsigned_char(b2)); }
+inline byte operator |(byte b1, int b2) { return static_cast<byte>(as_unsigned_char(b1) | b2); }
+inline byte operator |(unsigned long b1, byte b2) { return static_cast<byte>(b1 | as_unsigned_char(b2)); }
+inline byte operator |(byte b1, unsigned long b2) { return static_cast<byte>(as_unsigned_char(b1) | b2); }
+inline byte operator ||(byte b1, byte b2) { return static_cast<byte>(as_unsigned_char(b1) || as_unsigned_char(b2)); }
+inline byte operator ||(unsigned int b1, byte b2) { return static_cast<byte>(b1 || as_unsigned_char(b2)); }
+inline byte operator ||(byte b1, unsigned int b2) { return static_cast<byte>(as_unsigned_char(b1) || b2); }
+inline byte operator >>(byte b1, byte b2) { return static_cast<byte>(as_unsigned_char(b1) >> as_unsigned_char(b2)); }
+inline byte operator >>(unsigned int b1, byte b2) { return static_cast<byte>(b1 >> as_unsigned_char(b2)); }
+inline byte operator >>(byte b1, unsigned int b2) { return static_cast<byte>(as_unsigned_char(b1) >> b2); }
+inline byte operator <<(byte b1, byte b2) { return static_cast<byte>(as_unsigned_char(b1) << as_unsigned_char(b2)); }
+inline byte operator <<(unsigned int b1, byte b2) { return static_cast<byte>(b1 << as_unsigned_char(b2)); }
+inline byte operator <<(byte b1, unsigned int b2) { return static_cast<byte>(as_unsigned_char(b1) << b2); }
+inline byte operator <<(int b1, byte b2) { return static_cast<byte>(b1 << as_unsigned_char(b2)); }
+inline byte operator <<(byte b1, int b2) { return static_cast<byte>(as_unsigned_char(b1) << b2); }
+inline byte operator <<(unsigned char b1, byte b2) { return static_cast<byte>(b1 << as_unsigned_char(b2)); }
+inline byte operator <<(byte b1, unsigned char b2) { return static_cast<byte>(as_unsigned_char(b1) << b2); }
+inline byte operator &(byte b1, byte b2) { return static_cast<byte>(as_unsigned_char(b1) & as_unsigned_char(b2)); }
+inline byte operator &(unsigned int b1, byte b2) { return static_cast<byte>(b1 & as_unsigned_char(b2)); }
+inline byte operator &(byte b1, unsigned int b2) { return static_cast<byte>(as_unsigned_char(b1) & b2); }
+inline bool operator >(byte b1, byte b2) { return as_unsigned_char(b1) > as_unsigned_char(b2); }
+inline bool operator >(byte b1, unsigned int b2) { return as_unsigned_char(b1) > b2; }
+inline bool operator >(unsigned int b1, byte b2) { return b1 > as_unsigned_char(b2); }
+inline bool operator >=(byte b1, byte b2) { return as_unsigned_char(b1) >= as_unsigned_char(b2); }
+inline bool operator >=(byte b1, unsigned int b2) { return as_unsigned_char(b1) >= b2; }
+inline bool operator >=(unsigned int b1, byte b2) { return b1 >= as_unsigned_char(b2); }
+inline bool operator <(byte b1, byte b2) { return as_unsigned_char(b1) < as_unsigned_char(b2); }
+inline bool operator <(byte b1, unsigned int b2) { return as_unsigned_char(b1) < b2; }
+inline bool operator <(unsigned int b1, byte b2) { return b1 < as_unsigned_char(b2); }
+inline bool operator <=(byte b1, byte b2) { return as_unsigned_char(b1) <= as_unsigned_char(b2); }
+inline bool operator <=(byte b1, unsigned int b2) { return as_unsigned_char(b1) <= b2; }
+inline bool operator <=(unsigned int b1, byte b2) { return b1 <= as_unsigned_char(b2); }
 
 /// RAII utility class whose destructor calls a given function.
 class ScopeGuard

--- a/libdevcore/CommonData.cpp
+++ b/libdevcore/CommonData.cpp
@@ -93,14 +93,14 @@ std::string dev::randomWord()
 bytes dev::fromHex(std::string const& _s, WhenError _throw)
 {
 	unsigned s = (_s.size() >= 2 && _s[0] == '0' && _s[1] == 'x') ? 2 : 0;
-	std::vector<uint8_t> ret;
+	std::vector<byte> ret;
 	ret.reserve((_s.size() - s + 1) / 2);
 
 	if (_s.size() % 2)
 	{
 		int h = fromHexChar(_s[s++]);
 		if (h != -1)
-			ret.push_back(h);
+			ret.push_back((byte)h);
 		else if (_throw == WhenError::Throw)
 			BOOST_THROW_EXCEPTION(BadHexCharacter());
 		else
@@ -122,7 +122,7 @@ bytes dev::fromHex(std::string const& _s, WhenError _throw)
 
 bytes dev::asNibbles(bytesConstRef const& _s)
 {
-	std::vector<uint8_t> ret;
+	std::vector<byte> ret;
 	ret.reserve(_s.size() * 2);
 	for (auto i: _s)
 	{

--- a/libdevcore/CommonData.h
+++ b/libdevcore/CommonData.h
@@ -54,8 +54,8 @@ std::string toHex(Iterator _it, Iterator _end, std::string const& _prefix)
 	hex.replace(0, off, _prefix);
 	for (; _it != _end; _it++)
 	{
-		hex[off++] = hexdigits[(*_it >> 4) & 0x0f];
-		hex[off++] = hexdigits[*_it & 0x0f];
+		hex[off++] = hexdigits[static_cast<std::underlying_type<byte>::type>((*_it >> 4) & 0x0f)];
+		hex[off++] = hexdigits[static_cast<std::underlying_type<byte>::type>(*_it & 0x0f)];
 	}
 	return hex;
 }
@@ -139,7 +139,7 @@ inline T fromBigEndian(_In const& _bytes)
 {
 	T ret = (T)0;
 	for (auto i: _bytes)
-		ret = (T)((ret << 8) | (byte)(typename std::make_unsigned<decltype(i)>::type)i);
+		ret = (T)((ret << 8) | (typename std::make_unsigned<decltype(i)>::type)i);
 	return ret;
 }
 
@@ -157,13 +157,13 @@ inline bytes toCompactBigEndian(T _val, unsigned _min = 0)
 	static_assert(std::is_same<bigint, T>::value || !std::numeric_limits<T>::is_signed, "only unsigned types or bigint supported"); //bigint does not carry sign bit on shift
 	int i = 0;
 	for (T v = _val; v; ++i, v >>= 8) {}
-	bytes ret(std::max<unsigned>(_min, i), 0);
+	bytes ret(std::max<unsigned>(_min, i));
 	toBigEndian(_val, ret);
 	return ret;
 }
 inline bytes toCompactBigEndian(byte _val, unsigned _min = 0)
 {
-	return (_min || _val) ? bytes{ _val } : bytes{};
+	return as_unsigned_char(_min || _val) ? bytes{ _val } : bytes{};
 }
 
 /// Convenience function for toBigEndian.

--- a/libdevcore/CommonJS.cpp
+++ b/libdevcore/CommonJS.cpp
@@ -47,7 +47,7 @@ bytes jsToBytes(string const& _s, OnFailed _f)
 bytes padded(bytes _b, unsigned _l)
 {
 	while (_b.size() < _l)
-		_b.insert(_b.begin(), 0);
+		_b.insert(_b.begin(), static_cast<byte>(0));
 	return asBytes(asString(_b).substr(_b.size() - max(_l, _l)));
 }
 

--- a/libdevcore/FixedHash.h
+++ b/libdevcore/FixedHash.h
@@ -62,7 +62,7 @@ public:
 	enum ConstructFromHashType { AlignLeft, AlignRight, FailIfDifferent };
 
 	/// Construct an empty hash.
-	FixedHash() { m_data.fill(0); }
+	FixedHash() { m_data.fill(static_cast<byte>(0)); }
 
 	/// Construct from another hash, filling with zeroes or cropping as necessary.
 	template <unsigned M> explicit FixedHash(FixedHash<M> const& _h, ConstructFromHashType _t = AlignLeft) { m_data.fill(0); unsigned c = std::min(M, N); for (unsigned i = 0; i < c; ++i) m_data[_t == AlignRight ? N - 1 - i : i] = _h[_t == AlignRight ? M - 1 - i : i]; }
@@ -74,7 +74,7 @@ public:
 	explicit FixedHash(unsigned _u) { toBigEndian(_u, m_data); }
 
 	/// Explicitly construct, copying from a byte array.
-	explicit FixedHash(bytes const& _b, ConstructFromHashType _t = FailIfDifferent) { if (_b.size() == N) memcpy(m_data.data(), _b.data(), std::min<unsigned>(_b.size(), N)); else { m_data.fill(0); if (_t != FailIfDifferent) { auto c = std::min<unsigned>(_b.size(), N); for (unsigned i = 0; i < c; ++i) m_data[_t == AlignRight ? N - 1 - i : i] = _b[_t == AlignRight ? _b.size() - 1 - i : i]; } } }
+	explicit FixedHash(bytes const& _b, ConstructFromHashType _t = FailIfDifferent) { if (_b.size() == N) memcpy(m_data.data(), _b.data(), std::min<unsigned>(_b.size(), N)); else { m_data.fill(static_cast<byte>(0)); if (_t != FailIfDifferent) { auto c = std::min<unsigned>(_b.size(), N); for (unsigned i = 0; i < c; ++i) m_data[_t == AlignRight ? N - 1 - i : i] = _b[_t == AlignRight ? _b.size() - 1 - i : i]; } } }
 
 	/// Explicitly construct, copying from a byte array.
 	explicit FixedHash(bytesConstRef _b, ConstructFromHashType _t = FailIfDifferent) { if (_b.size() == N) memcpy(m_data.data(), _b.data(), std::min<unsigned>(_b.size(), N)); else { m_data.fill(0); if (_t != FailIfDifferent) { auto c = std::min<unsigned>(_b.size(), N); for (unsigned i = 0; i < c; ++i) m_data[_t == AlignRight ? N - 1 - i : i] = _b[_t == AlignRight ? _b.size() - 1 - i : i]; } } }
@@ -160,7 +160,7 @@ public:
 	void randomize(Engine& _eng)
 	{
 		for (auto& i: m_data)
-			i = (uint8_t)std::uniform_int_distribution<uint16_t>(0, 255)(_eng);
+			i = (byte)std::uniform_int_distribution<uint16_t>(0, 255)(_eng);
 	}
 
 	/// @returns a random valued object.
@@ -197,7 +197,7 @@ public:
 		{
 			unsigned index = 0;
 			for (unsigned j = 0; j < c_bloomBytes; ++j, ++p)
-				index = (index << 8) | *p;
+				index = as_unsigned_char((index << 8) | *p);
 			index &= c_mask;
 			ret[M - 1 - index / 8] |= (1 << (index % 8));
 		}

--- a/libdevcore/OverlayDB.cpp
+++ b/libdevcore/OverlayDB.cpp
@@ -57,7 +57,7 @@ void OverlayDB::commit()
 				if (i.second.second)
 				{
 					bytes b = i.first.asBytes();
-					b.push_back(255);	// for aux
+					b.push_back((byte)255);	// for aux
 					batch.Put(bytesConstRef(&b), bytesConstRef(&i.second.first));
 				}
 		}
@@ -95,7 +95,7 @@ bytes OverlayDB::lookupAux(h256 const& _h) const
 		return ret;
 	std::string v;
 	bytes b = _h.asBytes();
-	b.push_back(255);	// for aux
+	b.push_back((byte)(255));	// for aux
 	m_db->Get(m_readOptions, bytesConstRef(&b), &v);
 	if (v.empty())
 		cwarn << "Aux not found: " << _h;

--- a/libdevcore/RLP.h
+++ b/libdevcore/RLP.h
@@ -43,9 +43,9 @@ template <> struct intTraits<u160> { static const unsigned maxSize = 20; };
 template <> struct intTraits<u256> { static const unsigned maxSize = 32; };
 template <> struct intTraits<bigint> { static const unsigned maxSize = ~(unsigned)0; };
 
-static const byte c_rlpMaxLengthBytes = 8;
-static const byte c_rlpDataImmLenStart = 0x80;
-static const byte c_rlpListStart = 0xc0;
+static const byte c_rlpMaxLengthBytes = (byte)8;
+static const byte c_rlpDataImmLenStart = (byte)0x80;
+static const byte c_rlpListStart = (byte)0xc0;
 
 static const byte c_rlpDataImmLenCount = c_rlpListStart - c_rlpDataImmLenStart - c_rlpMaxLengthBytes;
 static const byte c_rlpDataIndLenZero = c_rlpDataImmLenStart + c_rlpDataImmLenCount - 1;
@@ -334,7 +334,7 @@ private:
 	bool isSingleByte() const { return !isNull() && m_data[0] < c_rlpDataImmLenStart; }
 
 	/// @returns the amount of bytes used to encode the length of the data. Valid for all types.
-	unsigned lengthSize() const { if (isData() && m_data[0] > c_rlpDataIndLenZero) return m_data[0] - c_rlpDataIndLenZero; if (isList() && m_data[0] > c_rlpListIndLenZero) return m_data[0] - c_rlpListIndLenZero; return 0; }
+	unsigned lengthSize() const { if (isData() && m_data[0] > c_rlpDataIndLenZero) return as_unsigned_char(m_data[0] - c_rlpDataIndLenZero); if (isList() && m_data[0] > c_rlpListIndLenZero) return as_unsigned_char(m_data[0] - c_rlpListIndLenZero); return 0; }
 
 	/// @returns the size in bytes of the payload, as given by the RLP as opposed to as inferred from m_data.
 	size_t length() const;
@@ -450,7 +450,7 @@ private:
 		m_out.resize(m_out.size() + _br);
 		byte* b = &m_out.back();
 		for (; _i; _i >>= 8)
-			*(b--) = (byte)_i;
+			*(b--) = (byte)(unsigned)_i;
 	}
 
 	/// Our output byte stream.

--- a/libdevcore/SHA3.cpp
+++ b/libdevcore/SHA3.cpp
@@ -215,7 +215,7 @@ bool sha3(bytesConstRef _input, bytesRef o_output)
 	// FIXME: What with unaligned memory?
 	if (o_output.size() != 32)
 		return false;
-	keccak::sha3_256(o_output.data(), 32, _input.data(), _input.size());
+	keccak::sha3_256((unsigned char *)o_output.data(), 32, (unsigned char *)_input.data(), _input.size());
 //	keccak::keccak(ret.data(), 32, (uint64_t const*)_input.data(), _input.size());
 	return true;
 }

--- a/libdevcore/TrieCommon.cpp
+++ b/libdevcore/TrieCommon.cpp
@@ -52,11 +52,11 @@ std::string hexPrefixEncode(bytes const& _hexVector, bool _leaf, int _begin, int
 	std::string ret(1, ((_leaf ? 2 : 0) | (odd ? 1 : 0)) * 16);
 	if (odd)
 	{
-		ret[0] |= _hexVector[begin];
+		ret[0] = as_unsigned_char(ret[0] | _hexVector[begin]);
 		++begin;
 	}
 	for (unsigned i = begin; i < end; i += 2)
-		ret += _hexVector[i] * 16 + _hexVector[i + 1];
+		ret = ret + (char)(as_unsigned_char(_hexVector[i]) * 16 + _hexVector[i + 1]);
 	return ret;
 }
 
@@ -74,9 +74,9 @@ std::string hexPrefixEncode(bytesConstRef _data, bool _leaf, int _beginNibble, i
 	{
 		byte n = nibble(_data, i);
 		if (d & 1)	// odd
-			ret.back() |= n;		// or the nibble onto the back
+			ret.back() = as_unsigned_char(n | ret.back());	// or the nibble onto the back
 		else
-			ret.push_back(n << 4);	// push the nibble on to the back << 4
+			ret.push_back(as_unsigned_char(n << 4));	// push the nibble on to the back << 4
 	}
 	return ret;
 }
@@ -98,31 +98,31 @@ std::string hexPrefixEncode(bytesConstRef _d1, unsigned _o1, bytesConstRef _d2, 
 	{
 		byte n = nibble(_d1, i);
 		if (d & 1)	// odd
-			ret.back() |= n;		// or the nibble onto the back
+			ret.back() = as_unsigned_char(ret.back() | n);		// or the nibble onto the back
 		else
-			ret.push_back(n << 4);	// push the nibble on to the back << 4
+			ret.push_back(as_unsigned_char(n << 4));	// push the nibble on to the back << 4
 	}
 	for (auto i = begin2; i < end2; ++i, ++d)
 	{
 		byte n = nibble(_d2, i);
 		if (d & 1)	// odd
-			ret.back() |= n;		// or the nibble onto the back
+			ret.back() = as_unsigned_char(ret.back() | n);		// or the nibble onto the back
 		else
-			ret.push_back(n << 4);	// push the nibble on to the back << 4
+			ret.push_back(as_unsigned_char(n << 4));	// push the nibble on to the back << 4
 	}
 	return ret;
 }
 
 byte uniqueInUse(RLP const& _orig, byte except)
 {
-	byte used = 255;
+	byte used = (byte)255;
 	for (unsigned i = 0; i < 17; ++i)
 		if (i != except && !_orig[i].isEmpty())
 		{
 			if (used == 255)
 				used = (byte)i;
 			else
-				return 255;
+				return (byte)255;
 		}
 	return used;
 }

--- a/libdevcore/TrieCommon.h
+++ b/libdevcore/TrieCommon.h
@@ -98,14 +98,14 @@ inline bool isLeaf(RLP const& _twoItem)
 {
 	assert(_twoItem.isList() && _twoItem.itemCount() == 2);
 	auto pl = _twoItem[0].payload();
-	return (pl[0] & 0x20) != 0;
+	return as_unsigned_char(pl[0] & 0x20) != 0;
 }
 
 inline NibbleSlice keyOf(bytesConstRef _hpe)
 {
 	if (!_hpe.size())
 		return NibbleSlice(_hpe, 0);
-	if (_hpe[0] & 0x10)
+	if (as_unsigned_char(_hpe[0] & 0x10))
 		return NibbleSlice(_hpe, 1);
 	else
 		return NibbleSlice(_hpe, 2);

--- a/libdevcore/vector_ref.h
+++ b/libdevcore/vector_ref.h
@@ -16,6 +16,9 @@
 namespace dev
 {
 
+// Binary data types.
+enum class byte : unsigned char {};
+
 /**
  * A modifiable reference to an existing object or vector in memory.
  */
@@ -45,7 +48,7 @@ public:
 
 	bool contentsEqual(std::vector<mutable_value_type> const& _c) const { if (!m_data || m_count == 0) return _c.empty(); else return _c.size() == m_count && !memcmp(_c.data(), m_data, m_count * sizeof(_T)); }
 	std::vector<mutable_value_type> toVector() const { return std::vector<mutable_value_type>(m_data, m_data + m_count); }
-	std::vector<unsigned char> toBytes() const { return std::vector<unsigned char>(reinterpret_cast<unsigned char const*>(m_data), reinterpret_cast<unsigned char const*>(m_data) + m_count * sizeof(_T)); }
+	std::vector<byte> toBytes() const { return std::vector<byte>(reinterpret_cast<byte const*>(m_data), reinterpret_cast<byte const*>(m_data) + m_count * sizeof(_T)); }
 	std::string toString() const { return std::string((char const*)m_data, ((char const*)m_data) + m_count * sizeof(_T)); }
 
 	template <class _T2> explicit operator vector_ref<_T2>() const { assert(m_count * sizeof(_T) / sizeof(_T2) * sizeof(_T2) / sizeof(_T) == m_count); return vector_ref<_T2>(reinterpret_cast<_T2*>(m_data), m_count * sizeof(_T) / sizeof(_T2)); }


### PR DESCRIPTION
This PR: 
1) Switch to C++17 style byte.
2) Fixed all compiler errors in `libdevcore` directory.


According to a `C++ 17` doc, 
1) `std::byte` is not an integer and not a character.
2) `std::byte` is storage of bits.

So, I have to define all `operators` for the new `byte`. It looks a little messy, but I can gradually change all functions so that those crypto functions don’t require `int`, `char` and `bigint` to interact with `byte`. In this way, the code should be much nicer~