### PR TITLE
cpp-build-env: Install LLVM dev package

### DIFF
--- a/scripts/docker/cpp-build-env.dockerfile
+++ b/scripts/docker/cpp-build-env.dockerfile
@@ -34,6 +34,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     # g++-7 \
     clang-5.0 \
     llvm-5.0 \
+    llvm-5.0-dev \
     # Dependencies
     libleveldb-dev \
   && rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
I need this to use the same docker image for EVMJIT builds.