### PR TITLE
Giving out snapshot through Warp protocol

### DIFF
--- a/eth/main.cpp
+++ b/eth/main.cpp
@@ -1025,7 +1025,7 @@ int main(int argc, char** argv)
 			SnapshotImporter importer(*stateImporter, *blockChainImporter);
 
 			auto snapshotStorage(createSnapshotStorage(filename));
-			importer.import(*snapshotStorage);
+			importer.import(*snapshotStorage, web3.ethereum()->blockChain().genesisHash());
 			// continue with regular sync from the snapshot block
 		}
 		catch (...)
@@ -1059,7 +1059,7 @@ int main(int argc, char** argv)
 	if (author)
 		cout << "Mining Beneficiary: " << renderFullAddress(author) << "\n";
 
-	if (bootstrap || !remoteHost.empty() || enableDiscovery || listenSet)
+	if (bootstrap || !remoteHost.empty() || enableDiscovery || listenSet || !preferredNodes.empty())
 	{
 		web3.startNetwork();
 		cout << "Node ID: " << web3.enode() << "\n";

--- a/eth/main.cpp
+++ b/eth/main.cpp
@@ -1025,8 +1025,8 @@ int main(int argc, char** argv)
 			SnapshotImporter importer(*stateImporter, *blockChainImporter);
 
 			auto snapshotStorage(createSnapshotStorage(filename));
-			importer.import(*snapshotStorage, web3.ethereum()->blockChain().genesisHash());
-			// continue with regular sync from the snapshot block
+            importer.import(*snapshotStorage, web3.ethereum()->blockChain().genesisHash());
+            // continue with regular sync from the snapshot block
 		}
 		catch (...)
 		{
@@ -1059,8 +1059,8 @@ int main(int argc, char** argv)
 	if (author)
 		cout << "Mining Beneficiary: " << renderFullAddress(author) << "\n";
 
-	if (bootstrap || !remoteHost.empty() || enableDiscovery || listenSet || !preferredNodes.empty())
-	{
+    if (bootstrap || !remoteHost.empty() || enableDiscovery || listenSet || !preferredNodes.empty())
+    {
 		web3.startNetwork();
 		cout << "Node ID: " << web3.enode() << "\n";
 	}

--- a/libdevcore/CommonIO.cpp
+++ b/libdevcore/CommonIO.cpp
@@ -39,20 +39,18 @@ namespace fs = boost::filesystem;
 
 namespace dev
 {
-
 namespace
 {
-
 void createDirectoryIfNotExistent(boost::filesystem::path const& _path)
 {
-	if (!fs::exists(_path))
-	{
-		fs::create_directories(_path);
-		DEV_IGNORE_EXCEPTIONS(fs::permissions(_path, fs::owner_all));
-	}
+    if (!fs::exists(_path))
+    {
+        fs::create_directories(_path);
+        DEV_IGNORE_EXCEPTIONS(fs::permissions(_path, fs::owner_all));
+    }
 }
 
-}
+}  // namespace
 
 string memDump(bytes const& _bytes, unsigned _width, bool _html)
 {
@@ -135,22 +133,22 @@ void writeFile(boost::filesystem::path const& _file, bytesConstRef _data, bool _
 	}
 	else
 	{
-		createDirectoryIfNotExistent(_file.parent_path());
+        createDirectoryIfNotExistent(_file.parent_path());
 
-		boost::filesystem::ofstream s(_file, ios::trunc | ios::binary);
+        boost::filesystem::ofstream s(_file, ios::trunc | ios::binary);
 		s.write(reinterpret_cast<char const*>(_data.data()), _data.size());
 		if (!s)
 			BOOST_THROW_EXCEPTION(FileError() << errinfo_comment("Could not write to file: " + _file.string()));
-		DEV_IGNORE_EXCEPTIONS(fs::permissions(_file, fs::owner_read | fs::owner_write));
-	}
+        DEV_IGNORE_EXCEPTIONS(fs::permissions(_file, fs::owner_read | fs::owner_write));
+    }
 }
 
 void copyDirectory(boost::filesystem::path const& _srcDir, boost::filesystem::path const& _dstDir)
 {
-	createDirectoryIfNotExistent(_dstDir);
+    createDirectoryIfNotExistent(_dstDir);
 
-	for (fs::directory_iterator file(_srcDir); file != fs::directory_iterator(); ++file)
-		fs::copy_file(file->path(), _dstDir / file->path().filename());
+    for (fs::directory_iterator file(_srcDir); file != fs::directory_iterator(); ++file)
+        fs::copy_file(file->path(), _dstDir / file->path().filename());
 }
 
 std::string getPassword(std::string const& _prompt)
@@ -202,4 +200,4 @@ std::string getPassword(std::string const& _prompt)
 #endif
 }
 
-}
+}  // namespace dev

--- a/libdevcore/CommonIO.h
+++ b/libdevcore/CommonIO.h
@@ -60,6 +60,10 @@ void writeFile(boost::filesystem::path const& _file, bytesConstRef _data, bool _
 /// Write the given binary data into the given file, replacing the file if it pre-exists.
 inline void writeFile(boost::filesystem::path const& _file, bytes const& _data, bool _writeDeleteRename = false) { writeFile(_file, bytesConstRef(&_data), _writeDeleteRename); }
 
+/// Non-recursively copies directory contents.
+/// Throws boost::filesystem_error on error.
+void copyDirectory(boost::filesystem::path const& _srcDir, boost::filesystem::path const& _dstDir);
+
 /// Nicely renders the given bytes to a string, optionally as HTML.
 /// @a _bytes: bytes array to be rendered as string. @a _width of a bytes line.
 std::string memDump(bytes const& _bytes, unsigned _width = 8, bool _html = false);

--- a/libethcore/Exceptions.h
+++ b/libethcore/Exceptions.h
@@ -86,5 +86,13 @@ DEV_SIMPLE_EXCEPTION(DatabaseAlreadyOpen);
 DEV_SIMPLE_EXCEPTION(DAGCreationFailure);
 DEV_SIMPLE_EXCEPTION(DAGComputeFailure);
 
+DEV_SIMPLE_EXCEPTION(UnsupportedSnapshotManifestVersion);
+DEV_SIMPLE_EXCEPTION(InvalidSnapshotManifest);
+DEV_SIMPLE_EXCEPTION(StateTrieReconstructionFailed);
+DEV_SIMPLE_EXCEPTION(InvalidStateChunkData);
+DEV_SIMPLE_EXCEPTION(InvalidBlockChunkData);
+DEV_SIMPLE_EXCEPTION(AccountAlreadyImported);
+DEV_SIMPLE_EXCEPTION(InvalidWarpStatusPacket);
+
 }
 }

--- a/libethcore/Exceptions.h
+++ b/libethcore/Exceptions.h
@@ -93,6 +93,5 @@ DEV_SIMPLE_EXCEPTION(InvalidStateChunkData);
 DEV_SIMPLE_EXCEPTION(InvalidBlockChunkData);
 DEV_SIMPLE_EXCEPTION(AccountAlreadyImported);
 DEV_SIMPLE_EXCEPTION(InvalidWarpStatusPacket);
-
 }
 }

--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -100,12 +100,12 @@ void Client::init(p2p::Host* _extNet, fs::path const& _dbPath, WithExisting _for
 	m_bq.setChain(bc());
 
 	m_lastGetWork = std::chrono::system_clock::now() - chrono::seconds(30);
-	m_tqReady = m_tq.onReady([=](){ this->onTransactionQueueReady(); });	// TODO: should read m_tq->onReady(thisThread, syncTransactionQueue);
-	m_tqReplaced = m_tq.onReplaced([=](h256 const&){ m_needStateReset = true; });
-	m_bqReady = m_bq.onReady([=](){ this->onBlockQueueReady(); });			// TODO: should read m_bq->onReady(thisThread, syncBlockQueue);
-	m_bq.setOnBad([=](Exception& ex){ this->onBadBlock(ex); });
-	bc().setOnBad([=](Exception& ex){ this->onBadBlock(ex); });
-	bc().setOnBlockImport([=](BlockHeader const& _info){
+	m_tqReady = m_tq.onReady([=]() { this->onTransactionQueueReady(); });	// TODO: should read m_tq->onReady(thisThread, syncTransactionQueue);
+	m_tqReplaced = m_tq.onReplaced([=](h256 const&) { m_needStateReset = true; });
+	m_bqReady = m_bq.onReady([=]() { this->onBlockQueueReady(); });			// TODO: should read m_bq->onReady(thisThread, syncBlockQueue);
+	m_bq.setOnBad([=](Exception& ex) { this->onBadBlock(ex); });
+	bc().setOnBad([=](Exception& ex) { this->onBadBlock(ex); });
+	bc().setOnBlockImport([=](BlockHeader const& _info) {
 		if (auto h = m_host.lock())
 			h->onBlockImported(_info);
 	});
@@ -120,6 +120,7 @@ void Client::init(p2p::Host* _extNet, fs::path const& _dbPath, WithExisting _for
 
 	_extNet->addCapability(host, EthereumHost::staticName(), EthereumHost::c_oldProtocolVersion); //TODO: remove this once v61+ protocol is common
 
+	m_warpHost = _extNet->registerCapability(make_shared<WarpHostCapability>(bc(), _networkId, _dbPath));
 
 	if (_dbPath.size())
 		Defaults::setDBPath(_dbPath);

--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -100,17 +100,21 @@ void Client::init(p2p::Host* _extNet, fs::path const& _dbPath, WithExisting _for
 	m_bq.setChain(bc());
 
 	m_lastGetWork = std::chrono::system_clock::now() - chrono::seconds(30);
-	m_tqReady = m_tq.onReady([=]() { this->onTransactionQueueReady(); });	// TODO: should read m_tq->onReady(thisThread, syncTransactionQueue);
-	m_tqReplaced = m_tq.onReplaced([=](h256 const&) { m_needStateReset = true; });
-	m_bqReady = m_bq.onReady([=]() { this->onBlockQueueReady(); });			// TODO: should read m_bq->onReady(thisThread, syncBlockQueue);
-	m_bq.setOnBad([=](Exception& ex) { this->onBadBlock(ex); });
-	bc().setOnBad([=](Exception& ex) { this->onBadBlock(ex); });
-	bc().setOnBlockImport([=](BlockHeader const& _info) {
-		if (auto h = m_host.lock())
+    m_tqReady = m_tq.onReady([=]() {
+        this->onTransactionQueueReady();
+    });  // TODO: should read m_tq->onReady(thisThread, syncTransactionQueue);
+    m_tqReplaced = m_tq.onReplaced([=](h256 const&) { m_needStateReset = true; });
+    m_bqReady = m_bq.onReady([=]() {
+        this->onBlockQueueReady();
+    });  // TODO: should read m_bq->onReady(thisThread, syncBlockQueue);
+    m_bq.setOnBad([=](Exception& ex) { this->onBadBlock(ex); });
+    bc().setOnBad([=](Exception& ex) { this->onBadBlock(ex); });
+    bc().setOnBlockImport([=](BlockHeader const& _info) {
+        if (auto h = m_host.lock())
 			h->onBlockImported(_info);
-	});
+    });
 
-	if (_forceAction == WithExisting::Rescue)
+    if (_forceAction == WithExisting::Rescue)
 		bc().rescue(m_stateDB);
 
 	m_gp->update(bc());
@@ -120,9 +124,10 @@ void Client::init(p2p::Host* _extNet, fs::path const& _dbPath, WithExisting _for
 
 	_extNet->addCapability(host, EthereumHost::staticName(), EthereumHost::c_oldProtocolVersion); //TODO: remove this once v61+ protocol is common
 
-	m_warpHost = _extNet->registerCapability(make_shared<WarpHostCapability>(bc(), _networkId, _dbPath));
+    m_warpHost =
+        _extNet->registerCapability(make_shared<WarpHostCapability>(bc(), _networkId, _dbPath));
 
-	if (_dbPath.size())
+    if (_dbPath.size())
 		Defaults::setDBPath(_dbPath);
 	doWork(false);
 }

--- a/libethereum/Client.h
+++ b/libethereum/Client.h
@@ -41,6 +41,7 @@
 #include "ClientBase.h"
 #include "StateImporter.h"
 #include "BlockChainImporter.h"
+#include "WarpHostCapability.h"
 
 #include <boost/filesystem/path.hpp>
 
@@ -319,6 +320,7 @@ protected:
 	std::chrono::system_clock::time_point m_lastGetWork;	///< Is there an active and valid remote worker?
 
 	std::weak_ptr<EthereumHost> m_host;		///< Our Ethereum Host. Don't do anything if we can't lock.
+	std::weak_ptr<WarpHostCapability> m_warpHost;
 
 	std::condition_variable m_signalled;
 	Mutex x_signalled;

--- a/libethereum/Client.h
+++ b/libethereum/Client.h
@@ -21,27 +21,27 @@
 
 #pragma once
 
-#include <thread>
-#include <condition_variable>
-#include <mutex>
-#include <list>
-#include <queue>
-#include <atomic>
-#include <string>
-#include <array>
+#include "Block.h"
+#include "BlockChain.h"
+#include "BlockChainImporter.h"
+#include "ClientBase.h"
+#include "CommonNet.h"
+#include "StateImporter.h"
+#include "WarpHostCapability.h"
 #include <libdevcore/Common.h>
 #include <libdevcore/CommonIO.h>
 #include <libdevcore/Guards.h>
 #include <libdevcore/Worker.h>
 #include <libethcore/SealEngine.h>
 #include <libp2p/Common.h>
-#include "BlockChain.h"
-#include "Block.h"
-#include "CommonNet.h"
-#include "ClientBase.h"
-#include "StateImporter.h"
-#include "BlockChainImporter.h"
-#include "WarpHostCapability.h"
+#include <array>
+#include <atomic>
+#include <condition_variable>
+#include <list>
+#include <mutex>
+#include <queue>
+#include <string>
+#include <thread>
 
 #include <boost/filesystem/path.hpp>
 
@@ -320,9 +320,9 @@ protected:
 	std::chrono::system_clock::time_point m_lastGetWork;	///< Is there an active and valid remote worker?
 
 	std::weak_ptr<EthereumHost> m_host;		///< Our Ethereum Host. Don't do anything if we can't lock.
-	std::weak_ptr<WarpHostCapability> m_warpHost;
+    std::weak_ptr<WarpHostCapability> m_warpHost;
 
-	std::condition_variable m_signalled;
+    std::condition_variable m_signalled;
 	Mutex x_signalled;
 
 	Handler<> m_tqReady;

--- a/libethereum/SnapshotImporter.cpp
+++ b/libethereum/SnapshotImporter.cpp
@@ -43,7 +43,7 @@ struct SnapshotImportLog: public LogChannel
 
 }
 
-void SnapshotImporter::import(SnapshotStorageFace const& _snapshotStorage)
+void SnapshotImporter::import(SnapshotStorageFace const& _snapshotStorage, h256 const& _genesisHash)
 {
 	(void)SnapshotImportLog::debug; // override "unused variable" error on macOS
 
@@ -69,7 +69,7 @@ void SnapshotImporter::import(SnapshotStorageFace const& _snapshotStorage)
 	importBlockChunks(_snapshotStorage, blockChunkHashes);
 
 	clog(SnapshotImportLog) << "Copying snapshot...";
-	_snapshotStorage.copyTo(getDataDir() / "snapshot");
+	_snapshotStorage.copyTo(getDataDir() / toHex(_genesisHash.ref().cropped(0, 4)) / "snapshot");
 }
 
 void SnapshotImporter::importStateChunks(SnapshotStorageFace const& _snapshotStorage, h256s const& _stateChunkHashes, h256 const& _stateRoot)

--- a/libethereum/SnapshotImporter.cpp
+++ b/libethereum/SnapshotImporter.cpp
@@ -19,14 +19,17 @@
 #include "Client.h"
 #include "SnapshotStorage.h"
 
+#include <libdevcore/FileSystem.h>
 #include <libdevcore/RLP.h>
 #include <libdevcore/TrieHash.h>
 #include <libethashseal/Ethash.h>
 
 #include <snappy.h>
 
-using namespace dev;
-using namespace eth;
+namespace dev
+{
+namespace eth
+{
 
 namespace
 {
@@ -64,6 +67,9 @@ void SnapshotImporter::import(SnapshotStorageFace const& _snapshotStorage)
 
 	h256s const blockChunkHashes = manifest[2].toVector<h256>(RLP::VeryStrict);
 	importBlockChunks(_snapshotStorage, blockChunkHashes);
+
+	clog(SnapshotImportLog) << "Copying snapshot...";
+	_snapshotStorage.copyTo(getDataDir() / "snapshot");
 }
 
 void SnapshotImporter::importStateChunks(SnapshotStorageFace const& _snapshotStorage, h256s const& _stateChunkHashes, h256 const& _stateRoot)
@@ -233,4 +239,7 @@ void SnapshotImporter::importBlockChunks(SnapshotStorageFace const& _snapshotSto
 			m_blockChainImporter.setChainStartBlockNumber(firstBlockNumber + 1);
 		}
 	}
+}
+
+}
 }

--- a/libethereum/SnapshotImporter.cpp
+++ b/libethereum/SnapshotImporter.cpp
@@ -36,7 +36,7 @@ namespace
 struct SnapshotImportLog: public LogChannel
 {
 	static char const* name() { return "SNAP"; }
-	static int const verbosity = 9;
+	static int const verbosity = 8;
 	static const bool debug = false;
 };
 

--- a/libethereum/SnapshotImporter.cpp
+++ b/libethereum/SnapshotImporter.cpp
@@ -30,7 +30,6 @@ namespace dev
 {
 namespace eth
 {
-
 namespace
 {
 
@@ -68,8 +67,8 @@ void SnapshotImporter::import(SnapshotStorageFace const& _snapshotStorage, h256 
 	h256s const blockChunkHashes = manifest[2].toVector<h256>(RLP::VeryStrict);
 	importBlockChunks(_snapshotStorage, blockChunkHashes);
 
-	clog(SnapshotImportLog) << "Copying snapshot...";
-	_snapshotStorage.copyTo(getDataDir() / toHex(_genesisHash.ref().cropped(0, 4)) / "snapshot");
+    clog(SnapshotImportLog) << "Copying snapshot...";
+    _snapshotStorage.copyTo(getDataDir() / toHex(_genesisHash.ref().cropped(0, 4)) / "snapshot");
 }
 
 void SnapshotImporter::importStateChunks(SnapshotStorageFace const& _snapshotStorage, h256s const& _stateChunkHashes, h256 const& _stateRoot)
@@ -241,5 +240,5 @@ void SnapshotImporter::importBlockChunks(SnapshotStorageFace const& _snapshotSto
 	}
 }
 
-}
-}
+}  // namespace eth
+}  // namespace dev

--- a/libethereum/SnapshotImporter.h
+++ b/libethereum/SnapshotImporter.h
@@ -36,19 +36,12 @@ class BlockChainImporterFace;
 class SnapshotStorageFace;
 class StateImporterFace;
 
-DEV_SIMPLE_EXCEPTION(UnsupportedSnapshotManifestVersion);
-DEV_SIMPLE_EXCEPTION(InvalidSnapshotManifest);
-DEV_SIMPLE_EXCEPTION(StateTrieReconstructionFailed);
-DEV_SIMPLE_EXCEPTION(InvalidStateChunkData);
-DEV_SIMPLE_EXCEPTION(InvalidBlockChunkData);
-DEV_SIMPLE_EXCEPTION(AccountAlreadyImported);
-
 class SnapshotImporter
 {
 public:
 	SnapshotImporter(StateImporterFace& _stateImporter, BlockChainImporterFace& _bcImporter): m_stateImporter(_stateImporter), m_blockChainImporter(_bcImporter) {}
 
-	void import(SnapshotStorageFace const& _snapshotStorage);
+	void import(SnapshotStorageFace const& _snapshotStorage, h256 const& _genesisHash);
 
 private:
 	void importStateChunks(SnapshotStorageFace const& _snapshotStorage, h256s const& _stateChunkHashes, h256 const& _stateRoot);

--- a/libethereum/SnapshotImporter.h
+++ b/libethereum/SnapshotImporter.h
@@ -41,7 +41,7 @@ class SnapshotImporter
 public:
 	SnapshotImporter(StateImporterFace& _stateImporter, BlockChainImporterFace& _bcImporter): m_stateImporter(_stateImporter), m_blockChainImporter(_bcImporter) {}
 
-	void import(SnapshotStorageFace const& _snapshotStorage, h256 const& _genesisHash);
+    void import(SnapshotStorageFace const& _snapshotStorage, h256 const& _genesisHash);
 
 private:
 	void importStateChunks(SnapshotStorageFace const& _snapshotStorage, h256s const& _stateChunkHashes, h256 const& _stateRoot);

--- a/libethereum/SnapshotStorage.cpp
+++ b/libethereum/SnapshotStorage.cpp
@@ -19,7 +19,6 @@
 #include <libdevcore/CommonIO.h>
 #include <libdevcore/SHA3.h>
 
-#include <boost/filesystem.hpp>
 #include <snappy.h>
 
 namespace dev
@@ -77,6 +76,11 @@ public:
 		assert(!chunkUncompressed.empty());
 
 		return chunkUncompressed;
+	}
+
+	void copyTo(boost::filesystem::path const& _path) const override
+	{
+		copyDirectory(m_snapshotDir, _path);
 	}
 
 private:

--- a/libethereum/SnapshotStorage.cpp
+++ b/libethereum/SnapshotStorage.cpp
@@ -51,9 +51,11 @@ std::string snappyUncompress(std::string const& _compressed)
 class SnapshotStorage: public SnapshotStorageFace
 {
 public:
-	explicit SnapshotStorage(boost::filesystem::path const& _snapshotDir): m_snapshotDir(_snapshotDir) {}
+    explicit SnapshotStorage(boost::filesystem::path const& _snapshotDir)
+      : m_snapshotDir(_snapshotDir)
+    {}
 
-	bytes readManifest() const override
+    bytes readManifest() const override
 	{
 		bytes const manifestBytes = dev::contents((m_snapshotDir / "MANIFEST").string());
 		if (manifestBytes.empty())
@@ -62,20 +64,20 @@ public:
 		return manifestBytes;
 	}
 
-	std::string readCompressedChunk(h256 const& _chunkHash) const override
-	{
+    std::string readCompressedChunk(h256 const& _chunkHash) const override
+    {
 		std::string const chunkCompressed = dev::contentsString((m_snapshotDir / toHex(_chunkHash)).string());
 		if (chunkCompressed.empty())
 			BOOST_THROW_EXCEPTION(FailedToReadChunkFile() << errinfo_hash256(_chunkHash));
 
-		return chunkCompressed;
-	}
+        return chunkCompressed;
+    }
 
-	std::string readChunk(h256 const& _chunkHash) const override
-	{
-		std::string const chunkCompressed = readCompressedChunk(_chunkHash);
+    std::string readChunk(h256 const& _chunkHash) const override
+    {
+        std::string const chunkCompressed = readCompressedChunk(_chunkHash);
 
-		h256 const chunkHash = sha3(chunkCompressed);
+        h256 const chunkHash = sha3(chunkCompressed);
 		if (chunkHash != _chunkHash)
 			BOOST_THROW_EXCEPTION(ChunkDataCorrupted() << errinfo_hash256(_chunkHash));
 
@@ -85,10 +87,10 @@ public:
 		return chunkUncompressed;
 	}
 
-	void copyTo(boost::filesystem::path const& _path) const override
-	{
-		copyDirectory(m_snapshotDir, _path);
-	}
+    void copyTo(boost::filesystem::path const& _path) const override
+    {
+        copyDirectory(m_snapshotDir, _path);
+    }
 
 private:
 	boost::filesystem::path const m_snapshotDir;
@@ -96,7 +98,8 @@ private:
 
 }
 
-std::unique_ptr<SnapshotStorageFace> createSnapshotStorage(boost::filesystem::path const& _snapshotDirPath)
+std::unique_ptr<SnapshotStorageFace> createSnapshotStorage(
+    boost::filesystem::path const& _snapshotDirPath)
 {
 	return std::unique_ptr<SnapshotStorageFace>(new SnapshotStorage(_snapshotDirPath));
 }

--- a/libethereum/SnapshotStorage.h
+++ b/libethereum/SnapshotStorage.h
@@ -45,13 +45,15 @@ public:
 
 	virtual bytes readManifest() const = 0;
 
+	virtual std::string readCompressedChunk(h256 const& _chunkHash) const = 0;
+
 	virtual std::string readChunk(h256 const& _chunkHash) const = 0;
 
 	virtual void copyTo(boost::filesystem::path const& _path) const = 0;
 };
 
 
-std::unique_ptr<SnapshotStorageFace> createSnapshotStorage(std::string const& _snapshotDirPath);
+std::unique_ptr<SnapshotStorageFace> createSnapshotStorage(boost::filesystem::path const& _snapshotDirPath);
 
 }
 }

--- a/libethereum/SnapshotStorage.h
+++ b/libethereum/SnapshotStorage.h
@@ -21,6 +21,8 @@
 #include <libdevcore/Exceptions.h>
 #include <libdevcore/FixedHash.h>
 
+#include <boost/filesystem.hpp>
+
 #include <memory>
 
 namespace dev
@@ -44,6 +46,8 @@ public:
 	virtual bytes readManifest() const = 0;
 
 	virtual std::string readChunk(h256 const& _chunkHash) const = 0;
+
+	virtual void copyTo(boost::filesystem::path const& _path) const = 0;
 };
 
 

--- a/libethereum/SnapshotStorage.h
+++ b/libethereum/SnapshotStorage.h
@@ -45,15 +45,15 @@ public:
 
 	virtual bytes readManifest() const = 0;
 
-	virtual std::string readCompressedChunk(h256 const& _chunkHash) const = 0;
+    virtual std::string readCompressedChunk(h256 const& _chunkHash) const = 0;
 
-	virtual std::string readChunk(h256 const& _chunkHash) const = 0;
+    virtual std::string readChunk(h256 const& _chunkHash) const = 0;
 
-	virtual void copyTo(boost::filesystem::path const& _path) const = 0;
+    virtual void copyTo(boost::filesystem::path const& _path) const = 0;
 };
 
 
-std::unique_ptr<SnapshotStorageFace> createSnapshotStorage(boost::filesystem::path const& _snapshotDirPath);
-
+std::unique_ptr<SnapshotStorageFace> createSnapshotStorage(
+    boost::filesystem::path const& _snapshotDirPath);
 }
 }

--- a/libethereum/WarpHostCapability.cpp
+++ b/libethereum/WarpHostCapability.cpp
@@ -1,0 +1,55 @@
+/*
+	This file is part of cpp-ethereum.
+
+	cpp-ethereum is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	cpp-ethereum is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "WarpHostCapability.h"
+#include "BlockChain.h"
+#include "SnapshotStorage.h"
+
+namespace dev
+{
+namespace eth
+{
+
+WarpHostCapability::WarpHostCapability(BlockChain const& _blockChain, u256 const& _networkId, boost::filesystem::path const& _dataDirPath):
+	m_blockChain(_blockChain),
+	m_networkId(_networkId)
+{
+	boost::filesystem::path const snapshotPath = _dataDirPath / toHex(m_blockChain.genesisHash().ref().cropped(0, 4)) / "snapshot";
+	if (boost::filesystem::exists(snapshotPath))
+		m_snapshot = createSnapshotStorage(snapshotPath);
+}
+
+std::shared_ptr<p2p::Capability> WarpHostCapability::newPeerCapability(std::shared_ptr<p2p::SessionFace> const& _s, unsigned _idOffset, p2p::CapDesc const& _cap)
+{
+	auto ret = HostCapability<WarpPeerCapability>::newPeerCapability(_s, _idOffset, _cap);
+
+	auto cap = p2p::capabilityFromSession<WarpPeerCapability>(*_s, _cap.second);
+	assert(cap);
+	cap->init(
+		c_WarpProtocolVersion,
+		m_networkId,
+		m_blockChain.details().totalDifficulty,
+		m_blockChain.currentHash(),
+		m_blockChain.genesisHash(),
+		m_snapshot
+	);
+
+	return ret;
+}
+
+}
+}

--- a/libethereum/WarpHostCapability.cpp
+++ b/libethereum/WarpHostCapability.cpp
@@ -1,18 +1,18 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 #include "WarpHostCapability.h"
@@ -23,33 +23,28 @@ namespace dev
 {
 namespace eth
 {
-
-WarpHostCapability::WarpHostCapability(BlockChain const& _blockChain, u256 const& _networkId, boost::filesystem::path const& _dataDirPath):
-	m_blockChain(_blockChain),
-	m_networkId(_networkId)
+WarpHostCapability::WarpHostCapability(BlockChain const& _blockChain, u256 const& _networkId,
+    boost::filesystem::path const& _dataDirPath)
+  : m_blockChain(_blockChain), m_networkId(_networkId)
 {
-	boost::filesystem::path const snapshotPath = _dataDirPath / toHex(m_blockChain.genesisHash().ref().cropped(0, 4)) / "snapshot";
-	if (boost::filesystem::exists(snapshotPath))
-		m_snapshot = createSnapshotStorage(snapshotPath);
+    boost::filesystem::path const snapshotPath =
+        _dataDirPath / toHex(m_blockChain.genesisHash().ref().cropped(0, 4)) / "snapshot";
+    if (boost::filesystem::exists(snapshotPath))
+        m_snapshot = createSnapshotStorage(snapshotPath);
 }
 
-std::shared_ptr<p2p::Capability> WarpHostCapability::newPeerCapability(std::shared_ptr<p2p::SessionFace> const& _s, unsigned _idOffset, p2p::CapDesc const& _cap)
+std::shared_ptr<p2p::Capability> WarpHostCapability::newPeerCapability(
+    std::shared_ptr<p2p::SessionFace> const& _s, unsigned _idOffset, p2p::CapDesc const& _cap)
 {
-	auto ret = HostCapability<WarpPeerCapability>::newPeerCapability(_s, _idOffset, _cap);
+    auto ret = HostCapability<WarpPeerCapability>::newPeerCapability(_s, _idOffset, _cap);
 
-	auto cap = p2p::capabilityFromSession<WarpPeerCapability>(*_s, _cap.second);
-	assert(cap);
-	cap->init(
-		c_WarpProtocolVersion,
-		m_networkId,
-		m_blockChain.details().totalDifficulty,
-		m_blockChain.currentHash(),
-		m_blockChain.genesisHash(),
-		m_snapshot
-	);
+    auto cap = p2p::capabilityFromSession<WarpPeerCapability>(*_s, _cap.second);
+    assert(cap);
+    cap->init(c_WarpProtocolVersion, m_networkId, m_blockChain.details().totalDifficulty,
+        m_blockChain.currentHash(), m_blockChain.genesisHash(), m_snapshot);
 
-	return ret;
+    return ret;
 }
 
-}
-}
+}  // namespace eth
+}  // namespace dev

--- a/libethereum/WarpHostCapability.h
+++ b/libethereum/WarpHostCapability.h
@@ -1,0 +1,46 @@
+/*
+	This file is part of cpp-ethereum.
+
+	cpp-ethereum is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	cpp-ethereum is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "WarpPeerCapability.h"
+
+#include <libdevcore/Worker.h>
+
+namespace dev
+{
+
+namespace eth
+{
+
+class WarpHostCapability: public p2p::HostCapability<WarpPeerCapability>
+{
+public:
+	WarpHostCapability(BlockChain const& _blockChain, u256 const& _networkId, boost::filesystem::path const& _dataDirPath);
+
+protected:
+	std::shared_ptr<p2p::Capability> newPeerCapability(std::shared_ptr<p2p::SessionFace> const& _s, unsigned _idOffset, p2p::CapDesc const& _cap) override;
+
+private:
+	BlockChain const& m_blockChain;
+	u256 const m_networkId;
+
+	std::shared_ptr<SnapshotStorageFace> m_snapshot;
+};
+
+}
+}

--- a/libethereum/WarpHostCapability.h
+++ b/libethereum/WarpHostCapability.h
@@ -1,18 +1,18 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 #pragma once
@@ -23,24 +23,24 @@
 
 namespace dev
 {
-
 namespace eth
 {
-
-class WarpHostCapability: public p2p::HostCapability<WarpPeerCapability>
+class WarpHostCapability : public p2p::HostCapability<WarpPeerCapability>
 {
 public:
-	WarpHostCapability(BlockChain const& _blockChain, u256 const& _networkId, boost::filesystem::path const& _dataDirPath);
+    WarpHostCapability(BlockChain const& _blockChain, u256 const& _networkId,
+        boost::filesystem::path const& _dataDirPath);
 
 protected:
-	std::shared_ptr<p2p::Capability> newPeerCapability(std::shared_ptr<p2p::SessionFace> const& _s, unsigned _idOffset, p2p::CapDesc const& _cap) override;
+    std::shared_ptr<p2p::Capability> newPeerCapability(std::shared_ptr<p2p::SessionFace> const& _s,
+        unsigned _idOffset, p2p::CapDesc const& _cap) override;
 
 private:
-	BlockChain const& m_blockChain;
-	u256 const m_networkId;
+    BlockChain const& m_blockChain;
+    u256 const m_networkId;
 
-	std::shared_ptr<SnapshotStorageFace> m_snapshot;
+    std::shared_ptr<SnapshotStorageFace> m_snapshot;
 };
 
-}
-}
+}  // namespace eth
+}  // namespace dev

--- a/libethereum/WarpPeerCapability.cpp
+++ b/libethereum/WarpPeerCapability.cpp
@@ -1,18 +1,18 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 #include "WarpPeerCapability.h"
@@ -24,115 +24,112 @@ namespace dev
 {
 namespace eth
 {
+WarpPeerCapability::WarpPeerCapability(std::shared_ptr<p2p::SessionFace> _s,
+    p2p::HostCapabilityFace* _h, unsigned _i, p2p::CapDesc const& /* _cap */)
+  : Capability(_s, _h, _i)
+{}
 
-WarpPeerCapability::WarpPeerCapability(std::shared_ptr<p2p::SessionFace> _s, p2p::HostCapabilityFace* _h, unsigned _i, p2p::CapDesc const& /* _cap */):
-	Capability(_s, _h, _i)
+void WarpPeerCapability::init(unsigned _hostProtocolVersion, u256 _hostNetworkId,
+    u256 _chainTotalDifficulty, h256 _chainCurrentHash, h256 _chainGenesisHash,
+    std::shared_ptr<SnapshotStorageFace const> _snapshot)
 {
-}
+    m_snapshot = _snapshot;
 
-void WarpPeerCapability::init(unsigned _hostProtocolVersion, u256 _hostNetworkId, u256 _chainTotalDifficulty, h256 _chainCurrentHash, h256 _chainGenesisHash, std::shared_ptr<SnapshotStorageFace const> _snapshot)
-{
-	m_snapshot = _snapshot;
-	
-	h256 snapshotBlockHash;
-	u256 snapshotBlockNumber;
-	if (m_snapshot)
-	{
-		bytes const snapshotManifest(m_snapshot->readManifest());
-		RLP manifest(snapshotManifest);
-		if (manifest.itemCount() != 6)
-			BOOST_THROW_EXCEPTION(InvalidSnapshotManifest());
-		snapshotBlockNumber = manifest[4].toInt<u256>(RLP::VeryStrict);
-		snapshotBlockHash = manifest[5].toHash<h256>(RLP::VeryStrict);
-	}
+    h256 snapshotBlockHash;
+    u256 snapshotBlockNumber;
+    if (m_snapshot)
+    {
+        bytes const snapshotManifest(m_snapshot->readManifest());
+        RLP manifest(snapshotManifest);
+        if (manifest.itemCount() != 6)
+            BOOST_THROW_EXCEPTION(InvalidSnapshotManifest());
+        snapshotBlockNumber = manifest[4].toInt<u256>(RLP::VeryStrict);
+        snapshotBlockHash = manifest[5].toHash<h256>(RLP::VeryStrict);
+    }
 
-	requestStatus(_hostProtocolVersion, _hostNetworkId, _chainTotalDifficulty, _chainCurrentHash, _chainGenesisHash, snapshotBlockHash, snapshotBlockNumber);
+    requestStatus(_hostProtocolVersion, _hostNetworkId, _chainTotalDifficulty, _chainCurrentHash,
+        _chainGenesisHash, snapshotBlockHash, snapshotBlockNumber);
 }
 
 bool WarpPeerCapability::interpret(unsigned _id, RLP const& _r)
 {
-	if (!m_snapshot)
-		return false;
+    if (!m_snapshot)
+        return false;
 
-	try
-	{
-		switch (_id)
-		{
-		case WarpStatusPacket:
-		{
-			if (_r.itemCount() < 7)
-				BOOST_THROW_EXCEPTION(InvalidWarpStatusPacket());
+    try
+    {
+        switch (_id)
+        {
+        case WarpStatusPacket:
+        {
+            if (_r.itemCount() < 7)
+                BOOST_THROW_EXCEPTION(InvalidWarpStatusPacket());
 
-			auto const protocolVersion = _r[0].toInt<unsigned>(RLP::VeryStrict);
-			auto const networkId = _r[1].toInt<u256>(RLP::VeryStrict);
-			auto const totalDifficulty = _r[2].toInt<u256>(RLP::VeryStrict);
-			auto const latestHash = _r[3].toHash<h256>(RLP::VeryStrict);
-			auto const genesisHash = _r[4].toHash<h256>(RLP::VeryStrict);
-			auto const snapshotHash = _r[5].toHash<h256>(RLP::VeryStrict);
-			auto const snapshotNumber = _r[6].toInt<u256>(RLP::VeryStrict);
+            auto const protocolVersion = _r[0].toInt<unsigned>(RLP::VeryStrict);
+            auto const networkId = _r[1].toInt<u256>(RLP::VeryStrict);
+            auto const totalDifficulty = _r[2].toInt<u256>(RLP::VeryStrict);
+            auto const latestHash = _r[3].toHash<h256>(RLP::VeryStrict);
+            auto const genesisHash = _r[4].toHash<h256>(RLP::VeryStrict);
+            auto const snapshotHash = _r[5].toHash<h256>(RLP::VeryStrict);
+            auto const snapshotNumber = _r[6].toInt<u256>(RLP::VeryStrict);
 
-			clog(p2p::NetMessageSummary) << "Status: "
-				<< "protocol version " << protocolVersion
-				<< "networkId " << networkId
-				<< "genesis hash " << genesisHash
-				<< "total difficulty " << totalDifficulty
-				<< "latest hash" << latestHash
-				<< "snapshot hash" << snapshotHash
-				<< "snapshot number" << snapshotNumber;
-			break;
-		}
-		case GetSnapshotManifest:
-		{
-			RLPStream s;
-			prep(s, SnapshotManifest, 1).appendRaw(m_snapshot->readManifest());
-			sealAndSend(s);
-			break;
-		}
-		case GetSnapshotData:
-		{
-			const h256 chunkHash = _r[0].toHash<h256>(RLP::VeryStrict);
+            clog(p2p::NetMessageSummary)
+                << "Status: "
+                << "protocol version " << protocolVersion << "networkId " << networkId
+                << "genesis hash " << genesisHash << "total difficulty " << totalDifficulty
+                << "latest hash" << latestHash << "snapshot hash" << snapshotHash
+                << "snapshot number" << snapshotNumber;
+            break;
+        }
+        case GetSnapshotManifest:
+        {
+            RLPStream s;
+            prep(s, SnapshotManifest, 1).appendRaw(m_snapshot->readManifest());
+            sealAndSend(s);
+            break;
+        }
+        case GetSnapshotData:
+        {
+            const h256 chunkHash = _r[0].toHash<h256>(RLP::VeryStrict);
 
-			RLPStream s;
-			prep(s, SnapshotData, 1).append(m_snapshot->readCompressedChunk(chunkHash));
-			sealAndSend(s);
-			break;
-		}
-		case GetBlockHeadersPacket:
-		{
-			// TODO We are being asked DAO fork block sometimes, need to be able to answer this
-			RLPStream s;
-			prep(s, BlockHeadersPacket);
-			sealAndSend(s);
-			break;
-		}
-		}
-	}
-	catch (Exception const&)
-	{
-		clog(p2p::NetWarn) << "Warp Peer causing an Exception:" << boost::current_exception_diagnostic_information() << _r;
-	}
-	catch (std::exception const& _e)
-	{
-		clog(p2p::NetWarn) << "Warp Peer causing an exception:" << _e.what() << _r;
-	}
+            RLPStream s;
+            prep(s, SnapshotData, 1).append(m_snapshot->readCompressedChunk(chunkHash));
+            sealAndSend(s);
+            break;
+        }
+        case GetBlockHeadersPacket:
+        {
+            // TODO We are being asked DAO fork block sometimes, need to be able to answer this
+            RLPStream s;
+            prep(s, BlockHeadersPacket);
+            sealAndSend(s);
+            break;
+        }
+        }
+    }
+    catch (Exception const&)
+    {
+        clog(p2p::NetWarn) << "Warp Peer causing an Exception:"
+                           << boost::current_exception_diagnostic_information() << _r;
+    }
+    catch (std::exception const& _e)
+    {
+        clog(p2p::NetWarn) << "Warp Peer causing an exception:" << _e.what() << _r;
+    }
 
-	return true;
+    return true;
 }
 
-void WarpPeerCapability::requestStatus(unsigned _hostProtocolVersion, u256 const& _hostNetworkId, u256 const& _chainTotalDifficulty, h256 const& _chainCurrentHash, h256 const& _chainGenesisHash, 
-	h256 const& _snapshotBlockHash, u256 const& _snapshotBlockNumber)
+void WarpPeerCapability::requestStatus(unsigned _hostProtocolVersion, u256 const& _hostNetworkId,
+    u256 const& _chainTotalDifficulty, h256 const& _chainCurrentHash, h256 const& _chainGenesisHash,
+    h256 const& _snapshotBlockHash, u256 const& _snapshotBlockNumber)
 {
-	RLPStream s;
-	prep(s, WarpStatusPacket, 7)
-		<< _hostProtocolVersion
-		<< _hostNetworkId
-		<< _chainTotalDifficulty
-		<< _chainCurrentHash
-		<< _chainGenesisHash
-		<< _snapshotBlockHash
-		<< _snapshotBlockNumber;
-	sealAndSend(s);
+    RLPStream s;
+    prep(s, WarpStatusPacket, 7) << _hostProtocolVersion << _hostNetworkId << _chainTotalDifficulty
+                                 << _chainCurrentHash << _chainGenesisHash << _snapshotBlockHash
+                                 << _snapshotBlockNumber;
+    sealAndSend(s);
 }
 
-}
-}
+}  // namespace eth
+}  // namespace dev

--- a/libethereum/WarpPeerCapability.cpp
+++ b/libethereum/WarpPeerCapability.cpp
@@ -1,0 +1,138 @@
+/*
+	This file is part of cpp-ethereum.
+
+	cpp-ethereum is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	cpp-ethereum is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "WarpPeerCapability.h"
+#include "SnapshotStorage.h"
+
+#include "libethcore/Exceptions.h"
+
+namespace dev
+{
+namespace eth
+{
+
+WarpPeerCapability::WarpPeerCapability(std::shared_ptr<p2p::SessionFace> _s, p2p::HostCapabilityFace* _h, unsigned _i, p2p::CapDesc const& /* _cap */):
+	Capability(_s, _h, _i)
+{
+}
+
+void WarpPeerCapability::init(unsigned _hostProtocolVersion, u256 _hostNetworkId, u256 _chainTotalDifficulty, h256 _chainCurrentHash, h256 _chainGenesisHash, std::shared_ptr<SnapshotStorageFace const> _snapshot)
+{
+	m_snapshot = _snapshot;
+	
+	h256 snapshotBlockHash;
+	u256 snapshotBlockNumber;
+	if (m_snapshot)
+	{
+		bytes const snapshotManifest(m_snapshot->readManifest());
+		RLP manifest(snapshotManifest);
+		if (manifest.itemCount() != 6)
+			BOOST_THROW_EXCEPTION(InvalidSnapshotManifest());
+		snapshotBlockNumber = manifest[4].toInt<u256>(RLP::VeryStrict);
+		snapshotBlockHash = manifest[5].toHash<h256>(RLP::VeryStrict);
+	}
+
+	requestStatus(_hostProtocolVersion, _hostNetworkId, _chainTotalDifficulty, _chainCurrentHash, _chainGenesisHash, snapshotBlockHash, snapshotBlockNumber);
+}
+
+bool WarpPeerCapability::interpret(unsigned _id, RLP const& _r)
+{
+	if (!m_snapshot)
+		return false;
+
+	try
+	{
+		switch (_id)
+		{
+		case WarpStatusPacket:
+		{
+			if (_r.itemCount() < 7)
+				BOOST_THROW_EXCEPTION(InvalidWarpStatusPacket());
+
+			auto const protocolVersion = _r[0].toInt<unsigned>(RLP::VeryStrict);
+			auto const networkId = _r[1].toInt<u256>(RLP::VeryStrict);
+			auto const totalDifficulty = _r[2].toInt<u256>(RLP::VeryStrict);
+			auto const latestHash = _r[3].toHash<h256>(RLP::VeryStrict);
+			auto const genesisHash = _r[4].toHash<h256>(RLP::VeryStrict);
+			auto const snapshotHash = _r[5].toHash<h256>(RLP::VeryStrict);
+			auto const snapshotNumber = _r[6].toInt<u256>(RLP::VeryStrict);
+
+			clog(p2p::NetMessageSummary) << "Status: "
+				<< "protocol version " << protocolVersion
+				<< "networkId " << networkId
+				<< "genesis hash " << genesisHash
+				<< "total difficulty " << totalDifficulty
+				<< "latest hash" << latestHash
+				<< "snapshot hash" << snapshotHash
+				<< "snapshot number" << snapshotNumber;
+			break;
+		}
+		case GetSnapshotManifest:
+		{
+			RLPStream s;
+			prep(s, SnapshotManifest, 1).appendRaw(m_snapshot->readManifest());
+			sealAndSend(s);
+			break;
+		}
+		case GetSnapshotData:
+		{
+			const h256 chunkHash = _r[0].toHash<h256>(RLP::VeryStrict);
+
+			RLPStream s;
+			prep(s, SnapshotData, 1).append(m_snapshot->readCompressedChunk(chunkHash));
+			sealAndSend(s);
+			break;
+		}
+		case GetBlockHeadersPacket:
+		{
+			// TODO We are being asked DAO fork block sometimes, need to be able to answer this
+			RLPStream s;
+			prep(s, BlockHeadersPacket);
+			sealAndSend(s);
+			break;
+		}
+		}
+	}
+	catch (Exception const&)
+	{
+		clog(p2p::NetWarn) << "Warp Peer causing an Exception:" << boost::current_exception_diagnostic_information() << _r;
+	}
+	catch (std::exception const& _e)
+	{
+		clog(p2p::NetWarn) << "Warp Peer causing an exception:" << _e.what() << _r;
+	}
+
+	return true;
+}
+
+void WarpPeerCapability::requestStatus(unsigned _hostProtocolVersion, u256 const& _hostNetworkId, u256 const& _chainTotalDifficulty, h256 const& _chainCurrentHash, h256 const& _chainGenesisHash, 
+	h256 const& _snapshotBlockHash, u256 const& _snapshotBlockNumber)
+{
+	RLPStream s;
+	prep(s, WarpStatusPacket, 7)
+		<< _hostProtocolVersion
+		<< _hostNetworkId
+		<< _chainTotalDifficulty
+		<< _chainCurrentHash
+		<< _chainGenesisHash
+		<< _snapshotBlockHash
+		<< _snapshotBlockNumber;
+	sealAndSend(s);
+}
+
+}
+}

--- a/libethereum/WarpPeerCapability.h
+++ b/libethereum/WarpPeerCapability.h
@@ -1,0 +1,70 @@
+/*
+	This file is part of cpp-ethereum.
+
+	cpp-ethereum is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	cpp-ethereum is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "CommonNet.h"
+
+#include <libdevcore/Common.h>
+#include <libp2p/Capability.h>
+
+namespace dev
+{
+namespace eth
+{
+
+class SnapshotStorageFace;
+
+const unsigned c_WarpProtocolVersion = 1;
+
+enum WarpSubprotocolPacketType: byte
+{
+	WarpStatusPacket = 0x00,
+	GetSnapshotManifest = 0x11,
+	SnapshotManifest = 0x12,
+	GetSnapshotData = 0x13,
+	SnapshotData = 0x14,
+
+	WarpSubprotocolPacketCount
+};
+
+class WarpPeerCapability: public p2p::Capability
+{
+public:
+	WarpPeerCapability(std::shared_ptr<p2p::SessionFace> _s, p2p::HostCapabilityFace* _h, unsigned _i, p2p::CapDesc const& _cap);
+
+	static std::string name() { return "par"; }
+
+	static u256 version() { return c_WarpProtocolVersion; }
+
+	static unsigned messageCount() { return WarpSubprotocolPacketCount; }
+
+	void init(unsigned _hostProtocolVersion, u256 _hostNetworkId, u256 _chainTotalDifficulty, h256 _chainCurrentHash, h256 _chainGenesisHash, std::shared_ptr<SnapshotStorageFace const> _snapshot);
+
+private:
+	using p2p::Capability::sealAndSend;
+
+	bool interpret(unsigned _id, RLP const& _r) override;
+
+	void requestStatus(unsigned _hostProtocolVersion, u256 const& _hostNetworkId, u256 const& _chainTotalDifficulty, h256 const& _chainCurrentHash, h256 const& _chainGenesisHash,
+		h256 const& _snapshotBlockHash, u256 const& _snapshotBlockNumber);
+
+	std::shared_ptr<SnapshotStorageFace const> m_snapshot;
+};
+
+}
+}

--- a/libethereum/WarpPeerCapability.h
+++ b/libethereum/WarpPeerCapability.h
@@ -1,18 +1,18 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 #pragma once
@@ -26,45 +26,49 @@ namespace dev
 {
 namespace eth
 {
-
 class SnapshotStorageFace;
 
 const unsigned c_WarpProtocolVersion = 1;
 
-enum WarpSubprotocolPacketType: byte
+enum WarpSubprotocolPacketType : byte
 {
-	WarpStatusPacket = 0x00,
-	GetSnapshotManifest = 0x11,
-	SnapshotManifest = 0x12,
-	GetSnapshotData = 0x13,
-	SnapshotData = 0x14,
+    WarpStatusPacket = 0x00,
+    GetSnapshotManifest = 0x11,
+    SnapshotManifest = 0x12,
+    GetSnapshotData = 0x13,
+    SnapshotData = 0x14,
 
-	WarpSubprotocolPacketCount
+    WarpSubprotocolPacketCount
 };
 
-class WarpPeerCapability: public p2p::Capability
+class WarpPeerCapability : public p2p::Capability
 {
 public:
-	WarpPeerCapability(std::shared_ptr<p2p::SessionFace> _s, p2p::HostCapabilityFace* _h, unsigned _i, p2p::CapDesc const& _cap);
+    WarpPeerCapability(std::shared_ptr<p2p::SessionFace> _s, p2p::HostCapabilityFace* _h,
+        unsigned _i, p2p::CapDesc const& _cap);
 
-	static std::string name() { return "par"; }
+    static std::string name() { return "par"; }
 
-	static u256 version() { return c_WarpProtocolVersion; }
+    static u256 version() { return c_WarpProtocolVersion; }
 
-	static unsigned messageCount() { return WarpSubprotocolPacketCount; }
+    static unsigned messageCount() { return WarpSubprotocolPacketCount; }
 
-	void init(unsigned _hostProtocolVersion, u256 _hostNetworkId, u256 _chainTotalDifficulty, h256 _chainCurrentHash, h256 _chainGenesisHash, std::shared_ptr<SnapshotStorageFace const> _snapshot);
+    void init(unsigned _hostProtocolVersion, u256 _hostNetworkId, u256 _chainTotalDifficulty,
+        h256 _chainCurrentHash, h256 _chainGenesisHash,
+        std::shared_ptr<SnapshotStorageFace const> _snapshot);
 
 private:
-	using p2p::Capability::sealAndSend;
+    using p2p::Capability::sealAndSend;
 
-	bool interpret(unsigned _id, RLP const& _r) override;
+    bool interpret(unsigned _id, RLP const& _r) override;
 
-	void requestStatus(unsigned _hostProtocolVersion, u256 const& _hostNetworkId, u256 const& _chainTotalDifficulty, h256 const& _chainCurrentHash, h256 const& _chainGenesisHash,
-		h256 const& _snapshotBlockHash, u256 const& _snapshotBlockNumber);
+    void requestStatus(unsigned _hostProtocolVersion, u256 const& _hostNetworkId,
+        u256 const& _chainTotalDifficulty, h256 const& _chainCurrentHash,
+        h256 const& _chainGenesisHash, h256 const& _snapshotBlockHash,
+        u256 const& _snapshotBlockNumber);
 
-	std::shared_ptr<SnapshotStorageFace const> m_snapshot;
+    std::shared_ptr<SnapshotStorageFace const> m_snapshot;
 };
 
-}
-}
+}  // namespace eth
+}  // namespace dev

--- a/test/unittests/libethereum/SnapshotImporterTest.cpp
+++ b/test/unittests/libethereum/SnapshotImporterTest.cpp
@@ -97,6 +97,7 @@ namespace
 			auto it = chunks.find(_chunkHash);
 			return it == chunks.end() ? std::string{} : std::string(it->second.begin(), it->second.end());
 		}
+		void copyTo(boost::filesystem::path const&) const override {}
 
 		bytes manifest;
 		std::map<h256, bytes> chunks;

--- a/test/unittests/libethereum/SnapshotImporterTest.cpp
+++ b/test/unittests/libethereum/SnapshotImporterTest.cpp
@@ -92,15 +92,15 @@ namespace
 	{
 	public:
 		bytes readManifest() const override { return manifest; }
-		std::string readCompressedChunk(h256 const&) const override { return std::string(); }
-		std::string readChunk(h256 const& _chunkHash) const override
+        std::string readCompressedChunk(h256 const&) const override { return std::string(); }
+        std::string readChunk(h256 const& _chunkHash) const override
 		{ 
 			auto it = chunks.find(_chunkHash);
 			return it == chunks.end() ? std::string{} : std::string(it->second.begin(), it->second.end());
 		}
-		void copyTo(boost::filesystem::path const&) const override {}
+        void copyTo(boost::filesystem::path const&) const override {}
 
-		bytes manifest;
+        bytes manifest;
 		std::map<h256, bytes> chunks;
 	};
 
@@ -199,7 +199,8 @@ BOOST_AUTO_TEST_CASE(SnapshotImporterSuite_importChecksManifestVersion)
 	s << h256{} << 0 << h256{};
 	snapshotStorage.manifest = createManifest(3, {}, {}, h256{}, 0, h256{});
 
-	BOOST_REQUIRE_THROW(snapshotImporter.import(snapshotStorage, h256{}), UnsupportedSnapshotManifestVersion);
+    BOOST_REQUIRE_THROW(
+        snapshotImporter.import(snapshotStorage, h256{}), UnsupportedSnapshotManifestVersion);
 }
 
 BOOST_AUTO_TEST_CASE(SnapshotImporterSuite_importNonsplittedAccount)
@@ -211,10 +212,10 @@ BOOST_AUTO_TEST_CASE(SnapshotImporterSuite_importNonsplittedAccount)
 	h256 addressHash = sha3("456");
 	bytes chunkBytes = createStateChunk({{addressHash, account}});
 	snapshotStorage.chunks[stateChunk] = chunkBytes;
-	
-	snapshotImporter.import(snapshotStorage, h256{});
 
-	BOOST_REQUIRE_EQUAL(stateImporter.importedAccounts.size(), 1);
+    snapshotImporter.import(snapshotStorage, h256{});
+
+    BOOST_REQUIRE_EQUAL(stateImporter.importedAccounts.size(), 1);
 	h256 const& importedAddress = stateImporter.importedAccounts.begin()->first;
 	BOOST_CHECK_EQUAL(importedAddress, addressHash);
 	ImportedAccount const& importedAccount = stateImporter.importedAccounts.begin()->second;
@@ -243,9 +244,9 @@ BOOST_AUTO_TEST_CASE(SnapshotImporterSuite_importSplittedAccount)
 	bytes chunk2 = createStateChunk({{addressHash, accountPart2}});
 	snapshotStorage.chunks[stateChunk2] = chunk2;
 
-	snapshotImporter.import(snapshotStorage, h256{});
+    snapshotImporter.import(snapshotStorage, h256{});
 
-	BOOST_REQUIRE_EQUAL(stateImporter.importedAccounts.size(), 1);
+    BOOST_REQUIRE_EQUAL(stateImporter.importedAccounts.size(), 1);
 	h256 const& importedAddress = stateImporter.importedAccounts.begin()->first;
 	BOOST_CHECK_EQUAL(importedAddress, addressHash);
 	ImportedAccount const& importedAccount = stateImporter.importedAccounts.begin()->second;
@@ -268,9 +269,9 @@ BOOST_AUTO_TEST_CASE(SnapshotImporterSuite_importAccountWithCode)
 	bytes chunkBytes = createStateChunk({{addressHash, account}});
 	snapshotStorage.chunks[stateChunk] = chunkBytes;
 
-	snapshotImporter.import(snapshotStorage, h256{});
+    snapshotImporter.import(snapshotStorage, h256{});
 
-	BOOST_REQUIRE_EQUAL(stateImporter.importedAccounts.size(), 1);
+    BOOST_REQUIRE_EQUAL(stateImporter.importedAccounts.size(), 1);
 	h256 const& importedAddress = stateImporter.importedAccounts.begin()->first;
 	BOOST_CHECK_EQUAL(importedAddress, addressHash);
 	ImportedAccount const& importedAccount = stateImporter.importedAccounts.begin()->second;
@@ -296,9 +297,9 @@ BOOST_AUTO_TEST_CASE(SnapshotImporterSuite_importAccountsWithEqualCode)
 
 	snapshotStorage.chunks[stateChunk] = createStateChunk({{addressHash1, account1}, {addressHash2, account2}});
 
-	snapshotImporter.import(snapshotStorage, h256{});
+    snapshotImporter.import(snapshotStorage, h256{});
 
-	BOOST_REQUIRE_EQUAL(stateImporter.importedAccounts.size(), 2);
+    BOOST_REQUIRE_EQUAL(stateImporter.importedAccounts.size(), 2);
 	BOOST_CHECK(stateImporter.importedAccounts.count(addressHash1) > 0);
 	BOOST_CHECK_EQUAL(stateImporter.importedAccounts[addressHash1].codeHash, codeHash);
 	BOOST_CHECK(stateImporter.importedAccounts.count(addressHash2) > 0);
@@ -325,9 +326,9 @@ BOOST_AUTO_TEST_CASE(SnapshotImporterSuite_commitStateOnceEveryChunk)
 	bytes chunk2 = createStateChunk({{addressHash2, accountPart2}});
 	snapshotStorage.chunks[stateChunk2] = chunk2;
 
-	snapshotImporter.import(snapshotStorage, h256{});
+    snapshotImporter.import(snapshotStorage, h256{});
 
-	BOOST_REQUIRE_EQUAL(stateImporter.importedAccounts.size(), 2);
+    BOOST_REQUIRE_EQUAL(stateImporter.importedAccounts.size(), 2);
 	BOOST_REQUIRE_EQUAL(stateImporter.commitCounter, 2);
 }
 
@@ -355,9 +356,9 @@ BOOST_AUTO_TEST_CASE(SnapshotImporterSuite_importEmptyBlock)
 	bytes chunkBytes = createSingleBlockChunk(parentNumber, parentHash, parentTotalDifficulty, block, RLPEmptyList);
 	snapshotStorage.chunks[blockChunk] = chunkBytes;
 
-	snapshotImporter.import(snapshotStorage, h256{});
+    snapshotImporter.import(snapshotStorage, h256{});
 
-	BOOST_REQUIRE_EQUAL(blockChainImporter.importedBlocks.size(), 1);
+    BOOST_REQUIRE_EQUAL(blockChainImporter.importedBlocks.size(), 1);
 	ImportedBlock const& importedBlock = blockChainImporter.importedBlocks.front();
 	BlockHeader const& header = importedBlock.header;
 	BOOST_CHECK_EQUAL(header.author(), author);
@@ -390,9 +391,9 @@ BOOST_AUTO_TEST_CASE(SnapshotImporterSuite_importBlockWithTransactions)
 	bytes chunkBytes = createSingleBlockChunk(345, sha3("678"), 910, block, receipts);
 	snapshotStorage.chunks[blockChunk] = chunkBytes;
 
-	snapshotImporter.import(snapshotStorage, h256{});
+    snapshotImporter.import(snapshotStorage, h256{});
 
-	BOOST_REQUIRE_EQUAL(blockChainImporter.importedBlocks.size(), 1);
+    BOOST_REQUIRE_EQUAL(blockChainImporter.importedBlocks.size(), 1);
 	ImportedBlock const& importedBlock = blockChainImporter.importedBlocks.front();
 	BOOST_CHECK_EQUAL_COLLECTIONS(importedBlock.transactions.begin(), importedBlock.transactions.end(), transactions.begin(), transactions.end());
 	BOOST_CHECK_EQUAL_COLLECTIONS(importedBlock.uncles.begin(), importedBlock.uncles.end(), uncles.begin(), uncles.end());

--- a/test/unittests/libethereum/SnapshotImporterTest.cpp
+++ b/test/unittests/libethereum/SnapshotImporterTest.cpp
@@ -92,6 +92,7 @@ namespace
 	{
 	public:
 		bytes readManifest() const override { return manifest; }
+		std::string readCompressedChunk(h256 const&) const override { return std::string(); }
 		std::string readChunk(h256 const& _chunkHash) const override
 		{ 
 			auto it = chunks.find(_chunkHash);
@@ -198,7 +199,7 @@ BOOST_AUTO_TEST_CASE(SnapshotImporterSuite_importChecksManifestVersion)
 	s << h256{} << 0 << h256{};
 	snapshotStorage.manifest = createManifest(3, {}, {}, h256{}, 0, h256{});
 
-	BOOST_REQUIRE_THROW(snapshotImporter.import(snapshotStorage), UnsupportedSnapshotManifestVersion);
+	BOOST_REQUIRE_THROW(snapshotImporter.import(snapshotStorage, h256{}), UnsupportedSnapshotManifestVersion);
 }
 
 BOOST_AUTO_TEST_CASE(SnapshotImporterSuite_importNonsplittedAccount)
@@ -211,7 +212,7 @@ BOOST_AUTO_TEST_CASE(SnapshotImporterSuite_importNonsplittedAccount)
 	bytes chunkBytes = createStateChunk({{addressHash, account}});
 	snapshotStorage.chunks[stateChunk] = chunkBytes;
 	
-	snapshotImporter.import(snapshotStorage);
+	snapshotImporter.import(snapshotStorage, h256{});
 
 	BOOST_REQUIRE_EQUAL(stateImporter.importedAccounts.size(), 1);
 	h256 const& importedAddress = stateImporter.importedAccounts.begin()->first;
@@ -242,7 +243,7 @@ BOOST_AUTO_TEST_CASE(SnapshotImporterSuite_importSplittedAccount)
 	bytes chunk2 = createStateChunk({{addressHash, accountPart2}});
 	snapshotStorage.chunks[stateChunk2] = chunk2;
 
-	snapshotImporter.import(snapshotStorage);
+	snapshotImporter.import(snapshotStorage, h256{});
 
 	BOOST_REQUIRE_EQUAL(stateImporter.importedAccounts.size(), 1);
 	h256 const& importedAddress = stateImporter.importedAccounts.begin()->first;
@@ -267,7 +268,7 @@ BOOST_AUTO_TEST_CASE(SnapshotImporterSuite_importAccountWithCode)
 	bytes chunkBytes = createStateChunk({{addressHash, account}});
 	snapshotStorage.chunks[stateChunk] = chunkBytes;
 
-	snapshotImporter.import(snapshotStorage);
+	snapshotImporter.import(snapshotStorage, h256{});
 
 	BOOST_REQUIRE_EQUAL(stateImporter.importedAccounts.size(), 1);
 	h256 const& importedAddress = stateImporter.importedAccounts.begin()->first;
@@ -295,7 +296,7 @@ BOOST_AUTO_TEST_CASE(SnapshotImporterSuite_importAccountsWithEqualCode)
 
 	snapshotStorage.chunks[stateChunk] = createStateChunk({{addressHash1, account1}, {addressHash2, account2}});
 
-	snapshotImporter.import(snapshotStorage);
+	snapshotImporter.import(snapshotStorage, h256{});
 
 	BOOST_REQUIRE_EQUAL(stateImporter.importedAccounts.size(), 2);
 	BOOST_CHECK(stateImporter.importedAccounts.count(addressHash1) > 0);
@@ -324,7 +325,7 @@ BOOST_AUTO_TEST_CASE(SnapshotImporterSuite_commitStateOnceEveryChunk)
 	bytes chunk2 = createStateChunk({{addressHash2, accountPart2}});
 	snapshotStorage.chunks[stateChunk2] = chunk2;
 
-	snapshotImporter.import(snapshotStorage);
+	snapshotImporter.import(snapshotStorage, h256{});
 
 	BOOST_REQUIRE_EQUAL(stateImporter.importedAccounts.size(), 2);
 	BOOST_REQUIRE_EQUAL(stateImporter.commitCounter, 2);
@@ -354,7 +355,7 @@ BOOST_AUTO_TEST_CASE(SnapshotImporterSuite_importEmptyBlock)
 	bytes chunkBytes = createSingleBlockChunk(parentNumber, parentHash, parentTotalDifficulty, block, RLPEmptyList);
 	snapshotStorage.chunks[blockChunk] = chunkBytes;
 
-	snapshotImporter.import(snapshotStorage);
+	snapshotImporter.import(snapshotStorage, h256{});
 
 	BOOST_REQUIRE_EQUAL(blockChainImporter.importedBlocks.size(), 1);
 	ImportedBlock const& importedBlock = blockChainImporter.importedBlocks.front();
@@ -389,7 +390,7 @@ BOOST_AUTO_TEST_CASE(SnapshotImporterSuite_importBlockWithTransactions)
 	bytes chunkBytes = createSingleBlockChunk(345, sha3("678"), 910, block, receipts);
 	snapshotStorage.chunks[blockChunk] = chunkBytes;
 
-	snapshotImporter.import(snapshotStorage);
+	snapshotImporter.import(snapshotStorage, h256{});
 
 	BOOST_REQUIRE_EQUAL(blockChainImporter.importedBlocks.size(), 1);
 	ImportedBlock const& importedBlock = blockChainImporter.importedBlocks.front();


### PR DESCRIPTION
1. Copy snapshot into data dir after importing it.
2. Support server-side of Warp protocol, so that cpp nodes could download snapshots from other cpp nodes.

Snapshot files won't ever change and the node will give out the same snapshot all the time.
Further improvements could support periodic generation of our own snapshots.