### PR TITLE
Refactor random test

### DIFF
--- a/test/tools/fuzzTesting/BoostRandomCode.cpp
+++ b/test/tools/fuzzTesting/BoostRandomCode.cpp
@@ -1,59 +1,71 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** @file BoostRandomCode.cpp
- * @date 2017
- */
 
-#include <string>
+#include "BoostRandomCode.h"
+
 #include <random>
-#include <test/tools/fuzzTesting/BoostRandomCode.h>
+#include <string>
 
 namespace dev
 {
 namespace test
 {
+BoostRandomCode::BoostRandomCode()
+{
+    percentDist = IntDistrib(0, 100);
+    opCodeDist = IntDistrib(0, 255);
+    opLengDist = IntDistrib(1, 32);
+    opMemrDist = IntDistrib(0, 10485760);
+    opSmallMemrDist = IntDistrib(0, 1024);
+    uniIntDist = IntDistrib(0, 0x7fffffff);
+
+    randOpCodeGen = std::bind(opCodeDist, gen);
+    randOpLengGen = std::bind(opLengDist, gen);
+    randOpMemrGen = std::bind(opMemrDist, gen);
+    randoOpSmallMemrGen = std::bind(opSmallMemrDist, gen);
+    randUniIntGen = std::bind(uniIntDist, gen);
+}
 
 u256 BoostRandomCode::randomUniInt(u256 const& _minVal, u256 const& _maxVal)
 {
-	assert(_minVal <= _maxVal);
-	refreshSeed();
-	std::uniform_int_distribution<uint64_t> uint64Dist{0, std::numeric_limits<uint64_t>::max()};
-	u256 value = _minVal + (u256)uint64Dist(gen) % (_maxVal - _minVal);
-	return value;
+    assert(_minVal <= _maxVal);
+    refreshSeed();
+    std::uniform_int_distribution<uint64_t> uint64Dist{0, std::numeric_limits<uint64_t>::max()};
+    u256 value = _minVal + (u256)uint64Dist(gen) % (_maxVal - _minVal);
+    return value;
 }
 
 void BoostRandomCode::refreshSeed()
 {
-	if (!Options::get().randomTestSeed.is_initialized())
-	{
-		auto now = std::chrono::steady_clock::now().time_since_epoch();
-		auto timeSinceEpoch = std::chrono::duration_cast<std::chrono::nanoseconds>(now).count();
-		gen.seed(static_cast<unsigned int>(timeSinceEpoch));
-	}
-	else
-		gen.seed(Options::get().randomTestSeed.get());
+    if (!Options::get().randomTestSeed.is_initialized())
+    {
+        auto now = std::chrono::steady_clock::now().time_since_epoch();
+        auto timeSinceEpoch = std::chrono::duration_cast<std::chrono::nanoseconds>(now).count();
+        gen.seed(static_cast<unsigned int>(timeSinceEpoch));
+    }
+    else
+        gen.seed(Options::get().randomTestSeed.get());
 }
 
 uint8_t BoostRandomCode::weightedOpcode(std::vector<int>& _weights)
 {
-	refreshSeed();
-	DescreteDistrib opCodeProbability = DescreteDistrib{_weights.begin(), _weights.end()};
-	return opCodeProbability(gen);
+    refreshSeed();
+    DescreteDistrib opCodeProbability = DescreteDistrib{_weights.begin(), _weights.end()};
+    return opCodeProbability(gen);
 }
-
 }
 }

--- a/test/tools/fuzzTesting/BoostRandomCode.cpp
+++ b/test/tools/fuzzTesting/BoostRandomCode.cpp
@@ -38,32 +38,28 @@ BoostRandomCode::BoostRandomCode()
     randOpMemrGen = std::bind(opMemrDist, gen);
     randoOpSmallMemrGen = std::bind(opSmallMemrDist, gen);
     randUniIntGen = std::bind(uniIntDist, gen);
-}
 
-u256 BoostRandomCode::randomUniInt(u256 const& _minVal, u256 const& _maxVal)
-{
-    assert(_minVal <= _maxVal);
-    refreshSeed();
-    std::uniform_int_distribution<uint64_t> uint64Dist{0, std::numeric_limits<uint64_t>::max()};
-    u256 value = _minVal + (u256)uint64Dist(gen) % (_maxVal - _minVal);
-    return value;
-}
-
-void BoostRandomCode::refreshSeed()
-{
-    if (!Options::get().randomTestSeed.is_initialized())
+    auto const& seedOption = Options::get().randomTestSeed;
+    if (seedOption)
+        gen.seed(*seedOption);
+    else
     {
         auto now = std::chrono::steady_clock::now().time_since_epoch();
         auto timeSinceEpoch = std::chrono::duration_cast<std::chrono::nanoseconds>(now).count();
         gen.seed(static_cast<unsigned int>(timeSinceEpoch));
     }
-    else
-        gen.seed(Options::get().randomTestSeed.get());
 }
 
-uint8_t BoostRandomCode::weightedOpcode(std::vector<int>& _weights)
+u256 BoostRandomCode::randomUniInt(u256 const& _minVal, u256 const& _maxVal)
 {
-    refreshSeed();
+    assert(_minVal <= _maxVal);
+    std::uniform_int_distribution<uint64_t> uint64Dist{0, std::numeric_limits<uint64_t>::max()};
+    u256 value = _minVal + (u256)uint64Dist(gen) % (_maxVal - _minVal);
+    return value;
+}
+
+uint8_t BoostRandomCode::weightedOpcode(std::vector<int> const& _weights)
+{
     DescreteDistrib opCodeProbability = DescreteDistrib{_weights.begin(), _weights.end()};
     return opCodeProbability(gen);
 }

--- a/test/tools/fuzzTesting/BoostRandomCode.h
+++ b/test/tools/fuzzTesting/BoostRandomCode.h
@@ -35,21 +35,7 @@ using IntGenerator = std::function<int()>;
 class BoostRandomCode: public RandomCodeBase
 {
 public:
-	BoostRandomCode()
-	{
-		percentDist = IntDistrib (0, 100);
-		opCodeDist = IntDistrib (0, 255);
-		opLengDist = IntDistrib (1, 32);
-		opMemrDist = IntDistrib (0, 10485760);
-		opSmallMemrDist = IntDistrib (0, 1024);
-		uniIntDist = IntDistrib (0, 0x7fffffff);
-
-		randOpCodeGen = std::bind(opCodeDist, gen);
-		randOpLengGen = std::bind(opLengDist, gen);
-		randOpMemrGen = std::bind(opMemrDist, gen);
-		randoOpSmallMemrGen = std::bind(opSmallMemrDist, gen);
-		randUniIntGen = std::bind(uniIntDist, gen);
-	}
+	BoostRandomCode();
 
 	/// Generate random
 	u256 randomUniInt(u256 const& _minVal = 0, u256 const& _maxVal = std::numeric_limits<uint64_t>::max());

--- a/test/tools/fuzzTesting/BoostRandomCode.h
+++ b/test/tools/fuzzTesting/BoostRandomCode.h
@@ -1,71 +1,63 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** @file BoostRandomCode.h
- * @date 2017
- */
 
 #pragma once
-#include <string>
+
+#include "RandomCode.h"
 #include <random>
-#include <test/tools/fuzzTesting/RandomCode.h>
 
 namespace dev
 {
 namespace test
 {
-
 using IntDistrib = std::uniform_int_distribution<>;
 using DescreteDistrib = std::discrete_distribution<>;
 using IntGenerator = std::function<int()>;
 
-class BoostRandomCode: public RandomCodeBase
+class BoostRandomCode : public RandomCodeBase
 {
 public:
-	BoostRandomCode();
+    BoostRandomCode();
 
-	/// Generate random
-	u256 randomUniInt(u256 const& _minVal = 0, u256 const& _maxVal = std::numeric_limits<uint64_t>::max());
-	int randomPercent() { refreshSeed(); return percentDist(gen); }
-	int randomSmallUniInt() { refreshSeed(); return opMemrDist(gen); }
-	int randomLength32() { refreshSeed(); return randOpLengGen(); }
-	int randomSmallMemoryLength() { refreshSeed(); return randoOpSmallMemrGen(); }
-	int randomMemoryLength() { refreshSeed(); return randOpMemrGen(); }
-	uint8_t randomOpcode() { refreshSeed(); return randOpCodeGen(); }
-	uint8_t weightedOpcode(std::vector<int>& _weights);
+    /// Generate random
+    u256 randomUniInt(u256 const& _minVal = 0,
+        u256 const& _maxVal = std::numeric_limits<uint64_t>::max()) override;
+    int randomPercent() override { return percentDist(gen); }
+    int randomSmallUniInt() override { return opMemrDist(gen); }
+    int randomLength32() override { return randOpLengGen(); }
+    int randomSmallMemoryLength() override { return randoOpSmallMemrGen(); }
+    int randomMemoryLength() override { return randOpMemrGen(); }
+    uint8_t randomOpcode() override { return randOpCodeGen(); }
+    uint8_t weightedOpcode(std::vector<int> const& _weights) override;
 
 private:
-	std::mt19937_64 gen;					///< Random generator
-	IntDistrib opCodeDist;					///< 0..255 opcodes
-	IntDistrib percentDist;					///< 0..100 percent
-	IntDistrib opLengDist;					///< 1..32  byte string
-	IntDistrib opMemrDist;					///< 1..10MB  byte string
-	IntDistrib opSmallMemrDist;				/// 0..1kb
-	IntDistrib uniIntDist;					///< 0..0x7fffffff
+    std::mt19937_64 gen;         ///< Random generator
+    IntDistrib opCodeDist;       ///< 0..255 opcodes
+    IntDistrib percentDist;      ///< 0..100 percent
+    IntDistrib opLengDist;       ///< 1..32  byte string
+    IntDistrib opMemrDist;       ///< 1..10MB  byte string
+    IntDistrib opSmallMemrDist;  /// 0..1kb
+    IntDistrib uniIntDist;       ///< 0..0x7fffffff
 
-	IntGenerator randUniIntGen;				///< Generate random UniformInt from uniIntDist
-	IntGenerator randOpCodeGen;				///< Generate random value from opCodeDist
-	IntGenerator randOpLengGen;				///< Generate random length from opLengDist
-	IntGenerator randOpMemrGen;				///< Generate random length from opMemrDist
-	IntGenerator randoOpSmallMemrGen;		///< Generate random length from opSmallMemrDist
-
-	void refreshSeed();
-
+    IntGenerator randUniIntGen;        ///< Generate random UniformInt from uniIntDist
+    IntGenerator randOpCodeGen;        ///< Generate random value from opCodeDist
+    IntGenerator randOpLengGen;        ///< Generate random length from opLengDist
+    IntGenerator randOpMemrGen;        ///< Generate random length from opMemrDist
+    IntGenerator randoOpSmallMemrGen;  ///< Generate random length from opSmallMemrDist
 };
-
-
 }
 }

--- a/test/tools/fuzzTesting/RandomCode.h
+++ b/test/tools/fuzzTesting/RandomCode.h
@@ -111,7 +111,7 @@ public:
 	virtual int randomSmallMemoryLength() = 0;
 	virtual int randomMemoryLength() = 0;
 	virtual uint8_t randomOpcode() = 0;
-	virtual uint8_t weightedOpcode(std::vector<int>& _weights) = 0;
+	virtual uint8_t weightedOpcode(std::vector<int> const& _weights) = 0;
 
 private:
 	std::vector<std::string> getTypes();

--- a/test/tools/fuzzTesting/fuzzHelper.cpp
+++ b/test/tools/fuzzTesting/fuzzHelper.cpp
@@ -264,7 +264,7 @@ std::string RandomCodeBase::generate(int _maxOpNumber, RandomCodeOptions const& 
 		return code;
 
 	//generate [0 ... _maxOpNumber] opcodes.
-	int size = (int)(test::RandomCode::get().randomPercent() * _maxOpNumber / 100);
+	int size = test::RandomCode::get().randomPercent() * _maxOpNumber / 100;
 	assert(size <= _maxOpNumber);
 
 	for (auto i = 0; i < size; i++)

--- a/test/tools/libtesteth/boostTest.cpp
+++ b/test/tools/libtesteth/boostTest.cpp
@@ -141,22 +141,36 @@ int main( int argc, char* argv[] )
 	dev::test::Options const& opt = dev::test::Options::get();
 	if (opt.createRandomTest || opt.singleTestFile.is_initialized())
 	{
-		// Disable initial output as the random test will output valid json to std
-		oldCoutStreamBuf = std::cout.rdbuf();
-		oldCerrStreamBuf = std::cerr.rdbuf();
-		std::cout.rdbuf(strCout.rdbuf());
-		std::cerr.rdbuf(strCout.rdbuf());
-
+		bool testSuiteFound = false;
 		for (int i = 0; i < argc; i++)
 		{
 			// replace test suite to custom tests
 			std::string arg = std::string{argv[i]};
 			if (arg == "-t" && i+1 < argc)
 			{
+				testSuiteFound = true;
 				argv[i + 1] = (char*)dynamicTestSuiteName.c_str();
 				break;
 			}
 		}
+
+		// BOOST ERROR could not be used here because boost main is not initialized
+		if (!testSuiteFound && opt.createRandomTest)
+		{
+			std::cerr << "createRandomTest requires a test suite to be set -t <TestSuite>\n";
+			return -1;
+		}
+		if (!testSuiteFound && opt.singleTestFile.is_initialized())
+		{
+			std::cerr << "singletest <file> <testname>  requires a test suite to be set -t <TestSuite>\n";
+			return -1;
+		}
+
+		// Disable initial output as the random test will output valid json to std
+		oldCoutStreamBuf = std::cout.rdbuf();
+		oldCerrStreamBuf = std::cerr.rdbuf();
+		std::cout.rdbuf(strCout.rdbuf());
+		std::cerr.rdbuf(strCout.rdbuf());
 
 		// add custom test suite
 		test_suite* ts1 = BOOST_TEST_SUITE("customTestSuite");


### PR DESCRIPTION
The contains a lot of code cleanups (using `override`, code formatting, etc), but the main goal to try to fix rndCode test on macOS.

Now the seed for BoostRandomCode is set once (it gets if from `test::Options` what is another dependency hiding anti-pattern). Not generating code should not reach for system clock for every random number.