### PR TITLE
Fix high memory consumption during snapshot import

### DIFF
--- a/libethereum/SnapshotImporter.h
+++ b/libethereum/SnapshotImporter.h
@@ -41,6 +41,7 @@ DEV_SIMPLE_EXCEPTION(InvalidSnapshotManifest);
 DEV_SIMPLE_EXCEPTION(StateTrieReconstructionFailed);
 DEV_SIMPLE_EXCEPTION(InvalidStateChunkData);
 DEV_SIMPLE_EXCEPTION(InvalidBlockChunkData);
+DEV_SIMPLE_EXCEPTION(AccountAlreadyImported);
 
 class SnapshotImporter
 {

--- a/libethereum/StateImporter.cpp
+++ b/libethereum/StateImporter.cpp
@@ -72,6 +72,7 @@ public:
 	std::string lookupCode(h256 const& _hash) const override { return m_trie.db()->lookup(_hash); }
 
 private:
+	// can be used only with already imported accounts
 	h256 accountStorageRoot(h256 const& _addressHash) const
 	{
 		std::string const account = m_trie.at(_addressHash);

--- a/libethereum/StateImporter.cpp
+++ b/libethereum/StateImporter.cpp
@@ -36,19 +36,16 @@ public:
 
 	void importAccount(h256 const& _addressHash, u256 const& _nonce, u256 const& _balance, std::map<h256, bytes> const& _storage, h256 const& _codeHash) override
 	{
-		if (containsAccount(_addressHash))
-			BOOST_THROW_EXCEPTION(AccountAlreadyImported());
-
 		RLPStream s(4);
 		s << _nonce << _balance;
 
-		h256 const storageRoot = EmptyTrie;
+		h256 const storageRoot = isAccountImported(_addressHash) ? accountStorageRoot(_addressHash) : EmptyTrie;
 		if (_storage.empty())
 			s.append(storageRoot);
 		else
 		{
 			SpecificTrieDB<GenericTrieDB<OverlayDB>, h256> storageDB(m_trie.db(), storageRoot);
-			for (auto const& hashAndValue : _storage)
+			for (auto const& hashAndValue: _storage)
 				storageDB.insert(hashAndValue.first, hashAndValue.second);
 
 			s.append(storageDB.root());
@@ -68,12 +65,24 @@ public:
 
 	void commitStateDatabase() override { m_trie.db()->commit(); }
 
+	bool isAccountImported(h256 const& _addressHash) const override { return m_trie.contains(_addressHash); }
+
 	h256 stateRoot() const override { return m_trie.root(); }
 
 	std::string lookupCode(h256 const& _hash) const override { return m_trie.db()->lookup(_hash); }
 
 private:
-	bool containsAccount(h256 const& _addressHash) const { return m_trie.contains(_addressHash); }
+	h256 accountStorageRoot(h256 const& _addressHash) const
+	{
+		std::string const account = m_trie.at(_addressHash);
+		assert(!account.empty());
+		
+		RLP accountRlp(account);
+		if (accountRlp.itemCount() < 3)
+			BOOST_THROW_EXCEPTION(InvalidAccountInTheDatabase());
+
+		return accountRlp[2].toHash<h256>(RLP::VeryStrict);
+	}
 
 	SpecificTrieDB<GenericTrieDB<OverlayDB>, h256> m_trie;
 };

--- a/libethereum/StateImporter.h
+++ b/libethereum/StateImporter.h
@@ -34,7 +34,7 @@ class OverlayDB;
 namespace eth
 {
 
-DEV_SIMPLE_EXCEPTION(AccountAlreadyImported);
+DEV_SIMPLE_EXCEPTION(InvalidAccountInTheDatabase);
 
 class StateImporterFace
 {
@@ -46,6 +46,8 @@ public:
 	virtual h256 importCode(bytesConstRef _code) = 0;
 
 	virtual void commitStateDatabase() = 0;
+
+	virtual bool isAccountImported(h256 const& _addressHash) const = 0;
 
 	virtual h256 stateRoot() const = 0;
 


### PR DESCRIPTION
The accounts with huge storage are splitted between several chunks of snapshot. Previous approach was to first collect the full storage of such account in `std::map` in memory and then construct a trie out of it and save to database. This consumed a lot of RAM.

The new approach is to commit to the database the parts of the storage of each chunk (so there's one commit per each chunk).