### PR TITLE
store randomcode seed on macOS

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -69,6 +69,11 @@ defaults:
       path: ~/build/test/testeth
       destination: testeth
 
+  store-randomcode-seed: &store-randomcode-seed
+    store_artifacts:
+      path: ~/build/test/randomCodeSeed.txt
+      destination: randomCodeSeed.txt
+
   save-deps-cache: &save-deps-cache
     cache-save:
       name: "Save dependencies cache"
@@ -177,6 +182,7 @@ jobs:
       - *store-testeth
       - *restore-ethash-dag
       - *test
+      - *store-randomcode-seed
       - *save-ethash-dag
       - *upload-coverage-data
 

--- a/test/tools/fuzzTesting/BoostRandomCode.cpp
+++ b/test/tools/fuzzTesting/BoostRandomCode.cpp
@@ -46,7 +46,12 @@ BoostRandomCode::BoostRandomCode()
     {
         auto now = std::chrono::steady_clock::now().time_since_epoch();
         auto timeSinceEpoch = std::chrono::duration_cast<std::chrono::nanoseconds>(now).count();
-        gen.seed(static_cast<unsigned int>(timeSinceEpoch));
+        unsigned int time = static_cast<unsigned int>(timeSinceEpoch);
+        gen.seed(time);
+
+        boost::filesystem::path debugFile(boost::filesystem::current_path());
+        debugFile /= "randomCodeSeed.txt";
+        writeFile(debugFile, asBytes(toString(time)));
     }
 }
 


### PR DESCRIPTION
store the seed of random code generator on macOs as artifact
so if it fails we could possibly reproduce the random code test