### PR TITLE
Move VM options to evm library

### DIFF
--- a/cmake/EthOptions.cmake
+++ b/cmake/EthOptions.cmake
@@ -39,13 +39,6 @@ macro(configure_project)
 		endif ()
 	endif ()
 
-	# Are we including the JIT EVM module?
-	# That pulls in a quite heavyweight LLVM dependency, which is
-	# not suitable for all platforms.
-	if (EVMJIT)
-		add_definitions(-DETH_EVMJIT)
-	endif ()
-
 	# FATDB is an option to include the reverse hashes for the trie,
 	# i.e. it allows you to iterate over the contents of the state.
 	if (FATDB)

--- a/eth/main.cpp
+++ b/eth/main.cpp
@@ -361,7 +361,7 @@ int main(int argc, char** argv)
         .add(clientMining)
         .add(clientNetworking)
         .add(importExportMode)
-        .add(getVMOptions(c_lineWidth))
+        .add(vmProgramOptions(c_lineWidth))
         .add(generalOptions);
 
 	po::variables_map vm;

--- a/eth/main.cpp
+++ b/eth/main.cpp
@@ -350,16 +350,19 @@ int main(int argc, char** argv)
 	po::options_description generalOptions("General Options", c_lineWidth);
 	generalOptions.add_options()
 		("db-path,d", po::value<string>()->value_name("<path>"), ("Load database from path\n(default: " + getDataDir().string() + ").\n").c_str())
-#if ETH_EVMJIT
-		("vm", po::value<string>()->value_name("<vm-kind>")->default_value("interpreter"), "Select VM implementation; options are: interpreter, jit or smart")
-#endif // ETH_EVMJIT
 		("verbosity,v", po::value<int>()->value_name("<0 - 9>"), "Set the log verbosity from 0 to 9 (default: 8).")
 		("version,V",  "Show the version and exit.")
 		("help,h",  "Show this help message and exit.\n");
 
 
-	po::options_description allowedOptions("Allowed options");
-	allowedOptions.add(clientDefaultMode).add(clientTransacting).add(clientMining).add(clientNetworking).add(importExportMode).add(generalOptions);
+    po::options_description allowedOptions("Allowed options");
+    allowedOptions.add(clientDefaultMode)
+        .add(clientTransacting)
+        .add(clientMining)
+        .add(clientNetworking)
+        .add(importExportMode)
+        .add(getVMOptions(c_lineWidth))
+        .add(generalOptions);
 
 	po::variables_map vm;
 	vector<string> unrecognisedOptions;
@@ -382,23 +385,6 @@ int main(int argc, char** argv)
 			return -1;
 		}
 
-#if ETH_EVMJIT
-	if (vm.count("vm"))
-	{
-		string vmKind = vm["vm"].as<string>();
-		if (vmKind == "interpreter")
-			VMFactory::setKind(VMKind::Interpreter);
-		else if (vmKind == "jit")
-			VMFactory::setKind(VMKind::JIT);
-		else if (vmKind == "smart")
-			VMFactory::setKind(VMKind::Smart);
-		else
-		{
-			cerr << "Unknown VM kind: " << vmKind << "\n";
-			return -1;
-		}
-	}
-#endif
 	if (vm.count("import-snapshot"))
 	{
 		mode = OperationMode::ImportSnapshot;

--- a/ethvm/main.cpp
+++ b/ethvm/main.cpp
@@ -163,7 +163,7 @@ int main(int argc, char** argv)
 
     po::options_description allowedOptions(
         "Usage ethvm <options> [trace|stats|output|test] (<file>|-)");
-    allowedOptions.add(getVMOptions(c_lineWidth))
+    allowedOptions.add(vmProgramOptions(c_lineWidth))
         .add(networkOptions)
         .add(optionsForTrace)
         .add(generalOptions)

--- a/libevm/CMakeLists.txt
+++ b/libevm/CMakeLists.txt
@@ -26,4 +26,5 @@ target_include_directories(evm PUBLIC ${CMAKE_SOURCE_DIR}/evmjit/include)
 
 if (EVMJIT)
 	target_link_libraries(evm PRIVATE evmjit)
+	target_compile_definitions(evm PRIVATE ETH_EVMJIT)
 endif()

--- a/libevm/CMakeLists.txt
+++ b/libevm/CMakeLists.txt
@@ -21,7 +21,7 @@ file(GLOB HEADERS "*.h")
 
 add_library(evm ${SOURCES} ${HEADERS})
 
-target_link_libraries(evm PUBLIC ethcore devcore PRIVATE jsoncpp_lib_static)
+target_link_libraries(evm PUBLIC ethcore devcore PRIVATE jsoncpp_lib_static Boost::program_options)
 target_include_directories(evm PUBLIC ${CMAKE_SOURCE_DIR}/evmjit/include)
 
 if (EVMJIT)

--- a/libevm/VMFactory.cpp
+++ b/libevm/VMFactory.cpp
@@ -79,7 +79,7 @@ void validate(boost::any& v, const std::vector<std::string>& values, VMKind* /* 
     throw po::validation_error(po::validation_error::invalid_option_value);
 }
 
-po::options_description getVMOptions(unsigned _lineLength)
+po::options_description vmProgramOptions(unsigned _lineLength)
 {
     // It must be a static object because boost expects const char*.
     static const std::string description = [] {

--- a/libevm/VMFactory.cpp
+++ b/libevm/VMFactory.cpp
@@ -81,13 +81,26 @@ void validate(boost::any& v, const std::vector<std::string>& values, VMKind* /* 
 
 po::options_description getVMOptions(unsigned _lineLength)
 {
+    // It must be a static object because boost expects const char*.
+    static const std::string description = [] {
+        std::string names;
+        for (auto& entry : vmKindsTable)
+        {
+            if (!names.empty())
+                names += ", ";
+            names += entry.name;
+        }
+
+        return "Select VM implementation. Available options are: " + names + ".";
+    }();
+
     po::options_description opts("VM Options", _lineLength);
     opts.add_options()("vm",
         po::value<VMKind>()
             ->value_name("<name>")
             ->default_value(VMKind::Interpreter, "interpreter")
             ->notifier(VMFactory::setKind),
-        "Select VM implementation; options are: interpreter, jit or smart");
+        description.data());
 
     return opts;
 }

--- a/libevm/VMFactory.h
+++ b/libevm/VMFactory.h
@@ -31,6 +31,10 @@ enum class VMKind
 	Smart
 };
 
+/// Provide a set of program options related to VMs.
+///
+/// @param _lineLength  The line length for description text wrapping, the same as in
+///                     boost::program_options::options_description::options_description().
 boost::program_options::options_description getVMOptions(
     unsigned _lineLength = boost::program_options::options_description::m_default_line_length);
 

--- a/libevm/VMFactory.h
+++ b/libevm/VMFactory.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "VMFace.h"
+#include <boost/program_options/options_description.hpp>
 
 namespace dev
 {
@@ -29,6 +30,9 @@ enum class VMKind
 	JIT,
 	Smart
 };
+
+boost::program_options::options_description getVMOptions(
+    unsigned _lineLength = boost::program_options::options_description::m_default_line_length);
 
 class VMFactory
 {

--- a/libevm/VMFactory.h
+++ b/libevm/VMFactory.h
@@ -35,7 +35,7 @@ enum class VMKind
 ///
 /// @param _lineLength  The line length for description text wrapping, the same as in
 ///                     boost::program_options::options_description::options_description().
-boost::program_options::options_description getVMOptions(
+boost::program_options::options_description vmProgramOptions(
     unsigned _lineLength = boost::program_options::options_description::m_default_line_length);
 
 class VMFactory


### PR DESCRIPTION
I'm kinda proud of this idea. The VM program options definition was moved to libevm, easy accessible by eth and ethvm. 

It also includes custom verifier for VMKind option. This part might not be perfect. boost::program_options does not handle sets of values by default. I have to list the available options manually...