### PR TITLE
Move randomWord() to tests

### DIFF
--- a/libdevcore/CommonData.cpp
+++ b/libdevcore/CommonData.cpp
@@ -78,18 +78,6 @@ std::string dev::escaped(std::string const& _s, bool _all)
 }
 
 
-// FIXME: Move to test utils.
-std::string dev::randomWord()
-{
-	static std::mt19937_64 s_eng(0);
-	std::string ret(std::uniform_int_distribution<size_t>(1, 5)(s_eng), ' ');
-	char const n[] = "qwertyuiop";//asdfghjklzxcvbnmQWERTYUIOPASDFGHJKLZXCVBNM1234567890";
-	std::uniform_int_distribution<int> d(0, sizeof(n) - 2);
-	for (char& c: ret)
-		c = n[d(s_eng)];
-	return ret;
-}
-
 bytes dev::fromHex(std::string const& _s, WhenError _throw)
 {
 	unsigned s = (_s.size() >= 2 && _s[0] == '0' && _s[1] == 'x') ? 2 : 0;

--- a/libdevcore/CommonData.h
+++ b/libdevcore/CommonData.h
@@ -208,9 +208,6 @@ unsigned commonPrefix(T const& _t, _U const& _u)
 	return s;
 }
 
-/// Creates a random, printable, word.
-std::string randomWord();
-
 /// Determine bytes required to encode the given integer value. @returns 0 if @a _i is zero.
 template <class T>
 inline unsigned bytesRequired(T _i)

--- a/test/unittests/libdevcrypto/trie.cpp
+++ b/test/unittests/libdevcrypto/trie.cpp
@@ -442,6 +442,21 @@ BOOST_AUTO_TEST_CASE(moreTrieTests)
 	}
 }
 
+namespace
+{
+/// Creates a random, printable, word.
+std::string randomWord()
+{
+    static std::mt19937_64 s_eng(0);
+    std::string ret(std::uniform_int_distribution<size_t>(1, 5)(s_eng), ' ');
+    char const n[] = "qwertyuiop";  // asdfghjklzxcvbnmQWERTYUIOPASDFGHJKLZXCVBNM1234567890";
+    std::uniform_int_distribution<int> d(0, sizeof(n) - 2);
+    for (char& c : ret)
+        c = n[d(s_eng)];
+    return ret;
+}
+}
+
 BOOST_AUTO_TEST_CASE(trieLowerBound)
 {
 	cnote << "Stress-testing Trie.lower_bound...";


### PR DESCRIPTION
I wanted to test `git clang-format` so I found single FIXME and fixed it.