### PR TITLE
Fix testeth VmTest false account creations and deletions

### DIFF
--- a/test/tools/jsontests/vm.h
+++ b/test/tools/jsontests/vm.h
@@ -58,7 +58,7 @@ public:
 	virtual bool exists(Address _a) override { return !!addresses.count(_a); }
 	virtual u256 balance(Address _a) override { return exists(_a) ? std::get<0>(addresses[_a]) : u256(); }
 	virtual void suicide(Address _a) override { std::get<0>(addresses[_a]) += std::get<0>(addresses[myAddress]); addresses.erase(myAddress); }
-	virtual bytes const& codeAt(Address _a) override { return std::get<3>(addresses[_a]); }
+	virtual bytes const& codeAt(Address _a) override { return exists(_a) ? std::get<3>(addresses[_a]) : defaultCode; }
 	virtual size_t codeSizeAt(Address _a) override { return std::get<3>(addresses[_a]).size(); }
 	virtual std::pair<h160, eth::owning_bytes_ref> create(u256 _endowment, u256& io_gas, bytesConstRef _init, eth::Instruction _op, u256 _salt, eth::OnOpFunc const&) override;
 	virtual std::pair<bool, eth::owning_bytes_ref> call(eth::CallParameters&) override;
@@ -81,6 +81,7 @@ public:
 
 	std::map<Address, std::tuple<u256, u256, std::map<u256, u256>, bytes>> addresses;
 	eth::Transactions callcreates;
+	bytes defaultCode;
 	bytes thisTxData;
 	bytes thisTxCode;
 	u256 gas;

--- a/test/tools/jsontests/vm.h
+++ b/test/tools/jsontests/vm.h
@@ -57,9 +57,9 @@ public:
 	virtual void setStore(u256 _n, u256 _v) override { std::get<2>(addresses[myAddress])[_n] = _v; }
 	virtual bool exists(Address _a) override { return !!addresses.count(_a); }
 	virtual u256 balance(Address _a) override { return exists(_a) ? std::get<0>(addresses[_a]) : u256(); }
-	virtual void suicide(Address _a) override { std::get<0>(addresses[_a]) += std::get<0>(addresses[myAddress]); addresses.erase(myAddress); }
+	virtual void suicide(Address _a) override { std::get<0>(addresses[_a]) += std::get<0>(addresses[myAddress]); }
 	virtual bytes const& codeAt(Address _a) override { return exists(_a) ? std::get<3>(addresses[_a]) : defaultCode; }
-	virtual size_t codeSizeAt(Address _a) override { return std::get<3>(addresses[_a]).size(); }
+	virtual size_t codeSizeAt(Address _a) override { return codeAt(_a).size(); }
 	virtual std::pair<h160, eth::owning_bytes_ref> create(u256 _endowment, u256& io_gas, bytesConstRef _init, eth::Instruction _op, u256 _salt, eth::OnOpFunc const&) override;
 	virtual std::pair<bool, eth::owning_bytes_ref> call(eth::CallParameters&) override;
 	virtual h256 blockHash(u256 _number) override;

--- a/test/tools/jsontests/vm.h
+++ b/test/tools/jsontests/vm.h
@@ -56,7 +56,7 @@ public:
 	virtual u256 store(u256 _n) override { return std::get<2>(addresses[myAddress])[_n]; }
 	virtual void setStore(u256 _n, u256 _v) override { std::get<2>(addresses[myAddress])[_n] = _v; }
 	virtual bool exists(Address _a) override { return !!addresses.count(_a); }
-	virtual u256 balance(Address _a) override { return std::get<0>(addresses[_a]); }
+	virtual u256 balance(Address _a) override { return exists(_a) ? std::get<0>(addresses[_a]) : u256(); }
 	virtual void suicide(Address _a) override { std::get<0>(addresses[_a]) += std::get<0>(addresses[myAddress]); addresses.erase(myAddress); }
 	virtual bytes const& codeAt(Address _a) override { return std::get<3>(addresses[_a]); }
 	virtual size_t codeSizeAt(Address _a) override { return std::get<3>(addresses[_a]).size(); }


### PR DESCRIPTION
It seems like the `VMTest` filler currently creates and deletes accounts in situations that deviate from the Ethereum specification:

* The `BALANCE` operation should not be able to create accounts. If the account whose balance is being looked up does not exist, the operation should simply push `0` onto the stack and not modify world state.
* The `EXTCODECOPY` operation has a similar issue as `BALANCE` in the sense that a default value should be returned when the account subject to the lookup does not exist.
* The `EXTCODESIZE` operation has a similar issue as `BALANCE` and `EXTCODECOPY` in the sense that a default value should be returned when the account subject to the lookup does not exist.
* The `SELFDESTRUCT` (formerly `SUICIDE`) operation should not be able to delete accounts. It should only mark the corresponding account for deletion (by adding it to the self-destruct set held within the transaction substate).

At the crux of the account creation issue in `BALANCE`, `EXTCODECOPY`, and `EXTCODESIZE` is that the `std::map` that holds the address-to-account mapping is not checked to see whether or not the address exists before performing the lookup. As a result, per `std::map`'s `operation[]` semantics the entry is default constructed for these non-existent addresses -- adding them to the world state.