### PR TITLE
Refactor logging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,8 +87,8 @@ include(EthUtils)
 
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
-hunter_add_package(Boost COMPONENTS program_options filesystem system thread context fiber)
-find_package(Boost CONFIG REQUIRED program_options filesystem system thread context fiber)
+hunter_add_package(Boost COMPONENTS program_options filesystem system thread context fiber log)
+find_package(Boost CONFIG REQUIRED program_options filesystem system thread context fiber log)
 
 hunter_add_package(jsoncpp)
 find_package(jsoncpp CONFIG REQUIRED)

--- a/eth/main.cpp
+++ b/eth/main.cpp
@@ -829,6 +829,7 @@ int main(int argc, char** argv)
         }
     }
 
+    setupLogging(g_logVerbosity);
 
     if (!privateChain.empty())
     {

--- a/libdevcore/CMakeLists.txt
+++ b/libdevcore/CMakeLists.txt
@@ -12,4 +12,4 @@ target_link_libraries(devcore Boost::filesystem Boost::system Boost::thread Thre
 
 find_package(LevelDB)
 target_include_directories(devcore SYSTEM PUBLIC ${LEVELDB_INCLUDE_DIRS})
-target_link_libraries(devcore ${LEVELDB_LIBRARIES})
+target_link_libraries(devcore ${LEVELDB_LIBRARIES} Boost::log)

--- a/libdevcore/CMakeLists.txt
+++ b/libdevcore/CMakeLists.txt
@@ -8,8 +8,8 @@ add_dependencies(devcore BuildInfo.h)
 # Needed to prevent including system-level boost headers:
 target_include_directories(devcore SYSTEM PUBLIC ${Boost_INCLUDE_DIR} PRIVATE ../utils)
 
-target_link_libraries(devcore Boost::filesystem Boost::system Boost::thread Threads::Threads)
+target_link_libraries(devcore Boost::filesystem Boost::system Boost::log Boost::thread Threads::Threads)
 
 find_package(LevelDB)
 target_include_directories(devcore SYSTEM PUBLIC ${LEVELDB_INCLUDE_DIRS})
-target_link_libraries(devcore ${LEVELDB_LIBRARIES} Boost::log)
+target_link_libraries(devcore ${LEVELDB_LIBRARIES})

--- a/libdevcore/Common.cpp
+++ b/libdevcore/Common.cpp
@@ -42,19 +42,15 @@ void InvariantChecker::checkInvariants(HasInvariants const* _this, char const* _
     }
 }
 
-struct TimerChannel: public LogChannel { static const char* name(); static const int verbosity = 0; };
-
-#if defined(_WIN32)
-const char* TimerChannel::name() { return EthRed " ! "; }
-#else
-const char* TimerChannel::name() { return EthRed " ⚡ "; }
-#endif
-
 TimerHelper::~TimerHelper()
 {
     auto e = std::chrono::high_resolution_clock::now() - m_t;
     if (!m_ms || e > chrono::milliseconds(m_ms))
-        clog(TimerChannel) << m_id << chrono::duration_cast<chrono::milliseconds>(e).count() << "ms";
+    {
+        Logger logger{createLogger(0, "timer")};
+        BOOST_LOG(logger) << m_id << chrono::duration_cast<chrono::milliseconds>(e).count()
+                          << " ms";
+    }
 }
 
 int64_t utcTime()

--- a/libdevcore/Common.cpp
+++ b/libdevcore/Common.cpp
@@ -48,7 +48,7 @@ TimerHelper::~TimerHelper()
     if (!m_ms || e > chrono::milliseconds(m_ms))
     {
         Logger logger{createLogger(0, "timer")};
-        BOOST_LOG(logger) << m_id << chrono::duration_cast<chrono::milliseconds>(e).count()
+        BOOST_LOG(logger) << m_id << " " << chrono::duration_cast<chrono::milliseconds>(e).count()
                           << " ms";
     }
 }

--- a/libdevcore/Log.cpp
+++ b/libdevcore/Log.cpp
@@ -62,23 +62,6 @@ bool isChannelVisible(std::type_info const* _ch, bool _default)
     return _default;
 }
 
-LogOverrideAux::LogOverrideAux(std::type_info const* _ch, bool _value):
-    m_ch(_ch)
-{
-    Guard l(x_logOverride);
-    m_old = s_logOverride.count(_ch) ? (int)s_logOverride[_ch] : c_null;
-    s_logOverride[m_ch] = _value;
-}
-
-LogOverrideAux::~LogOverrideAux()
-{
-    Guard l(x_logOverride);
-    if (m_old == c_null)
-        s_logOverride.erase(m_ch);
-    else
-        s_logOverride[m_ch] = (bool)m_old;
-}
-
 #if defined(_WIN32)
 const char* LogChannel::name() { return EthGray "..."; }
 const char* LeftChannel::name() { return EthNavy "<--"; }

--- a/libdevcore/Log.cpp
+++ b/libdevcore/Log.cpp
@@ -64,19 +64,8 @@ bool isChannelVisible(std::type_info const* _ch, bool _default)
 
 #if defined(_WIN32)
 const char* LogChannel::name() { return EthGray "..."; }
-const char* LeftChannel::name() { return EthNavy "<--"; }
-const char* RightChannel::name() { return EthGreen "-->"; }
-const char* WarnChannel::name() { return EthOnRed EthBlackBold "  X"; }
-const char* NoteChannel::name() { return EthBlue "  i"; }
-const char* DebugChannel::name() { return EthWhite "  D"; }
-
 #else
 const char* LogChannel::name() { return EthGray "···"; }
-const char* LeftChannel::name() { return EthNavy "◀▬▬"; }
-const char* RightChannel::name() { return EthGreen "▬▬▶"; }
-const char* WarnChannel::name() { return EthOnRed EthBlackBold "  ✘"; }
-const char* NoteChannel::name() { return EthBlue "  ℹ"; }
-const char* DebugChannel::name() { return EthWhite "  ◇"; }
 #endif
 
 LogOutputStreamBase::LogOutputStreamBase(char const* _id, std::type_info const* _info, unsigned _v, bool _autospacing):

--- a/libdevcore/Log.h
+++ b/libdevcore/Log.h
@@ -97,11 +97,6 @@ std::string getThreadName();
 /// The default logging channels. Each has an associated verbosity and three-letter prefix (name() ).
 /// Channels should inherit from LogChannel and define name() and verbosity.
 struct LogChannel { static const char* name(); static const int verbosity = 1; static const bool debug = true; };
-struct LeftChannel: public LogChannel { static const char* name(); };
-struct RightChannel: public LogChannel { static const char* name(); };
-struct WarnChannel: public LogChannel { static const char* name(); static const int verbosity = 0; static const bool debug = false; };
-struct NoteChannel: public LogChannel { static const char* name(); static const bool debug = false; };
-struct DebugChannel : public LogChannel { static const char* name(); static const int verbosity = 0; };
 
 enum class LogTag
 {

--- a/libdevcore/Worker.cpp
+++ b/libdevcore/Worker.cpp
@@ -64,7 +64,7 @@ void Worker::startWorking()
 				}
 				catch (std::exception const& _e)
 				{
-					clog(WarnChannel) << "Exception thrown in Worker thread: " << _e.what();
+					cwarn << "Exception thrown in Worker thread: " << _e.what();
 				}
 
 //				ex = WorkerState::Stopping;

--- a/libethereum/Block.cpp
+++ b/libethereum/Block.cpp
@@ -489,7 +489,6 @@ u256 Block::enact(VerifiedBlockRef const& _block, BlockChain const& _bc)
         {
             try
             {
-                LogOverride<ExecutiveWarnChannel> o(false);
 //				cnote << "Enacting transaction: " << tr.nonce() << tr.from() << state().transactionsFrom(tr.from()) << tr.value();
                 execute(_bc.lastBlockHashes(), tr);
 //				cnote << "Now: " << tr.from() << state().transactionsFrom(tr.from());

--- a/libethereum/Executive.cpp
+++ b/libethereum/Executive.cpp
@@ -233,7 +233,7 @@ void Executive::initialize(Transaction const& _transaction)
         {
             BOOST_LOG(m_execLogger)
                 << "Sender: " << m_t.sender().hex() << " Invalid Nonce: Require " << nonceReq
-                << " Got" << m_t.nonce();
+                << " Got " << m_t.nonce();
             m_excepted = TransactionException::InvalidNonce;
             BOOST_THROW_EXCEPTION(InvalidNonce() << RequirementError((bigint)nonceReq, (bigint)m_t.nonce()));
         }
@@ -243,8 +243,8 @@ void Executive::initialize(Transaction const& _transaction)
         bigint totalCost = m_t.value() + gasCost;
         if (m_s.balance(m_t.sender()) < totalCost)
         {
-            BOOST_LOG(m_execLogger) << "Not enough cash: Require >" << totalCost << "=" << m_t.gas()
-                                    << "*" << m_t.gasPrice() << "+" << m_t.value() << " Got"
+            BOOST_LOG(m_execLogger) << "Not enough cash: Require > " << totalCost << " = " << m_t.gas()
+                                    << " * " << m_t.gasPrice() << " + " << m_t.value() << " Got"
                                     << m_s.balance(m_t.sender()) << " for sender: " << m_t.sender();
             m_excepted = TransactionException::NotEnoughCash;
             m_excepted = TransactionException::NotEnoughCash;
@@ -259,7 +259,7 @@ bool Executive::execute()
     // Entry point for a user-executed transaction.
 
     // Pay...
-    clog(StateDetail) << "Paying" << formatBalance(m_gasCost) << "from sender for gas (" << m_t.gas() << "gas at" << formatBalance(m_t.gasPrice()) << ")";
+    clog(StateDetail) << "Paying " << formatBalance(m_gasCost) << " from sender for gas (" << m_t.gas() << " gas at " << formatBalance(m_t.gasPrice()) << ")";
     m_s.subBalance(m_t.sender(), m_gasCost);
 
     if (m_t.isCreation())

--- a/libethereum/Executive.cpp
+++ b/libethereum/Executive.cpp
@@ -32,8 +32,31 @@ using namespace std;
 using namespace dev;
 using namespace dev::eth;
 
-const char* VMTraceChannel::name() { return "EVM"; }
-const char* ExecutiveWarnChannel::name() { return WarnChannel::name(); }
+namespace
+{
+std::string dumpStackAndMemory(LegacyVM const& _vm)
+{
+    ostringstream o;
+    o << "\n    STACK\n";
+    for (auto i : _vm.stack())
+        o << (h256)i << "\n";
+    o << "    MEMORY\n"
+      << ((_vm.memory().size() > 1000) ? " mem size greater than 1000 bytes " :
+                                         memDump(_vm.memory()));
+    return o.str();
+};
+
+std::string dumpStorage(ExtVM const& _ext)
+{
+    ostringstream o;
+    o << "    STORAGE\n";
+    for (auto const& i : _ext.state().storage(_ext.myAddress))
+        o << showbase << hex << i.second.first << ": " << i.second.second << "\n";
+    return o.str();
+};
+
+
+}  // namespace
 
 StandardTrace::StandardTrace():
     m_trace(Json::arrayValue)
@@ -202,13 +225,15 @@ void Executive::initialize(Transaction const& _transaction)
         }
         catch (InvalidSignature const&)
         {
-            clog(ExecutiveWarnChannel) << "Invalid Signature";
+            BOOST_LOG(m_execLogger) << "Invalid Signature";
             m_excepted = TransactionException::InvalidSignature;
             throw;
         }
         if (m_t.nonce() != nonceReq)
         {
-            clog(ExecutiveWarnChannel) << "Sender: " << m_t.sender().hex() << " Invalid Nonce: Require" << nonceReq << " Got" << m_t.nonce();
+            BOOST_LOG(m_execLogger)
+                << "Sender: " << m_t.sender().hex() << " Invalid Nonce: Require " << nonceReq
+                << " Got" << m_t.nonce();
             m_excepted = TransactionException::InvalidNonce;
             BOOST_THROW_EXCEPTION(InvalidNonce() << RequirementError((bigint)nonceReq, (bigint)m_t.nonce()));
         }
@@ -218,7 +243,10 @@ void Executive::initialize(Transaction const& _transaction)
         bigint totalCost = m_t.value() + gasCost;
         if (m_s.balance(m_t.sender()) < totalCost)
         {
-            clog(ExecutiveWarnChannel) << "Not enough cash: Require >" << totalCost << "=" << m_t.gas() << "*" << m_t.gasPrice() << "+" << m_t.value() << " Got" << m_s.balance(m_t.sender()) << "for sender: " << m_t.sender();
+            BOOST_LOG(m_execLogger) << "Not enough cash: Require >" << totalCost << "=" << m_t.gas()
+                                    << "*" << m_t.gasPrice() << "+" << m_t.value() << " Got"
+                                    << m_s.balance(m_t.sender()) << " for sender: " << m_t.sender();
+            m_excepted = TransactionException::NotEnoughCash;
             m_excepted = TransactionException::NotEnoughCash;
             BOOST_THROW_EXCEPTION(NotEnoughCash() << RequirementError(totalCost, (bigint)m_s.balance(m_t.sender())) << errinfo_comment(m_t.sender().hex()));
         }
@@ -373,30 +401,22 @@ bool Executive::executeCreate(Address const& _sender, u256 const& _endowment, u2
 
 OnOpFunc Executive::simpleTrace()
 {
-    return [](uint64_t steps, uint64_t PC, Instruction inst, bigint newMemSize, bigint gasCost,
-               bigint gas, VMFace const* _vm, ExtVMFace const* voidExt) {
+    Logger& traceLogger = m_vmTraceLogger;
+
+    return [&traceLogger](uint64_t steps, uint64_t PC, Instruction inst, bigint newMemSize,
+               bigint gasCost, bigint gas, VMFace const* _vm, ExtVMFace const* voidExt) {
         ExtVM const& ext = *static_cast<ExtVM const*>(voidExt);
         auto vm = dynamic_cast<LegacyVM const*>(_vm);
 
         ostringstream o;
         if (vm)
-        {
-            o << endl << "    STACK" << endl;
-            for (auto i : vm->stack())
-                o << (h256)i << endl;
-            o << "    MEMORY" << endl
-              << ((vm->memory().size() > 1000) ? " mem size greater than 1000 bytes " :
-                                                 memDump(vm->memory()));
-        }
-        o << "    STORAGE" << endl;
-        for (auto const& i: ext.state().storage(ext.myAddress))
-            o << showbase << hex << i.second.first << ": " << i.second.second << endl;
-        dev::LogOutputStream<VMTraceChannel, false>() << o.str();
-        dev::LogOutputStream<VMTraceChannel, false>()
-            << " < " << dec << ext.depth << " : " << ext.myAddress << " : #" << steps << " : "
-            << hex << setw(4) << setfill('0') << PC << " : " << instructionInfo(inst).name << " : "
-            << dec << gas << " : -" << dec << gasCost << " : " << newMemSize << "x32"
-            << " >";
+            BOOST_LOG(traceLogger) << dumpStackAndMemory(*vm);
+        BOOST_LOG(traceLogger) << dumpStorage(ext);
+        BOOST_LOG(traceLogger) << " < " << dec << ext.depth << " : " << ext.myAddress << " : #"
+                               << steps << " : " << hex << setw(4) << setfill('0') << PC << " : "
+                               << instructionInfo(inst).name << " : " << dec << gas << " : -" << dec
+                               << gasCost << " : " << newMemSize << "x32"
+                               << " >";
     };
 }
 

--- a/libethereum/Executive.h
+++ b/libethereum/Executive.h
@@ -43,9 +43,6 @@ class ExtVM;
 class SealEngineFace;
 struct Manifest;
 
-struct VMTraceChannel: public LogChannel { static const char* name(); static const int verbosity = 11; };
-struct ExecutiveWarnChannel: public LogChannel { static const char* name(); static const int verbosity = 1; };
-
 class StandardTrace
 {
 public:
@@ -170,7 +167,7 @@ public:
     bool go(OnOpFunc const& _onOp = OnOpFunc());
 
     /// Operation function for providing a simple trace of the VM execution.
-    static OnOpFunc simpleTrace();
+    OnOpFunc simpleTrace();
 
     /// @returns gas remaining after the transaction/operation. Valid after the transaction has been executed.
     u256 gas() const { return m_gas; }
@@ -212,6 +209,9 @@ private:
     bool m_isCreation = false;
     Address m_newAddress;
     size_t m_savepoint = 0;
+
+    Logger m_execLogger{createLogger(1, "exec")};
+    Logger m_vmTraceLogger{createLogger(11, "vmtrace")};
 };
 
 }

--- a/libethereum/State.cpp
+++ b/libethereum/State.cpp
@@ -555,17 +555,16 @@ void State::rollback(size_t _savepoint)
 
 std::pair<ExecutionResult, TransactionReceipt> State::execute(EnvInfo const& _envInfo, SealEngineFace const& _sealEngine, Transaction const& _t, Permanence _p, OnOpFunc const& _onOp)
 {
-    auto onOp = _onOp;
-#if ETH_VMTRACE
-    if (isChannelVisible<VMTraceChannel>())
-        onOp = Executive::simpleTrace(); // override tracer
-#endif
-
     // Create and initialize the executive. This will throw fairly cheaply and quickly if the
     // transaction is bad in any way.
     Executive e(*this, _envInfo, _sealEngine);
     ExecutionResult res;
     e.setResultRecipient(res);
+
+    auto onOp = _onOp;
+#if ETH_VMTRACE
+    onOp = e.simpleTrace();  // override tracer
+#endif
 
     u256 const startGasUsed = _envInfo.gasUsed();
     bool const statusCode = executeTransaction(e, _t, onOp);

--- a/test/tools/jsontests/vm.cpp
+++ b/test/tools/jsontests/vm.cpp
@@ -36,6 +36,15 @@ using namespace dev::eth;
 using namespace dev::test;
 namespace fs = boost::filesystem;
 
+namespace
+{
+struct VMTraceChannel : public LogChannel
+{
+    static const char* name() { return "EVM"; }
+    static const int verbosity = 11;
+};
+}  // namespace
+
 FakeExtVM::FakeExtVM(EnvInfo const& _envInfo, unsigned _depth):			/// TODO: XXX: remove the default argument & fix.
     ExtVMFace(_envInfo, Address(), Address(), Address(), 0, 1, bytesConstRef(), bytes(), EmptySHA3, false, false, _depth)
 {}
@@ -247,11 +256,16 @@ eth::OnOpFunc FakeExtVM::simpleTrace() const
         for (auto const& i: std::get<2>(ext.addresses.find(ext.myAddress)->second))
             o << std::showbase << std::hex << i.first << ": " << i.second << "\n";
 
-        dev::LogOutputStream<eth::VMTraceChannel, false>() << o.str();
-        dev::LogOutputStream<eth::VMTraceChannel, false>() << " | " << std::dec << ext.depth << " | " << ext.myAddress << " | #" << steps << " | " << std::hex << std::setw(4) << std::setfill('0') << pc << " : " << instructionInfo(inst).name << " | " << std::dec << gas << " | -" << std::dec << gasCost << " | " << newMemSize << "x32" << " ]";
+        dev::LogOutputStream<VMTraceChannel, false>() << o.str();
+        dev::LogOutputStream<VMTraceChannel, false>()
+            << " | " << std::dec << ext.depth << " | " << ext.myAddress << " | #" << steps << " | "
+            << std::hex << std::setw(4) << std::setfill('0') << pc << " : "
+            << instructionInfo(inst).name << " | " << std::dec << gas << " | -" << std::dec
+            << gasCost << " | " << newMemSize << "x32"
+            << " ]";
 
         /*creates json stack trace*/
-        if (eth::VMTraceChannel::verbosity <= g_logVerbosity)
+        if (VMTraceChannel::verbosity <= g_logVerbosity)
         {
             Object o_step;
 

--- a/test/tools/libtesteth/Options.cpp
+++ b/test/tools/libtesteth/Options.cpp
@@ -33,7 +33,7 @@ void printHelp()
     cout << "Usage: \n";
     cout << std::left;
     cout << "\nSetting test suite\n";
-    cout << setw(30) <<	"-t <TestSuite>" << setw(25) << "Execute test operations\n";
+    cout << setw(30) << "-t <TestSuite>" << setw(25) << "Execute test operations\n";
     cout << setw(30) << "-t <TestSuite>/<TestCase>\n";
     cout << setw(30) << "--testpath <PathToTheTestRepo>\n";
 
@@ -335,7 +335,9 @@ Options::Options(int argc, const char** argv)
 
     //Default option
     if (logVerbosity == Verbosity::NiceReport)
-        g_logVerbosity = -1;	//disable cnote but leave cerr and cout
+        g_logVerbosity = -1;    //disable cnote but leave cerr and cout
+
+    setupLogging(g_logVerbosity);
 }
 
 Options const& Options::get(int argc, const char** argv)


### PR DESCRIPTION
Rewriting logging system using boost.log

- [x] Create basic logging primitives in `Log.h`
- [ ] Change all logging statements to use new logging
- [ ] Separate global logger for critical errors, also probably remove `cdebug`, `clog`, `cnote`, `ctrace` or leave only one of them
- [ ] `setupLogging()` in all executables
- [ ] Get rid of global verbosity variable (make it argument to `setupLogging()` instead)
- [ ] new command line parameter for filtering channels (probably create program options group to handle it easily in all tools)
- [ ] Handle exceptions from logging system

### Summary of changes noticeable to user
- Names of many channels will be changed, all channels will have readable names to allow filtering by channel (e.g. there will be `warn` instead of `  ✘`)
- Channel names won't be colored, so log will be less colorful overall
- "AutoSpacing" feature is removed - it allowed to output to log stream not caring about spaces between values, like `cwarn << "Transaction hash" << hash << "already imported";` Now spaces need to be explicit like `cwarn << "Transaction hash " << hash << " already imported";` I'll try to change this in all log messages, but I might miss some.
- Some channels were supposed to be visible only in Debug build (the ones with `LogChannel::debug == true`) - but this was working only for Windows, where `NDEBUG` macro is defined in debug, for other platforms debug channels were visible in Release, too. This difference is removed, channel visibility will depend only on filtering, but not on build type.

Log message line will look like
```
2018-04-17 12:15:59 eth timer Block import 5123675 3184 ms
```
(`eth` is the name of the thread, `timer` is the name of the channel)