### PR TITLE
Search for expectations that match the network in interest

### DIFF
--- a/test/tools/libtesteth/ImportTest.cpp
+++ b/test/tools/libtesteth/ImportTest.cpp
@@ -90,12 +90,15 @@ void ImportTest::makeBlockchainTestFromStateTest(vector<eth::Network> const& _ne
 
             for (auto const& net : _networks)
             {
+                auto trDup = tr;
+                trDup.netId = net;
+
                 // Calculate the block reward
                 ChainParams const chainParams{genesisInfo(net)};
                 EVMSchedule const schedule = chainParams.scheduleForBlockNumber(1);
                 u256 const blockReward = chainParams.blockReward(schedule);
 
-                TrExpectSection search{tr, smap};
+                TrExpectSection search{trDup, smap};
                 for (auto const& exp : m_testInputObject.at("expect").get_array())
                 {
                     TrExpectSection* search2 = &search;


### PR DESCRIPTION
This commit reverts an adverse effect of
https://github.com/ethereum/cpp-ethereum/commit/4bbcd2db5df8258e550cf78a792da388df55640f#diff-e01cd53eebd917cc35354ffc7719d8adL126
where a line was removed during a refactoring.

The removal caused https://github.com/ethereum/cpp-ethereum/issues/4799.
This commit fixes #4799