### PR TITLE
Enable Warp server only if we have snapshot

### DIFF
--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -20,17 +20,19 @@
  */
 
 #include "Client.h"
+#include "Block.h"
+#include "Defaults.h"
+#include "EthereumHost.h"
+#include "Executive.h"
+#include "SnapshotStorage.h"
+#include "TransactionQueue.h"
+#include <libdevcore/Log.h>
+#include <libp2p/Host.h>
+#include <boost/filesystem.hpp>
 #include <chrono>
 #include <memory>
 #include <thread>
-#include <boost/filesystem.hpp>
-#include <libdevcore/Log.h>
-#include <libp2p/Host.h>
-#include "Defaults.h"
-#include "Executive.h"
-#include "EthereumHost.h"
-#include "Block.h"
-#include "TransactionQueue.h"
+
 using namespace std;
 using namespace dev;
 using namespace dev::eth;
@@ -87,19 +89,19 @@ Client::~Client()
 
 void Client::init(p2p::Host* _extNet, fs::path const& _dbPath, WithExisting _forceAction, u256 _networkId)
 {
-	DEV_TIMED_FUNCTION_ABOVE(500);
+    DEV_TIMED_FUNCTION_ABOVE(500);
 
-	// Cannot be opened until after blockchain is open, since BlockChain may upgrade the database.
+    // Cannot be opened until after blockchain is open, since BlockChain may upgrade the database.
 	// TODO: consider returning the upgrade mechanism here. will delaying the opening of the blockchain database
 	// until after the construction.
-	m_stateDB = State::openDB(_dbPath, bc().genesisHash(), _forceAction);
+    m_stateDB = State::openDB(_dbPath, bc().genesisHash(), _forceAction);
 	// LAZY. TODO: move genesis state construction/commiting to stateDB openning and have this just take the root from the genesis block.
-	m_preSeal = bc().genesisBlock(m_stateDB);
-	m_postSeal = m_preSeal;
+    m_preSeal = bc().genesisBlock(m_stateDB);
+    m_postSeal = m_preSeal;
 
-	m_bq.setChain(bc());
+    m_bq.setChain(bc());
 
-	m_lastGetWork = std::chrono::system_clock::now() - chrono::seconds(30);
+    m_lastGetWork = std::chrono::system_clock::now() - chrono::seconds(30);
     m_tqReady = m_tq.onReady([=]() {
         this->onTransactionQueueReady();
     });  // TODO: should read m_tq->onReady(thisThread, syncTransactionQueue);
@@ -111,21 +113,26 @@ void Client::init(p2p::Host* _extNet, fs::path const& _dbPath, WithExisting _for
     bc().setOnBad([=](Exception& ex) { this->onBadBlock(ex); });
     bc().setOnBlockImport([=](BlockHeader const& _info) {
         if (auto h = m_host.lock())
-			h->onBlockImported(_info);
+            h->onBlockImported(_info);
     });
 
     if (_forceAction == WithExisting::Rescue)
-		bc().rescue(m_stateDB);
+        bc().rescue(m_stateDB);
 
-	m_gp->update(bc());
+    m_gp->update(bc());
 
 	auto host = _extNet->registerCapability(make_shared<EthereumHost>(bc(), m_stateDB, m_tq, m_bq, _networkId));
-	m_host = host;
+    m_host = host;
 
 	_extNet->addCapability(host, EthereumHost::staticName(), EthereumHost::c_oldProtocolVersion); //TODO: remove this once v61+ protocol is common
 
-    m_warpHost =
-        _extNet->registerCapability(make_shared<WarpHostCapability>(bc(), _networkId, _dbPath));
+    auto const snapshotPath = importedSnapshotPath(_dbPath, bc().genesisHash());
+    if (fs::exists(snapshotPath))
+    {
+        std::shared_ptr<SnapshotStorageFace> snapshotStorage = createSnapshotStorage(snapshotPath);
+        m_warpHost = _extNet->registerCapability(
+            make_shared<WarpHostCapability>(bc(), _networkId, snapshotStorage));
+    }
 
     if (_dbPath.size())
 		Defaults::setDBPath(_dbPath);

--- a/libethereum/SnapshotImporter.cpp
+++ b/libethereum/SnapshotImporter.cpp
@@ -68,7 +68,7 @@ void SnapshotImporter::import(SnapshotStorageFace const& _snapshotStorage, h256 
 	importBlockChunks(_snapshotStorage, blockChunkHashes);
 
     clog(SnapshotImportLog) << "Copying snapshot...";
-    _snapshotStorage.copyTo(getDataDir() / toHex(_genesisHash.ref().cropped(0, 4)) / "snapshot");
+    _snapshotStorage.copyTo(importedSnapshotPath(getDataDir(), _genesisHash));
 }
 
 void SnapshotImporter::importStateChunks(SnapshotStorageFace const& _snapshotStorage, h256s const& _stateChunkHashes, h256 const& _stateRoot)

--- a/libethereum/SnapshotStorage.cpp
+++ b/libethereum/SnapshotStorage.cpp
@@ -21,6 +21,8 @@
 
 #include <snappy.h>
 
+namespace fs = boost::filesystem;
+
 namespace dev
 {
 namespace eth
@@ -51,9 +53,7 @@ std::string snappyUncompress(std::string const& _compressed)
 class SnapshotStorage: public SnapshotStorageFace
 {
 public:
-    explicit SnapshotStorage(boost::filesystem::path const& _snapshotDir)
-      : m_snapshotDir(_snapshotDir)
-    {}
+    explicit SnapshotStorage(fs::path const& _snapshotDir) : m_snapshotDir(_snapshotDir) {}
 
     bytes readManifest() const override
 	{
@@ -87,22 +87,22 @@ public:
 		return chunkUncompressed;
 	}
 
-    void copyTo(boost::filesystem::path const& _path) const override
-    {
-        copyDirectory(m_snapshotDir, _path);
-    }
+    void copyTo(fs::path const& _path) const override { copyDirectory(m_snapshotDir, _path); }
 
 private:
-	boost::filesystem::path const m_snapshotDir;
+    fs::path const m_snapshotDir;
 };
 
 }
 
-std::unique_ptr<SnapshotStorageFace> createSnapshotStorage(
-    boost::filesystem::path const& _snapshotDirPath)
+std::unique_ptr<SnapshotStorageFace> createSnapshotStorage(fs::path const& _snapshotDirPath)
 {
 	return std::unique_ptr<SnapshotStorageFace>(new SnapshotStorage(_snapshotDirPath));
 }
 
+fs::path importedSnapshotPath(fs::path const& _dataDir, h256 const& _genesisHash)
+{
+    return _dataDir / toHex(_genesisHash.ref().cropped(0, 4)) / "snapshot";
+}
 }
 }

--- a/libethereum/SnapshotStorage.h
+++ b/libethereum/SnapshotStorage.h
@@ -55,5 +55,8 @@ public:
 
 std::unique_ptr<SnapshotStorageFace> createSnapshotStorage(
     boost::filesystem::path const& _snapshotDirPath);
+
+boost::filesystem::path importedSnapshotPath(
+    boost::filesystem::path const& _dataDir, h256 const& _genesisHash);
 }
 }

--- a/libethereum/WarpHostCapability.cpp
+++ b/libethereum/WarpHostCapability.cpp
@@ -24,13 +24,9 @@ namespace dev
 namespace eth
 {
 WarpHostCapability::WarpHostCapability(BlockChain const& _blockChain, u256 const& _networkId,
-    boost::filesystem::path const& _dataDirPath)
-  : m_blockChain(_blockChain), m_networkId(_networkId)
+    std::shared_ptr<SnapshotStorageFace> _snapshotStorage)
+  : m_blockChain(_blockChain), m_networkId(_networkId), m_snapshot(_snapshotStorage)
 {
-    boost::filesystem::path const snapshotPath =
-        _dataDirPath / toHex(m_blockChain.genesisHash().ref().cropped(0, 4)) / "snapshot";
-    if (boost::filesystem::exists(snapshotPath))
-        m_snapshot = createSnapshotStorage(snapshotPath);
 }
 
 std::shared_ptr<p2p::Capability> WarpHostCapability::newPeerCapability(

--- a/libethereum/WarpHostCapability.h
+++ b/libethereum/WarpHostCapability.h
@@ -29,7 +29,7 @@ class WarpHostCapability : public p2p::HostCapability<WarpPeerCapability>
 {
 public:
     WarpHostCapability(BlockChain const& _blockChain, u256 const& _networkId,
-        boost::filesystem::path const& _dataDirPath);
+        std::shared_ptr<SnapshotStorageFace> _snapshotStorage);
 
 protected:
     std::shared_ptr<p2p::Capability> newPeerCapability(std::shared_ptr<p2p::SessionFace> const& _s,

--- a/libethereum/WarpPeerCapability.cpp
+++ b/libethereum/WarpPeerCapability.cpp
@@ -33,19 +33,15 @@ void WarpPeerCapability::init(unsigned _hostProtocolVersion, u256 _hostNetworkId
     u256 _chainTotalDifficulty, h256 _chainCurrentHash, h256 _chainGenesisHash,
     std::shared_ptr<SnapshotStorageFace const> _snapshot)
 {
-    m_snapshot = _snapshot;
+    assert(_snapshot);
+    m_snapshot = std::move(_snapshot);
 
-    h256 snapshotBlockHash;
-    u256 snapshotBlockNumber;
-    if (m_snapshot)
-    {
-        bytes const snapshotManifest(m_snapshot->readManifest());
-        RLP manifest(snapshotManifest);
-        if (manifest.itemCount() != 6)
-            BOOST_THROW_EXCEPTION(InvalidSnapshotManifest());
-        snapshotBlockNumber = manifest[4].toInt<u256>(RLP::VeryStrict);
-        snapshotBlockHash = manifest[5].toHash<h256>(RLP::VeryStrict);
-    }
+    bytes const snapshotManifest(m_snapshot->readManifest());
+    RLP manifest(snapshotManifest);
+    if (manifest.itemCount() != 6)
+        BOOST_THROW_EXCEPTION(InvalidSnapshotManifest());
+    u256 const snapshotBlockNumber = manifest[4].toInt<u256>(RLP::VeryStrict);
+    h256 const snapshotBlockHash = manifest[5].toHash<h256>(RLP::VeryStrict);
 
     requestStatus(_hostProtocolVersion, _hostNetworkId, _chainTotalDifficulty, _chainCurrentHash,
         _chainGenesisHash, snapshotBlockHash, snapshotBlockNumber);
@@ -53,9 +49,8 @@ void WarpPeerCapability::init(unsigned _hostProtocolVersion, u256 _hostNetworkId
 
 bool WarpPeerCapability::interpret(unsigned _id, RLP const& _r)
 {
-    if (!m_snapshot)
-        return false;
-
+    assert(m_snapshot);
+    
     try
     {
         switch (_id)


### PR DESCRIPTION
Previously it always created Warp capability and reported snapshot number 0, snapshot hash 0.

Also imported snapshot path construction was duplicated in `SnapshotImporter` and `WarpHostCapability`, now it's in a single place in `importedSnapshotPath()`