### PR TITLE
filltests only on expected networks

### DIFF
--- a/test/tools/fuzzTesting/createRandomTest.cpp
+++ b/test/tools/fuzzTesting/createRandomTest.cpp
@@ -222,6 +222,21 @@ std::string const c_testExampleStateTest = R"(
 		"currentTimestamp" : "1000",
 		"previousHash" : "[HASH32]"
 		},
+	"expect" : [
+		{
+			"indexes" : {
+				"data" : -1,
+				"gas" : -1,
+				"value" : -1
+			},
+			"network" : [">=Frontier"],
+			"result" : {
+				"a94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+						"nonce" : "1"
+					}
+			}
+		}
+	],
 	"pre" : {
 		"ffffffffffffffffffffffffffffffffffffffff" : {
 			"balance" : "[HEX]",

--- a/test/tools/jsontests/StateTests.cpp
+++ b/test/tools/jsontests/StateTests.cpp
@@ -72,9 +72,9 @@ json_spirit::mValue StateTestSuite::doTests(json_spirit::mValue const& _input, b
 
 		ImportTest importer(inputTest, outputTest);
 		Listener::ExecTimeGuard guard{i.first};
-		importer.executeTest();
+        importer.executeTest(_fillin);
 
-		if (_fillin)
+        if (_fillin)
 		{
 #if ETH_FATDB
 			if (inputTest.count("_info"))

--- a/test/tools/libtesteth/ImportTest.cpp
+++ b/test/tools/libtesteth/ImportTest.cpp
@@ -205,7 +205,7 @@ bytes ImportTest::executeTest(bool _isFilling)
     }
 
     vector<transactionToExecute> transactionResults;
-	for (auto const& net : networks)
+    for (auto const& net : networks)
 	{
 		if (isDisabledNetwork(net))
 			continue;
@@ -308,7 +308,7 @@ json_spirit::mObject ImportTest::makeAllFieldsHex(json_spirit::mObject const& _i
         bool isData = (key == "data");
 
         if (_isHeader && key == "nonce")
-			isHash = true;
+            isHash = true;
 
 		std::string str;
 		json_spirit::mValue value = i.second;
@@ -318,13 +318,14 @@ json_spirit::mObject ImportTest::makeAllFieldsHex(json_spirit::mObject const& _i
 		else if (value.type() == json_spirit::str_type)
             str = isData ? replaceCode(value.get_str()) : value.get_str();
         else if (value.type() == json_spirit::array_type)
-		{
+        {
 			json_spirit::mArray arr;
 			for (auto const& j: value.get_array())
 			{
                 str = isData ? replaceCode(j.get_str()) : j.get_str();
-                arr.push_back((str.substr(0, 2) == "0x") ? str : toCompactHexPrefixed(toInt(str), 1));
-			}
+                arr.push_back(
+                    (str.substr(0, 2) == "0x") ? str : toCompactHexPrefixed(toInt(str), 1));
+            }
 			output[key] = arr;
 			continue;
 		}
@@ -345,7 +346,7 @@ void ImportTest::importEnv(json_spirit::mObject const& _o)
             {"currentGasLimit", jsonVType::str_type}, {"currentNumber", jsonVType::str_type},
             {"currentTimestamp", jsonVType::str_type}, {"previousHash", jsonVType::str_type}});
     auto gasLimit = toInt(_o.at("currentGasLimit"));
-	BOOST_REQUIRE(gasLimit <= std::numeric_limits<int64_t>::max());
+    BOOST_REQUIRE(gasLimit <= std::numeric_limits<int64_t>::max());
 	BlockHeader header;
 	header.setGasLimit(gasLimit.convert_to<int64_t>());
 	header.setDifficulty(toInt(_o.at("currentDifficulty")));
@@ -364,7 +365,7 @@ void ImportTest::importState(json_spirit::mObject const& _o, State& _state, Acco
     replaceCodeInState(
         o);  // Compile LLL and other src code of the test Fillers using external call to lllc
     std::string jsondata = json_spirit::write_string((json_spirit::mValue)o, false);
-	_state.populateFrom(jsonToAccountMap(jsondata, 0, &o_mask));
+    _state.populateFrom(jsonToAccountMap(jsondata, 0, &o_mask));
 }
 
 void ImportTest::importState(json_spirit::mObject const& _o, State& _state)
@@ -379,7 +380,7 @@ void ImportTest::importState(json_spirit::mObject const& _o, State& _state)
     }
 
     AccountMaskMap mask;
-	importState(_o, _state, mask);
+    importState(_o, _state, mask);
 }
 
 void ImportTest::importTransaction (json_spirit::mObject const& _o, eth::Transaction& o_tr)
@@ -393,7 +394,7 @@ void ImportTest::importTransaction (json_spirit::mObject const& _o, eth::Transac
                 {"value", jsonVType::str_type}});
 
         if (bigint(_o.at("nonce").get_str()) >= c_max256plus1)
-			BOOST_THROW_EXCEPTION(ValueTooLarge() << errinfo_comment("Transaction 'nonce' is equal or greater than 2**256") );
+            BOOST_THROW_EXCEPTION(ValueTooLarge() << errinfo_comment("Transaction 'nonce' is equal or greater than 2**256") );
 		if (bigint(_o.at("gasPrice").get_str()) >= c_max256plus1)
 			BOOST_THROW_EXCEPTION(ValueTooLarge() << errinfo_comment("Transaction 'gasPrice' is equal or greater than 2**256") );
 		if (bigint(_o.at("gasLimit").get_str()) >= c_max256plus1)
@@ -414,7 +415,7 @@ void ImportTest::importTransaction (json_spirit::mObject const& _o, eth::Transac
                 {"to", jsonVType::str_type}, {"value", jsonVType::str_type}});
 
         RLPStream transactionRLPStream = createRLPStreamFromTransactionFields(_o);
-		RLP transactionRLP(transactionRLPStream.out());
+        RLP transactionRLP(transactionRLPStream.out());
 		try
 		{
 			o_tr = Transaction(transactionRLP.data(), CheckTransaction::Everything);
@@ -448,8 +449,8 @@ void ImportTest::importTransaction(json_spirit::mObject const& o_tr)
                 {"v", jsonVType::str_type}, {"r", jsonVType::str_type}, {"s", jsonVType::str_type},
                 {"to", jsonVType::str_type}, {"value", jsonVType::array_type}});
 
-    //Parse extended transaction
-	size_t dataVectorSize = o_tr.at("data").get_array().size();
+    // Parse extended transaction
+    size_t dataVectorSize = o_tr.at("data").get_array().size();
 	size_t gasVectorSize = o_tr.at("gasLimit").get_array().size();
 	size_t valueVectorSize = o_tr.at("value").get_array().size();
 
@@ -562,7 +563,7 @@ void ImportTest::parseJsonStrValueIntoSet(json_spirit::mValue const& _json, set<
 		for (auto const& val: _json.get_array())
             _out.emplace(val.get_str());
     }
-	else
+    else
         _out.emplace(_json.get_str());
 }
 
@@ -603,7 +604,7 @@ void ImportTest::checkAllowedNetwork(string const& _network)
 
 void ImportTest::checkAllowedNetwork(std::set<std::string> const& _networks)
 {
-    for (auto const& net: _networks)
+    for (auto const& net : _networks)
         ImportTest::checkAllowedNetwork(net);
 }
 
@@ -629,7 +630,7 @@ bool ImportTest::checkGeneralTestSectionSearch(json_spirit::mObject const& _expe
     }
 
     vector<int> d;
-	vector<int> g;
+    vector<int> g;
 	vector<int> v;
     set<string> network;
     if (_network.empty())
@@ -639,21 +640,22 @@ bool ImportTest::checkGeneralTestSectionSearch(json_spirit::mObject const& _expe
 
     // replace ">=Homestead" with "Homestead, EIP150, ..."
     network = test::translateNetworks(network);
-    BOOST_CHECK_MESSAGE(network.size() > 0, TestOutputHelper::get().testName() + " Network array not set!");
+    BOOST_CHECK_MESSAGE(
+        network.size() > 0, TestOutputHelper::get().testName() + " Network array not set!");
 
-	if (!Options::get().singleTestNet.empty())
+    if (!Options::get().singleTestNet.empty())
 	{
 		//skip this check if we execute transactions only on another specified network
         if (!network.count(Options::get().singleTestNet) && !network.count(string{"ALL"}))
             return false;
-	}
+    }
 
 	if (_expects.count("indexes"))
 	{
         BOOST_REQUIRE_MESSAGE(_expects.at("indexes").type() == jsonVType::obj_type,
             "indexes field expected to be json Object!");
         json_spirit::mObject const& indexes = _expects.at("indexes").get_obj();
-		parseJsonIntValueIntoVector(indexes.at("data"), d);
+        parseJsonIntValueIntoVector(indexes.at("data"), d);
 		parseJsonIntValueIntoVector(indexes.at("gas"), g);
 		parseJsonIntValueIntoVector(indexes.at("value"), v);
 		BOOST_CHECK_MESSAGE(d.size() > 0 && g.size() > 0 && v.size() > 0, TestOutputHelper::get().testName() + " Indexes arrays not set!");
@@ -744,7 +746,7 @@ bool ImportTest::checkGeneralTestSectionSearch(json_spirit::mObject const& _expe
                     if (network.size() == 1 && d.size() == 1 && g.size() == 1 && v.size() == 1)
                         break;
             }
-	}
+    }
 	if (!_search) //if search for a single transaction in one of the expect sections then don't need this output.
 		BOOST_CHECK_MESSAGE(foundResults, TestOutputHelper::get().testName() + " Expect results was not found in test execution!");
 	return foundResults;
@@ -783,7 +785,7 @@ int ImportTest::exportTest()
 	{
         BOOST_REQUIRE_MESSAGE(m_testInputObject.at("expect").type() == jsonVType::array_type,
             "expect section is required to be json Array!");
-        for (auto const& exp: m_testInputObject.at("expect").get_array())
+        for (auto const& exp : m_testInputObject.at("expect").get_array())
         {
             BOOST_REQUIRE_MESSAGE(exp.type() == jsonVType::obj_type,
                 "expect section element is required to be json Object!");
@@ -791,7 +793,7 @@ int ImportTest::exportTest()
         }
     }
 
-	std::map<string, json_spirit::mArray> postState;
+    std::map<string, json_spirit::mArray> postState;
 	for(size_t i = 0; i < m_transactions.size(); i++)
 	{
 		transactionToExecute const& tr = m_transactions[i];

--- a/test/tools/libtesteth/ImportTest.cpp
+++ b/test/tools/libtesteth/ImportTest.cpp
@@ -184,10 +184,20 @@ bytes ImportTest::executeTest(bool _isFilling)
     if (!Options::get().singleTestNet.empty())
         networks.emplace(stringToNetId(Options::get().singleTestNet));
     else
-        networks =
-            (Options::get().filltests && m_testInputObject.count("expect")) ?
-                getAllNetworksFromExpectSections(m_testInputObject.at("expect").get_array()) :
-                getNetworks();
+    {
+        if (_isFilling)
+        {
+            // Run tests only on networks from expect sections
+            BOOST_REQUIRE(m_testInputObject.count("expect") > 0);
+            networks = getAllNetworksFromExpectSections(m_testInputObject.at("expect").get_array());
+        }
+        else
+        {
+            // Run tests only on networks that are in post state of the filled test
+            for (auto const& post : m_testInputObject.at("post").get_obj())
+                networks.emplace(test::stringToNetId(post.first));
+        }
+    }
 
     vector<transactionToExecute> transactionResults;
 	for (auto const& net : networks)

--- a/test/tools/libtesteth/ImportTest.cpp
+++ b/test/tools/libtesteth/ImportTest.cpp
@@ -168,7 +168,12 @@ set<eth::Network> ImportTest::getAllNetworksFromExpectSections(json_spirit::mArr
 {
     set<string> allNetworks;
     for (auto const& exp : _expects)
+    {
+        requireJsonFields(exp.get_obj(), "expect",
+            {{"indexes", jsonVType::obj_type}, {"network", jsonVType::array_type},
+                {"result", jsonVType::obj_type}});
         ImportTest::parseJsonStrValueIntoSet(exp.get_obj().at("network"), allNetworks);
+    }
 
     allNetworks = test::translateNetworks(allNetworks);
     set<eth::Network> networkSet;

--- a/test/tools/libtesteth/ImportTest.cpp
+++ b/test/tools/libtesteth/ImportTest.cpp
@@ -188,20 +188,17 @@ bytes ImportTest::executeTest(bool _isFilling)
     set<eth::Network> networks;
     if (!Options::get().singleTestNet.empty())
         networks.emplace(stringToNetId(Options::get().singleTestNet));
+    else if (_isFilling)
+    {
+        // Run tests only on networks from expect sections
+        BOOST_REQUIRE(m_testInputObject.count("expect") > 0);
+        networks = getAllNetworksFromExpectSections(m_testInputObject.at("expect").get_array());
+    }
     else
     {
-        if (_isFilling)
-        {
-            // Run tests only on networks from expect sections
-            BOOST_REQUIRE(m_testInputObject.count("expect") > 0);
-            networks = getAllNetworksFromExpectSections(m_testInputObject.at("expect").get_array());
-        }
-        else
-        {
-            // Run tests only on networks that are in post state of the filled test
-            for (auto const& post : m_testInputObject.at("post").get_obj())
-                networks.emplace(test::stringToNetId(post.first));
-        }
+        // Run tests only on networks that are in post state of the filled test
+        for (auto const& post : m_testInputObject.at("post").get_obj())
+            networks.emplace(test::stringToNetId(post.first));
     }
 
     vector<transactionToExecute> transactionResults;

--- a/test/tools/libtesteth/ImportTest.h
+++ b/test/tools/libtesteth/ImportTest.h
@@ -43,6 +43,8 @@ public:
 	static json_spirit::mObject makeAllFieldsHex(json_spirit::mObject const& _o, bool _isHeader = false);
     static void parseJsonStrValueIntoSet(
         json_spirit::mValue const& _json, std::set<std::string>& _out);
+    static std::set<eth::Network> getAllNetworksFromExpectSections(
+        json_spirit::mArray const& _expects);
 
     //check functions
 	//check that networks in the vector are allowed
@@ -50,8 +52,8 @@ public:
     static void checkAllowedNetwork(std::set<std::string> const& _networks);
     static void checkBalance(eth::State const& _pre, eth::State const& _post, bigint _miningReward = 0);
 
-	bytes executeTest();
-	int exportTest();
+    bytes executeTest(bool _isFilling);
+    int exportTest();
 	static int compareStates(eth::State const& _stateExpect, eth::State const& _statePost, eth::AccountMaskMap const _expectedStateOptions = eth::AccountMaskMap(), WhenError _throw = WhenError::Throw);
 	bool checkGeneralTestSection(json_spirit::mObject const& _expects, std::vector<size_t>& _errorTransactions, std::string const& _network="") const;
 	void traceStateDiff();

--- a/test/unittests/libtesteth/blockchainTest.cpp
+++ b/test/unittests/libtesteth/blockchainTest.cpp
@@ -37,6 +37,7 @@ BOOST_AUTO_TEST_CASE(fillingExpectationOnMultipleNetworks)
 				],
 				"expect" : [
 					{
+						"indexes" : { "dataind": -1, "gasind": -1, "valueind": -1 },
 						"network" : ["Frontier", "Homestead"],
 						"result" : {
 							"0x1000000000000000000000000000000000000000" : {
@@ -99,6 +100,7 @@ BOOST_AUTO_TEST_CASE(fillingWithWrongExpectation)
 				],
 				"expect" : [
 					{
+						"indexes" : { "dataind": -1, "gasind": -1, "valueind": -1 },
 						"network" : ["Frontier", "Homestead"],
 						"result" : {
 							"0x1000000000000000000000000000000000000000" : {

--- a/test/unittests/libtesteth/blockchainTest.cpp
+++ b/test/unittests/libtesteth/blockchainTest.cpp
@@ -30,121 +30,121 @@ BOOST_FIXTURE_TEST_SUITE(BlockChainTestSuite, TestOutputHelperFixture)
 
 BOOST_AUTO_TEST_CASE(fillingExpectationOnMultipleNetworks)
 {
-	std::string const s = R"(
+    std::string const s = R"(
 		{
-			"BLOCKHASH_Bounds" : {
-			"blocks" : [
-			],
-			"expect" : [
-				{
-					"network" : ["Frontier", "Homestead"],
-					"result" : {
-						"0x1000000000000000000000000000000000000000" : {
-							"balance" : "0x00"
-						},
-						"0x1000000000000000000000000000000000000001" : {
-							"balance" : "0x00"
+			"FilltestUnitTest" : {
+				"blocks" : [
+				],
+				"expect" : [
+					{
+						"network" : ["Frontier", "Homestead"],
+						"result" : {
+							"0x1000000000000000000000000000000000000000" : {
+								"balance" : "0x00"
+							},
+							"0x1000000000000000000000000000000000000001" : {
+								"balance" : "0x00"
+							}
 						}
 					}
-				}
-			],
-			"genesisBlockHeader" : {
-				"bloom" : "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-				"coinbase" : "2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
-				"difficulty" : "131072",
-				"extraData" : "0x42",
-				"gasLimit" : "0x7fffffffffffffff",
-				"gasUsed" : "0",
-				"mixHash" : "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
-				"nonce" : "0x0102030405060708",
-				"number" : "0",
-				"parentHash" : "0x0000000000000000000000000000000000000000000000000000000000000000",
-				"receiptTrie" : "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
-				"stateRoot" : "0xf99eb1626cfa6db435c0836235942d7ccaa935f1ae247d3f1c21e495685f903a",
-				"timestamp" : "0x03b6",
-				"transactionsTrie" : "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
-				"uncleHash" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
-			},
-			"pre" : {
-				"0x1000000000000000000000000000000000000000" : {
+				],
+				"genesisBlockHeader" : {
+					"bloom" : "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+					"coinbase" : "2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+					"difficulty" : "131072",
+					"extraData" : "0x42",
+					"gasLimit" : "0x7fffffffffffffff",
+					"gasUsed" : "0",
+					"mixHash" : "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+					"nonce" : "0x0102030405060708",
+					"number" : "0",
+					"parentHash" : "0x0000000000000000000000000000000000000000000000000000000000000000",
+					"receiptTrie" : "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+					"stateRoot" : "0xf99eb1626cfa6db435c0836235942d7ccaa935f1ae247d3f1c21e495685f903a",
+					"timestamp" : "0x03b6",
+					"transactionsTrie" : "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+					"uncleHash" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+				},
+				"pre" : {
+					"0x1000000000000000000000000000000000000000" : {
+						"balance" : "0x00",
+						"code" : "0x60004060005563ffffffff4060015567ffffffffffffffff406002556fffffffffffffffffffffffffffffffff406003557fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff40600455",
+						"nonce" : "0x00",
+						"storage" : {
+						}
+					},
+				"0x1000000000000000000000000000000000000001" : {
 					"balance" : "0x00",
 					"code" : "0x60004060005563ffffffff4060015567ffffffffffffffff406002556fffffffffffffffffffffffffffffffff406003557fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff40600455",
 					"nonce" : "0x00",
 					"storage" : {
 					}
-				},
-			"0x1000000000000000000000000000000000000001" : {
-				"balance" : "0x00",
-				"code" : "0x60004060005563ffffffff4060015567ffffffffffffffff406002556fffffffffffffffffffffffffffffffff406003557fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff40600455",
-				"nonce" : "0x00",
-				"storage" : {
 				}
-			}
 		}
 	)";
-	json_spirit::mValue input;
+    json_spirit::mValue input;
 	json_spirit::read_string(s, input);
 	BlockchainTestSuite suite;
 	json_spirit::mValue output = suite.doTests(input, true);
-	BOOST_CHECK_MESSAGE(output.get_obj().size() == getNetworks().size(), "A wrong number of tests were generated.");
+    BOOST_CHECK_MESSAGE(output.get_obj().size() == 2, "A wrong number of tests were generated.");
 }
 
 BOOST_AUTO_TEST_CASE_EXPECTED_FAILURES(fillingWithWrongExpectation, 2)
 BOOST_AUTO_TEST_CASE(fillingWithWrongExpectation)
 {
-	std::string const s = R"(
+    std::string const s = R"(
 		{
-			"BLOCKHASH_Bounds" : {
-			"blocks" : [
-			],
-			"expect" : [
-				{
-					"network" : ["Frontier", "Homestead"],
-					"result" : {
-						"0x1000000000000000000000000000000000000000" : {
-							"balance" : "0x01"
-						},
-						"0x1000000000000000000000000000000000000001" : {
-							"balance" : "0x00"
+			"WrongExpectSectionUnitTest" : {
+				"blocks" : [
+				],
+				"expect" : [
+					{
+						"network" : ["Frontier", "Homestead"],
+						"result" : {
+							"0x1000000000000000000000000000000000000000" : {
+								"balance" : "0x01"
+							},
+							"0x1000000000000000000000000000000000000001" : {
+								"balance" : "0x00"
+							}
 						}
 					}
-				}
-			],
-			"genesisBlockHeader" : {
-				"bloom" : "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-				"coinbase" : "2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
-				"difficulty" : "131072",
-				"extraData" : "0x42",
-				"gasLimit" : "0x7fffffffffffffff",
-				"gasUsed" : "0",
-				"mixHash" : "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
-				"nonce" : "0x0102030405060708",
-				"number" : "0",
-				"parentHash" : "0x0000000000000000000000000000000000000000000000000000000000000000",
-				"receiptTrie" : "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
-				"stateRoot" : "0xf99eb1626cfa6db435c0836235942d7ccaa935f1ae247d3f1c21e495685f903a",
-				"timestamp" : "0x03b6",
-				"transactionsTrie" : "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
-				"uncleHash" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
-			},
-			"pre" : {
-				"0x1000000000000000000000000000000000000000" : {
+				],
+				"genesisBlockHeader" : {
+					"bloom" : "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+					"coinbase" : "2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+					"difficulty" : "131072",
+					"extraData" : "0x42",
+					"gasLimit" : "0x7fffffffffffffff",
+					"gasUsed" : "0",
+					"mixHash" : "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+					"nonce" : "0x0102030405060708",
+					"number" : "0",
+					"parentHash" : "0x0000000000000000000000000000000000000000000000000000000000000000",
+					"receiptTrie" : "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+					"stateRoot" : "0xf99eb1626cfa6db435c0836235942d7ccaa935f1ae247d3f1c21e495685f903a",
+					"timestamp" : "0x03b6",
+					"transactionsTrie" : "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+					"uncleHash" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+				},
+				"pre" : {
+					"0x1000000000000000000000000000000000000000" : {
+						"balance" : "0x00",
+						"code" : "0x60004060005563ffffffff4060015567ffffffffffffffff406002556fffffffffffffffffffffffffffffffff406003557fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff40600455",
+						"nonce" : "0x00",
+						"storage" : {
+						}
+					},
+				"0x1000000000000000000000000000000000000001" : {
 					"balance" : "0x00",
 					"code" : "0x60004060005563ffffffff4060015567ffffffffffffffff406002556fffffffffffffffffffffffffffffffff406003557fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff40600455",
 					"nonce" : "0x00",
 					"storage" : {
 					}
-				},
-			"0x1000000000000000000000000000000000000001" : {
-				"balance" : "0x00",
-				"code" : "0x60004060005563ffffffff4060015567ffffffffffffffff406002556fffffffffffffffffffffffffffffffff406003557fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff40600455",
-				"nonce" : "0x00",
-				"storage" : {
 				}
-			}
 		}
 	)";
-	json_spirit::mValue input;
+    json_spirit::mValue input;
 	json_spirit::read_string(s, input);
 
 	BlockchainTestSuite suite;


### PR DESCRIPTION
fixed the bug: --filltests --fillchain  leaded to blockchain tests being generated twice

testeth optimize: fill tests only on those networks that are specified in expect section of StateTests/BlockchainTests 

expect section is now required. 


TODO:
optimize and refill the test fillers. 
*this PR breaks --filltests command on existing test cases