### PR TITLE
Improve exceptions

### DIFF
--- a/libdevcore/CommonIO.cpp
+++ b/libdevcore/CommonIO.cpp
@@ -1,18 +1,18 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file CommonIO.cpp
  * @author Gav Wood <i@gavwood.com>
@@ -54,91 +54,91 @@ void createDirectoryIfNotExistent(boost::filesystem::path const& _path)
 
 string memDump(bytes const& _bytes, unsigned _width, bool _html)
 {
-	stringstream ret;
-	if (_html)
-		ret << "<pre style=\"font-family: Monospace,Lucida Console,Courier,Courier New,sans-serif; font-size: small\">";
-	for (unsigned i = 0; i < _bytes.size(); i += _width)
-	{
-		ret << hex << setw(4) << setfill('0') << i << " ";
-		for (unsigned j = i; j < i + _width; ++j)
-			if (j < _bytes.size())
-				if (_bytes[j] >= 32 && _bytes[j] < 127)
-					if ((char)_bytes[j] == '<' && _html)
-						ret << "&lt;";
-					else if ((char)_bytes[j] == '&' && _html)
-						ret << "&amp;";
-					else
-						ret << (char)_bytes[j];
-				else
-					ret << '?';
-			else
-				ret << ' ';
-		ret << " ";
-		for (unsigned j = i; j < i + _width && j < _bytes.size(); ++j)
-			ret << setfill('0') << setw(2) << hex << (unsigned)_bytes[j] << " ";
-		ret << "\n";
-	}
-	if (_html)
-		ret << "</pre>";
-	return ret.str();
+    stringstream ret;
+    if (_html)
+        ret << "<pre style=\"font-family: Monospace,Lucida Console,Courier,Courier New,sans-serif; font-size: small\">";
+    for (unsigned i = 0; i < _bytes.size(); i += _width)
+    {
+        ret << hex << setw(4) << setfill('0') << i << " ";
+        for (unsigned j = i; j < i + _width; ++j)
+            if (j < _bytes.size())
+                if (_bytes[j] >= 32 && _bytes[j] < 127)
+                    if ((char)_bytes[j] == '<' && _html)
+                        ret << "&lt;";
+                    else if ((char)_bytes[j] == '&' && _html)
+                        ret << "&amp;";
+                    else
+                        ret << (char)_bytes[j];
+                else
+                    ret << '?';
+            else
+                ret << ' ';
+        ret << " ";
+        for (unsigned j = i; j < i + _width && j < _bytes.size(); ++j)
+            ret << setfill('0') << setw(2) << hex << (unsigned)_bytes[j] << " ";
+        ret << "\n";
+    }
+    if (_html)
+        ret << "</pre>";
+    return ret.str();
 }
 
 template <typename _T>
 inline _T contentsGeneric(boost::filesystem::path const& _file)
 {
-	_T ret;
-	size_t const c_elementSize = sizeof(typename _T::value_type);
-	boost::filesystem::ifstream is(_file, std::ifstream::binary);
-	if (!is)
-		return ret;
+    _T ret;
+    size_t const c_elementSize = sizeof(typename _T::value_type);
+    boost::filesystem::ifstream is(_file, std::ifstream::binary);
+    if (!is)
+        return ret;
 
-	// get length of file:
-	is.seekg(0, is.end);
-	streamoff length = is.tellg();
-	if (length == 0)
-		return ret; // do not read empty file (MSVC does not like it)
-	is.seekg(0, is.beg);
+    // get length of file:
+    is.seekg(0, is.end);
+    streamoff length = is.tellg();
+    if (length == 0)
+        return ret; // do not read empty file (MSVC does not like it)
+    is.seekg(0, is.beg);
 
-	ret.resize((length + c_elementSize - 1) / c_elementSize);
-	is.read(const_cast<char*>(reinterpret_cast<char const*>(ret.data())), length);
-	return ret;
+    ret.resize((length + c_elementSize - 1) / c_elementSize);
+    is.read(const_cast<char*>(reinterpret_cast<char const*>(ret.data())), length);
+    return ret;
 }
 
 bytes contents(boost::filesystem::path const& _file)
 {
-	return contentsGeneric<bytes>(_file);
+    return contentsGeneric<bytes>(_file);
 }
 
 bytesSec contentsSec(boost::filesystem::path const& _file)
 {
-	bytes b = contentsGeneric<bytes>(_file);
-	bytesSec ret(b);
-	bytesRef(&b).cleanse();
-	return ret;
+    bytes b = contentsGeneric<bytes>(_file);
+    bytesSec ret(b);
+    bytesRef(&b).cleanse();
+    return ret;
 }
 
 string contentsString(boost::filesystem::path const& _file)
 {
-	return contentsGeneric<string>(_file);
+    return contentsGeneric<string>(_file);
 }
 
 void writeFile(boost::filesystem::path const& _file, bytesConstRef _data, bool _writeDeleteRename)
 {
-	if (_writeDeleteRename)
-	{
-		fs::path tempPath = appendToFilename(_file, "-%%%%%%"); // XXX should not convert to string for this
-		writeFile(tempPath, _data, false);
-		// will delete _file if it exists
-		fs::rename(tempPath, _file);
-	}
-	else
-	{
+    if (_writeDeleteRename)
+    {
+        fs::path tempPath = appendToFilename(_file, "-%%%%%%"); // XXX should not convert to string for this
+        writeFile(tempPath, _data, false);
+        // will delete _file if it exists
+        fs::rename(tempPath, _file);
+    }
+    else
+    {
         createDirectoryIfNotExistent(_file.parent_path());
 
         boost::filesystem::ofstream s(_file, ios::trunc | ios::binary);
-		s.write(reinterpret_cast<char const*>(_data.data()), _data.size());
-		if (!s)
-			BOOST_THROW_EXCEPTION(FileError() << errinfo_comment("Could not write to file: " + _file.string()));
+        s.write(reinterpret_cast<char const*>(_data.data()), _data.size());
+        if (!s)
+            BOOST_THROW_EXCEPTION(FileError() << errinfo_comment("Could not write to file: " + _file.string()));
         DEV_IGNORE_EXCEPTIONS(fs::permissions(_file, fs::owner_read | fs::owner_write));
     }
 }
@@ -154,49 +154,53 @@ void copyDirectory(boost::filesystem::path const& _srcDir, boost::filesystem::pa
 std::string getPassword(std::string const& _prompt)
 {
 #if defined(_WIN32)
-	cout << _prompt << flush;
-	// Get current Console input flags
-	HANDLE hStdin;
-	DWORD fdwSaveOldMode;
-	if ((hStdin = GetStdHandle(STD_INPUT_HANDLE)) == INVALID_HANDLE_VALUE)
-		BOOST_THROW_EXCEPTION(ExternalFunctionFailure("GetStdHandle"));
-	if (!GetConsoleMode(hStdin, &fdwSaveOldMode))
-		BOOST_THROW_EXCEPTION(ExternalFunctionFailure("GetConsoleMode"));
-	// Set console flags to no echo
-	if (!SetConsoleMode(hStdin, fdwSaveOldMode & (~ENABLE_ECHO_INPUT)))
-		BOOST_THROW_EXCEPTION(ExternalFunctionFailure("SetConsoleMode"));
-	// Read the string
-	std::string ret;
-	std::getline(cin, ret);
-	// Restore old input mode
-	if (!SetConsoleMode(hStdin, fdwSaveOldMode))
-		BOOST_THROW_EXCEPTION(ExternalFunctionFailure("SetConsoleMode"));
-	return ret;
+    cout << _prompt << flush;
+    // Get current Console input flags
+    HANDLE hStdin;
+    DWORD fdwSaveOldMode;
+    if ((hStdin = GetStdHandle(STD_INPUT_HANDLE)) == INVALID_HANDLE_VALUE)
+        BOOST_THROW_EXCEPTION(
+            ExternalFunctionFailure() << errinfo_externalFunction("GetStdHandle"));
+    if (!GetConsoleMode(hStdin, &fdwSaveOldMode))
+        BOOST_THROW_EXCEPTION(
+            ExternalFunctionFailure() << errinfo_externalFunction("GetConsoleMode"));
+    // Set console flags to no echo
+    if (!SetConsoleMode(hStdin, fdwSaveOldMode & (~ENABLE_ECHO_INPUT)))
+        BOOST_THROW_EXCEPTION(
+            ExternalFunctionFailure() << errinfo_externalFunction("SetConsoleMode"));
+    // Read the string
+    std::string ret;
+    std::getline(cin, ret);
+    // Restore old input mode
+    if (!SetConsoleMode(hStdin, fdwSaveOldMode))
+        BOOST_THROW_EXCEPTION(
+            ExternalFunctionFailure() << errinfo_externalFunction("SetConsoleMode"));
+    return ret;
 #else
-	struct termios oflags;
-	struct termios nflags;
-	char password[256];
+    struct termios oflags;
+    struct termios nflags;
+    char password[256];
 
-	// disable echo in the terminal
-	tcgetattr(fileno(stdin), &oflags);
-	nflags = oflags;
-	nflags.c_lflag &= ~ECHO;
-	nflags.c_lflag |= ECHONL;
+    // disable echo in the terminal
+    tcgetattr(fileno(stdin), &oflags);
+    nflags = oflags;
+    nflags.c_lflag &= ~ECHO;
+    nflags.c_lflag |= ECHONL;
 
-	if (tcsetattr(fileno(stdin), TCSANOW, &nflags) != 0)
-		BOOST_THROW_EXCEPTION(ExternalFunctionFailure("tcsetattr"));
+    if (tcsetattr(fileno(stdin), TCSANOW, &nflags) != 0)
+        BOOST_THROW_EXCEPTION(ExternalFunctionFailure() << errinfo_externalFunction("tcsetattr"));
 
-	printf("%s", _prompt.c_str());
-	if (!fgets(password, sizeof(password), stdin))
-		BOOST_THROW_EXCEPTION(ExternalFunctionFailure("fgets"));
-	password[strlen(password) - 1] = 0;
+    printf("%s", _prompt.c_str());
+    if (!fgets(password, sizeof(password), stdin))
+        BOOST_THROW_EXCEPTION(ExternalFunctionFailure() << errinfo_externalFunction("fgets"));
+    password[strlen(password) - 1] = 0;
 
-	// restore terminal
-	if (tcsetattr(fileno(stdin), TCSANOW, &oflags) != 0)
-		BOOST_THROW_EXCEPTION(ExternalFunctionFailure("tcsetattr"));
+    // restore terminal
+    if (tcsetattr(fileno(stdin), TCSANOW, &oflags) != 0)
+        BOOST_THROW_EXCEPTION(ExternalFunctionFailure() << errinfo_externalFunction("tcsetattr"));
 
 
-	return password;
+    return password;
 #endif
 }
 

--- a/libdevcore/Exceptions.h
+++ b/libdevcore/Exceptions.h
@@ -33,15 +33,26 @@
 
 namespace dev
 {
+// error information to be added to exceptions
+using errinfo_invalidSymbol = boost::error_info<struct tag_invalidSymbol, char>;
+using errinfo_wrongAddress = boost::error_info<struct tag_address, std::string>;
+using errinfo_comment = boost::error_info<struct tag_comment, std::string>;
+using errinfo_required = boost::error_info<struct tag_required, bigint>;
+using errinfo_got = boost::error_info<struct tag_got, bigint>;
+using errinfo_min = boost::error_info<struct tag_min, bigint>;
+using errinfo_max = boost::error_info<struct tag_max, bigint>;
+using RequirementError = boost::tuple<errinfo_required, errinfo_got>;
+using errinfo_hash256 = boost::error_info<struct tag_hash, h256>;
+using errinfo_required_h256 = boost::error_info<struct tag_required_h256, h256>;
+using errinfo_got_h256 = boost::error_info<struct tag_get_h256, h256>;
+using Hash256RequirementError = boost::tuple<errinfo_required_h256, errinfo_got_h256>;
+using errinfo_extraData = boost::error_info<struct tag_extraData, bytes>;
 
 /// Base class for all exceptions.
 struct Exception: virtual std::exception, virtual boost::exception
 {
-	Exception(std::string _message = std::string()): m_message(std::move(_message)) {}
-	const char* what() const noexcept override { return m_message.empty() ? std::exception::what() : m_message.c_str(); }
-
-private:
-	std::string m_message;
+    Exception() {}
+    Exception(std::string _message) { *this << errinfo_comment(_message); }
 };
 
 #define DEV_SIMPLE_EXCEPTION(X) struct X: virtual Exception { const char* what() const noexcept override { return #X; } }
@@ -68,20 +79,5 @@ DEV_SIMPLE_EXCEPTION(UnknownField);
 
 struct InterfaceNotSupported: virtual Exception { public: InterfaceNotSupported(std::string const& _f): Exception("Interface " + _f + " not supported.") {} };
 struct ExternalFunctionFailure: virtual Exception { public: ExternalFunctionFailure(std::string const& _f): Exception("Function " + _f + "() failed.") {} };
-
-// error information to be added to exceptions
-using errinfo_invalidSymbol = boost::error_info<struct tag_invalidSymbol, char>;
-using errinfo_wrongAddress = boost::error_info<struct tag_address, std::string>;
-using errinfo_comment = boost::error_info<struct tag_comment, std::string>;
-using errinfo_required = boost::error_info<struct tag_required, bigint>;
-using errinfo_got = boost::error_info<struct tag_got, bigint>;
-using errinfo_min = boost::error_info<struct tag_min, bigint>;
-using errinfo_max = boost::error_info<struct tag_max, bigint>;
-using RequirementError = boost::tuple<errinfo_required, errinfo_got>;
-using errinfo_hash256 = boost::error_info<struct tag_hash, h256>;
-using errinfo_required_h256 = boost::error_info<struct tag_required_h256, h256>;
-using errinfo_got_h256 = boost::error_info<struct tag_get_h256, h256>;
-using Hash256RequirementError = boost::tuple<errinfo_required_h256, errinfo_got_h256>;
-using errinfo_extraData = boost::error_info<struct tag_extraData, bytes>;
 
 }

--- a/libdevcore/Exceptions.h
+++ b/libdevcore/Exceptions.h
@@ -37,15 +37,22 @@ namespace dev
 /// Base class for all exceptions.
 struct Exception : virtual std::exception, virtual boost::exception
 {
+    const char* what() const noexcept override { return boost::diagnostic_information_what(*this); }
 };
 
-#define DEV_SIMPLE_EXCEPTION(X) struct X: virtual Exception { const char* what() const noexcept override { return #X; } }
+#define DEV_SIMPLE_EXCEPTION(X)  \
+    struct X : virtual Exception \
+    {                            \
+    }
 
 /// Base class for all RLP exceptions.
 struct RLPException : virtual Exception
 {
 };
-#define DEV_SIMPLE_EXCEPTION_RLP(X) struct X: virtual RLPException { const char* what() const noexcept override { return #X; } }
+#define DEV_SIMPLE_EXCEPTION_RLP(X) \
+    struct X : virtual RLPException \
+    {                               \
+    }
 
 DEV_SIMPLE_EXCEPTION_RLP(BadCast);
 DEV_SIMPLE_EXCEPTION_RLP(BadRLP);

--- a/libdevcore/Exceptions.h
+++ b/libdevcore/Exceptions.h
@@ -1,18 +1,18 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file Exceptions.h
  * @author Gav Wood <i@gavwood.com>
@@ -21,18 +21,50 @@
 
 #pragma once
 
-#include <exception>
-#include <string>
+#include "FixedHash.h"
+#include <boost/exception/diagnostic_information.hpp>
+#include <boost/exception/errinfo_api_function.hpp>
 #include <boost/exception/exception.hpp>
 #include <boost/exception/info.hpp>
 #include <boost/exception/info_tuple.hpp>
-#include <boost/exception/diagnostic_information.hpp>
 #include <boost/throw_exception.hpp>
 #include <boost/tuple/tuple.hpp>
-#include "FixedHash.h"
+#include <exception>
+#include <string>
 
 namespace dev
 {
+/// Base class for all exceptions.
+struct Exception : virtual std::exception, virtual boost::exception
+{
+};
+
+#define DEV_SIMPLE_EXCEPTION(X) struct X: virtual Exception { const char* what() const noexcept override { return #X; } }
+
+/// Base class for all RLP exceptions.
+struct RLPException : virtual Exception
+{
+};
+#define DEV_SIMPLE_EXCEPTION_RLP(X) struct X: virtual RLPException { const char* what() const noexcept override { return #X; } }
+
+DEV_SIMPLE_EXCEPTION_RLP(BadCast);
+DEV_SIMPLE_EXCEPTION_RLP(BadRLP);
+DEV_SIMPLE_EXCEPTION_RLP(OversizeRLP);
+DEV_SIMPLE_EXCEPTION_RLP(UndersizeRLP);
+
+DEV_SIMPLE_EXCEPTION(BadHexCharacter);
+DEV_SIMPLE_EXCEPTION(NoNetworking);
+DEV_SIMPLE_EXCEPTION(NoUPnPDevice);
+DEV_SIMPLE_EXCEPTION(RootNotFound);
+DEV_SIMPLE_EXCEPTION(BadRoot);
+DEV_SIMPLE_EXCEPTION(FileError);
+DEV_SIMPLE_EXCEPTION(Overflow);
+DEV_SIMPLE_EXCEPTION(FailedInvariant);
+DEV_SIMPLE_EXCEPTION(ValueTooLarge);
+DEV_SIMPLE_EXCEPTION(UnknownField);
+DEV_SIMPLE_EXCEPTION(InterfaceNotSupported);
+DEV_SIMPLE_EXCEPTION(ExternalFunctionFailure);
+
 // error information to be added to exceptions
 using errinfo_invalidSymbol = boost::error_info<struct tag_invalidSymbol, char>;
 using errinfo_wrongAddress = boost::error_info<struct tag_address, std::string>;
@@ -47,37 +79,6 @@ using errinfo_required_h256 = boost::error_info<struct tag_required_h256, h256>;
 using errinfo_got_h256 = boost::error_info<struct tag_get_h256, h256>;
 using Hash256RequirementError = boost::tuple<errinfo_required_h256, errinfo_got_h256>;
 using errinfo_extraData = boost::error_info<struct tag_extraData, bytes>;
-
-/// Base class for all exceptions.
-struct Exception: virtual std::exception, virtual boost::exception
-{
-    Exception() {}
-    Exception(std::string _message) { *this << errinfo_comment(_message); }
-};
-
-#define DEV_SIMPLE_EXCEPTION(X) struct X: virtual Exception { const char* what() const noexcept override { return #X; } }
-
-/// Base class for all RLP exceptions.
-struct RLPException: virtual Exception { RLPException(std::string _message = std::string()): Exception(_message) {} };
-#define DEV_SIMPLE_EXCEPTION_RLP(X) struct X: virtual RLPException { const char* what() const noexcept override { return #X; } }
-
-DEV_SIMPLE_EXCEPTION_RLP(BadCast);
-DEV_SIMPLE_EXCEPTION_RLP(BadRLP);
-DEV_SIMPLE_EXCEPTION_RLP(OversizeRLP);
-DEV_SIMPLE_EXCEPTION_RLP(UndersizeRLP);
-
-DEV_SIMPLE_EXCEPTION(BadHexCharacter);
-DEV_SIMPLE_EXCEPTION(NoNetworking);
-DEV_SIMPLE_EXCEPTION(NoUPnPDevice);
-DEV_SIMPLE_EXCEPTION(RootNotFound);
-struct BadRoot: virtual Exception { public: BadRoot(h256 const& _root): Exception("BadRoot " + _root.hex()), root(_root) {} h256 root; };
-DEV_SIMPLE_EXCEPTION(FileError);
-DEV_SIMPLE_EXCEPTION(Overflow);
-DEV_SIMPLE_EXCEPTION(FailedInvariant);
-DEV_SIMPLE_EXCEPTION(ValueTooLarge);
-DEV_SIMPLE_EXCEPTION(UnknownField);
-
-struct InterfaceNotSupported: virtual Exception { public: InterfaceNotSupported(std::string const& _f): Exception("Interface " + _f + " not supported.") {} };
-struct ExternalFunctionFailure: virtual Exception { public: ExternalFunctionFailure(std::string const& _f): Exception("Function " + _f + "() failed.") {} };
-
+using errinfo_externalFunction = boost::errinfo_api_function;
+using errinfo_interface = boost::error_info<struct tag_interface, std::string>;
 }

--- a/libdevcore/TrieDB.h
+++ b/libdevcore/TrieDB.h
@@ -1,18 +1,18 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file TrieDB.h
  * @author Gav Wood <i@gavwood.com>
@@ -32,16 +32,16 @@ namespace dev
 
 struct TrieDBChannel: public LogChannel
 {
-	static const char* name() { return "-T-"; }
-	static const int verbosity = 17;
+    static const char* name() { return "-T-"; }
+    static const int verbosity = 17;
 };
 #define tdebug clog(TrieDBChannel)
 
 struct InvalidTrie: virtual dev::Exception {};
 
 enum class Verification {
-	Skip,
-	Normal
+    Skip,
+    Normal
 };
 
 /**
@@ -63,250 +63,258 @@ template <class _DB>
 class GenericTrieDB
 {
 public:
-	using DB = _DB;
+    using DB = _DB;
 
-	explicit GenericTrieDB(DB* _db = nullptr): m_db(_db) {}
-	GenericTrieDB(DB* _db, h256 const& _root, Verification _v = Verification::Normal) { open(_db, _root, _v); }
-	~GenericTrieDB() {}
+    explicit GenericTrieDB(DB* _db = nullptr): m_db(_db) {}
+    GenericTrieDB(DB* _db, h256 const& _root, Verification _v = Verification::Normal) { open(_db, _root, _v); }
+    ~GenericTrieDB() {}
 
-	void open(DB* _db) { m_db = _db; }
-	void open(DB* _db, h256 const& _root, Verification _v = Verification::Normal) { m_db = _db; setRoot(_root, _v); }
+    void open(DB* _db) { m_db = _db; }
+    void open(DB* _db, h256 const& _root, Verification _v = Verification::Normal) { m_db = _db; setRoot(_root, _v); }
 
-	void init() { setRoot(forceInsertNode(&RLPNull)); assert(node(m_root).size()); }
+    void init() { setRoot(forceInsertNode(&RLPNull)); assert(node(m_root).size()); }
 
-	void setRoot(h256 const& _root, Verification _v = Verification::Normal)
-	{
-		m_root = _root;
-		if (_v == Verification::Normal)
-		{
-			if (m_root == EmptyTrie && !m_db->exists(m_root))
-				init();
-		}
-		if (_v == Verification::Normal)
-			if (!node(m_root).size())
-				BOOST_THROW_EXCEPTION(RootNotFound());
-	}
+    void setRoot(h256 const& _root, Verification _v = Verification::Normal)
+    {
+        m_root = _root;
+        if (_v == Verification::Normal)
+        {
+            if (m_root == EmptyTrie && !m_db->exists(m_root))
+                init();
+        }
+        if (_v == Verification::Normal)
+            if (!node(m_root).size())
+                BOOST_THROW_EXCEPTION(RootNotFound());
+    }
 
-	/// True if the trie is uninitialised (i.e. that the DB doesn't contain the root node).
-	bool isNull() const { return !node(m_root).size(); }
-	/// True if the trie is initialised but empty (i.e. that the DB contains the root node which is empty).
-	bool isEmpty() const { return m_root == EmptyTrie && node(m_root).size(); }
+    /// True if the trie is uninitialised (i.e. that the DB doesn't contain the root node).
+    bool isNull() const { return !node(m_root).size(); }
+    /// True if the trie is initialised but empty (i.e. that the DB contains the root node which is empty).
+    bool isEmpty() const { return m_root == EmptyTrie && node(m_root).size(); }
 
-	h256 const& root() const { if (node(m_root).empty()) BOOST_THROW_EXCEPTION(BadRoot(m_root)); /*std::cout << "Returning root as " << ret << " (really " << m_root << ")" << std::endl;*/ return m_root; }	// patch the root in the case of the empty trie. TODO: handle this properly.
+    h256 const& root() const
+    {
+        if (node(m_root).empty())
+            BOOST_THROW_EXCEPTION(BadRoot() << errinfo_hash256(m_root));
+        return m_root;
+    }  // patch the root in the case of the empty trie. TODO: handle this properly.
 
-	std::string at(bytes const& _key) const { return at(&_key); }
-	std::string at(bytesConstRef _key) const;
-	void insert(bytes const& _key, bytes const& _value) { insert(&_key, &_value); }
-	void insert(bytesConstRef _key, bytes const& _value) { insert(_key, &_value); }
-	void insert(bytes const& _key, bytesConstRef _value) { insert(&_key, _value); }
-	void insert(bytesConstRef _key, bytesConstRef _value);
-	void remove(bytes const& _key) { remove(&_key); }
-	void remove(bytesConstRef _key);
-	bool contains(bytes const& _key) const { return contains(&_key); }
-	bool contains(bytesConstRef _key) const { return !at(_key).empty(); }
+    std::string at(bytes const& _key) const { return at(&_key); }
+    std::string at(bytesConstRef _key) const;
+    void insert(bytes const& _key, bytes const& _value) { insert(&_key, &_value); }
+    void insert(bytesConstRef _key, bytes const& _value) { insert(_key, &_value); }
+    void insert(bytes const& _key, bytesConstRef _value) { insert(&_key, _value); }
+    void insert(bytesConstRef _key, bytesConstRef _value);
+    void remove(bytes const& _key) { remove(&_key); }
+    void remove(bytesConstRef _key);
+    bool contains(bytes const& _key) const { return contains(&_key); }
+    bool contains(bytesConstRef _key) const { return !at(_key).empty(); }
 
-	class iterator
-	{
-	public:
-		using value_type = std::pair<bytesConstRef, bytesConstRef>;
+    class iterator
+    {
+    public:
+        using value_type = std::pair<bytesConstRef, bytesConstRef>;
 
-		iterator() {}
-		explicit iterator(GenericTrieDB const* _db);
-		iterator(GenericTrieDB const* _db, bytesConstRef _key);
+        iterator() {}
+        explicit iterator(GenericTrieDB const* _db);
+        iterator(GenericTrieDB const* _db, bytesConstRef _key);
 
-		iterator& operator++() { next(); return *this; }
+        iterator& operator++() { next(); return *this; }
 
-		value_type operator*() const { return at(); }
-		value_type operator->() const { return at(); }
+        value_type operator*() const { return at(); }
+        value_type operator->() const { return at(); }
 
-		bool operator==(iterator const& _c) const { return _c.m_trail == m_trail; }
-		bool operator!=(iterator const& _c) const { return _c.m_trail != m_trail; }
+        bool operator==(iterator const& _c) const { return _c.m_trail == m_trail; }
+        bool operator!=(iterator const& _c) const { return _c.m_trail != m_trail; }
 
-		value_type at() const;
+        value_type at() const;
 
-	private:
-		void next();
-		void next(NibbleSlice _key);
+    private:
+        void next();
+        void next(NibbleSlice _key);
 
-		struct Node
-		{
-			std::string rlp;
-			std::string key;		// as hexPrefixEncoding.
-			byte child;				// 255 -> entering, 16 -> actually at the node, 17 -> exiting, 0-15 -> actual children.
+        struct Node
+        {
+            std::string rlp;
+            std::string key;		// as hexPrefixEncoding.
+            byte child;				// 255 -> entering, 16 -> actually at the node, 17 -> exiting, 0-15 -> actual children.
 
-			// 255 -> 16 -> 0 -> 1 -> ... -> 15 -> 17
+            // 255 -> 16 -> 0 -> 1 -> ... -> 15 -> 17
 
-			void setChild(unsigned _i) { child = _i; }
-			void setFirstChild() { child = 16; }
-			void incrementChild() { child = child == 16 ? 0 : child == 15 ? 17 : (child + 1); }
+            void setChild(unsigned _i) { child = _i; }
+            void setFirstChild() { child = 16; }
+            void incrementChild() { child = child == 16 ? 0 : child == 15 ? 17 : (child + 1); }
 
-			bool operator==(Node const& _c) const { return rlp == _c.rlp && key == _c.key && child == _c.child; }
-			bool operator!=(Node const& _c) const { return !operator==(_c); }
-		};
+            bool operator==(Node const& _c) const { return rlp == _c.rlp && key == _c.key && child == _c.child; }
+            bool operator!=(Node const& _c) const { return !operator==(_c); }
+        };
 
-	protected:
-		std::vector<Node> m_trail;
-		GenericTrieDB<DB> const* m_that;
-	};
+    protected:
+        std::vector<Node> m_trail;
+        GenericTrieDB<DB> const* m_that;
+    };
 
-	iterator begin() const { return iterator(this); }
-	iterator end() const { return iterator(); }
+    iterator begin() const { return iterator(this); }
+    iterator end() const { return iterator(); }
 
-	iterator lower_bound(bytesConstRef _key) const { return iterator(this, _key); }
+    iterator lower_bound(bytesConstRef _key) const { return iterator(this, _key); }
 
-	/// Used for debugging, scans the whole trie.
-	void descendKey(h256 const& _k, h256Hash& _keyMask, bool _wasExt, std::ostream* _out, int _indent = 0) const
-	{
-		_keyMask.erase(_k);
-		if (_k == m_root && _k == EmptyTrie)	// root allowed to be empty
-			return;
-		descendList(RLP(node(_k)), _keyMask, _wasExt, _out, _indent);	// if not, it must be a list
-	}
+    /// Used for debugging, scans the whole trie.
+    void descendKey(h256 const& _k, h256Hash& _keyMask, bool _wasExt, std::ostream* _out, int _indent = 0) const
+    {
+        _keyMask.erase(_k);
+        if (_k == m_root && _k == EmptyTrie)	// root allowed to be empty
+            return;
+        std::string const s = node(_k);
+        RLP r = RLP(s);
+        descendList(r, _keyMask, _wasExt, _out, _indent);  // if not, it must be a list
+    }
 
-	/// Used for debugging, scans the whole trie.
-	void descendEntry(RLP const& _r, h256Hash& _keyMask, bool _wasExt, std::ostream* _out, int _indent) const
-	{
-		if (_r.isData() && _r.size() == 32)
-			descendKey(_r.toHash<h256>(), _keyMask, _wasExt, _out, _indent);
-		else if (_r.isList())
-			descendList(_r, _keyMask, _wasExt, _out, _indent);
-		else
-			BOOST_THROW_EXCEPTION(InvalidTrie());
-	}
+    /// Used for debugging, scans the whole trie.
+    void descendEntry(
+        RLP const& _r, h256Hash& _keyMask, bool _wasExt, std::ostream* _out, int _indent) const
+    {
+        if (_r.isData() && _r.size() == 32)
+            descendKey(_r.toHash<h256>(), _keyMask, _wasExt, _out, _indent);
+        else if (_r.isList())
+            descendList(_r, _keyMask, _wasExt, _out, _indent);
+        else
+            BOOST_THROW_EXCEPTION(InvalidTrie());
+    }
 
-	/// Used for debugging, scans the whole trie.
-	void descendList(RLP const& _r, h256Hash& _keyMask, bool _wasExt, std::ostream* _out, int _indent) const
-	{
-		if (_r.isList() && _r.itemCount() == 2 && (!_wasExt || _out))
-		{
-			if (_out)
-				(*_out) << std::string(_indent * 2, ' ') << (_wasExt ? "!2 " : "2  ") << sha3(_r.data()) << ": " << _r << "\n";
-			if (!isLeaf(_r))						// don't go down leaves
-				descendEntry(_r[1], _keyMask, true, _out, _indent + 1);
-		}
-		else if (_r.isList() && _r.itemCount() == 17)
-		{
-			if (_out)
-				(*_out) << std::string(_indent * 2, ' ') << "17 " << sha3(_r.data()) << ": " << _r << "\n";
-			for (unsigned i = 0; i < 16; ++i)
-				if (!_r[i].isEmpty())				// 16 branches are allowed to be empty
-					descendEntry(_r[i], _keyMask, false, _out, _indent + 1);
-		}
-		else
-			BOOST_THROW_EXCEPTION(InvalidTrie());
-	}
+    /// Used for debugging, scans the whole trie.
+    void descendList(RLP const& _r, h256Hash& _keyMask, bool _wasExt, std::ostream* _out, int _indent) const
+    {
+        if (_r.isList() && _r.itemCount() == 2 && (!_wasExt || _out))
+        {
+            if (_out)
+                (*_out) << std::string(_indent * 2, ' ') << (_wasExt ? "!2 " : "2  ") << sha3(_r.data()) << ": " << _r << "\n";
+            if (!isLeaf(_r))						// don't go down leaves
+                descendEntry(_r[1], _keyMask, true, _out, _indent + 1);
+        }
+        else if (_r.isList() && _r.itemCount() == 17)
+        {
+            if (_out)
+                (*_out) << std::string(_indent * 2, ' ') << "17 " << sha3(_r.data()) << ": " << _r << "\n";
+            for (unsigned i = 0; i < 16; ++i)
+                if (!_r[i].isEmpty())				// 16 branches are allowed to be empty
+                    descendEntry(_r[i], _keyMask, false, _out, _indent + 1);
+        }
+        else
+            BOOST_THROW_EXCEPTION(InvalidTrie());
+    }
 
-	/// Used for debugging, scans the whole trie.
-	h256Hash leftOvers(std::ostream* _out = nullptr) const
-	{
-		h256Hash k = m_db->keys();
-		descendKey(m_root, k, false, _out);
-		return k;
-	}
+    /// Used for debugging, scans the whole trie.
+    h256Hash leftOvers(std::ostream* _out = nullptr) const
+    {
+        h256Hash k = m_db->keys();
+        descendKey(m_root, k, false, _out);
+        return k;
+    }
 
-	/// Used for debugging, scans the whole trie.
-	void debugStructure(std::ostream& _out) const
-	{
-		leftOvers(&_out);
-	}
+    /// Used for debugging, scans the whole trie.
+    void debugStructure(std::ostream& _out) const
+    {
+        leftOvers(&_out);
+    }
 
-	/// Used for debugging, scans the whole trie.
-	/// @param _requireNoLeftOvers if true, requires that all keys are reachable.
-	bool check(bool _requireNoLeftOvers) const
-	{
-		try
-		{
-			return leftOvers().empty() || !_requireNoLeftOvers;
-		}
-		catch (...)
-		{
-			cwarn << boost::current_exception_diagnostic_information();
-			return false;
-		}
-	}
+    /// Used for debugging, scans the whole trie.
+    /// @param _requireNoLeftOvers if true, requires that all keys are reachable.
+    bool check(bool _requireNoLeftOvers) const
+    {
+        try
+        {
+            return leftOvers().empty() || !_requireNoLeftOvers;
+        }
+        catch (...)
+        {
+            cwarn << boost::current_exception_diagnostic_information();
+            return false;
+        }
+    }
 
-	/// Get the underlying database.
-	/// @warning This can be used to bypass the trie code. Don't use these unless you *really*
-	/// know what you're doing.
-	DB const* db() const { return m_db; }
-	DB* db() { return m_db; }
+    /// Get the underlying database.
+    /// @warning This can be used to bypass the trie code. Don't use these unless you *really*
+    /// know what you're doing.
+    DB const* db() const { return m_db; }
+    DB* db() { return m_db; }
 
 private:
-	RLPStream& streamNode(RLPStream& _s, bytes const& _b);
+    RLPStream& streamNode(RLPStream& _s, bytes const& _b);
 
-	std::string atAux(RLP const& _here, NibbleSlice _key) const;
+    std::string atAux(RLP const& _here, NibbleSlice _key) const;
 
-	void mergeAtAux(RLPStream& _out, RLP const& _replace, NibbleSlice _key, bytesConstRef _value);
-	bytes mergeAt(RLP const& _replace, NibbleSlice _k, bytesConstRef _v, bool _inLine = false);
-	bytes mergeAt(RLP const& _replace, h256 const& _replaceHash, NibbleSlice _k, bytesConstRef _v, bool _inLine = false);
+    void mergeAtAux(RLPStream& _out, RLP const& _replace, NibbleSlice _key, bytesConstRef _value);
+    bytes mergeAt(RLP const& _replace, NibbleSlice _k, bytesConstRef _v, bool _inLine = false);
+    bytes mergeAt(RLP const& _replace, h256 const& _replaceHash, NibbleSlice _k, bytesConstRef _v, bool _inLine = false);
 
-	bool deleteAtAux(RLPStream& _out, RLP const& _replace, NibbleSlice _key);
-	bytes deleteAt(RLP const& _replace, NibbleSlice _k);
+    bool deleteAtAux(RLPStream& _out, RLP const& _replace, NibbleSlice _key);
+    bytes deleteAt(RLP const& _replace, NibbleSlice _k);
 
-	// in: null (DEL)  -- OR --  [_k, V] (DEL)
-	// out: [_k, _s]
-	// -- OR --
-	// in: [V0, ..., V15, S16] (DEL)  AND  _k == {}
-	// out: [V0, ..., V15, _s]
-	bytes place(RLP const& _orig, NibbleSlice _k, bytesConstRef _s);
+    // in: null (DEL)  -- OR --  [_k, V] (DEL)
+    // out: [_k, _s]
+    // -- OR --
+    // in: [V0, ..., V15, S16] (DEL)  AND  _k == {}
+    // out: [V0, ..., V15, _s]
+    bytes place(RLP const& _orig, NibbleSlice _k, bytesConstRef _s);
 
-	// in: [K, S] (DEL)
-	// out: null
-	// -- OR --
-	// in: [V0, ..., V15, S] (DEL)
-	// out: [V0, ..., V15, null]
-	bytes remove(RLP const& _orig);
+    // in: [K, S] (DEL)
+    // out: null
+    // -- OR --
+    // in: [V0, ..., V15, S] (DEL)
+    // out: [V0, ..., V15, null]
+    bytes remove(RLP const& _orig);
 
-	// in: [K1 & K2, V] (DEL) : nibbles(K1) == _s, 0 < _s <= nibbles(K1 & K2)
-	// out: [K1, H] ; [K2, V] => H (INS)  (being  [K1, [K2, V]]  if necessary)
-	bytes cleve(RLP const& _orig, unsigned _s);
+    // in: [K1 & K2, V] (DEL) : nibbles(K1) == _s, 0 < _s <= nibbles(K1 & K2)
+    // out: [K1, H] ; [K2, V] => H (INS)  (being  [K1, [K2, V]]  if necessary)
+    bytes cleve(RLP const& _orig, unsigned _s);
 
-	// in: [K1, H] (DEL) ; H <= [K2, V] (DEL)  (being  [K1, [K2, V]] (DEL)  if necessary)
-	// out: [K1 & K2, V]
-	bytes graft(RLP const& _orig);
+    // in: [K1, H] (DEL) ; H <= [K2, V] (DEL)  (being  [K1, [K2, V]] (DEL)  if necessary)
+    // out: [K1 & K2, V]
+    bytes graft(RLP const& _orig);
 
-	// in: [V0, ... V15, S] (DEL)
-	// out1: [k{i}, Vi]    where i < 16
-	// out2: [k{}, S]      where i == 16
-	bytes merge(RLP const& _orig, byte _i);
+    // in: [V0, ... V15, S] (DEL)
+    // out1: [k{i}, Vi]    where i < 16
+    // out2: [k{}, S]      where i == 16
+    bytes merge(RLP const& _orig, byte _i);
 
-	// in: [k{}, S] (DEL)
-	// out: [null ** 16, S]
-	// -- OR --
-	// in: [k{i}, N] (DEL)
-	// out: [null ** i, N, null ** (16 - i)]
-	// -- OR --
-	// in: [k{i}K, V] (DEL)
-	// out: [null ** i, H, null ** (16 - i)] ; [K, V] => H (INS)  (being [null ** i, [K, V], null ** (16 - i)]  if necessary)
-	bytes branch(RLP const& _orig);
+    // in: [k{}, S] (DEL)
+    // out: [null ** 16, S]
+    // -- OR --
+    // in: [k{i}, N] (DEL)
+    // out: [null ** i, N, null ** (16 - i)]
+    // -- OR --
+    // in: [k{i}K, V] (DEL)
+    // out: [null ** i, H, null ** (16 - i)] ; [K, V] => H (INS)  (being [null ** i, [K, V], null ** (16 - i)]  if necessary)
+    bytes branch(RLP const& _orig);
 
-	bool isTwoItemNode(RLP const& _n) const;
-	std::string deref(RLP const& _n) const;
+    bool isTwoItemNode(RLP const& _n) const;
+    std::string deref(RLP const& _n) const;
 
-	std::string node(h256 const& _h) const { return m_db->lookup(_h); }
+    std::string node(h256 const& _h) const { return m_db->lookup(_h); }
 
-	// These are low-level node insertion functions that just go straight through into the DB.
-	h256 forceInsertNode(bytesConstRef _v) { auto h = sha3(_v); forceInsertNode(h, _v); return h; }
-	void forceInsertNode(h256 const& _h, bytesConstRef _v) { m_db->insert(_h, _v); }
-	void forceKillNode(h256 const& _h) { m_db->kill(_h); }
+    // These are low-level node insertion functions that just go straight through into the DB.
+    h256 forceInsertNode(bytesConstRef _v) { auto h = sha3(_v); forceInsertNode(h, _v); return h; }
+    void forceInsertNode(h256 const& _h, bytesConstRef _v) { m_db->insert(_h, _v); }
+    void forceKillNode(h256 const& _h) { m_db->kill(_h); }
 
-	// This are semantically-aware node insertion functions that only kills when the node's
-	// data is < 32 bytes. It can safely be used when pruning the trie but won't work correctly
-	// for the special case of the root (which is always looked up via a hash). In that case,
-	// use forceKillNode().
-	void killNode(RLP const& _d) { if (_d.data().size() >= 32) forceKillNode(sha3(_d.data())); }
-	void killNode(RLP const& _d, h256 const& _h) { if (_d.data().size() >= 32) forceKillNode(_h); }
+    // This are semantically-aware node insertion functions that only kills when the node's
+    // data is < 32 bytes. It can safely be used when pruning the trie but won't work correctly
+    // for the special case of the root (which is always looked up via a hash). In that case,
+    // use forceKillNode().
+    void killNode(RLP const& _d) { if (_d.data().size() >= 32) forceKillNode(sha3(_d.data())); }
+    void killNode(RLP const& _d, h256 const& _h) { if (_d.data().size() >= 32) forceKillNode(_h); }
 
-	h256 m_root;
-	DB* m_db = nullptr;
+    h256 m_root;
+    DB* m_db = nullptr;
 };
 
 template <class DB>
 std::ostream& operator<<(std::ostream& _out, GenericTrieDB<DB> const& _db)
 {
-	for (auto const& i: _db)
-		_out << escaped(i.first.toString(), false) << ": " << escaped(i.second.toString(), false) << std::endl;
-	return _out;
+    for (auto const& i: _db)
+        _out << escaped(i.first.toString(), false) << ": " << escaped(i.second.toString(), false) << std::endl;
+    return _out;
 }
 
 /**
@@ -316,179 +324,179 @@ template <class Generic, class _KeyType>
 class SpecificTrieDB: public Generic
 {
 public:
-	using DB = typename Generic::DB;
-	using KeyType = _KeyType;
+    using DB = typename Generic::DB;
+    using KeyType = _KeyType;
 
-	SpecificTrieDB(DB* _db = nullptr): Generic(_db) {}
-	SpecificTrieDB(DB* _db, h256 _root, Verification _v = Verification::Normal): Generic(_db, _root, _v) {}
+    SpecificTrieDB(DB* _db = nullptr): Generic(_db) {}
+    SpecificTrieDB(DB* _db, h256 _root, Verification _v = Verification::Normal): Generic(_db, _root, _v) {}
 
-	std::string operator[](KeyType _k) const { return at(_k); }
+    std::string operator[](KeyType _k) const { return at(_k); }
 
-	bool contains(KeyType _k) const { return Generic::contains(bytesConstRef((byte const*)&_k, sizeof(KeyType))); }
-	std::string at(KeyType _k) const { return Generic::at(bytesConstRef((byte const*)&_k, sizeof(KeyType))); }
-	void insert(KeyType _k, bytesConstRef _value) { Generic::insert(bytesConstRef((byte const*)&_k, sizeof(KeyType)), _value); }
-	void insert(KeyType _k, bytes const& _value) { insert(_k, bytesConstRef(&_value)); }
-	void remove(KeyType _k) { Generic::remove(bytesConstRef((byte const*)&_k, sizeof(KeyType))); }
+    bool contains(KeyType _k) const { return Generic::contains(bytesConstRef((byte const*)&_k, sizeof(KeyType))); }
+    std::string at(KeyType _k) const { return Generic::at(bytesConstRef((byte const*)&_k, sizeof(KeyType))); }
+    void insert(KeyType _k, bytesConstRef _value) { Generic::insert(bytesConstRef((byte const*)&_k, sizeof(KeyType)), _value); }
+    void insert(KeyType _k, bytes const& _value) { insert(_k, bytesConstRef(&_value)); }
+    void remove(KeyType _k) { Generic::remove(bytesConstRef((byte const*)&_k, sizeof(KeyType))); }
 
-	class iterator: public Generic::iterator
-	{
-	public:
-		using Super = typename Generic::iterator;
-		using value_type = std::pair<KeyType, bytesConstRef>;
+    class iterator: public Generic::iterator
+    {
+    public:
+        using Super = typename Generic::iterator;
+        using value_type = std::pair<KeyType, bytesConstRef>;
 
-		iterator() {}
-		iterator(Generic const* _db): Super(_db) {}
-		iterator(Generic const* _db, bytesConstRef _k): Super(_db, _k) {}
+        iterator() {}
+        iterator(Generic const* _db): Super(_db) {}
+        iterator(Generic const* _db, bytesConstRef _k): Super(_db, _k) {}
 
-		value_type operator*() const { return at(); }
-		value_type operator->() const { return at(); }
+        value_type operator*() const { return at(); }
+        value_type operator->() const { return at(); }
 
-		value_type at() const;
-	};
+        value_type at() const;
+    };
 
-	iterator begin() const { return this; }
-	iterator end() const { return iterator(); }
-	iterator lower_bound(KeyType _k) const { return iterator(this, bytesConstRef((byte const*)&_k, sizeof(KeyType))); }
+    iterator begin() const { return this; }
+    iterator end() const { return iterator(); }
+    iterator lower_bound(KeyType _k) const { return iterator(this, bytesConstRef((byte const*)&_k, sizeof(KeyType))); }
 };
 
 template <class Generic, class KeyType>
 std::ostream& operator<<(std::ostream& _out, SpecificTrieDB<Generic, KeyType> const& _db)
 {
-	for (auto const& i: _db)
-		_out << i.first << ": " << escaped(i.second.toString(), false) << std::endl;
-	return _out;
+    for (auto const& i: _db)
+        _out << i.first << ": " << escaped(i.second.toString(), false) << std::endl;
+    return _out;
 }
 
 template <class _DB>
 class HashedGenericTrieDB: private SpecificTrieDB<GenericTrieDB<_DB>, h256>
 {
-	using Super = SpecificTrieDB<GenericTrieDB<_DB>, h256>;
+    using Super = SpecificTrieDB<GenericTrieDB<_DB>, h256>;
 
 public:
-	using DB = _DB;
+    using DB = _DB;
 
-	HashedGenericTrieDB(DB* _db = nullptr): Super(_db) {}
-	HashedGenericTrieDB(DB* _db, h256 _root, Verification _v = Verification::Normal): Super(_db, _root, _v) {}
+    HashedGenericTrieDB(DB* _db = nullptr): Super(_db) {}
+    HashedGenericTrieDB(DB* _db, h256 _root, Verification _v = Verification::Normal): Super(_db, _root, _v) {}
 
-	using Super::open;
-	using Super::init;
-	using Super::setRoot;
+    using Super::open;
+    using Super::init;
+    using Super::setRoot;
 
-	/// True if the trie is uninitialised (i.e. that the DB doesn't contain the root node).
-	using Super::isNull;
-	/// True if the trie is initialised but empty (i.e. that the DB contains the root node which is empty).
-	using Super::isEmpty;
+    /// True if the trie is uninitialised (i.e. that the DB doesn't contain the root node).
+    using Super::isNull;
+    /// True if the trie is initialised but empty (i.e. that the DB contains the root node which is empty).
+    using Super::isEmpty;
 
-	using Super::root;
-	using Super::db;
+    using Super::root;
+    using Super::db;
 
-	using Super::leftOvers;
-	using Super::check;
-	using Super::debugStructure;
+    using Super::leftOvers;
+    using Super::check;
+    using Super::debugStructure;
 
-	std::string at(bytesConstRef _key) const { return Super::at(sha3(_key)); }
-	bool contains(bytesConstRef _key) const { return Super::contains(sha3(_key)); }
-	void insert(bytesConstRef _key, bytesConstRef _value) { Super::insert(sha3(_key), _value); }
-	void remove(bytesConstRef _key) { Super::remove(sha3(_key)); }
+    std::string at(bytesConstRef _key) const { return Super::at(sha3(_key)); }
+    bool contains(bytesConstRef _key) const { return Super::contains(sha3(_key)); }
+    void insert(bytesConstRef _key, bytesConstRef _value) { Super::insert(sha3(_key), _value); }
+    void remove(bytesConstRef _key) { Super::remove(sha3(_key)); }
 
-	// empty from the PoV of the iterator interface; still need a basic iterator impl though.
-	class iterator
-	{
-	public:
-		using value_type = std::pair<bytesConstRef, bytesConstRef>;
+    // empty from the PoV of the iterator interface; still need a basic iterator impl though.
+    class iterator
+    {
+    public:
+        using value_type = std::pair<bytesConstRef, bytesConstRef>;
 
-		iterator() {}
-		iterator(HashedGenericTrieDB const*) {}
-		iterator(HashedGenericTrieDB const*, bytesConstRef) {}
+        iterator() {}
+        iterator(HashedGenericTrieDB const*) {}
+        iterator(HashedGenericTrieDB const*, bytesConstRef) {}
 
-		iterator& operator++() { return *this; }
-		value_type operator*() const { return value_type(); }
-		value_type operator->() const { return value_type(); }
+        iterator& operator++() { return *this; }
+        value_type operator*() const { return value_type(); }
+        value_type operator->() const { return value_type(); }
 
-		bool operator==(iterator const&) const { return true; }
-		bool operator!=(iterator const&) const { return false; }
+        bool operator==(iterator const&) const { return true; }
+        bool operator!=(iterator const&) const { return false; }
 
-		value_type at() const { return value_type(); }
-	};
-	iterator begin() const { return iterator(); }
-	iterator end() const { return iterator(); }
-	iterator lower_bound(bytesConstRef) const { return iterator(); }
+        value_type at() const { return value_type(); }
+    };
+    iterator begin() const { return iterator(); }
+    iterator end() const { return iterator(); }
+    iterator lower_bound(bytesConstRef) const { return iterator(); }
 };
 
 // Hashed & Hash-key mapping
 template <class _DB>
 class FatGenericTrieDB: private SpecificTrieDB<GenericTrieDB<_DB>, h256>
 {
-	using Super = SpecificTrieDB<GenericTrieDB<_DB>, h256>;
+    using Super = SpecificTrieDB<GenericTrieDB<_DB>, h256>;
 
 public:
-	using DB = _DB;
-	FatGenericTrieDB(DB* _db = nullptr): Super(_db) {}
-	FatGenericTrieDB(DB* _db, h256 _root, Verification _v = Verification::Normal): Super(_db, _root, _v) {}
+    using DB = _DB;
+    FatGenericTrieDB(DB* _db = nullptr): Super(_db) {}
+    FatGenericTrieDB(DB* _db, h256 _root, Verification _v = Verification::Normal): Super(_db, _root, _v) {}
 
-	using Super::init;
-	using Super::isNull;
-	using Super::isEmpty;
-	using Super::root;
-	using Super::leftOvers;
-	using Super::check;
-	using Super::open;
-	using Super::setRoot;
-	using Super::db;
-	using Super::debugStructure;
+    using Super::init;
+    using Super::isNull;
+    using Super::isEmpty;
+    using Super::root;
+    using Super::leftOvers;
+    using Super::check;
+    using Super::open;
+    using Super::setRoot;
+    using Super::db;
+    using Super::debugStructure;
 
-	std::string at(bytesConstRef _key) const { return Super::at(sha3(_key)); }
-	bool contains(bytesConstRef _key) const { return Super::contains(sha3(_key)); }
-	void insert(bytesConstRef _key, bytesConstRef _value)
-	{
-		h256 hash = sha3(_key);
-		Super::insert(hash, _value);
-		Super::db()->insertAux(hash, _key);
-	}
+    std::string at(bytesConstRef _key) const { return Super::at(sha3(_key)); }
+    bool contains(bytesConstRef _key) const { return Super::contains(sha3(_key)); }
+    void insert(bytesConstRef _key, bytesConstRef _value)
+    {
+        h256 hash = sha3(_key);
+        Super::insert(hash, _value);
+        Super::db()->insertAux(hash, _key);
+    }
 
-	void remove(bytesConstRef _key) { Super::remove(sha3(_key)); }
+    void remove(bytesConstRef _key) { Super::remove(sha3(_key)); }
 
-	// iterates over <key, value> pairs
-	class iterator: public GenericTrieDB<_DB>::iterator
-	{
-	public:
-		using Super = typename GenericTrieDB<_DB>::iterator;
+    // iterates over <key, value> pairs
+    class iterator: public GenericTrieDB<_DB>::iterator
+    {
+    public:
+        using Super = typename GenericTrieDB<_DB>::iterator;
 
-		iterator() { }
-		iterator(FatGenericTrieDB const* _trie) : Super(_trie) { }
+        iterator() { }
+        iterator(FatGenericTrieDB const* _trie) : Super(_trie) { }
 
-		typename Super::value_type at() const
-		{
-			auto hashed = Super::at();
-			m_key = static_cast<FatGenericTrieDB const*>(Super::m_that)->db()->lookupAux(h256(hashed.first));
-			return std::make_pair(&m_key, std::move(hashed.second));
-		}
+        typename Super::value_type at() const
+        {
+            auto hashed = Super::at();
+            m_key = static_cast<FatGenericTrieDB const*>(Super::m_that)->db()->lookupAux(h256(hashed.first));
+            return std::make_pair(&m_key, std::move(hashed.second));
+        }
 
-	private:
-		mutable bytes m_key;
-	};
+    private:
+        mutable bytes m_key;
+    };
 
-	iterator begin() const { return iterator(); }
-	iterator end() const { return iterator(); }
+    iterator begin() const { return iterator(); }
+    iterator end() const { return iterator(); }
 
-	// iterates over <hashedKey, value> pairs
-	class HashedIterator: public GenericTrieDB<_DB>::iterator
-	{
-	public:
-		using Super = typename GenericTrieDB<_DB>::iterator;
+    // iterates over <hashedKey, value> pairs
+    class HashedIterator: public GenericTrieDB<_DB>::iterator
+    {
+    public:
+        using Super = typename GenericTrieDB<_DB>::iterator;
 
-		HashedIterator() {}
-		HashedIterator(FatGenericTrieDB const* _trie) : Super(_trie) {}
+        HashedIterator() {}
+        HashedIterator(FatGenericTrieDB const* _trie) : Super(_trie) {}
 
-		bytes key() const
-		{
-			auto hashed = Super::at();
-			return static_cast<FatGenericTrieDB const*>(Super::m_that)->db()->lookupAux(h256(hashed.first));
-		}
-	};
+        bytes key() const
+        {
+            auto hashed = Super::at();
+            return static_cast<FatGenericTrieDB const*>(Super::m_that)->db()->lookupAux(h256(hashed.first));
+        }
+    };
 
-	HashedIterator hashedBegin() const { return HashedIterator(this); }
-	HashedIterator hashedEnd() const { return HashedIterator(); }
+    HashedIterator hashedBegin() const { return HashedIterator(this); }
+    HashedIterator hashedEnd() const { return HashedIterator(); }
 };
 
 template <class KeyType, class DB> using TrieDB = SpecificTrieDB<GenericTrieDB<DB>, KeyType>;
@@ -501,599 +509,601 @@ namespace dev
 
 template <class DB> GenericTrieDB<DB>::iterator::iterator(GenericTrieDB const* _db)
 {
-	m_that = _db;
-	m_trail.push_back({_db->node(_db->m_root), std::string(1, '\0'), 255});	// one null byte is the HPE for the empty key.
-	next();
+    m_that = _db;
+    m_trail.push_back({_db->node(_db->m_root), std::string(1, '\0'), 255});	// one null byte is the HPE for the empty key.
+    next();
 }
 
 template <class DB> GenericTrieDB<DB>::iterator::iterator(GenericTrieDB const* _db, bytesConstRef _fullKey)
 {
-	m_that = _db;
-	m_trail.push_back({_db->node(_db->m_root), std::string(1, '\0'), 255});	// one null byte is the HPE for the empty key.
-	next(_fullKey);
+    m_that = _db;
+    m_trail.push_back({_db->node(_db->m_root), std::string(1, '\0'), 255});	// one null byte is the HPE for the empty key.
+    next(_fullKey);
 }
 
 template <class DB> typename GenericTrieDB<DB>::iterator::value_type GenericTrieDB<DB>::iterator::at() const
 {
-	assert(m_trail.size());
-	Node const& b = m_trail.back();
-	assert(b.key.size());
-	assert(!(b.key[0] & 0x10));	// should be an integer number of bytes (i.e. not an odd number of nibbles).
+    assert(m_trail.size());
+    Node const& b = m_trail.back();
+    assert(b.key.size());
+    assert(!(b.key[0] & 0x10));	// should be an integer number of bytes (i.e. not an odd number of nibbles).
 
-	RLP rlp(b.rlp);
-	return std::make_pair(bytesConstRef(b.key).cropped(1), rlp[rlp.itemCount() == 2 ? 1 : 16].payload());
+    RLP rlp(b.rlp);
+    return std::make_pair(bytesConstRef(b.key).cropped(1), rlp[rlp.itemCount() == 2 ? 1 : 16].payload());
 }
 
 template <class DB> void GenericTrieDB<DB>::iterator::next(NibbleSlice _key)
 {
-	NibbleSlice k = _key;
-	while (true)
-	{
-		if (m_trail.empty())
-		{
-			m_that = nullptr;
-			return;
-		}
+    NibbleSlice k = _key;
+    while (true)
+    {
+        if (m_trail.empty())
+        {
+            m_that = nullptr;
+            return;
+        }
 
-		Node const& b = m_trail.back();
-		RLP rlp(b.rlp);
+        Node const& b = m_trail.back();
+        RLP rlp(b.rlp);
 
-		if (m_trail.back().child == 255)
-		{
-			// Entering. Look for first...
-			if (rlp.isEmpty())
-			{
-				// Kill our search as soon as we hit an empty node.
-				k.clear();
-				m_trail.pop_back();
-				continue;
-			}
-			if (!rlp.isList() || (rlp.itemCount() != 2 && rlp.itemCount() != 17))
-			{
+        if (m_trail.back().child == 255)
+        {
+            // Entering. Look for first...
+            if (rlp.isEmpty())
+            {
+                // Kill our search as soon as we hit an empty node.
+                k.clear();
+                m_trail.pop_back();
+                continue;
+            }
+            if (!rlp.isList() || (rlp.itemCount() != 2 && rlp.itemCount() != 17))
+            {
 #if ETH_PARANOIA
-				cwarn << "BIG FAT ERROR. STATE TRIE CORRUPTED!!!!!";
-				cwarn << b.rlp.size() << toHex(b.rlp);
-				cwarn << rlp;
-				auto c = rlp.itemCount();
-				cwarn << c;
-				BOOST_THROW_EXCEPTION(InvalidTrie());
+                cwarn << "BIG FAT ERROR. STATE TRIE CORRUPTED!!!!!";
+                cwarn << b.rlp.size() << toHex(b.rlp);
+                cwarn << rlp;
+                auto c = rlp.itemCount();
+                cwarn << c;
+                BOOST_THROW_EXCEPTION(InvalidTrie());
 #else
-				m_that = nullptr;
-				return;
+                m_that = nullptr;
+                return;
 #endif
-			}
-			if (rlp.itemCount() == 2)
-			{
-				// Just turn it into a valid Branch
-				auto keyOfRLP = keyOf(rlp);
+            }
+            if (rlp.itemCount() == 2)
+            {
+                // Just turn it into a valid Branch
+                auto keyOfRLP = keyOf(rlp);
 
-				// TODO: do something different depending on how keyOfRLP compares to k.mid(0, std::min(k.size(), keyOfRLP.size()));
-				// if == all is good - continue descent.
-				// if > discard key and continue descent.
-				// if < discard key and skip node.
+                // TODO: do something different depending on how keyOfRLP compares to k.mid(0, std::min(k.size(), keyOfRLP.size()));
+                // if == all is good - continue descent.
+                // if > discard key and continue descent.
+                // if < discard key and skip node.
 
-				if (!k.contains(keyOfRLP))
-				{
-					if (!k.isEarlierThan(keyOfRLP))
-					{
-						k.clear();
-						m_trail.pop_back();
-						continue;
-					}
-					k.clear();
-				}
+                if (!k.contains(keyOfRLP))
+                {
+                    if (!k.isEarlierThan(keyOfRLP))
+                    {
+                        k.clear();
+                        m_trail.pop_back();
+                        continue;
+                    }
+                    k.clear();
+                }
 
-				k = k.mid(std::min(k.size(), keyOfRLP.size()));
-				m_trail.back().key = hexPrefixEncode(keyOf(m_trail.back().key), keyOfRLP, false);
-				if (isLeaf(rlp))
-				{
-					// leaf - exit now.
-					if (k.empty())
-					{
-						m_trail.back().child = 0;
-						return;
-					}
-					// Still data in key we're supposed to be looking for when we're at a leaf. Go for next one.
-					k.clear();
-					m_trail.pop_back();
-					continue;
-				}
+                k = k.mid(std::min(k.size(), keyOfRLP.size()));
+                m_trail.back().key = hexPrefixEncode(keyOf(m_trail.back().key), keyOfRLP, false);
+                if (isLeaf(rlp))
+                {
+                    // leaf - exit now.
+                    if (k.empty())
+                    {
+                        m_trail.back().child = 0;
+                        return;
+                    }
+                    // Still data in key we're supposed to be looking for when we're at a leaf. Go for next one.
+                    k.clear();
+                    m_trail.pop_back();
+                    continue;
+                }
 
-				// enter child.
-				m_trail.back().rlp = m_that->deref(rlp[1]);
-				// no need to set .child as 255 - it's already done.
-				continue;
-			}
-			else
-			{
-				// Already a branch - look for first valid.
-				if (k.size())
-				{
-					m_trail.back().setChild(k[0]);
-					k = k.mid(1);
-				}
-				else
-					m_trail.back().setChild(16);
-				// run through to...
-			}
-		}
-		else
-		{
-			// Continuing/exiting. Look for next...
-			if (!(rlp.isList() && rlp.itemCount() == 17))
-			{
-				k.clear();
-				m_trail.pop_back();
-				continue;
-			}
-			// else run through to...
-			m_trail.back().incrementChild();
-		}
+                // enter child.
+                m_trail.back().rlp = m_that->deref(rlp[1]);
+                // no need to set .child as 255 - it's already done.
+                continue;
+            }
+            else
+            {
+                // Already a branch - look for first valid.
+                if (k.size())
+                {
+                    m_trail.back().setChild(k[0]);
+                    k = k.mid(1);
+                }
+                else
+                    m_trail.back().setChild(16);
+                // run through to...
+            }
+        }
+        else
+        {
+            // Continuing/exiting. Look for next...
+            if (!(rlp.isList() && rlp.itemCount() == 17))
+            {
+                k.clear();
+                m_trail.pop_back();
+                continue;
+            }
+            // else run through to...
+            m_trail.back().incrementChild();
+        }
 
-		// ...here. should only get here if we're a list.
-		assert(rlp.isList() && rlp.itemCount() == 17);
-		for (;; m_trail.back().incrementChild())
-			if (m_trail.back().child == 17)
-			{
-				// finished here.
-				k.clear();
-				m_trail.pop_back();
-				break;
-			}
-			else if (!rlp[m_trail.back().child].isEmpty())
-			{
-				if (m_trail.back().child == 16)
-					return;	// have a value at this node - exit now.
-				else
-				{
-					// lead-on to another node - enter child.
-					// fixed so that Node passed into push_back is constructed *before* m_trail is potentially resized (which invalidates back and rlp)
-					Node const& back = m_trail.back();
-					m_trail.push_back(Node{
-						m_that->deref(rlp[back.child]),
-						 hexPrefixEncode(keyOf(back.key), NibbleSlice(bytesConstRef(&back.child, 1), 1), false),
-						 255
-						});
-					break;
-				}
-			}
-		else
-			k.clear();
-	}
+        // ...here. should only get here if we're a list.
+        assert(rlp.isList() && rlp.itemCount() == 17);
+        for (;; m_trail.back().incrementChild())
+            if (m_trail.back().child == 17)
+            {
+                // finished here.
+                k.clear();
+                m_trail.pop_back();
+                break;
+            }
+            else if (!rlp[m_trail.back().child].isEmpty())
+            {
+                if (m_trail.back().child == 16)
+                    return;	// have a value at this node - exit now.
+                else
+                {
+                    // lead-on to another node - enter child.
+                    // fixed so that Node passed into push_back is constructed *before* m_trail is potentially resized (which invalidates back and rlp)
+                    Node const& back = m_trail.back();
+                    m_trail.push_back(Node{
+                        m_that->deref(rlp[back.child]),
+                         hexPrefixEncode(keyOf(back.key), NibbleSlice(bytesConstRef(&back.child, 1), 1), false),
+                         255
+                        });
+                    break;
+                }
+            }
+        else
+            k.clear();
+    }
 }
 
 template <class DB> void GenericTrieDB<DB>::iterator::next()
 {
-	while (true)
-	{
-		if (m_trail.empty())
-		{
-			m_that = nullptr;
-			return;
-		}
+    while (true)
+    {
+        if (m_trail.empty())
+        {
+            m_that = nullptr;
+            return;
+        }
 
-		Node const& b = m_trail.back();
-		RLP rlp(b.rlp);
+        Node const& b = m_trail.back();
+        RLP rlp(b.rlp);
 
-		if (m_trail.back().child == 255)
-		{
-			// Entering. Look for first...
-			if (rlp.isEmpty())
-			{
-				m_trail.pop_back();
-				continue;
-			}
-			if (!(rlp.isList() && (rlp.itemCount() == 2 || rlp.itemCount() == 17)))
-			{
+        if (m_trail.back().child == 255)
+        {
+            // Entering. Look for first...
+            if (rlp.isEmpty())
+            {
+                m_trail.pop_back();
+                continue;
+            }
+            if (!(rlp.isList() && (rlp.itemCount() == 2 || rlp.itemCount() == 17)))
+            {
 #if ETH_PARANOIA
-				cwarn << "BIG FAT ERROR. STATE TRIE CORRUPTED!!!!!";
-				cwarn << b.rlp.size() << toHex(b.rlp);
-				cwarn << rlp;
-				auto c = rlp.itemCount();
-				cwarn << c;
-				BOOST_THROW_EXCEPTION(InvalidTrie());
+                cwarn << "BIG FAT ERROR. STATE TRIE CORRUPTED!!!!!";
+                cwarn << b.rlp.size() << toHex(b.rlp);
+                cwarn << rlp;
+                auto c = rlp.itemCount();
+                cwarn << c;
+                BOOST_THROW_EXCEPTION(InvalidTrie());
 #else
-				m_that = nullptr;
-				return;
+                m_that = nullptr;
+                return;
 #endif
-			}
-			if (rlp.itemCount() == 2)
-			{
-				// Just turn it into a valid Branch
-				m_trail.back().key = hexPrefixEncode(keyOf(m_trail.back().key), keyOf(rlp), false);
-				if (isLeaf(rlp))
-				{
-					// leaf - exit now.
-					m_trail.back().child = 0;
-					return;
-				}
+            }
+            if (rlp.itemCount() == 2)
+            {
+                // Just turn it into a valid Branch
+                m_trail.back().key = hexPrefixEncode(keyOf(m_trail.back().key), keyOf(rlp), false);
+                if (isLeaf(rlp))
+                {
+                    // leaf - exit now.
+                    m_trail.back().child = 0;
+                    return;
+                }
 
-				// enter child.
-				m_trail.back().rlp = m_that->deref(rlp[1]);
-				// no need to set .child as 255 - it's already done.
-				continue;
-			}
-			else
-			{
-				// Already a branch - look for first valid.
-				m_trail.back().setFirstChild();
-				// run through to...
-			}
-		}
-		else
-		{
-			// Continuing/exiting. Look for next...
-			if (!(rlp.isList() && rlp.itemCount() == 17))
-			{
-				m_trail.pop_back();
-				continue;
-			}
-			// else run through to...
-			m_trail.back().incrementChild();
-		}
+                // enter child.
+                m_trail.back().rlp = m_that->deref(rlp[1]);
+                // no need to set .child as 255 - it's already done.
+                continue;
+            }
+            else
+            {
+                // Already a branch - look for first valid.
+                m_trail.back().setFirstChild();
+                // run through to...
+            }
+        }
+        else
+        {
+            // Continuing/exiting. Look for next...
+            if (!(rlp.isList() && rlp.itemCount() == 17))
+            {
+                m_trail.pop_back();
+                continue;
+            }
+            // else run through to...
+            m_trail.back().incrementChild();
+        }
 
-		// ...here. should only get here if we're a list.
-		assert(rlp.isList() && rlp.itemCount() == 17);
-		for (;; m_trail.back().incrementChild())
-			if (m_trail.back().child == 17)
-			{
-				// finished here.
-				m_trail.pop_back();
-				break;
-			}
-			else if (!rlp[m_trail.back().child].isEmpty())
-			{
-				if (m_trail.back().child == 16)
-					return;	// have a value at this node - exit now.
-				else
-				{
-					// lead-on to another node - enter child.
-					// fixed so that Node passed into push_back is constructed *before* m_trail is potentially resized (which invalidates back and rlp)
-					Node const& back = m_trail.back();
-					m_trail.push_back(Node{
-						m_that->deref(rlp[back.child]),
-						 hexPrefixEncode(keyOf(back.key), NibbleSlice(bytesConstRef(&back.child, 1), 1), false),
-						 255
-						});
-					break;
-				}
-			}
-	}
+        // ...here. should only get here if we're a list.
+        assert(rlp.isList() && rlp.itemCount() == 17);
+        for (;; m_trail.back().incrementChild())
+            if (m_trail.back().child == 17)
+            {
+                // finished here.
+                m_trail.pop_back();
+                break;
+            }
+            else if (!rlp[m_trail.back().child].isEmpty())
+            {
+                if (m_trail.back().child == 16)
+                    return;	// have a value at this node - exit now.
+                else
+                {
+                    // lead-on to another node - enter child.
+                    // fixed so that Node passed into push_back is constructed *before* m_trail is potentially resized (which invalidates back and rlp)
+                    Node const& back = m_trail.back();
+                    m_trail.push_back(Node{
+                        m_that->deref(rlp[back.child]),
+                         hexPrefixEncode(keyOf(back.key), NibbleSlice(bytesConstRef(&back.child, 1), 1), false),
+                         255
+                        });
+                    break;
+                }
+            }
+    }
 }
 
 template <class KeyType, class DB> typename SpecificTrieDB<KeyType, DB>::iterator::value_type SpecificTrieDB<KeyType, DB>::iterator::at() const
 {
-	auto p = Super::at();
-	value_type ret;
-	assert(p.first.size() == sizeof(KeyType));
-	memcpy(&ret.first, p.first.data(), sizeof(KeyType));
-	ret.second = p.second;
-	return ret;
+    auto p = Super::at();
+    value_type ret;
+    assert(p.first.size() == sizeof(KeyType));
+    memcpy(&ret.first, p.first.data(), sizeof(KeyType));
+    ret.second = p.second;
+    return ret;
 }
 
 template <class DB> void GenericTrieDB<DB>::insert(bytesConstRef _key, bytesConstRef _value)
 {
 #if ETH_PARANOIA
-	tdebug << "Insert" << toHex(_key.cropped(0, 4)) << "=>" << toHex(_value);
+    tdebug << "Insert" << toHex(_key.cropped(0, 4)) << "=>" << toHex(_value);
 #endif
 
-	std::string rootValue = node(m_root);
-	assert(rootValue.size());
-	bytes b = mergeAt(RLP(rootValue), m_root, NibbleSlice(_key), _value);
+    std::string rootValue = node(m_root);
+    assert(rootValue.size());
+    bytes b = mergeAt(RLP(rootValue), m_root, NibbleSlice(_key), _value);
 
-	// mergeAt won't attempt to delete the node if it's less than 32 bytes
-	// However, we know it's the root node and thus always hashed.
-	// So, if it's less than 32 (and thus should have been deleted but wasn't) then we delete it here.
-	if (rootValue.size() < 32)
-		forceKillNode(m_root);
-	m_root = forceInsertNode(&b);
+    // mergeAt won't attempt to delete the node if it's less than 32 bytes
+    // However, we know it's the root node and thus always hashed.
+    // So, if it's less than 32 (and thus should have been deleted but wasn't) then we delete it here.
+    if (rootValue.size() < 32)
+        forceKillNode(m_root);
+    m_root = forceInsertNode(&b);
 }
 
 template <class DB> std::string GenericTrieDB<DB>::at(bytesConstRef _key) const
 {
-	return atAux(RLP(node(m_root)), _key);
+    return atAux(RLP(node(m_root)), _key);
 }
 
 template <class DB> std::string GenericTrieDB<DB>::atAux(RLP const& _here, NibbleSlice _key) const
 {
-	if (_here.isEmpty() || _here.isNull())
-		// not found.
-		return std::string();
-	unsigned itemCount = _here.itemCount();
-	assert(_here.isList() && (itemCount == 2 || itemCount == 17));
-	if (itemCount == 2)
-	{
-		auto k = keyOf(_here);
-		if (_key == k && isLeaf(_here))
-			// reached leaf and it's us
-			return _here[1].toString();
-		else if (_key.contains(k) && !isLeaf(_here))
-			// not yet at leaf and it might yet be us. onwards...
-			return atAux(_here[1].isList() ? _here[1] : RLP(node(_here[1].toHash<h256>())), _key.mid(k.size()));
-		else
-			// not us.
-			return std::string();
-	}
-	else
-	{
-		if (_key.size() == 0)
-			return _here[16].toString();
-		auto n = _here[_key[0]];
-		if (n.isEmpty())
-			return std::string();
-		else
-			return atAux(n.isList() ? n : RLP(node(n.toHash<h256>())), _key.mid(1));
-	}
+    if (_here.isEmpty() || _here.isNull())
+        // not found.
+        return std::string();
+    unsigned itemCount = _here.itemCount();
+    assert(_here.isList() && (itemCount == 2 || itemCount == 17));
+    if (itemCount == 2)
+    {
+        auto k = keyOf(_here);
+        if (_key == k && isLeaf(_here))
+            // reached leaf and it's us
+            return _here[1].toString();
+        else if (_key.contains(k) && !isLeaf(_here))
+            // not yet at leaf and it might yet be us. onwards...
+            return atAux(_here[1].isList() ? _here[1] : RLP(node(_here[1].toHash<h256>())), _key.mid(k.size()));
+        else
+            // not us.
+            return std::string();
+    }
+    else
+    {
+        if (_key.size() == 0)
+            return _here[16].toString();
+        auto n = _here[_key[0]];
+        if (n.isEmpty())
+            return std::string();
+        else
+            return atAux(n.isList() ? n : RLP(node(n.toHash<h256>())), _key.mid(1));
+    }
 }
 
 template <class DB> bytes GenericTrieDB<DB>::mergeAt(RLP const& _orig, NibbleSlice _k, bytesConstRef _v, bool _inLine)
 {
-	return mergeAt(_orig, sha3(_orig.data()), _k, _v, _inLine);
+    return mergeAt(_orig, sha3(_orig.data()), _k, _v, _inLine);
 }
 
 template <class DB> bytes GenericTrieDB<DB>::mergeAt(RLP const& _orig, h256 const& _origHash, NibbleSlice _k, bytesConstRef _v, bool _inLine)
 {
 #if ETH_PARANOIA
-	tdebug << "mergeAt " << _orig << _k << sha3(_orig.data());
+    tdebug << "mergeAt " << _orig << _k << sha3(_orig.data());
 #endif
 
-	// The caller will make sure that the bytes are inserted properly.
-	// - This might mean inserting an entry into m_over
-	// We will take care to ensure that (our reference to) _orig is killed.
+    // The caller will make sure that the bytes are inserted properly.
+    // - This might mean inserting an entry into m_over
+    // We will take care to ensure that (our reference to) _orig is killed.
 
-	// Empty - just insert here
-	if (_orig.isEmpty())
-		return place(_orig, _k, _v);
+    // Empty - just insert here
+    if (_orig.isEmpty())
+        return place(_orig, _k, _v);
 
-	unsigned itemCount = _orig.itemCount();
-	assert(_orig.isList() && (itemCount == 2 || itemCount == 17));
-	if (itemCount == 2)
-	{
-		// pair...
-		NibbleSlice k = keyOf(_orig);
+    unsigned itemCount = _orig.itemCount();
+    assert(_orig.isList() && (itemCount == 2 || itemCount == 17));
+    if (itemCount == 2)
+    {
+        // pair...
+        NibbleSlice k = keyOf(_orig);
 
-		// exactly our node - place value in directly.
-		if (k == _k && isLeaf(_orig))
-			return place(_orig, _k, _v);
+        // exactly our node - place value in directly.
+        if (k == _k && isLeaf(_orig))
+            return place(_orig, _k, _v);
 
-		// partial key is our key - move down.
-		if (_k.contains(k) && !isLeaf(_orig))
-		{
-			if (!_inLine)
-				killNode(_orig, _origHash);
-			RLPStream s(2);
-			s.append(_orig[0]);
-			mergeAtAux(s, _orig[1], _k.mid(k.size()), _v);
-			return s.out();
-		}
+        // partial key is our key - move down.
+        if (_k.contains(k) && !isLeaf(_orig))
+        {
+            if (!_inLine)
+                killNode(_orig, _origHash);
+            RLPStream s(2);
+            s.append(_orig[0]);
+            mergeAtAux(s, _orig[1], _k.mid(k.size()), _v);
+            return s.out();
+        }
 
-		auto sh = _k.shared(k);
+        auto sh = _k.shared(k);
 //		std::cout << _k << " sh " << k << " = " << sh << std::endl;
-		if (sh)
-		{
-			// shared stuff - cleve at disagreement.
-			auto cleved = cleve(_orig, sh);
-			return mergeAt(RLP(cleved), _k, _v, true);
-		}
-		else
-		{
-			// nothing shared - branch
-			auto branched = branch(_orig);
-			return mergeAt(RLP(branched), _k, _v, true);
-		}
-	}
-	else
-	{
-		// branch...
+        if (sh)
+        {
+            // shared stuff - cleve at disagreement.
+            auto cleved = cleve(_orig, sh);
+            return mergeAt(RLP(cleved), _k, _v, true);
+        }
+        else
+        {
+            // nothing shared - branch
+            auto branched = branch(_orig);
+            return mergeAt(RLP(branched), _k, _v, true);
+        }
+    }
+    else
+    {
+        // branch...
 
-		// exactly our node - place value.
-		if (_k.size() == 0)
-			return place(_orig, _k, _v);
+        // exactly our node - place value.
+        if (_k.size() == 0)
+            return place(_orig, _k, _v);
 
-		// Kill the node.
-		if (!_inLine)
-			killNode(_orig, _origHash);
+        // Kill the node.
+        if (!_inLine)
+            killNode(_orig, _origHash);
 
-		// not exactly our node - delve to next level at the correct index.
-		byte n = _k[0];
-		RLPStream r(17);
-		for (byte i = 0; i < 17; ++i)
-			if (i == n)
-				mergeAtAux(r, _orig[i], _k.mid(1), _v);
-			else
-				r.append(_orig[i]);
-		return r.out();
-	}
+        // not exactly our node - delve to next level at the correct index.
+        byte n = _k[0];
+        RLPStream r(17);
+        for (byte i = 0; i < 17; ++i)
+            if (i == n)
+                mergeAtAux(r, _orig[i], _k.mid(1), _v);
+            else
+                r.append(_orig[i]);
+        return r.out();
+    }
 
 }
 
 template <class DB> void GenericTrieDB<DB>::mergeAtAux(RLPStream& _out, RLP const& _orig, NibbleSlice _k, bytesConstRef _v)
 {
-	RLP r = _orig;
-	std::string s;
-	// _orig is always a segment of a node's RLP - removing it alone is pointless. However, if may be a hash, in which case we deref and we know it is removable.
-	bool isRemovable = false;
-	if (!r.isList() && !r.isEmpty())
-	{
-		s = node(_orig.toHash<h256>());
-		r = RLP(s);
-		assert(!r.isNull());
-		isRemovable = true;
-	}
-	bytes b = mergeAt(r, _k, _v, !isRemovable);
-	streamNode(_out, b);
+    RLP r = _orig;
+    std::string s;
+    // _orig is always a segment of a node's RLP - removing it alone is pointless. However, if may be a hash, in which case we deref and we know it is removable.
+    bool isRemovable = false;
+    if (!r.isList() && !r.isEmpty())
+    {
+        h256 h = _orig.toHash<h256>();
+        //        std::cerr << "going down non-inline node " << h << "\n";
+        s = node(h);
+        r = RLP(s);
+        assert(!r.isNull());
+        isRemovable = true;
+    }
+    bytes b = mergeAt(r, _k, _v, !isRemovable);
+    streamNode(_out, b);
 }
 
 template <class DB> void GenericTrieDB<DB>::remove(bytesConstRef _key)
 {
 #if ETH_PARANOIA
-	tdebug << "Remove" << toHex(_key.cropped(0, 4).toBytes());
+    tdebug << "Remove" << toHex(_key.cropped(0, 4).toBytes());
 #endif
 
-	std::string rv = node(m_root);
-	bytes b = deleteAt(RLP(rv), NibbleSlice(_key));
-	if (b.size())
-	{
-		if (rv.size() < 32)
-			forceKillNode(m_root);
-		m_root = forceInsertNode(&b);
-	}
+    std::string rv = node(m_root);
+    bytes b = deleteAt(RLP(rv), NibbleSlice(_key));
+    if (b.size())
+    {
+        if (rv.size() < 32)
+            forceKillNode(m_root);
+        m_root = forceInsertNode(&b);
+    }
 }
 
 template <class DB> bool GenericTrieDB<DB>::isTwoItemNode(RLP const& _n) const
 {
-	return (_n.isData() && RLP(node(_n.toHash<h256>())).itemCount() == 2)
-			|| (_n.isList() && _n.itemCount() == 2);
+    return (_n.isData() && RLP(node(_n.toHash<h256>())).itemCount() == 2)
+            || (_n.isList() && _n.itemCount() == 2);
 }
 
 template <class DB> std::string GenericTrieDB<DB>::deref(RLP const& _n) const
 {
-	return _n.isList() ? _n.data().toString() : node(_n.toHash<h256>());
+    return _n.isList() ? _n.data().toString() : node(_n.toHash<h256>());
 }
 
 template <class DB> bytes GenericTrieDB<DB>::deleteAt(RLP const& _orig, NibbleSlice _k)
 {
 #if ETH_PARANOIA
-	tdebug << "deleteAt " << _orig << _k << sha3(_orig.data());
+    tdebug << "deleteAt " << _orig << _k << sha3(_orig.data());
 #endif
 
-	// The caller will make sure that the bytes are inserted properly.
-	// - This might mean inserting an entry into m_over
-	// We will take care to ensure that (our reference to) _orig is killed.
+    // The caller will make sure that the bytes are inserted properly.
+    // - This might mean inserting an entry into m_over
+    // We will take care to ensure that (our reference to) _orig is killed.
 
-	// Empty - not found - no change.
-	if (_orig.isEmpty())
-		return bytes();
+    // Empty - not found - no change.
+    if (_orig.isEmpty())
+        return bytes();
 
-	assert(_orig.isList() && (_orig.itemCount() == 2 || _orig.itemCount() == 17));
-	if (_orig.itemCount() == 2)
-	{
-		// pair...
-		NibbleSlice k = keyOf(_orig);
+    assert(_orig.isList() && (_orig.itemCount() == 2 || _orig.itemCount() == 17));
+    if (_orig.itemCount() == 2)
+    {
+        // pair...
+        NibbleSlice k = keyOf(_orig);
 
-		// exactly our node - return null.
-		if (k == _k && isLeaf(_orig))
-		{
-			killNode(_orig);
-			return RLPNull;
-		}
+        // exactly our node - return null.
+        if (k == _k && isLeaf(_orig))
+        {
+            killNode(_orig);
+            return RLPNull;
+        }
 
-		// partial key is our key - move down.
-		if (_k.contains(k))
-		{
-			RLPStream s;
-			s.appendList(2) << _orig[0];
-			if (!deleteAtAux(s, _orig[1], _k.mid(k.size())))
-				return bytes();
-			killNode(_orig);
-			RLP r(s.out());
-			if (isTwoItemNode(r[1]))
-				return graft(r);
-			return s.out();
-		}
-		else
-			// not found - no change.
-			return bytes();
-	}
-	else
-	{
-		// branch...
+        // partial key is our key - move down.
+        if (_k.contains(k))
+        {
+            RLPStream s;
+            s.appendList(2) << _orig[0];
+            if (!deleteAtAux(s, _orig[1], _k.mid(k.size())))
+                return bytes();
+            killNode(_orig);
+            RLP r(s.out());
+            if (isTwoItemNode(r[1]))
+                return graft(r);
+            return s.out();
+        }
+        else
+            // not found - no change.
+            return bytes();
+    }
+    else
+    {
+        // branch...
 
-		// exactly our node - remove and rejig.
-		if (_k.size() == 0 && !_orig[16].isEmpty())
-		{
-			// Kill the node.
-			killNode(_orig);
+        // exactly our node - remove and rejig.
+        if (_k.size() == 0 && !_orig[16].isEmpty())
+        {
+            // Kill the node.
+            killNode(_orig);
 
-			byte used = uniqueInUse(_orig, 16);
-			if (used != 255)
-				if (isTwoItemNode(_orig[used]))
-				{
-					auto merged = merge(_orig, used);
-					return graft(RLP(merged));
-				}
-				else
-					return merge(_orig, used);
-			else
-			{
-				RLPStream r(17);
-				for (byte i = 0; i < 16; ++i)
-					r << _orig[i];
-				r << "";
-				return r.out();
-			}
-		}
-		else
-		{
-			// not exactly our node - delve to next level at the correct index.
-			RLPStream r(17);
-			byte n = _k[0];
-			for (byte i = 0; i < 17; ++i)
-				if (i == n)
-					if (!deleteAtAux(r, _orig[i], _k.mid(1)))	// bomb out if the key didn't turn up.
-						return bytes();
-					else {}
-				else
-					r << _orig[i];
+            byte used = uniqueInUse(_orig, 16);
+            if (used != 255)
+                if (isTwoItemNode(_orig[used]))
+                {
+                    auto merged = merge(_orig, used);
+                    return graft(RLP(merged));
+                }
+                else
+                    return merge(_orig, used);
+            else
+            {
+                RLPStream r(17);
+                for (byte i = 0; i < 16; ++i)
+                    r << _orig[i];
+                r << "";
+                return r.out();
+            }
+        }
+        else
+        {
+            // not exactly our node - delve to next level at the correct index.
+            RLPStream r(17);
+            byte n = _k[0];
+            for (byte i = 0; i < 17; ++i)
+                if (i == n)
+                    if (!deleteAtAux(r, _orig[i], _k.mid(1)))	// bomb out if the key didn't turn up.
+                        return bytes();
+                    else {}
+                else
+                    r << _orig[i];
 
-			// Kill the node.
-			killNode(_orig);
+            // Kill the node.
+            killNode(_orig);
 
-			// check if we ended up leaving the node invalid.
-			RLP rlp(r.out());
-			byte used = uniqueInUse(rlp, 255);
-			if (used == 255)	// no - all ok.
-				return r.out();
+            // check if we ended up leaving the node invalid.
+            RLP rlp(r.out());
+            byte used = uniqueInUse(rlp, 255);
+            if (used == 255)	// no - all ok.
+                return r.out();
 
-			// yes; merge
-			if (isTwoItemNode(rlp[used]))
-			{
-				auto merged = merge(rlp, used);
-				return graft(RLP(merged));
-			}
-			else
-				return merge(rlp, used);
-		}
-	}
+            // yes; merge
+            if (isTwoItemNode(rlp[used]))
+            {
+                auto merged = merge(rlp, used);
+                return graft(RLP(merged));
+            }
+            else
+                return merge(rlp, used);
+        }
+    }
 
 }
 
 template <class DB> bool GenericTrieDB<DB>::deleteAtAux(RLPStream& _out, RLP const& _orig, NibbleSlice _k)
 {
 
-	bytes b = _orig.isEmpty() ? bytes() : deleteAt(_orig.isList() ? _orig : RLP(node(_orig.toHash<h256>())), _k);
+    bytes b = _orig.isEmpty() ? bytes() : deleteAt(_orig.isList() ? _orig : RLP(node(_orig.toHash<h256>())), _k);
 
-	if (!b.size())	// not found - no change.
-		return false;
+    if (!b.size())	// not found - no change.
+        return false;
 
 /*	if (_orig.isList())
-		killNode(_orig);
-	else
-		killNode(_orig.toHash<h256>());*/
+        killNode(_orig);
+    else
+        killNode(_orig.toHash<h256>());*/
 
-	streamNode(_out, b);
-	return true;
+    streamNode(_out, b);
+    return true;
 }
 
 template <class DB> bytes GenericTrieDB<DB>::place(RLP const& _orig, NibbleSlice _k, bytesConstRef _s)
 {
 #if ETH_PARANOIA
-	tdebug << "place " << _orig << _k;
+    tdebug << "place " << _orig << _k;
 #endif
 
-	killNode(_orig);
-	if (_orig.isEmpty())
-		return rlpList(hexPrefixEncode(_k, true), _s);
+    killNode(_orig);
+    if (_orig.isEmpty())
+        return rlpList(hexPrefixEncode(_k, true), _s);
 
-	assert(_orig.isList() && (_orig.itemCount() == 2 || _orig.itemCount() == 17));
-	if (_orig.itemCount() == 2)
-		return rlpList(_orig[0], _s);
+    assert(_orig.isList() && (_orig.itemCount() == 2 || _orig.itemCount() == 17));
+    if (_orig.itemCount() == 2)
+        return rlpList(_orig[0], _s);
 
-	auto s = RLPStream(17);
-	for (unsigned i = 0; i < 16; ++i)
-		s << _orig[i];
-	s << _s;
-	return s.out();
+    auto s = RLPStream(17);
+    for (unsigned i = 0; i < 16; ++i)
+        s << _orig[i];
+    s << _s;
+    return s.out();
 }
 
 // in1: [K, S] (DEL)
@@ -1103,73 +1113,73 @@ template <class DB> bytes GenericTrieDB<DB>::place(RLP const& _orig, NibbleSlice
 template <class DB> bytes GenericTrieDB<DB>::remove(RLP const& _orig)
 {
 #if ETH_PARANOIA
-	tdebug << "kill " << _orig;
+    tdebug << "kill " << _orig;
 #endif
 
-	killNode(_orig);
+    killNode(_orig);
 
-	assert(_orig.isList() && (_orig.itemCount() == 2 || _orig.itemCount() == 17));
-	if (_orig.itemCount() == 2)
-		return RLPNull;
-	RLPStream r(17);
-	for (unsigned i = 0; i < 16; ++i)
-		r << _orig[i];
-	r << "";
-	return r.out();
+    assert(_orig.isList() && (_orig.itemCount() == 2 || _orig.itemCount() == 17));
+    if (_orig.itemCount() == 2)
+        return RLPNull;
+    RLPStream r(17);
+    for (unsigned i = 0; i < 16; ++i)
+        r << _orig[i];
+    r << "";
+    return r.out();
 }
 
 template <class DB> RLPStream& GenericTrieDB<DB>::streamNode(RLPStream& _s, bytes const& _b)
 {
-	if (_b.size() < 32)
-		_s.appendRaw(_b);
-	else
-		_s.append(forceInsertNode(&_b));
-	return _s;
+    if (_b.size() < 32)
+        _s.appendRaw(_b);
+    else
+        _s.append(forceInsertNode(&_b));
+    return _s;
 }
 
 template <class DB> bytes GenericTrieDB<DB>::cleve(RLP const& _orig, unsigned _s)
 {
 #if ETH_PARANOIA
-	tdebug << "cleve " << _orig << _s;
+    tdebug << "cleve " << _orig << _s;
 #endif
 
-	killNode(_orig);
-	assert(_orig.isList() && _orig.itemCount() == 2);
-	auto k = keyOf(_orig);
-	assert(_s && _s <= k.size());
+    killNode(_orig);
+    assert(_orig.isList() && _orig.itemCount() == 2);
+    auto k = keyOf(_orig);
+    assert(_s && _s <= k.size());
 
-	RLPStream bottom(2);
-	bottom << hexPrefixEncode(k, isLeaf(_orig), /*ugh*/(int)_s) << _orig[1];
+    RLPStream bottom(2);
+    bottom << hexPrefixEncode(k, isLeaf(_orig), /*ugh*/(int)_s) << _orig[1];
 
-	RLPStream top(2);
-	top << hexPrefixEncode(k, false, 0, /*ugh*/(int)_s);
-	streamNode(top, bottom.out());
+    RLPStream top(2);
+    top << hexPrefixEncode(k, false, 0, /*ugh*/(int)_s);
+    streamNode(top, bottom.out());
 
-	return top.out();
+    return top.out();
 }
 
 template <class DB> bytes GenericTrieDB<DB>::graft(RLP const& _orig)
 {
 #if ETH_PARANOIA
-	tdebug << "graft " << _orig;
+    tdebug << "graft " << _orig;
 #endif
 
-	assert(_orig.isList() && _orig.itemCount() == 2);
-	std::string s;
-	RLP n;
-	if (_orig[1].isList())
-		n = _orig[1];
-	else
-	{
-		// remove second item from the trie after derefrencing it into s & n.
-		auto lh = _orig[1].toHash<h256>();
-		s = node(lh);
-		forceKillNode(lh);
-		n = RLP(s);
-	}
-	assert(n.itemCount() == 2);
+    assert(_orig.isList() && _orig.itemCount() == 2);
+    std::string s;
+    RLP n;
+    if (_orig[1].isList())
+        n = _orig[1];
+    else
+    {
+        // remove second item from the trie after derefrencing it into s & n.
+        auto lh = _orig[1].toHash<h256>();
+        s = node(lh);
+        forceKillNode(lh);
+        n = RLP(s);
+    }
+    assert(n.itemCount() == 2);
 
-	return rlpList(hexPrefixEncode(keyOf(_orig), keyOf(n), isLeaf(n)), n[1]);
+    return rlpList(hexPrefixEncode(keyOf(_orig), keyOf(n), isLeaf(n)), n[1]);
 //	auto ret =
 //	std::cout << keyOf(_orig) << " ++ " << keyOf(n) << " == " << keyOf(RLP(ret)) << std::endl;
 //	return ret;
@@ -1178,54 +1188,54 @@ template <class DB> bytes GenericTrieDB<DB>::graft(RLP const& _orig)
 template <class DB> bytes GenericTrieDB<DB>::merge(RLP const& _orig, byte _i)
 {
 #if ETH_PARANOIA
-	tdebug << "merge " << _orig << (int)_i;
+    tdebug << "merge " << _orig << (int)_i;
 #endif
 
-	assert(_orig.isList() && _orig.itemCount() == 17);
-	RLPStream s(2);
-	if (_i != 16)
-	{
-		assert(!_orig[_i].isEmpty());
-		s << hexPrefixEncode(bytesConstRef(&_i, 1), false, 1, 2, 0);
-	}
-	else
-		s << hexPrefixEncode(bytes(), true);
-	s << _orig[_i];
-	return s.out();
+    assert(_orig.isList() && _orig.itemCount() == 17);
+    RLPStream s(2);
+    if (_i != 16)
+    {
+        assert(!_orig[_i].isEmpty());
+        s << hexPrefixEncode(bytesConstRef(&_i, 1), false, 1, 2, 0);
+    }
+    else
+        s << hexPrefixEncode(bytes(), true);
+    s << _orig[_i];
+    return s.out();
 }
 
 template <class DB> bytes GenericTrieDB<DB>::branch(RLP const& _orig)
 {
 #if ETH_PARANOIA
-	tdebug << "branch " << _orig;
+    tdebug << "branch " << _orig;
 #endif
 
-	assert(_orig.isList() && _orig.itemCount() == 2);
-	killNode(_orig);
+    assert(_orig.isList() && _orig.itemCount() == 2);
+    killNode(_orig);
 
-	auto k = keyOf(_orig);
-	RLPStream r(17);
-	if (k.size() == 0)
-	{
-		assert(isLeaf(_orig));
-		for (unsigned i = 0; i < 16; ++i)
-			r << "";
-		r << _orig[1];
-	}
-	else
-	{
-		byte b = k[0];
-		for (unsigned i = 0; i < 16; ++i)
-			if (i == b)
-				if (isLeaf(_orig) || k.size() > 1)
-					streamNode(r, rlpList(hexPrefixEncode(k.mid(1), isLeaf(_orig)), _orig[1]));
-				else
-					r << _orig[1];
-			else
-				r << "";
-		r << "";
-	}
-	return r.out();
+    auto k = keyOf(_orig);
+    RLPStream r(17);
+    if (k.size() == 0)
+    {
+        assert(isLeaf(_orig));
+        for (unsigned i = 0; i < 16; ++i)
+            r << "";
+        r << _orig[1];
+    }
+    else
+    {
+        byte b = k[0];
+        for (unsigned i = 0; i < 16; ++i)
+            if (i == b)
+                if (isLeaf(_orig) || k.size() > 1)
+                    streamNode(r, rlpList(hexPrefixEncode(k.mid(1), isLeaf(_orig)), _orig[1]));
+                else
+                    r << _orig[1];
+            else
+                r << "";
+        r << "";
+    }
+    return r.out();
 }
 
 }

--- a/libethashseal/EthashAux.cpp
+++ b/libethashseal/EthashAux.cpp
@@ -130,7 +130,7 @@ EthashAux::LightAllocation::LightAllocation(h256 const& _seedHash)
 	uint64_t blockNumber = EthashAux::number(_seedHash);
 	light = ethash_light_new(blockNumber);
 	if (!light)
-		BOOST_THROW_EXCEPTION(ExternalFunctionFailure("ethash_light_new()"));
+		BOOST_THROW_EXCEPTION(ExternalFunctionFailure() << errinfo_externalFunction("ethash_light_new()"));
 	size = ethash_get_cachesize(blockNumber);
 }
 
@@ -152,7 +152,7 @@ EthashAux::FullAllocation::FullAllocation(ethash_light_t _light, ethash_callback
 	if (!full)
 	{
 		clog(DAGChannel) << "DAG Generation Failure. Reason: "  << strerror(errno);
-		BOOST_THROW_EXCEPTION(ExternalFunctionFailure("ethash_full_new"));
+		BOOST_THROW_EXCEPTION(ExternalFunctionFailure() << errinfo_externalFunction("ethash_full_new"));
 	}
 }
 

--- a/libethereum/BlockChain.cpp
+++ b/libethereum/BlockChain.cpp
@@ -717,7 +717,8 @@ ImportRoute BlockChain::import(VerifiedBlockRef const& _block, OverlayDB const& 
     }
     catch (BadRoot& ex)
     {
-        cwarn << "*** BadRoot error! Trying to import" << _block.info.hash() << "needed root" << ex.root;
+        cwarn << "*** BadRoot error! Trying to import" << _block.info.hash() << "needed root"
+              << *boost::get_error_info<errinfo_hash256>(ex);
         cwarn << _block.info;
         // Attempt in import later.
         BOOST_THROW_EXCEPTION(TransientError());

--- a/libethereum/ClientBase.h
+++ b/libethereum/ClientBase.h
@@ -1,18 +1,18 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
  */
 /** @file ClientBase.h
  * @author Gav Wood <i@gavwood.com>
@@ -37,11 +37,11 @@ namespace eth
 
 struct InstalledFilter
 {
-	InstalledFilter(LogFilter const& _f): filter(_f) {}
+    InstalledFilter(LogFilter const& _f): filter(_f) {}
 
-	LogFilter filter;
-	unsigned refCount = 1;
-	LocalisedLogEntries changes;
+    LogFilter filter;
+    unsigned refCount = 1;
+    LocalisedLogEntries changes;
 };
 
 static const h256 PendingChangedFilter = u256(0);
@@ -52,16 +52,16 @@ static const LocalisedLogEntry InitialChange(SpecialLogEntry);
 
 struct ClientWatch
 {
-	ClientWatch(): lastPoll(std::chrono::system_clock::now()) {}
-	explicit ClientWatch(h256 _id, Reaping _r): id(_id), lastPoll(_r == Reaping::Automatic ? std::chrono::system_clock::now() : std::chrono::system_clock::time_point::max()) {}
+    ClientWatch(): lastPoll(std::chrono::system_clock::now()) {}
+    explicit ClientWatch(h256 _id, Reaping _r): id(_id), lastPoll(_r == Reaping::Automatic ? std::chrono::system_clock::now() : std::chrono::system_clock::time_point::max()) {}
 
-	h256 id;
+    h256 id;
 #if INITIAL_STATE_AS_CHANGES
-	LocalisedLogEntries changes = LocalisedLogEntries{ InitialChange };
+    LocalisedLogEntries changes = LocalisedLogEntries{ InitialChange };
 #else
-	LocalisedLogEntries changes;
+    LocalisedLogEntries changes;
 #endif
-	mutable std::chrono::system_clock::time_point lastPoll = std::chrono::system_clock::now();
+    mutable std::chrono::system_clock::time_point lastPoll = std::chrono::system_clock::now();
 };
 
 struct WatchChannel: public LogChannel { static const char* name(); static const int verbosity = 7; };
@@ -76,106 +76,122 @@ struct WorkChannel: public LogChannel { static const char* name(); static const 
 class ClientBase: public Interface
 {
 public:
-	ClientBase() {}
-	virtual ~ClientBase() {}
+    ClientBase() {}
+    virtual ~ClientBase() {}
 
-	/// Estimate gas usage for call/create.
-	/// @param _maxGas An upper bound value for estimation, if not provided default value of c_maxGasEstimate will be used.
-	/// @param _callback Optional callback function for progress reporting
-	virtual std::pair<u256, ExecutionResult> estimateGas(Address const& _from, u256 _value, Address _dest, bytes const& _data, int64_t _maxGas, u256 _gasPrice, BlockNumber _blockNumber, GasEstimationCallback const& _callback) override;
+    /// Estimate gas usage for call/create.
+    /// @param _maxGas An upper bound value for estimation, if not provided default value of c_maxGasEstimate will be used.
+    /// @param _callback Optional callback function for progress reporting
+    virtual std::pair<u256, ExecutionResult> estimateGas(Address const& _from, u256 _value, Address _dest, bytes const& _data, int64_t _maxGas, u256 _gasPrice, BlockNumber _blockNumber, GasEstimationCallback const& _callback) override;
 
-	using Interface::balanceAt;
-	using Interface::countAt;
-	using Interface::stateAt;
-	using Interface::codeAt;
-	using Interface::codeHashAt;
-	using Interface::storageAt;
+    using Interface::balanceAt;
+    using Interface::countAt;
+    using Interface::stateAt;
+    using Interface::codeAt;
+    using Interface::codeHashAt;
+    using Interface::storageAt;
 
-	virtual u256 balanceAt(Address _a, BlockNumber _block) const override;
-	virtual u256 countAt(Address _a, BlockNumber _block) const override;
-	virtual u256 stateAt(Address _a, u256 _l, BlockNumber _block) const override;
-	virtual h256 stateRootAt(Address _a, BlockNumber _block) const override;
-	virtual bytes codeAt(Address _a, BlockNumber _block) const override;
-	virtual h256 codeHashAt(Address _a, BlockNumber _block) const override;
-	virtual std::map<h256, std::pair<u256, u256>> storageAt(Address _a, BlockNumber _block) const override;
+    virtual u256 balanceAt(Address _a, BlockNumber _block) const override;
+    virtual u256 countAt(Address _a, BlockNumber _block) const override;
+    virtual u256 stateAt(Address _a, u256 _l, BlockNumber _block) const override;
+    virtual h256 stateRootAt(Address _a, BlockNumber _block) const override;
+    virtual bytes codeAt(Address _a, BlockNumber _block) const override;
+    virtual h256 codeHashAt(Address _a, BlockNumber _block) const override;
+    virtual std::map<h256, std::pair<u256, u256>> storageAt(Address _a, BlockNumber _block) const override;
 
-	virtual LocalisedLogEntries logs(unsigned _watchId) const override;
-	virtual LocalisedLogEntries logs(LogFilter const& _filter) const override;
-	virtual void prependLogsFromBlock(LogFilter const& _filter, h256 const& _blockHash, BlockPolarity _polarity, LocalisedLogEntries& io_logs) const;
+    virtual LocalisedLogEntries logs(unsigned _watchId) const override;
+    virtual LocalisedLogEntries logs(LogFilter const& _filter) const override;
+    virtual void prependLogsFromBlock(LogFilter const& _filter, h256 const& _blockHash, BlockPolarity _polarity, LocalisedLogEntries& io_logs) const;
 
-	/// Install, uninstall and query watches.
-	virtual unsigned installWatch(LogFilter const& _filter, Reaping _r = Reaping::Automatic) override;
-	virtual unsigned installWatch(h256 _filterId, Reaping _r = Reaping::Automatic) override;
-	virtual bool uninstallWatch(unsigned _watchId) override;
-	virtual LocalisedLogEntries peekWatch(unsigned _watchId) const override;
-	virtual LocalisedLogEntries checkWatch(unsigned _watchId) override;
+    /// Install, uninstall and query watches.
+    virtual unsigned installWatch(LogFilter const& _filter, Reaping _r = Reaping::Automatic) override;
+    virtual unsigned installWatch(h256 _filterId, Reaping _r = Reaping::Automatic) override;
+    virtual bool uninstallWatch(unsigned _watchId) override;
+    virtual LocalisedLogEntries peekWatch(unsigned _watchId) const override;
+    virtual LocalisedLogEntries checkWatch(unsigned _watchId) override;
 
-	virtual h256 hashFromNumber(BlockNumber _number) const override;
-	virtual BlockNumber numberFromHash(h256 _blockHash) const override;
-	virtual int compareBlockHashes(h256 _h1, h256 _h2) const override;
-	virtual BlockHeader blockInfo(h256 _hash) const override;
-	virtual BlockDetails blockDetails(h256 _hash) const override;
-	virtual Transaction transaction(h256 _transactionHash) const override;
-	virtual LocalisedTransaction localisedTransaction(h256 const& _transactionHash) const override;
-	virtual Transaction transaction(h256 _blockHash, unsigned _i) const override;
-	virtual LocalisedTransaction localisedTransaction(h256 const& _blockHash, unsigned _i) const override;
-	virtual TransactionReceipt transactionReceipt(h256 const& _transactionHash) const override;
-	virtual LocalisedTransactionReceipt localisedTransactionReceipt(h256 const& _transactionHash) const override;
-	virtual std::pair<h256, unsigned> transactionLocation(h256 const& _transactionHash) const override;
-	virtual Transactions transactions(h256 _blockHash) const override;
-	virtual TransactionHashes transactionHashes(h256 _blockHash) const override;
-	virtual BlockHeader uncle(h256 _blockHash, unsigned _i) const override;
-	virtual UncleHashes uncleHashes(h256 _blockHash) const override;
-	virtual unsigned transactionCount(h256 _blockHash) const override;
-	virtual unsigned uncleCount(h256 _blockHash) const override;
-	virtual unsigned number() const override;
-	virtual Transactions pending() const override;
-	virtual h256s pendingHashes() const override;
-	virtual BlockHeader pendingInfo() const override;
-	virtual BlockDetails pendingDetails() const override;
+    virtual h256 hashFromNumber(BlockNumber _number) const override;
+    virtual BlockNumber numberFromHash(h256 _blockHash) const override;
+    virtual int compareBlockHashes(h256 _h1, h256 _h2) const override;
+    virtual BlockHeader blockInfo(h256 _hash) const override;
+    virtual BlockDetails blockDetails(h256 _hash) const override;
+    virtual Transaction transaction(h256 _transactionHash) const override;
+    virtual LocalisedTransaction localisedTransaction(h256 const& _transactionHash) const override;
+    virtual Transaction transaction(h256 _blockHash, unsigned _i) const override;
+    virtual LocalisedTransaction localisedTransaction(h256 const& _blockHash, unsigned _i) const override;
+    virtual TransactionReceipt transactionReceipt(h256 const& _transactionHash) const override;
+    virtual LocalisedTransactionReceipt localisedTransactionReceipt(h256 const& _transactionHash) const override;
+    virtual std::pair<h256, unsigned> transactionLocation(h256 const& _transactionHash) const override;
+    virtual Transactions transactions(h256 _blockHash) const override;
+    virtual TransactionHashes transactionHashes(h256 _blockHash) const override;
+    virtual BlockHeader uncle(h256 _blockHash, unsigned _i) const override;
+    virtual UncleHashes uncleHashes(h256 _blockHash) const override;
+    virtual unsigned transactionCount(h256 _blockHash) const override;
+    virtual unsigned uncleCount(h256 _blockHash) const override;
+    virtual unsigned number() const override;
+    virtual Transactions pending() const override;
+    virtual h256s pendingHashes() const override;
+    virtual BlockHeader pendingInfo() const override;
+    virtual BlockDetails pendingDetails() const override;
 
-	virtual EVMSchedule evmSchedule() const override { return sealEngine()->evmSchedule(pendingInfo().number()); }
+    virtual EVMSchedule evmSchedule() const override { return sealEngine()->evmSchedule(pendingInfo().number()); }
 
-	virtual ImportResult injectBlock(bytes const& _block) override;
+    virtual ImportResult injectBlock(bytes const& _block) override;
 
-	using Interface::addresses;
-	virtual Addresses addresses(BlockNumber _block) const override;
-	virtual u256 gasLimitRemaining() const override;
-	virtual u256 gasBidPrice() const override { return DefaultGasPrice; }
+    using Interface::addresses;
+    virtual Addresses addresses(BlockNumber _block) const override;
+    virtual u256 gasLimitRemaining() const override;
+    virtual u256 gasBidPrice() const override { return DefaultGasPrice; }
 
-	/// Get the block author
-	virtual Address author() const override;
+    /// Get the block author
+    virtual Address author() const override;
 
-	virtual bool isKnown(h256 const& _hash) const override;
-	virtual bool isKnown(BlockNumber _block) const override;
-	virtual bool isKnownTransaction(h256 const& _transactionHash) const override;
-	virtual bool isKnownTransaction(h256 const& _blockHash, unsigned _i) const override;
+    virtual bool isKnown(h256 const& _hash) const override;
+    virtual bool isKnown(BlockNumber _block) const override;
+    virtual bool isKnownTransaction(h256 const& _transactionHash) const override;
+    virtual bool isKnownTransaction(h256 const& _blockHash, unsigned _i) const override;
 
-	virtual void startSealing() override { BOOST_THROW_EXCEPTION(InterfaceNotSupported("ClientBase::startSealing")); }
-	virtual void stopSealing() override { BOOST_THROW_EXCEPTION(InterfaceNotSupported("ClientBase::stopSealing")); }
-	virtual bool wouldSeal() const override { BOOST_THROW_EXCEPTION(InterfaceNotSupported("ClientBase::wouldSeal")); }
+    virtual void startSealing() override
+    {
+        BOOST_THROW_EXCEPTION(
+            InterfaceNotSupported() << errinfo_interface("ClientBase::startSealing"));
+    }
+    virtual void stopSealing() override
+    {
+        BOOST_THROW_EXCEPTION(
+            InterfaceNotSupported() << errinfo_interface("ClientBase::stopSealing"));
+    }
+    virtual bool wouldSeal() const override
+    {
+        BOOST_THROW_EXCEPTION(
+            InterfaceNotSupported() << errinfo_interface("ClientBase::wouldSeal"));
+    }
 
-	virtual SyncStatus syncStatus() const override { BOOST_THROW_EXCEPTION(InterfaceNotSupported("ClientBase::syncStatus")); }
+    virtual SyncStatus syncStatus() const override
+    {
+        BOOST_THROW_EXCEPTION(
+            InterfaceNotSupported() << errinfo_interface("ClientBase::syncStatus"));
+    }
 
-	Block block(BlockNumber _h) const;
+    Block block(BlockNumber _h) const;
 
 protected:
-	/// The interface that must be implemented in any class deriving this.
-	/// {
-	virtual BlockChain& bc() = 0;
-	virtual BlockChain const& bc() const = 0;
-	virtual Block block(h256 const& _h) const = 0;
-	virtual Block preSeal() const = 0;
-	virtual Block postSeal() const = 0;
-	virtual void prepareForTransaction() = 0;
-	/// }
+    /// The interface that must be implemented in any class deriving this.
+    /// {
+    virtual BlockChain& bc() = 0;
+    virtual BlockChain const& bc() const = 0;
+    virtual Block block(h256 const& _h) const = 0;
+    virtual Block preSeal() const = 0;
+    virtual Block postSeal() const = 0;
+    virtual void prepareForTransaction() = 0;
+    /// }
 
-	// filters
-	mutable Mutex x_filtersWatches;							///< Our lock.
-	std::unordered_map<h256, InstalledFilter> m_filters;	///< The dictionary of filters that are active.
-	std::unordered_map<h256, h256s> m_specialFilters = std::unordered_map<h256, std::vector<h256>>{{PendingChangedFilter, {}}, {ChainChangedFilter, {}}};
-															///< The dictionary of special filters and their additional data
-	std::map<unsigned, ClientWatch> m_watches;				///< Each and every watch - these reference a filter.
+    // filters
+    mutable Mutex x_filtersWatches;							///< Our lock.
+    std::unordered_map<h256, InstalledFilter> m_filters;	///< The dictionary of filters that are active.
+    std::unordered_map<h256, h256s> m_specialFilters = std::unordered_map<h256, std::vector<h256>>{{PendingChangedFilter, {}}, {ChainChangedFilter, {}}};
+                                                            ///< The dictionary of special filters and their additional data
+    std::map<unsigned, ClientWatch> m_watches;				///< Each and every watch - these reference a filter.
 };
 
 }}

--- a/libwebthree/WebThree.h
+++ b/libwebthree/WebThree.h
@@ -132,7 +132,12 @@ public:
 
     // The mainline interfaces:
 
-    eth::Client* ethereum() const { if (!m_ethereum) BOOST_THROW_EXCEPTION(InterfaceNotSupported("eth")); return m_ethereum.get(); }
+    eth::Client* ethereum() const
+    {
+        if (!m_ethereum)
+            BOOST_THROW_EXCEPTION(InterfaceNotSupported() << errinfo_interface("eth"));
+        return m_ethereum.get();
+    }
 
     // Misc stuff:
 

--- a/test/tools/libtesteth/Options.cpp
+++ b/test/tools/libtesteth/Options.cpp
@@ -1,18 +1,18 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file
  * Class for handling testeth custom options
@@ -30,47 +30,47 @@ using namespace dev::eth;
 
 void printHelp()
 {
-	cout << "Usage: \n";
-	cout << std::left;
-	cout << "\nSetting test suite\n";
-	cout << setw(30) <<	"-t <TestSuite>" << setw(25) << "Execute test operations\n";
-	cout << setw(30) << "-t <TestSuite>/<TestCase>\n";
-	cout << setw(30) << "--testpath <PathToTheTestRepo>\n";
+    cout << "Usage: \n";
+    cout << std::left;
+    cout << "\nSetting test suite\n";
+    cout << setw(30) <<	"-t <TestSuite>" << setw(25) << "Execute test operations\n";
+    cout << setw(30) << "-t <TestSuite>/<TestCase>\n";
+    cout << setw(30) << "--testpath <PathToTheTestRepo>\n";
 
-	cout << "\nDebugging\n";
-	cout << setw(30) << "-d <index>" << setw(25) << "Set the transaction data array index when running GeneralStateTests\n";
-	cout << setw(30) << "-g <index>" << setw(25) << "Set the transaction gas array index when running GeneralStateTests\n";
-	cout << setw(30) << "-v <index>" << setw(25) << "Set the transaction value array index when running GeneralStateTests\n";
-	cout << setw(30) << "--singletest <TestName>" << setw(25) << "Run on a single test\n";
-	cout << setw(30) << "--singletest <TestFile> <TestName>\n";
-	cout << setw(30) << "--verbosity <level>" << setw(25) << "Set logs verbosity. 0 - silent, 1 - only errors, 2 - informative, >2 - detailed\n";
-	cout << setw(30) << "--vm <interpreter|jit|smart|hera>" << setw(25) << "Set VM type for VMTests suite\n";
-	cout << setw(30) << "--vmtrace" << setw(25) << "Enable VM trace for the test. (Require build with VMTRACE=1)\n";
-	cout << setw(30) << "--jsontrace <Options>" << setw(25) << "Enable VM trace to stdout in json format. Argument is a json config: '{ \"disableStorage\" : false, \"disableMemory\" : false, \"disableStack\" : false, \"fullStorage\" : true }'\n";
-	cout << setw(30) << "--stats <OutFile>" << setw(25) << "Output debug stats to the file\n";
-	cout << setw(30) << "--exectimelog" << setw(25) << "Output execution time for each test suite\n";
-	cout << setw(30) << "--statediff" << setw(25) << "Trace state difference for state tests\n";
+    cout << "\nDebugging\n";
+    cout << setw(30) << "-d <index>" << setw(25) << "Set the transaction data array index when running GeneralStateTests\n";
+    cout << setw(30) << "-g <index>" << setw(25) << "Set the transaction gas array index when running GeneralStateTests\n";
+    cout << setw(30) << "-v <index>" << setw(25) << "Set the transaction value array index when running GeneralStateTests\n";
+    cout << setw(30) << "--singletest <TestName>" << setw(25) << "Run on a single test\n";
+    cout << setw(30) << "--singletest <TestFile> <TestName>\n";
+    cout << setw(30) << "--verbosity <level>" << setw(25) << "Set logs verbosity. 0 - silent, 1 - only errors, 2 - informative, >2 - detailed\n";
+    cout << setw(30) << "--vm <interpreter|jit|smart|hera>" << setw(25) << "Set VM type for VMTests suite\n";
+    cout << setw(30) << "--vmtrace" << setw(25) << "Enable VM trace for the test. (Require build with VMTRACE=1)\n";
+    cout << setw(30) << "--jsontrace <Options>" << setw(25) << "Enable VM trace to stdout in json format. Argument is a json config: '{ \"disableStorage\" : false, \"disableMemory\" : false, \"disableStack\" : false, \"fullStorage\" : true }'\n";
+    cout << setw(30) << "--stats <OutFile>" << setw(25) << "Output debug stats to the file\n";
+    cout << setw(30) << "--exectimelog" << setw(25) << "Output execution time for each test suite\n";
+    cout << setw(30) << "--statediff" << setw(25) << "Trace state difference for state tests\n";
 
-	cout << "\nAdditional Tests\n";
-	cout << setw(30) << "--all" << setw(25) << "Enable all tests\n";
+    cout << "\nAdditional Tests\n";
+    cout << setw(30) << "--all" << setw(25) << "Enable all tests\n";
 
-	cout << "\nTest Generation\n";
-	cout << setw(30) << "--filltests" << setw(25) << "Run test fillers\n";
-	cout << setw(30) << "--fillchain" << setw(25) << "When filling the state tests, fill tests as blockchain instead\n";
-	cout << setw(30) << "--randomcode <MaxOpcodeNum>" << setw(25) << "Generate smart random EVM code\n";
-	cout << setw(30) << "--createRandomTest" << setw(25) << "Create random test and output it to the console\n";
-	cout << setw(30) << "--createRandomTest <PathToOptions.json>" << setw(25) << "Use following options file for random code generation\n";
-	cout << setw(30) << "--seed <uint>" << setw(25) << "Define a seed for random test\n";
-	cout << setw(30) << "--options <PathTo.json>" << setw(25) << "Use following options file for random code generation\n";
-	//cout << setw(30) << "--fulloutput" << setw(25) << "Disable address compression in the output field\n";
+    cout << "\nTest Generation\n";
+    cout << setw(30) << "--filltests" << setw(25) << "Run test fillers\n";
+    cout << setw(30) << "--fillchain" << setw(25) << "When filling the state tests, fill tests as blockchain instead\n";
+    cout << setw(30) << "--randomcode <MaxOpcodeNum>" << setw(25) << "Generate smart random EVM code\n";
+    cout << setw(30) << "--createRandomTest" << setw(25) << "Create random test and output it to the console\n";
+    cout << setw(30) << "--createRandomTest <PathToOptions.json>" << setw(25) << "Use following options file for random code generation\n";
+    cout << setw(30) << "--seed <uint>" << setw(25) << "Define a seed for random test\n";
+    cout << setw(30) << "--options <PathTo.json>" << setw(25) << "Use following options file for random code generation\n";
+    //cout << setw(30) << "--fulloutput" << setw(25) << "Disable address compression in the output field\n";
 
-	cout << setw(30) << "--help" << setw(25) << "Display list of command arguments\n";
-	cout << setw(30) << "--version" << setw(25) << "Display build information\n";
+    cout << setw(30) << "--help" << setw(25) << "Display list of command arguments\n";
+    cout << setw(30) << "--version" << setw(25) << "Display build information\n";
 }
 
 void printVersion()
 {
-	cout << prepareVersionString() << "\n";
+    cout << prepareVersionString() << "\n";
 }
 
 Options::Options(int argc, const char** argv)
@@ -96,243 +96,251 @@ Options::Options(int argc, const char** argv)
         po::notify(vm);
     }
 
-	trDataIndex = -1;
-	trGasIndex = -1;
-	trValueIndex = -1;
-	bool seenSeparator = false; // true if "--" has been seen.
-	for (auto i = 0; i < argc; ++i)
-	{
-		auto arg = std::string{argv[i]};
-		auto throwIfNoArgumentFollows = [&i, &argc, &arg]()
-		{
-			if (i + 1 >= argc)
-				BOOST_THROW_EXCEPTION(InvalidOption(arg + " option is missing an argument."));
-		};
-		auto throwIfAfterSeparator = [&seenSeparator, &arg]()
-		{
-			if (seenSeparator)
-				BOOST_THROW_EXCEPTION(InvalidOption(arg + " option appears after the separator --."));
-		};
-		if (arg == "--")
-		{
-			if (seenSeparator)
-				BOOST_THROW_EXCEPTION(InvalidOption("The separator -- appears more than once in the command line."));
-			seenSeparator = true;
-			continue;
-		}
-		if (arg == "--help")
-		{
-			printHelp();
-			exit(0);
-		}
-		else if (arg == "--version")
-		{
-			printVersion();
-			exit(0);
-		}
-		else if (arg == "--vm" || arg == "--evmc")
-		{
-			// Skip VM options because they are handled by vmProgramOptions().
-			throwIfNoArgumentFollows();
-			++i;
-		}
-		else if (arg == "--vmtrace")
-		{
+    trDataIndex = -1;
+    trGasIndex = -1;
+    trValueIndex = -1;
+    bool seenSeparator = false; // true if "--" has been seen.
+    for (auto i = 0; i < argc; ++i)
+    {
+        auto arg = std::string{argv[i]};
+        auto throwIfNoArgumentFollows = [&i, &argc, &arg]()
+        {
+            if (i + 1 >= argc)
+                BOOST_THROW_EXCEPTION(
+                    InvalidOption() << errinfo_comment(arg + " option is missing an argument."));
+        };
+        auto throwIfAfterSeparator = [&seenSeparator, &arg]()
+        {
+            if (seenSeparator)
+                BOOST_THROW_EXCEPTION(InvalidOption() << errinfo_comment(
+                                          arg + " option appears after the separator --."));
+        };
+        if (arg == "--")
+        {
+            if (seenSeparator)
+                BOOST_THROW_EXCEPTION(
+                    InvalidOption() << errinfo_comment(
+                        "The separator -- appears more than once in the command line."));
+            seenSeparator = true;
+            continue;
+        }
+        if (arg == "--help")
+        {
+            printHelp();
+            exit(0);
+        }
+        else if (arg == "--version")
+        {
+            printVersion();
+            exit(0);
+        }
+        else if (arg == "--vm" || arg == "--evmc")
+        {
+            // Skip VM options because they are handled by vmProgramOptions().
+            throwIfNoArgumentFollows();
+            ++i;
+        }
+        else if (arg == "--vmtrace")
+        {
 #if ETH_VMTRACE
-			vmtrace = true;
-			g_logVerbosity = 13;
+            vmtrace = true;
+            g_logVerbosity = 13;
 #else
-			cerr << "--vmtrace option requires a build with cmake -DVMTRACE=1\n";
-			exit(1);
+            cerr << "--vmtrace option requires a build with cmake -DVMTRACE=1\n";
+            exit(1);
 #endif
-		}
-		else if (arg == "--jsontrace")
-		{
-			throwIfNoArgumentFollows();
-			jsontrace = true;
-			auto arg = std::string{argv[++i]};
-			Json::Value value;
-			Json::Reader().parse(arg, value);
-			jsontraceOptions = debugOptions(value);
-		}
-		else if (arg == "--filltests")
-			filltests = true;
-		else if (arg == "--fillchain")
-			fillchain = true;
-		else if (arg == "--stats")
-		{
-			throwIfNoArgumentFollows();
-			stats = true;
-			statsOutFile = argv[++i];
-		}
-		else if (arg == "--exectimelog")
-			exectimelog = true;
-		else if (arg == "--all")
-			all = true;
-		else if (arg == "--singletest")
-		{
-			throwIfNoArgumentFollows();
-			singleTest = true;
-			auto name1 = std::string{argv[++i]};
-			if (i + 1 < argc) // two params
-			{
-				auto name2 = std::string{argv[++i]};
-				if (name2[0] == '-') // not param, another option
-				{
-					singleTestName = std::move(name1);
-					i--;
-				}
-				else
-				{
-					singleTestFile = std::move(name1);
-					singleTestName = std::move(name2);
-				}
-			}
-			else
-				singleTestName = std::move(name1);
-		}
-		else if (arg == "--singlenet")
-		{
-			throwIfNoArgumentFollows();
-			singleTestNet = std::string{argv[++i]};
+        }
+        else if (arg == "--jsontrace")
+        {
+            throwIfNoArgumentFollows();
+            jsontrace = true;
+            auto arg = std::string{argv[++i]};
+            Json::Value value;
+            Json::Reader().parse(arg, value);
+            jsontraceOptions = debugOptions(value);
+        }
+        else if (arg == "--filltests")
+            filltests = true;
+        else if (arg == "--fillchain")
+            fillchain = true;
+        else if (arg == "--stats")
+        {
+            throwIfNoArgumentFollows();
+            stats = true;
+            statsOutFile = argv[++i];
+        }
+        else if (arg == "--exectimelog")
+            exectimelog = true;
+        else if (arg == "--all")
+            all = true;
+        else if (arg == "--singletest")
+        {
+            throwIfNoArgumentFollows();
+            singleTest = true;
+            auto name1 = std::string{argv[++i]};
+            if (i + 1 < argc) // two params
+            {
+                auto name2 = std::string{argv[++i]};
+                if (name2[0] == '-') // not param, another option
+                {
+                    singleTestName = std::move(name1);
+                    i--;
+                }
+                else
+                {
+                    singleTestFile = std::move(name1);
+                    singleTestName = std::move(name2);
+                }
+            }
+            else
+                singleTestName = std::move(name1);
+        }
+        else if (arg == "--singlenet")
+        {
+            throwIfNoArgumentFollows();
+            singleTestNet = std::string{argv[++i]};
             ImportTest::checkAllowedNetwork(singleTestNet);
         }
         else if (arg == "--fulloutput")
             fulloutput = true;
-		else if (arg == "--verbosity")
-		{
-			throwIfNoArgumentFollows();
-			static std::ostringstream strCout; //static string to redirect logs to
-			std::string indentLevel = std::string{argv[++i]};
-			if (indentLevel == "0")
-			{
-				logVerbosity = Verbosity::None;
-				std::cout.rdbuf(strCout.rdbuf());
-				std::cerr.rdbuf(strCout.rdbuf());
-			}
-			else if (indentLevel == "1")
-				logVerbosity = Verbosity::NiceReport;
-			else
-				logVerbosity = Verbosity::Full;
+        else if (arg == "--verbosity")
+        {
+            throwIfNoArgumentFollows();
+            static std::ostringstream strCout; //static string to redirect logs to
+            std::string indentLevel = std::string{argv[++i]};
+            if (indentLevel == "0")
+            {
+                logVerbosity = Verbosity::None;
+                std::cout.rdbuf(strCout.rdbuf());
+                std::cerr.rdbuf(strCout.rdbuf());
+            }
+            else if (indentLevel == "1")
+                logVerbosity = Verbosity::NiceReport;
+            else
+                logVerbosity = Verbosity::Full;
 
-			int indentLevelInt = atoi(argv[i]);
-			if (indentLevelInt > g_logVerbosity)
-				g_logVerbosity = indentLevelInt;
-		}
-		else if (arg == "--options")
-		{
-			throwIfNoArgumentFollows();
-			boost::filesystem::path file(std::string{argv[++i]});
-			if (boost::filesystem::exists(file))
-				randomCodeOptionsPath = file;
-			else
-			{
-				std::cerr << "Options file not found! Default options at: tests/src/randomCodeOptions.json\n";
-				exit(0);
-			}
-		}
-		else if (arg == "-t")
-		{
-			throwIfAfterSeparator();
-			throwIfNoArgumentFollows();
-			rCurrentTestSuite = std::string{argv[++i]};
-		}
-		else if (arg == "--nonetwork")
-			nonetwork = true;
-		else if (arg == "-d")
-		{
-			throwIfNoArgumentFollows();
-			trDataIndex = atoi(argv[++i]);
-		}
-		else if (arg == "-g")
-		{
-			throwIfNoArgumentFollows();
-			trGasIndex = atoi(argv[++i]);
-		}
-		else if (arg == "-v")
-		{
-			throwIfNoArgumentFollows();
-			trValueIndex = atoi(argv[++i]);
-		}
-		else if (arg == "--testpath")
-		{
-			throwIfNoArgumentFollows();
-			testpath = std::string{argv[++i]};
-		}
-		else if (arg == "--statediff")
-			statediff = true;
-		else if (arg == "--randomcode")
-		{
-			throwIfNoArgumentFollows();
-			int maxCodes = atoi(argv[++i]);
-			if (maxCodes > 1000 || maxCodes <= 0)
-			{
-				cerr << "Argument for the option is invalid! (use range: 1...1000)\n";
-				exit(1);
-			}
-			test::RandomCodeOptions options;
-			cout << test::RandomCode::get().generate(maxCodes, options) << "\n";
-			exit(0);
-		}
-		else if (arg == "--createRandomTest")
-		{
-			createRandomTest = true;
-			if (i + 1 < argc) // two params
-			{
-				auto options = std::string{argv[++i]};
-				if (options[0] == '-') // not param, another option
-					i--;
-				else
-				{
-					boost::filesystem::path file(options);
-					if (boost::filesystem::exists(file))
-						randomCodeOptionsPath = file;
-					else
-						BOOST_THROW_EXCEPTION(InvalidOption("Options file not found! Default options at: tests/src/randomCodeOptions.json\n"));
-				}
-			}
-		}
-		else if (arg == "--seed")
-		{
-			throwIfNoArgumentFollows();
-			u256 input = toInt(argv[++i]);
-			if (input > std::numeric_limits<uint64_t>::max())
-				BOOST_WARN("Seed is > u64. Using u64_max instead.");
-			randomTestSeed = static_cast<uint64_t>(min<u256>(std::numeric_limits<uint64_t>::max(), input));
-		}
-		else if (seenSeparator)
-		{
-			cerr << "Unknown option: " + arg << "\n";
-			exit(1);
-		}
-	}
+            int indentLevelInt = atoi(argv[i]);
+            if (indentLevelInt > g_logVerbosity)
+                g_logVerbosity = indentLevelInt;
+        }
+        else if (arg == "--options")
+        {
+            throwIfNoArgumentFollows();
+            boost::filesystem::path file(std::string{argv[++i]});
+            if (boost::filesystem::exists(file))
+                randomCodeOptionsPath = file;
+            else
+            {
+                std::cerr << "Options file not found! Default options at: tests/src/randomCodeOptions.json\n";
+                exit(0);
+            }
+        }
+        else if (arg == "-t")
+        {
+            throwIfAfterSeparator();
+            throwIfNoArgumentFollows();
+            rCurrentTestSuite = std::string{argv[++i]};
+        }
+        else if (arg == "--nonetwork")
+            nonetwork = true;
+        else if (arg == "-d")
+        {
+            throwIfNoArgumentFollows();
+            trDataIndex = atoi(argv[++i]);
+        }
+        else if (arg == "-g")
+        {
+            throwIfNoArgumentFollows();
+            trGasIndex = atoi(argv[++i]);
+        }
+        else if (arg == "-v")
+        {
+            throwIfNoArgumentFollows();
+            trValueIndex = atoi(argv[++i]);
+        }
+        else if (arg == "--testpath")
+        {
+            throwIfNoArgumentFollows();
+            testpath = std::string{argv[++i]};
+        }
+        else if (arg == "--statediff")
+            statediff = true;
+        else if (arg == "--randomcode")
+        {
+            throwIfNoArgumentFollows();
+            int maxCodes = atoi(argv[++i]);
+            if (maxCodes > 1000 || maxCodes <= 0)
+            {
+                cerr << "Argument for the option is invalid! (use range: 1...1000)\n";
+                exit(1);
+            }
+            test::RandomCodeOptions options;
+            cout << test::RandomCode::get().generate(maxCodes, options) << "\n";
+            exit(0);
+        }
+        else if (arg == "--createRandomTest")
+        {
+            createRandomTest = true;
+            if (i + 1 < argc) // two params
+            {
+                auto options = std::string{argv[++i]};
+                if (options[0] == '-') // not param, another option
+                    i--;
+                else
+                {
+                    boost::filesystem::path file(options);
+                    if (boost::filesystem::exists(file))
+                        randomCodeOptionsPath = file;
+                    else
+                        BOOST_THROW_EXCEPTION(InvalidOption() << errinfo_comment(
+                                                  "Options file not found! Default options at: "
+                                                  "tests/src/randomCodeOptions.json\n"));
+                }
+            }
+        }
+        else if (arg == "--seed")
+        {
+            throwIfNoArgumentFollows();
+            u256 input = toInt(argv[++i]);
+            if (input > std::numeric_limits<uint64_t>::max())
+                BOOST_WARN("Seed is > u64. Using u64_max instead.");
+            randomTestSeed = static_cast<uint64_t>(min<u256>(std::numeric_limits<uint64_t>::max(), input));
+        }
+        else if (seenSeparator)
+        {
+            cerr << "Unknown option: " + arg << "\n";
+            exit(1);
+        }
+    }
 
-	//check restrickted options
-	if (createRandomTest)
-	{
-		if (trValueIndex >= 0 || trGasIndex >= 0 || trDataIndex >= 0 || nonetwork || singleTest
-			|| all || stats || filltests || fillchain)
-		{
-			cerr << "--createRandomTest cannot be used with any of the options: " <<
-					"trValueIndex, trGasIndex, trDataIndex, nonetwork, singleTest, all, " <<
-					"stats, filltests, fillchain \n";
-			exit(1);
-		}
-	}
-	else
-	{
-		if (randomTestSeed.is_initialized())
-			BOOST_THROW_EXCEPTION(InvalidOption("--seed <uint> could be used only with --createRandomTest \n"));
-	}
+    //check restrickted options
+    if (createRandomTest)
+    {
+        if (trValueIndex >= 0 || trGasIndex >= 0 || trDataIndex >= 0 || nonetwork || singleTest
+            || all || stats || filltests || fillchain)
+        {
+            cerr << "--createRandomTest cannot be used with any of the options: " <<
+                    "trValueIndex, trGasIndex, trDataIndex, nonetwork, singleTest, all, " <<
+                    "stats, filltests, fillchain \n";
+            exit(1);
+        }
+    }
+    else
+    {
+        if (randomTestSeed.is_initialized())
+            BOOST_THROW_EXCEPTION(
+                InvalidOption() << errinfo_comment(
+                    "--seed <uint> could be used only with --createRandomTest \n"));
+    }
 
-	//Default option
-	if (logVerbosity == Verbosity::NiceReport)
-		g_logVerbosity = -1;	//disable cnote but leave cerr and cout
+    //Default option
+    if (logVerbosity == Verbosity::NiceReport)
+        g_logVerbosity = -1;	//disable cnote but leave cerr and cout
 }
 
 Options const& Options::get(int argc, const char** argv)
 {
-	static Options instance(argc, argv);
-	return instance;
+    static Options instance(argc, argv);
+    return instance;
 }
 

--- a/test/tools/libtesteth/Options.h
+++ b/test/tools/libtesteth/Options.h
@@ -1,18 +1,18 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file
  * Class for handling testeth custom options
@@ -31,56 +31,53 @@ namespace test
 
 enum class Verbosity
 {
-	None,
-	NiceReport,
-	Full
+    None,
+    NiceReport,
+    Full
 };
+
+DEV_SIMPLE_EXCEPTION(InvalidOption);
 
 class Options
 {
 public:
-	struct InvalidOption: public Exception
-	{
-		InvalidOption(std::string _message = std::string()): Exception(_message) {}
-	};
+    bool vmtrace = false;	///< Create EVM execution tracer
+    bool filltests = false; ///< Create JSON test files from execution results
+    bool fillchain = false; ///< Fill tests as a blockchain tests if possible
+    bool stats = false;		///< Execution time and stats for state tests
+    std::string statsOutFile; ///< Stats output file. "out" for standard output
+    bool exectimelog = false; ///< Print execution time for each test suite
+    std::string rCurrentTestSuite; ///< Remember test suite before boost overwrite (for random tests)
+    bool statediff = false;///< Fill full post state in General tests
+    bool fulloutput = false;///< Replace large output to just it's length
+    bool createRandomTest = false; ///< Generate random test
+    boost::optional<uint64_t> randomTestSeed; ///< Define a seed for random test
+    bool jsontrace = false; ///< Vmtrace to stdout in json format
+    eth::StandardTrace::DebugOptions jsontraceOptions; ///< output config for jsontrace
+    std::string testpath;	///< Custom test folder path
+    Verbosity logVerbosity = Verbosity::NiceReport;
+    boost::optional<boost::filesystem::path> randomCodeOptionsPath; ///< Options for random code generation in fuzz tests
 
-	bool vmtrace = false;	///< Create EVM execution tracer
-	bool filltests = false; ///< Create JSON test files from execution results
-	bool fillchain = false; ///< Fill tests as a blockchain tests if possible
-	bool stats = false;		///< Execution time and stats for state tests
-	std::string statsOutFile; ///< Stats output file. "out" for standard output
-	bool exectimelog = false; ///< Print execution time for each test suite
-	std::string rCurrentTestSuite; ///< Remember test suite before boost overwrite (for random tests)
-	bool statediff = false;///< Fill full post state in General tests
-	bool fulloutput = false;///< Replace large output to just it's length
-	bool createRandomTest = false; ///< Generate random test
-	boost::optional<uint64_t> randomTestSeed; ///< Define a seed for random test
-	bool jsontrace = false; ///< Vmtrace to stdout in json format
-	eth::StandardTrace::DebugOptions jsontraceOptions; ///< output config for jsontrace
-	std::string testpath;	///< Custom test folder path
-	Verbosity logVerbosity = Verbosity::NiceReport;
-	boost::optional<boost::filesystem::path> randomCodeOptionsPath; ///< Options for random code generation in fuzz tests
+    /// Test selection
+    /// @{
+    bool singleTest = false;
+    boost::optional<std::string> singleTestFile;
+    std::string singleTestName;
+    std::string singleTestNet;
+    int trDataIndex;	///< GeneralState data
+    int trGasIndex;		///< GeneralState gas
+    int trValueIndex;	///< GeneralState value
+    bool all = false;	///< Running every test, including time consuming ones.
+    bool nonetwork = false;///< For libp2p
+    /// @}
 
-	/// Test selection
-	/// @{
-	bool singleTest = false;
-	boost::optional<std::string> singleTestFile;
-	std::string singleTestName;
-	std::string singleTestNet;
-	int trDataIndex;	///< GeneralState data
-	int trGasIndex;		///< GeneralState gas
-	int trValueIndex;	///< GeneralState value
-	bool all = false;	///< Running every test, including time consuming ones.
-	bool nonetwork = false;///< For libp2p
-	/// @}
-
-	/// Get reference to options
-	/// The first time used, options are parsed with argc, argv
-	static Options const& get(int argc = 0, const char** argv = 0);
+    /// Get reference to options
+    /// The first time used, options are parsed with argc, argv
+    static Options const& get(int argc = 0, const char** argv = 0);
 
 private:
-	Options(int argc = 0, const char** argv = 0);
-	Options(Options const&) = delete;
+    Options(int argc = 0, const char** argv = 0);
+    Options(Options const&) = delete;
 };
 
 } //namespace test

--- a/test/tools/libtesteth/boostTest.cpp
+++ b/test/tools/libtesteth/boostTest.cpp
@@ -133,9 +133,9 @@ int main(int argc, const char* argv[])
     {
         dev::test::Options::get(argc, argv);
     }
-    catch (dev::test::Options::InvalidOption const& e)
+    catch (dev::test::InvalidOption const& e)
     {
-        std::cerr << e.what() << "\n";
+        std::cerr << *boost::get_error_info<errinfo_comment>(e) << "\n";
         exit(1);
     }
 

--- a/test/tools/libtestutils/FixedClient.h
+++ b/test/tools/libtestutils/FixedClient.h
@@ -1,18 +1,18 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
  
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
  
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
  
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
  */
 /** @file FixedClient.h
  * @author Marek Kotewicz <marek@ethdev.com>
@@ -37,26 +37,29 @@ namespace test
 class FixedClient: public dev::eth::ClientBase
 {
 public:
-	FixedClient(eth::BlockChain const& _bc, eth::Block const& _block) :  m_bc(_bc), m_block(_block) {}
+    FixedClient(eth::BlockChain const& _bc, eth::Block const& _block) :  m_bc(_bc), m_block(_block) {}
 
-	// stub
-	void flushTransactions() override {}
-	eth::BlockChain& bc() override { BOOST_THROW_EXCEPTION(InterfaceNotSupported("FixedClient::bc()")); }
-	eth::BlockChain const& bc() const override { return m_bc; }
-	using ClientBase::block;
-	eth::Block block(h256 const& _h) const override;
-	eth::Block preSeal() const override { ReadGuard l(x_stateDB); return m_block; }
-	eth::Block postSeal() const override { ReadGuard l(x_stateDB); return m_block; }
-	void setAuthor(Address const& _us) override { WriteGuard l(x_stateDB); m_block.setAuthor(_us); }
-	void prepareForTransaction() override {}
-	std::pair<h256, Address> submitTransaction(eth::TransactionSkeleton const&, Secret const&) override { return {}; };
-	eth::ImportResult injectTransaction(bytes const&, eth::IfDropped) override { return {}; }
-	eth::ExecutionResult call(Address const&, u256, Address, bytes const&, u256, u256, eth::BlockNumber, eth::FudgeFactor) override { return {}; };
+    // stub
+    void flushTransactions() override {}
+    eth::BlockChain& bc() override
+    {
+        BOOST_THROW_EXCEPTION(InterfaceNotSupported() << errinfo_interface("FixedClient::bc()"));
+    }
+    eth::BlockChain const& bc() const override { return m_bc; }
+    using ClientBase::block;
+    eth::Block block(h256 const& _h) const override;
+    eth::Block preSeal() const override { ReadGuard l(x_stateDB); return m_block; }
+    eth::Block postSeal() const override { ReadGuard l(x_stateDB); return m_block; }
+    void setAuthor(Address const& _us) override { WriteGuard l(x_stateDB); m_block.setAuthor(_us); }
+    void prepareForTransaction() override {}
+    std::pair<h256, Address> submitTransaction(eth::TransactionSkeleton const&, Secret const&) override { return {}; };
+    eth::ImportResult injectTransaction(bytes const&, eth::IfDropped) override { return {}; }
+    eth::ExecutionResult call(Address const&, u256, Address, bytes const&, u256, u256, eth::BlockNumber, eth::FudgeFactor) override { return {}; };
 
 private:
-	eth::BlockChain const& m_bc;
-	eth::Block m_block;
-	mutable SharedMutex x_stateDB;			///< Lock on the state DB, effectively a lock on m_postSeal.
+    eth::BlockChain const& m_bc;
+    eth::Block m_block;
+    mutable SharedMutex x_stateDB;			///< Lock on the state DB, effectively a lock on m_postSeal.
 };
 
 }

--- a/test/unittests/libethereum/Transaction.cpp
+++ b/test/unittests/libethereum/Transaction.cpp
@@ -1,18 +1,18 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file Transaction.cpp
  * @author Dmitrii Khokhlov <winsvega@mail.ru>
@@ -33,164 +33,165 @@ BOOST_FIXTURE_TEST_SUITE(libethereum, TestOutputHelperFixture)
 
 BOOST_AUTO_TEST_CASE(TransactionGasRequired)
 {
-	Transaction tr(fromHex("0xf86d800182521c94095e7baea6a6c7c4c2dfeb977efac326af552d870a8e0358ac39584bc98a7c979f984b031ba048b55bfa915ac795c431978d8a6a992b628d557da5ff759b307d495a36649353a0efffd310ac743f371de3b9f7f9cb56c0b28ad43601b4ab949f53faa07bd2c804"), CheckTransaction::None);
-	BOOST_CHECK_EQUAL(tr.baseGasRequired(FrontierSchedule), 21952);
+    Transaction tr(fromHex("0xf86d800182521c94095e7baea6a6c7c4c2dfeb977efac326af552d870a8e0358ac39584bc98a7c979f984b031ba048b55bfa915ac795c431978d8a6a992b628d557da5ff759b307d495a36649353a0efffd310ac743f371de3b9f7f9cb56c0b28ad43601b4ab949f53faa07bd2c804"), CheckTransaction::None);
+    BOOST_CHECK_EQUAL(tr.baseGasRequired(FrontierSchedule), 21952);
 }
 
 BOOST_AUTO_TEST_CASE(ExecutionResultOutput)
 {
-	std::stringstream buffer;
-	ExecutionResult exRes;
+    std::stringstream buffer;
+    ExecutionResult exRes;
 
-	exRes.gasUsed = u256("12345");
-	exRes.newAddress = Address("a94f5374fce5edbc8e2a8697c15331677e6ebf0b");
-	exRes.output = fromHex("001122334455");
+    exRes.gasUsed = u256("12345");
+    exRes.newAddress = Address("a94f5374fce5edbc8e2a8697c15331677e6ebf0b");
+    exRes.output = fromHex("001122334455");
 
-	buffer << exRes;
-	BOOST_CHECK_MESSAGE(buffer.str() == "{12345, a94f5374fce5edbc8e2a8697c15331677e6ebf0b, 001122334455}", "Error ExecutionResultOutput");
+    buffer << exRes;
+    BOOST_CHECK_MESSAGE(buffer.str() == "{12345, a94f5374fce5edbc8e2a8697c15331677e6ebf0b, 001122334455}", "Error ExecutionResultOutput");
 }
 
 BOOST_AUTO_TEST_CASE(transactionExceptionOutput)
 {
-	std::stringstream buffer;
-	buffer << TransactionException::BadInstruction;
-	BOOST_CHECK_MESSAGE(buffer.str() == "BadInstruction", "Error output TransactionException::BadInstruction");
-	buffer.str(std::string());
+    std::stringstream buffer;
+    buffer << TransactionException::BadInstruction;
+    BOOST_CHECK_MESSAGE(buffer.str() == "BadInstruction", "Error output TransactionException::BadInstruction");
+    buffer.str(std::string());
 
-	buffer << TransactionException::None;
-	BOOST_CHECK_MESSAGE(buffer.str() == "None", "Error output TransactionException::None");
-	buffer.str(std::string());
+    buffer << TransactionException::None;
+    BOOST_CHECK_MESSAGE(buffer.str() == "None", "Error output TransactionException::None");
+    buffer.str(std::string());
 
-	buffer << TransactionException::BadRLP;
-	BOOST_CHECK_MESSAGE(buffer.str() == "BadRLP", "Error output TransactionException::BadRLP");
-	buffer.str(std::string());
+    buffer << TransactionException::BadRLP;
+    BOOST_CHECK_MESSAGE(buffer.str() == "BadRLP", "Error output TransactionException::BadRLP");
+    buffer.str(std::string());
 
-	buffer << TransactionException::InvalidFormat;
-	BOOST_CHECK_MESSAGE(buffer.str() == "InvalidFormat", "Error output TransactionException::InvalidFormat");
-	buffer.str(std::string());
+    buffer << TransactionException::InvalidFormat;
+    BOOST_CHECK_MESSAGE(buffer.str() == "InvalidFormat", "Error output TransactionException::InvalidFormat");
+    buffer.str(std::string());
 
-	buffer << TransactionException::OutOfGasIntrinsic;
-	BOOST_CHECK_MESSAGE(buffer.str() == "OutOfGasIntrinsic", "Error output TransactionException::OutOfGasIntrinsic");
-	buffer.str(std::string());
+    buffer << TransactionException::OutOfGasIntrinsic;
+    BOOST_CHECK_MESSAGE(buffer.str() == "OutOfGasIntrinsic", "Error output TransactionException::OutOfGasIntrinsic");
+    buffer.str(std::string());
 
-	buffer << TransactionException::InvalidSignature;
-	BOOST_CHECK_MESSAGE(buffer.str() == "InvalidSignature", "Error output TransactionException::InvalidSignature");
-	buffer.str(std::string());
+    buffer << TransactionException::InvalidSignature;
+    BOOST_CHECK_MESSAGE(buffer.str() == "InvalidSignature", "Error output TransactionException::InvalidSignature");
+    buffer.str(std::string());
 
-	buffer << TransactionException::InvalidNonce;
-	BOOST_CHECK_MESSAGE(buffer.str() == "InvalidNonce", "Error output TransactionException::InvalidNonce");
-	buffer.str(std::string());
+    buffer << TransactionException::InvalidNonce;
+    BOOST_CHECK_MESSAGE(buffer.str() == "InvalidNonce", "Error output TransactionException::InvalidNonce");
+    buffer.str(std::string());
 
-	buffer << TransactionException::NotEnoughCash;
-	BOOST_CHECK_MESSAGE(buffer.str() == "NotEnoughCash", "Error output TransactionException::NotEnoughCash");
-	buffer.str(std::string());
+    buffer << TransactionException::NotEnoughCash;
+    BOOST_CHECK_MESSAGE(buffer.str() == "NotEnoughCash", "Error output TransactionException::NotEnoughCash");
+    buffer.str(std::string());
 
-	buffer << TransactionException::OutOfGasBase;
-	BOOST_CHECK_MESSAGE(buffer.str() == "OutOfGasBase", "Error output TransactionException::OutOfGasBase");
-	buffer.str(std::string());
+    buffer << TransactionException::OutOfGasBase;
+    BOOST_CHECK_MESSAGE(buffer.str() == "OutOfGasBase", "Error output TransactionException::OutOfGasBase");
+    buffer.str(std::string());
 
-	buffer << TransactionException::BlockGasLimitReached;
-	BOOST_CHECK_MESSAGE(buffer.str() == "BlockGasLimitReached", "Error output TransactionException::BlockGasLimitReached");
-	buffer.str(std::string());
+    buffer << TransactionException::BlockGasLimitReached;
+    BOOST_CHECK_MESSAGE(buffer.str() == "BlockGasLimitReached", "Error output TransactionException::BlockGasLimitReached");
+    buffer.str(std::string());
 
-	buffer << TransactionException::BadInstruction;
-	BOOST_CHECK_MESSAGE(buffer.str() == "BadInstruction", "Error output TransactionException::BadInstruction");
-	buffer.str(std::string());
+    buffer << TransactionException::BadInstruction;
+    BOOST_CHECK_MESSAGE(buffer.str() == "BadInstruction", "Error output TransactionException::BadInstruction");
+    buffer.str(std::string());
 
-	buffer << TransactionException::BadJumpDestination;
-	BOOST_CHECK_MESSAGE(buffer.str() == "BadJumpDestination", "Error output TransactionException::BadJumpDestination");
-	buffer.str(std::string());
+    buffer << TransactionException::BadJumpDestination;
+    BOOST_CHECK_MESSAGE(buffer.str() == "BadJumpDestination", "Error output TransactionException::BadJumpDestination");
+    buffer.str(std::string());
 
-	buffer << TransactionException::OutOfGas;
-	BOOST_CHECK_MESSAGE(buffer.str() == "OutOfGas", "Error output TransactionException::OutOfGas");
-	buffer.str(std::string());
+    buffer << TransactionException::OutOfGas;
+    BOOST_CHECK_MESSAGE(buffer.str() == "OutOfGas", "Error output TransactionException::OutOfGas");
+    buffer.str(std::string());
 
-	buffer << TransactionException::OutOfStack;
-	BOOST_CHECK_MESSAGE(buffer.str() == "OutOfStack", "Error output TransactionException::OutOfStack");
-	buffer.str(std::string());
+    buffer << TransactionException::OutOfStack;
+    BOOST_CHECK_MESSAGE(buffer.str() == "OutOfStack", "Error output TransactionException::OutOfStack");
+    buffer.str(std::string());
 
-	buffer << TransactionException::StackUnderflow;
-	BOOST_CHECK_MESSAGE(buffer.str() == "StackUnderflow", "Error output TransactionException::StackUnderflow");
-	buffer.str(std::string());
+    buffer << TransactionException::StackUnderflow;
+    BOOST_CHECK_MESSAGE(buffer.str() == "StackUnderflow", "Error output TransactionException::StackUnderflow");
+    buffer.str(std::string());
 
-	buffer << TransactionException(-1);
-	BOOST_CHECK_MESSAGE(buffer.str() == "Unknown", "Error output TransactionException::StackUnderflow");
-	buffer.str(std::string());
+    buffer << TransactionException(-1);
+    BOOST_CHECK_MESSAGE(buffer.str() == "Unknown", "Error output TransactionException::StackUnderflow");
+    buffer.str(std::string());
 }
 
 BOOST_AUTO_TEST_CASE(toTransactionExceptionConvert)
 {
-	RLPException rlpEx("exception");//toTransactionException(*(dynamic_cast<Exception*>
-	BOOST_CHECK_MESSAGE(toTransactionException(rlpEx) == TransactionException::BadRLP, "RLPException !=> TransactionException");
-	OutOfGasIntrinsic oogEx;
-	BOOST_CHECK_MESSAGE(toTransactionException(oogEx) == TransactionException::OutOfGasIntrinsic, "OutOfGasIntrinsic !=> TransactionException");
-	InvalidSignature sigEx;
-	BOOST_CHECK_MESSAGE(toTransactionException(sigEx) == TransactionException::InvalidSignature, "InvalidSignature !=> TransactionException");
-	OutOfGasBase oogbEx;
-	BOOST_CHECK_MESSAGE(toTransactionException(oogbEx) == TransactionException::OutOfGasBase, "OutOfGasBase !=> TransactionException");
-	InvalidNonce nonceEx;
-	BOOST_CHECK_MESSAGE(toTransactionException(nonceEx) == TransactionException::InvalidNonce, "InvalidNonce !=> TransactionException");
-	NotEnoughCash cashEx;
-	BOOST_CHECK_MESSAGE(toTransactionException(cashEx) == TransactionException::NotEnoughCash, "NotEnoughCash !=> TransactionException");
-	BlockGasLimitReached blGasEx;
-	BOOST_CHECK_MESSAGE(toTransactionException(blGasEx) == TransactionException::BlockGasLimitReached, "BlockGasLimitReached !=> TransactionException");
-	BadInstruction badInsEx;
-	BOOST_CHECK_MESSAGE(toTransactionException(badInsEx) == TransactionException::BadInstruction, "BadInstruction !=> TransactionException");
-	BadJumpDestination badJumpEx;
-	BOOST_CHECK_MESSAGE(toTransactionException(badJumpEx) == TransactionException::BadJumpDestination, "BadJumpDestination !=> TransactionException");
-	OutOfGas oogEx2;
-	BOOST_CHECK_MESSAGE(toTransactionException(oogEx2) == TransactionException::OutOfGas, "OutOfGas !=> TransactionException");
-	OutOfStack oosEx;
-	BOOST_CHECK_MESSAGE(toTransactionException(oosEx) == TransactionException::OutOfStack, "OutOfStack !=> TransactionException");
-	StackUnderflow stackEx;
-	BOOST_CHECK_MESSAGE(toTransactionException(stackEx) == TransactionException::StackUnderflow, "StackUnderflow !=> TransactionException");
-	Exception notEx;
-	BOOST_CHECK_MESSAGE(toTransactionException(notEx) == TransactionException::Unknown, "Unexpected should be TransactionException::Unknown");
+    RLPException rlpEx;  // toTransactionException(*(dynamic_cast<Exception*>
+    BOOST_CHECK_MESSAGE(toTransactionException(rlpEx) == TransactionException::BadRLP,
+        "RLPException !=> TransactionException");
+    OutOfGasIntrinsic oogEx;
+    BOOST_CHECK_MESSAGE(toTransactionException(oogEx) == TransactionException::OutOfGasIntrinsic, "OutOfGasIntrinsic !=> TransactionException");
+    InvalidSignature sigEx;
+    BOOST_CHECK_MESSAGE(toTransactionException(sigEx) == TransactionException::InvalidSignature, "InvalidSignature !=> TransactionException");
+    OutOfGasBase oogbEx;
+    BOOST_CHECK_MESSAGE(toTransactionException(oogbEx) == TransactionException::OutOfGasBase, "OutOfGasBase !=> TransactionException");
+    InvalidNonce nonceEx;
+    BOOST_CHECK_MESSAGE(toTransactionException(nonceEx) == TransactionException::InvalidNonce, "InvalidNonce !=> TransactionException");
+    NotEnoughCash cashEx;
+    BOOST_CHECK_MESSAGE(toTransactionException(cashEx) == TransactionException::NotEnoughCash, "NotEnoughCash !=> TransactionException");
+    BlockGasLimitReached blGasEx;
+    BOOST_CHECK_MESSAGE(toTransactionException(blGasEx) == TransactionException::BlockGasLimitReached, "BlockGasLimitReached !=> TransactionException");
+    BadInstruction badInsEx;
+    BOOST_CHECK_MESSAGE(toTransactionException(badInsEx) == TransactionException::BadInstruction, "BadInstruction !=> TransactionException");
+    BadJumpDestination badJumpEx;
+    BOOST_CHECK_MESSAGE(toTransactionException(badJumpEx) == TransactionException::BadJumpDestination, "BadJumpDestination !=> TransactionException");
+    OutOfGas oogEx2;
+    BOOST_CHECK_MESSAGE(toTransactionException(oogEx2) == TransactionException::OutOfGas, "OutOfGas !=> TransactionException");
+    OutOfStack oosEx;
+    BOOST_CHECK_MESSAGE(toTransactionException(oosEx) == TransactionException::OutOfStack, "OutOfStack !=> TransactionException");
+    StackUnderflow stackEx;
+    BOOST_CHECK_MESSAGE(toTransactionException(stackEx) == TransactionException::StackUnderflow, "StackUnderflow !=> TransactionException");
+    Exception notEx;
+    BOOST_CHECK_MESSAGE(toTransactionException(notEx) == TransactionException::Unknown, "Unexpected should be TransactionException::Unknown");
 }
 
 BOOST_AUTO_TEST_CASE(blockVerifyZeroTransaction)
 {
-	TestBlockChain::s_sealEngineNetwork = eth::Network::ByzantiumTest;
-	TestBlock genesis = TestBlockChain::defaultGenesisBlock();
-	TestBlockChain bc(genesis);
+    TestBlockChain::s_sealEngineNetwork = eth::Network::ByzantiumTest;
+    TestBlock genesis = TestBlockChain::defaultGenesisBlock();
+    TestBlockChain bc(genesis);
 
-	TestTransaction tr = TestTransaction::defaultZeroTransaction();
-	TestBlock block;
-	block.addTransaction(tr);
-	block.mine(bc);
-	bc.addBlock(block);
-	BOOST_CHECK_MESSAGE(bc.getInterface().info().number() == 1, "Mining Block with zero transaction failed!");
+    TestTransaction tr = TestTransaction::defaultZeroTransaction();
+    TestBlock block;
+    block.addTransaction(tr);
+    block.mine(bc);
+    bc.addBlock(block);
+    BOOST_CHECK_MESSAGE(bc.getInterface().info().number() == 1, "Mining Block with zero transaction failed!");
 
-	//Transaction should be able to mine on BYZANTIUM
-	//Not implemented yet
-	//BOOST_CHECK_MESSAGE(bc.interface().transactions().size() == 1, "Failed importing zero transaction to block!");
+    //Transaction should be able to mine on BYZANTIUM
+    //Not implemented yet
+    //BOOST_CHECK_MESSAGE(bc.interface().transactions().size() == 1, "Failed importing zero transaction to block!");
 }
 
 BOOST_AUTO_TEST_CASE(GettingSenderForUnsignedTransactionThrows)
 {
-	Transaction tx(0, 0, 10000, Address("a94f5374fce5edbc8e2a8697c15331677e6ebf0b"), bytes(), 0);
-	BOOST_CHECK(!tx.hasSignature());
+    Transaction tx(0, 0, 10000, Address("a94f5374fce5edbc8e2a8697c15331677e6ebf0b"), bytes(), 0);
+    BOOST_CHECK(!tx.hasSignature());
 
-	BOOST_REQUIRE_THROW(tx.sender(), TransactionIsUnsigned);
+    BOOST_REQUIRE_THROW(tx.sender(), TransactionIsUnsigned);
 }
 
 BOOST_AUTO_TEST_CASE(GettingSignatureForUnsignedTransactionThrows)
 {
-	Transaction tx(0, 0, 10000, Address("a94f5374fce5edbc8e2a8697c15331677e6ebf0b"), bytes(), 0);
-	BOOST_REQUIRE_THROW(tx.signature(), TransactionIsUnsigned);
+    Transaction tx(0, 0, 10000, Address("a94f5374fce5edbc8e2a8697c15331677e6ebf0b"), bytes(), 0);
+    BOOST_REQUIRE_THROW(tx.signature(), TransactionIsUnsigned);
 }
 
 BOOST_AUTO_TEST_CASE(StreamRLPWithSignatureForUnsignedTransactionThrows)
 {
-	Transaction tx(0, 0, 10000, Address("a94f5374fce5edbc8e2a8697c15331677e6ebf0b"), bytes(), 0);
-	RLPStream s;
-	BOOST_REQUIRE_THROW(tx.streamRLP(s, IncludeSignature::WithSignature, false), TransactionIsUnsigned);
+    Transaction tx(0, 0, 10000, Address("a94f5374fce5edbc8e2a8697c15331677e6ebf0b"), bytes(), 0);
+    RLPStream s;
+    BOOST_REQUIRE_THROW(tx.streamRLP(s, IncludeSignature::WithSignature, false), TransactionIsUnsigned);
 }
 
 BOOST_AUTO_TEST_CASE(CheckLowSForUnsignedTransactionThrows)
 {
-	Transaction tx(0, 0, 10000, Address("a94f5374fce5edbc8e2a8697c15331677e6ebf0b"), bytes(), 0);
-	BOOST_REQUIRE_THROW(tx.checkLowS(), TransactionIsUnsigned);
+    Transaction tx(0, 0, 10000, Address("a94f5374fce5edbc8e2a8697c15331677e6ebf0b"), bytes(), 0);
+    BOOST_REQUIRE_THROW(tx.checkLowS(), TransactionIsUnsigned);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/unittests/libp2p/eip-8.cpp
+++ b/test/unittests/libp2p/eip-8.cpp
@@ -1,18 +1,18 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file discovery.cpp
  * @author Felix Lange <fjl@twurst.com>
@@ -36,115 +36,115 @@ BOOST_FIXTURE_TEST_SUITE(eip8, TestOutputHelperFixture)
 
 BOOST_AUTO_TEST_CASE(test_discovery_packets)
 {
-	bi::udp::endpoint ep;
-	bytes packet;
+    bi::udp::endpoint ep;
+    bytes packet;
 
-	packet = fromHex(
-		"e9614ccfd9fc3e74360018522d30e1419a143407ffcce748de3e22116b7e8dc92ff74788c0b6663a"
-		"aa3d67d641936511c8f8d6ad8698b820a7cf9e1be7155e9a241f556658c55428ec0563514365799a"
-		"4be2be5a685a80971ddcfa80cb422cdd0101ec04cb847f000001820cfa8215a8d790000000000000"
-		"000000000000000000018208ae820d058443b9a3550102"
-	);
-	auto ping1 = dynamic_cast<PingNode&>(*DiscoveryDatagram::interpretUDP(ep, bytesConstRef(&packet)));
-	BOOST_CHECK_EQUAL(ping1.version, 4);
-	BOOST_CHECK_EQUAL(ping1.ts, 1136239445);
-	BOOST_CHECK_EQUAL(ping1.source, NodeIPEndpoint(bi::address::from_string("127.0.0.1"), 3322, 5544));
-	BOOST_CHECK_EQUAL(ping1.destination, NodeIPEndpoint(bi::address::from_string("::1"), 2222, 3333));
+    packet = fromHex(
+        "e9614ccfd9fc3e74360018522d30e1419a143407ffcce748de3e22116b7e8dc92ff74788c0b6663a"
+        "aa3d67d641936511c8f8d6ad8698b820a7cf9e1be7155e9a241f556658c55428ec0563514365799a"
+        "4be2be5a685a80971ddcfa80cb422cdd0101ec04cb847f000001820cfa8215a8d790000000000000"
+        "000000000000000000018208ae820d058443b9a3550102"
+    );
+    auto ping1 = dynamic_cast<PingNode&>(*DiscoveryDatagram::interpretUDP(ep, bytesConstRef(&packet)));
+    BOOST_CHECK_EQUAL(ping1.version, 4);
+    BOOST_CHECK_EQUAL(ping1.ts, 1136239445);
+    BOOST_CHECK_EQUAL(ping1.source, NodeIPEndpoint(bi::address::from_string("127.0.0.1"), 3322, 5544));
+    BOOST_CHECK_EQUAL(ping1.destination, NodeIPEndpoint(bi::address::from_string("::1"), 2222, 3333));
 
-	packet = fromHex(
-		"577be4349c4dd26768081f58de4c6f375a7a22f3f7adda654d1428637412c3d7fe917cadc56d4e5e"
-		"7ffae1dbe3efffb9849feb71b262de37977e7c7a44e677295680e9e38ab26bee2fcbae207fba3ff3"
-		"d74069a50b902a82c9903ed37cc993c50001f83e82022bd79020010db83c4d001500000000abcdef"
-		"12820cfa8215a8d79020010db885a308d313198a2e037073488208ae82823a8443b9a355c5010203"
-		"040531b9019afde696e582a78fa8d95ea13ce3297d4afb8ba6433e4154caa5ac6431af1b80ba7602"
-		"3fa4090c408f6b4bc3701562c031041d4702971d102c9ab7fa5eed4cd6bab8f7af956f7d565ee191"
-		"7084a95398b6a21eac920fe3dd1345ec0a7ef39367ee69ddf092cbfe5b93e5e568ebc491983c09c7"
-		"6d922dc3"
-	);
-	auto ping2 = dynamic_cast<PingNode&>(*DiscoveryDatagram::interpretUDP(ep, bytesConstRef(&packet)));
-	BOOST_CHECK_EQUAL(ping2.version, 555);
-	BOOST_CHECK_EQUAL(ping2.source, NodeIPEndpoint(bi::address::from_string("2001:db8:3c4d:15::abcd:ef12"), 3322, 5544));
-	BOOST_CHECK_EQUAL(ping2.destination, NodeIPEndpoint(bi::address::from_string("2001:db8:85a3:8d3:1319:8a2e:370:7348"), 2222, 33338));
-	BOOST_CHECK_EQUAL(ping2.ts, 1136239445);
+    packet = fromHex(
+        "577be4349c4dd26768081f58de4c6f375a7a22f3f7adda654d1428637412c3d7fe917cadc56d4e5e"
+        "7ffae1dbe3efffb9849feb71b262de37977e7c7a44e677295680e9e38ab26bee2fcbae207fba3ff3"
+        "d74069a50b902a82c9903ed37cc993c50001f83e82022bd79020010db83c4d001500000000abcdef"
+        "12820cfa8215a8d79020010db885a308d313198a2e037073488208ae82823a8443b9a355c5010203"
+        "040531b9019afde696e582a78fa8d95ea13ce3297d4afb8ba6433e4154caa5ac6431af1b80ba7602"
+        "3fa4090c408f6b4bc3701562c031041d4702971d102c9ab7fa5eed4cd6bab8f7af956f7d565ee191"
+        "7084a95398b6a21eac920fe3dd1345ec0a7ef39367ee69ddf092cbfe5b93e5e568ebc491983c09c7"
+        "6d922dc3"
+    );
+    auto ping2 = dynamic_cast<PingNode&>(*DiscoveryDatagram::interpretUDP(ep, bytesConstRef(&packet)));
+    BOOST_CHECK_EQUAL(ping2.version, 555);
+    BOOST_CHECK_EQUAL(ping2.source, NodeIPEndpoint(bi::address::from_string("2001:db8:3c4d:15::abcd:ef12"), 3322, 5544));
+    BOOST_CHECK_EQUAL(ping2.destination, NodeIPEndpoint(bi::address::from_string("2001:db8:85a3:8d3:1319:8a2e:370:7348"), 2222, 33338));
+    BOOST_CHECK_EQUAL(ping2.ts, 1136239445);
 
-	packet = fromHex(
-		"09b2428d83348d27cdf7064ad9024f526cebc19e4958f0fdad87c15eb598dd61d08423e0bf66b206"
-		"9869e1724125f820d851c136684082774f870e614d95a2855d000f05d1648b2d5945470bc187c2d2"
-		"216fbe870f43ed0909009882e176a46b0102f846d79020010db885a308d313198a2e037073488208"
-		"ae82823aa0fbc914b16819237dcd8801d7e53f69e9719adecb3cc0e790c57e91ca4461c9548443b9"
-		"a355c6010203c2040506a0c969a58f6f9095004c0177a6b47f451530cab38966a25cca5cb58f0555"
-		"42124e"
-	);
-	auto pong = dynamic_cast<Pong&>(*DiscoveryDatagram::interpretUDP(ep, bytesConstRef(&packet)));
-	BOOST_CHECK_EQUAL(pong.destination, NodeIPEndpoint(bi::address::from_string("2001:db8:85a3:8d3:1319:8a2e:370:7348"), 2222, 33338));
-	BOOST_CHECK_EQUAL(pong.echo, h256("fbc914b16819237dcd8801d7e53f69e9719adecb3cc0e790c57e91ca4461c954"));
-	BOOST_CHECK_EQUAL(pong.ts, 1136239445);
+    packet = fromHex(
+        "09b2428d83348d27cdf7064ad9024f526cebc19e4958f0fdad87c15eb598dd61d08423e0bf66b206"
+        "9869e1724125f820d851c136684082774f870e614d95a2855d000f05d1648b2d5945470bc187c2d2"
+        "216fbe870f43ed0909009882e176a46b0102f846d79020010db885a308d313198a2e037073488208"
+        "ae82823aa0fbc914b16819237dcd8801d7e53f69e9719adecb3cc0e790c57e91ca4461c9548443b9"
+        "a355c6010203c2040506a0c969a58f6f9095004c0177a6b47f451530cab38966a25cca5cb58f0555"
+        "42124e"
+    );
+    auto pong = dynamic_cast<Pong&>(*DiscoveryDatagram::interpretUDP(ep, bytesConstRef(&packet)));
+    BOOST_CHECK_EQUAL(pong.destination, NodeIPEndpoint(bi::address::from_string("2001:db8:85a3:8d3:1319:8a2e:370:7348"), 2222, 33338));
+    BOOST_CHECK_EQUAL(pong.echo, h256("fbc914b16819237dcd8801d7e53f69e9719adecb3cc0e790c57e91ca4461c954"));
+    BOOST_CHECK_EQUAL(pong.ts, 1136239445);
 
-	packet = fromHex(
-		"c7c44041b9f7c7e41934417ebac9a8e1a4c6298f74553f2fcfdcae6ed6fe53163eb3d2b52e39fe91"
-		"831b8a927bf4fc222c3902202027e5e9eb812195f95d20061ef5cd31d502e47ecb61183f74a504fe"
-		"04c51e73df81f25c4d506b26db4517490103f84eb840ca634cae0d49acb401d8a4c6b6fe8c55b70d"
-		"115bf400769cc1400f3258cd31387574077f301b421bc84df7266c44e9e6d569fc56be0081290476"
-		"7bf5ccd1fc7f8443b9a35582999983999999280dc62cc8255c73471e0a61da0c89acdc0e035e260a"
-		"dd7fc0c04ad9ebf3919644c91cb247affc82b69bd2ca235c71eab8e49737c937a2c396"
-	);
-	auto findnode = dynamic_cast<FindNode&>(*DiscoveryDatagram::interpretUDP(ep, bytesConstRef(&packet)));
-	BOOST_CHECK_EQUAL(findnode.target, Public("ca634cae0d49acb401d8a4c6b6fe8c55b70d115bf400769cc1400f3258cd31387574077f301b421bc84df7266c44e9e6d569fc56be00812904767bf5ccd1fc7f"));
-	BOOST_CHECK_EQUAL(findnode.ts, 1136239445);
+    packet = fromHex(
+        "c7c44041b9f7c7e41934417ebac9a8e1a4c6298f74553f2fcfdcae6ed6fe53163eb3d2b52e39fe91"
+        "831b8a927bf4fc222c3902202027e5e9eb812195f95d20061ef5cd31d502e47ecb61183f74a504fe"
+        "04c51e73df81f25c4d506b26db4517490103f84eb840ca634cae0d49acb401d8a4c6b6fe8c55b70d"
+        "115bf400769cc1400f3258cd31387574077f301b421bc84df7266c44e9e6d569fc56be0081290476"
+        "7bf5ccd1fc7f8443b9a35582999983999999280dc62cc8255c73471e0a61da0c89acdc0e035e260a"
+        "dd7fc0c04ad9ebf3919644c91cb247affc82b69bd2ca235c71eab8e49737c937a2c396"
+    );
+    auto findnode = dynamic_cast<FindNode&>(*DiscoveryDatagram::interpretUDP(ep, bytesConstRef(&packet)));
+    BOOST_CHECK_EQUAL(findnode.target, Public("ca634cae0d49acb401d8a4c6b6fe8c55b70d115bf400769cc1400f3258cd31387574077f301b421bc84df7266c44e9e6d569fc56be00812904767bf5ccd1fc7f"));
+    BOOST_CHECK_EQUAL(findnode.ts, 1136239445);
 
-	packet = fromHex(
-		"c679fc8fe0b8b12f06577f2e802d34f6fa257e6137a995f6f4cbfc9ee50ed3710faf6e66f932c4c8"
-		"d81d64343f429651328758b47d3dbc02c4042f0fff6946a50f4a49037a72bb550f3a7872363a83e1"
-		"b9ee6469856c24eb4ef80b7535bcf99c0004f9015bf90150f84d846321163782115c82115db84031"
-		"55e1427f85f10a5c9a7755877748041af1bcd8d474ec065eb33df57a97babf54bfd2103575fa8291"
-		"15d224c523596b401065a97f74010610fce76382c0bf32f84984010203040101b840312c55512422"
-		"cf9b8a4097e9a6ad79402e87a15ae909a4bfefa22398f03d20951933beea1e4dfa6f968212385e82"
-		"9f04c2d314fc2d4e255e0d3bc08792b069dbf8599020010db83c4d001500000000abcdef12820d05"
-		"820d05b84038643200b172dcfef857492156971f0e6aa2c538d8b74010f8e140811d53b98c765dd2"
-		"d96126051913f44582e8c199ad7c6d6819e9a56483f637feaac9448aacf8599020010db885a308d3"
-		"13198a2e037073488203e78203e8b8408dcab8618c3253b558d459da53bd8fa68935a719aff8b811"
-		"197101a4b2b47dd2d47295286fc00cc081bb542d760717d1bdd6bec2c37cd72eca367d6dd3b9df73"
-		"8443b9a355010203b525a138aa34383fec3d2719a0"
-	);
-	auto neighbours = dynamic_cast<Neighbours&>(*DiscoveryDatagram::interpretUDP(ep, bytesConstRef(&packet)));
-	BOOST_REQUIRE_EQUAL(neighbours.neighbours.size(), 4);
-	BOOST_CHECK_EQUAL(neighbours.neighbours[0].endpoint, NodeIPEndpoint(bi::address::from_string("99.33.22.55"), 4444, 4445));
-	BOOST_CHECK_EQUAL(neighbours.neighbours[0].node, Public("3155e1427f85f10a5c9a7755877748041af1bcd8d474ec065eb33df57a97babf54bfd2103575fa829115d224c523596b401065a97f74010610fce76382c0bf32"));
-	BOOST_CHECK_EQUAL(neighbours.neighbours[1].endpoint, NodeIPEndpoint(bi::address::from_string("1.2.3.4"), 1, 1));
-	BOOST_CHECK_EQUAL(neighbours.neighbours[1].node, Public("312c55512422cf9b8a4097e9a6ad79402e87a15ae909a4bfefa22398f03d20951933beea1e4dfa6f968212385e829f04c2d314fc2d4e255e0d3bc08792b069db"));
-	BOOST_CHECK_EQUAL(neighbours.neighbours[2].endpoint, NodeIPEndpoint(bi::address::from_string("2001:db8:3c4d:15::abcd:ef12"), 3333, 3333));
-	BOOST_CHECK_EQUAL(neighbours.neighbours[2].node, Public("38643200b172dcfef857492156971f0e6aa2c538d8b74010f8e140811d53b98c765dd2d96126051913f44582e8c199ad7c6d6819e9a56483f637feaac9448aac"));
-	BOOST_CHECK_EQUAL(neighbours.neighbours[3].endpoint, NodeIPEndpoint(bi::address::from_string("2001:db8:85a3:8d3:1319:8a2e:370:7348"), 999, 1000));
-	BOOST_CHECK_EQUAL(neighbours.neighbours[3].node, Public("8dcab8618c3253b558d459da53bd8fa68935a719aff8b811197101a4b2b47dd2d47295286fc00cc081bb542d760717d1bdd6bec2c37cd72eca367d6dd3b9df73"));
-	BOOST_CHECK_EQUAL(neighbours.ts, 1136239445);
+    packet = fromHex(
+        "c679fc8fe0b8b12f06577f2e802d34f6fa257e6137a995f6f4cbfc9ee50ed3710faf6e66f932c4c8"
+        "d81d64343f429651328758b47d3dbc02c4042f0fff6946a50f4a49037a72bb550f3a7872363a83e1"
+        "b9ee6469856c24eb4ef80b7535bcf99c0004f9015bf90150f84d846321163782115c82115db84031"
+        "55e1427f85f10a5c9a7755877748041af1bcd8d474ec065eb33df57a97babf54bfd2103575fa8291"
+        "15d224c523596b401065a97f74010610fce76382c0bf32f84984010203040101b840312c55512422"
+        "cf9b8a4097e9a6ad79402e87a15ae909a4bfefa22398f03d20951933beea1e4dfa6f968212385e82"
+        "9f04c2d314fc2d4e255e0d3bc08792b069dbf8599020010db83c4d001500000000abcdef12820d05"
+        "820d05b84038643200b172dcfef857492156971f0e6aa2c538d8b74010f8e140811d53b98c765dd2"
+        "d96126051913f44582e8c199ad7c6d6819e9a56483f637feaac9448aacf8599020010db885a308d3"
+        "13198a2e037073488203e78203e8b8408dcab8618c3253b558d459da53bd8fa68935a719aff8b811"
+        "197101a4b2b47dd2d47295286fc00cc081bb542d760717d1bdd6bec2c37cd72eca367d6dd3b9df73"
+        "8443b9a355010203b525a138aa34383fec3d2719a0"
+    );
+    auto neighbours = dynamic_cast<Neighbours&>(*DiscoveryDatagram::interpretUDP(ep, bytesConstRef(&packet)));
+    BOOST_REQUIRE_EQUAL(neighbours.neighbours.size(), 4);
+    BOOST_CHECK_EQUAL(neighbours.neighbours[0].endpoint, NodeIPEndpoint(bi::address::from_string("99.33.22.55"), 4444, 4445));
+    BOOST_CHECK_EQUAL(neighbours.neighbours[0].node, Public("3155e1427f85f10a5c9a7755877748041af1bcd8d474ec065eb33df57a97babf54bfd2103575fa829115d224c523596b401065a97f74010610fce76382c0bf32"));
+    BOOST_CHECK_EQUAL(neighbours.neighbours[1].endpoint, NodeIPEndpoint(bi::address::from_string("1.2.3.4"), 1, 1));
+    BOOST_CHECK_EQUAL(neighbours.neighbours[1].node, Public("312c55512422cf9b8a4097e9a6ad79402e87a15ae909a4bfefa22398f03d20951933beea1e4dfa6f968212385e829f04c2d314fc2d4e255e0d3bc08792b069db"));
+    BOOST_CHECK_EQUAL(neighbours.neighbours[2].endpoint, NodeIPEndpoint(bi::address::from_string("2001:db8:3c4d:15::abcd:ef12"), 3333, 3333));
+    BOOST_CHECK_EQUAL(neighbours.neighbours[2].node, Public("38643200b172dcfef857492156971f0e6aa2c538d8b74010f8e140811d53b98c765dd2d96126051913f44582e8c199ad7c6d6819e9a56483f637feaac9448aac"));
+    BOOST_CHECK_EQUAL(neighbours.neighbours[3].endpoint, NodeIPEndpoint(bi::address::from_string("2001:db8:85a3:8d3:1319:8a2e:370:7348"), 999, 1000));
+    BOOST_CHECK_EQUAL(neighbours.neighbours[3].node, Public("8dcab8618c3253b558d459da53bd8fa68935a719aff8b811197101a4b2b47dd2d47295286fc00cc081bb542d760717d1bdd6bec2c37cd72eca367d6dd3b9df73"));
+    BOOST_CHECK_EQUAL(neighbours.ts, 1136239445);
 }
 
 class TestHandshake: public RLPXHandshake
 {
 public:
-	TestHandshake(Host* _host, std::shared_ptr<RLPXSocket> const& _socket):
-		RLPXHandshake(_host, _socket) {};
-	TestHandshake(Host* _host, std::shared_ptr<RLPXSocket> const& _socket, NodeID _remote):
-		RLPXHandshake(_host, _socket, _remote) {};
+    TestHandshake(Host* _host, std::shared_ptr<RLPXSocket> const& _socket):
+        RLPXHandshake(_host, _socket) {};
+    TestHandshake(Host* _host, std::shared_ptr<RLPXSocket> const& _socket, NodeID _remote):
+        RLPXHandshake(_host, _socket, _remote) {};
 
-	/// Creates a handshake attached to a Host with the given alias,
-	/// then runs it through the key establishment, supplying packet
-	/// as the input on the socket.
-	///
-	/// If remoteID is supplied, the handshake runs in initiator mode.
-	static shared_ptr<TestHandshake> runWithInput(Secret _hostAlias, bytes _packet, NodeID _remoteID = NodeID());
+    /// Creates a handshake attached to a Host with the given alias,
+    /// then runs it through the key establishment, supplying packet
+    /// as the input on the socket.
+    ///
+    /// If remoteID is supplied, the handshake runs in initiator mode.
+    static shared_ptr<TestHandshake> runWithInput(Secret _hostAlias, bytes _packet, NodeID _remoteID = NodeID());
 
-	/// transition is overridden to stop after key establishment.
- 	virtual void transition(boost::system::error_code _ec);
+    /// transition is overridden to stop after key establishment.
+    virtual void transition(boost::system::error_code _ec);
 
-	/// Reports whether we made it through the key establishment without error.
-	bool completedKeyEstablishment() { return m_nextState == ReadHello; }
+    /// Reports whether we made it through the key establishment without error.
+    bool completedKeyEstablishment() { return m_nextState == ReadHello; }
 
-	/// Checks whether Auth-related members match the values in the EIP-8 test vectors.
-	void checkAuthValuesEIP8(uint64_t _expectedRemoteVersion);
+    /// Checks whether Auth-related members match the values in the EIP-8 test vectors.
+    void checkAuthValuesEIP8(uint64_t _expectedRemoteVersion);
 
-	/// Checks whether Ack-related members match the values in the EIP-8 test vectors.
-	void checkAckValuesEIP8(uint64_t _expectedRemoteVersion);
+    /// Checks whether Ack-related members match the values in the EIP-8 test vectors.
+    void checkAckValuesEIP8(uint64_t _expectedRemoteVersion);
 };
 
 // This test checks that pre-EIP-8 'plain' format is still accepted.
@@ -159,20 +159,20 @@ public:
 #if !defined(_WIN32)
 BOOST_AUTO_TEST_CASE(test_handshake_plain_auth)
 {
-	Secret keyB("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291");
-	bytes auth(fromHex(
-		"048ca79ad18e4b0659fab4853fe5bc58eb83992980f4c9cc147d2aa31532efd29a3d3dc6a3d89eaf"
-		"913150cfc777ce0ce4af2758bf4810235f6e6ceccfee1acc6b22c005e9e3a49d6448610a58e98744"
-		"ba3ac0399e82692d67c1f58849050b3024e21a52c9d3b01d871ff5f210817912773e610443a9ef14"
-		"2e91cdba0bd77b5fdf0769b05671fc35f83d83e4d3b0b000c6b2a1b1bba89e0fc51bf4e460df3105"
-		"c444f14be226458940d6061c296350937ffd5e3acaceeaaefd3c6f74be8e23e0f45163cc7ebd7622"
-		"0f0128410fd05250273156d548a414444ae2f7dea4dfca2d43c057adb701a715bf59f6fb66b2d1d2"
-		"0f2c703f851cbf5ac47396d9ca65b6260bd141ac4d53e2de585a73d1750780db4c9ee4cd4d225173"
-		"a4592ee77e2bd94d0be3691f3b406f9bba9b591fc63facc016bfa8"
-	));
-	shared_ptr<TestHandshake> h = TestHandshake::runWithInput(keyB, auth);
-	BOOST_REQUIRE(h->completedKeyEstablishment());
-	h->checkAuthValuesEIP8(4);
+    Secret keyB("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291");
+    bytes auth(fromHex(
+        "048ca79ad18e4b0659fab4853fe5bc58eb83992980f4c9cc147d2aa31532efd29a3d3dc6a3d89eaf"
+        "913150cfc777ce0ce4af2758bf4810235f6e6ceccfee1acc6b22c005e9e3a49d6448610a58e98744"
+        "ba3ac0399e82692d67c1f58849050b3024e21a52c9d3b01d871ff5f210817912773e610443a9ef14"
+        "2e91cdba0bd77b5fdf0769b05671fc35f83d83e4d3b0b000c6b2a1b1bba89e0fc51bf4e460df3105"
+        "c444f14be226458940d6061c296350937ffd5e3acaceeaaefd3c6f74be8e23e0f45163cc7ebd7622"
+        "0f0128410fd05250273156d548a414444ae2f7dea4dfca2d43c057adb701a715bf59f6fb66b2d1d2"
+        "0f2c703f851cbf5ac47396d9ca65b6260bd141ac4d53e2de585a73d1750780db4c9ee4cd4d225173"
+        "a4592ee77e2bd94d0be3691f3b406f9bba9b591fc63facc016bfa8"
+    ));
+    shared_ptr<TestHandshake> h = TestHandshake::runWithInput(keyB, auth);
+    BOOST_REQUIRE(h->completedKeyEstablishment());
+    h->checkAuthValuesEIP8(4);
 }
 #endif // !defined(_WIN32)
 
@@ -186,23 +186,23 @@ BOOST_AUTO_TEST_CASE(test_handshake_plain_auth)
 #if !defined(_WIN32)
 BOOST_AUTO_TEST_CASE(test_handshake_eip8_auth1)
 {
-	Secret keyB("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291");
-	bytes auth(fromHex(
-		"01b304ab7578555167be8154d5cc456f567d5ba302662433674222360f08d5f1534499d3678b513b"
-		"0fca474f3a514b18e75683032eb63fccb16c156dc6eb2c0b1593f0d84ac74f6e475f1b8d56116b84"
-		"9634a8c458705bf83a626ea0384d4d7341aae591fae42ce6bd5c850bfe0b999a694a49bbbaf3ef6c"
-		"da61110601d3b4c02ab6c30437257a6e0117792631a4b47c1d52fc0f8f89caadeb7d02770bf999cc"
-		"147d2df3b62e1ffb2c9d8c125a3984865356266bca11ce7d3a688663a51d82defaa8aad69da39ab6"
-		"d5470e81ec5f2a7a47fb865ff7cca21516f9299a07b1bc63ba56c7a1a892112841ca44b6e0034dee"
-		"70c9adabc15d76a54f443593fafdc3b27af8059703f88928e199cb122362a4b35f62386da7caad09"
-		"c001edaeb5f8a06d2b26fb6cb93c52a9fca51853b68193916982358fe1e5369e249875bb8d0d0ec3"
-		"6f917bc5e1eafd5896d46bd61ff23f1a863a8a8dcd54c7b109b771c8e61ec9c8908c733c0263440e"
-		"2aa067241aaa433f0bb053c7b31a838504b148f570c0ad62837129e547678c5190341e4f1693956c"
-		"3bf7678318e2d5b5340c9e488eefea198576344afbdf66db5f51204a6961a63ce072c8926c"
-	));
-	shared_ptr<TestHandshake> h = TestHandshake::runWithInput(keyB, auth);
-	BOOST_REQUIRE(h->completedKeyEstablishment());
-	h->checkAuthValuesEIP8(4);
+    Secret keyB("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291");
+    bytes auth(fromHex(
+        "01b304ab7578555167be8154d5cc456f567d5ba302662433674222360f08d5f1534499d3678b513b"
+        "0fca474f3a514b18e75683032eb63fccb16c156dc6eb2c0b1593f0d84ac74f6e475f1b8d56116b84"
+        "9634a8c458705bf83a626ea0384d4d7341aae591fae42ce6bd5c850bfe0b999a694a49bbbaf3ef6c"
+        "da61110601d3b4c02ab6c30437257a6e0117792631a4b47c1d52fc0f8f89caadeb7d02770bf999cc"
+        "147d2df3b62e1ffb2c9d8c125a3984865356266bca11ce7d3a688663a51d82defaa8aad69da39ab6"
+        "d5470e81ec5f2a7a47fb865ff7cca21516f9299a07b1bc63ba56c7a1a892112841ca44b6e0034dee"
+        "70c9adabc15d76a54f443593fafdc3b27af8059703f88928e199cb122362a4b35f62386da7caad09"
+        "c001edaeb5f8a06d2b26fb6cb93c52a9fca51853b68193916982358fe1e5369e249875bb8d0d0ec3"
+        "6f917bc5e1eafd5896d46bd61ff23f1a863a8a8dcd54c7b109b771c8e61ec9c8908c733c0263440e"
+        "2aa067241aaa433f0bb053c7b31a838504b148f570c0ad62837129e547678c5190341e4f1693956c"
+        "3bf7678318e2d5b5340c9e488eefea198576344afbdf66db5f51204a6961a63ce072c8926c"
+    ));
+    shared_ptr<TestHandshake> h = TestHandshake::runWithInput(keyB, auth);
+    BOOST_REQUIRE(h->completedKeyEstablishment());
+    h->checkAuthValuesEIP8(4);
 }
 #endif // !defined(_WIN32)
 
@@ -216,24 +216,24 @@ BOOST_AUTO_TEST_CASE(test_handshake_eip8_auth1)
 #if !defined(_WIN32)
 BOOST_AUTO_TEST_CASE(test_handshake_eip8_auth2)
 {
-	Secret keyB("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291");
-	bytes auth(fromHex(
-		"01b8044c6c312173685d1edd268aa95e1d495474c6959bcdd10067ba4c9013df9e40ff45f5bfd6f7"
-		"2471f93a91b493f8e00abc4b80f682973de715d77ba3a005a242eb859f9a211d93a347fa64b597bf"
-		"280a6b88e26299cf263b01b8dfdb712278464fd1c25840b995e84d367d743f66c0e54a586725b7bb"
-		"f12acca27170ae3283c1073adda4b6d79f27656993aefccf16e0d0409fe07db2dc398a1b7e8ee93b"
-		"cd181485fd332f381d6a050fba4c7641a5112ac1b0b61168d20f01b479e19adf7fdbfa0905f63352"
-		"bfc7e23cf3357657455119d879c78d3cf8c8c06375f3f7d4861aa02a122467e069acaf513025ff19"
-		"6641f6d2810ce493f51bee9c966b15c5043505350392b57645385a18c78f14669cc4d960446c1757"
-		"1b7c5d725021babbcd786957f3d17089c084907bda22c2b2675b4378b114c601d858802a55345a15"
-		"116bc61da4193996187ed70d16730e9ae6b3bb8787ebcaea1871d850997ddc08b4f4ea668fbf3740"
-		"7ac044b55be0908ecb94d4ed172ece66fd31bfdadf2b97a8bc690163ee11f5b575a4b44e36e2bfb2"
-		"f0fce91676fd64c7773bac6a003f481fddd0bae0a1f31aa27504e2a533af4cef3b623f4791b2cca6"
-		"d490"
-	));
-	shared_ptr<TestHandshake> h = TestHandshake::runWithInput(keyB, auth);
-	BOOST_REQUIRE(h->completedKeyEstablishment());
-	h->checkAuthValuesEIP8(56);
+    Secret keyB("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291");
+    bytes auth(fromHex(
+        "01b8044c6c312173685d1edd268aa95e1d495474c6959bcdd10067ba4c9013df9e40ff45f5bfd6f7"
+        "2471f93a91b493f8e00abc4b80f682973de715d77ba3a005a242eb859f9a211d93a347fa64b597bf"
+        "280a6b88e26299cf263b01b8dfdb712278464fd1c25840b995e84d367d743f66c0e54a586725b7bb"
+        "f12acca27170ae3283c1073adda4b6d79f27656993aefccf16e0d0409fe07db2dc398a1b7e8ee93b"
+        "cd181485fd332f381d6a050fba4c7641a5112ac1b0b61168d20f01b479e19adf7fdbfa0905f63352"
+        "bfc7e23cf3357657455119d879c78d3cf8c8c06375f3f7d4861aa02a122467e069acaf513025ff19"
+        "6641f6d2810ce493f51bee9c966b15c5043505350392b57645385a18c78f14669cc4d960446c1757"
+        "1b7c5d725021babbcd786957f3d17089c084907bda22c2b2675b4378b114c601d858802a55345a15"
+        "116bc61da4193996187ed70d16730e9ae6b3bb8787ebcaea1871d850997ddc08b4f4ea668fbf3740"
+        "7ac044b55be0908ecb94d4ed172ece66fd31bfdadf2b97a8bc690163ee11f5b575a4b44e36e2bfb2"
+        "f0fce91676fd64c7773bac6a003f481fddd0bae0a1f31aa27504e2a533af4cef3b623f4791b2cca6"
+        "d490"
+    ));
+    shared_ptr<TestHandshake> h = TestHandshake::runWithInput(keyB, auth);
+    BOOST_REQUIRE(h->completedKeyEstablishment());
+    h->checkAuthValuesEIP8(56);
 }
 #endif // !defined(_WIN32)
 
@@ -247,19 +247,19 @@ BOOST_AUTO_TEST_CASE(test_handshake_eip8_auth2)
 #if !defined(_WIN32)
 BOOST_AUTO_TEST_CASE(test_handshake_eip8_ack_plain)
 {
-	Secret keyA("49a7b37aa6f6645917e7b807e9d1c00d4fa71f18343b0d4122a4d2df64dd6fee");
-	bytes ack(fromHex(
-		"049f8abcfa9c0dc65b982e98af921bc0ba6e4243169348a236abe9df5f93aa69d99cadddaa387662"
-		"b0ff2c08e9006d5a11a278b1b3331e5aaabf0a32f01281b6f4ede0e09a2d5f585b26513cb794d963"
-		"5a57563921c04a9090b4f14ee42be1a5461049af4ea7a7f49bf4c97a352d39c8d02ee4acc416388c"
-		"1c66cec761d2bc1c72da6ba143477f049c9d2dde846c252c111b904f630ac98e51609b3b1f58168d"
-		"dca6505b7196532e5f85b259a20c45e1979491683fee108e9660edbf38f3add489ae73e3dda2c71b"
-		"d1497113d5c755e942d1"
-	));
-	NodeID initiatorPubk("fda1cff674c90c9a197539fe3dfb53086ace64f83ed7c6eabec741f7f381cc803e52ab2cd55d5569bce4347107a310dfd5f88a010cd2ffd1005ca406f1842877");
-	shared_ptr<TestHandshake> h = TestHandshake::runWithInput(keyA, ack, initiatorPubk);
-	BOOST_REQUIRE(h->completedKeyEstablishment());
-	h->checkAckValuesEIP8(4);
+    Secret keyA("49a7b37aa6f6645917e7b807e9d1c00d4fa71f18343b0d4122a4d2df64dd6fee");
+    bytes ack(fromHex(
+        "049f8abcfa9c0dc65b982e98af921bc0ba6e4243169348a236abe9df5f93aa69d99cadddaa387662"
+        "b0ff2c08e9006d5a11a278b1b3331e5aaabf0a32f01281b6f4ede0e09a2d5f585b26513cb794d963"
+        "5a57563921c04a9090b4f14ee42be1a5461049af4ea7a7f49bf4c97a352d39c8d02ee4acc416388c"
+        "1c66cec761d2bc1c72da6ba143477f049c9d2dde846c252c111b904f630ac98e51609b3b1f58168d"
+        "dca6505b7196532e5f85b259a20c45e1979491683fee108e9660edbf38f3add489ae73e3dda2c71b"
+        "d1497113d5c755e942d1"
+    ));
+    NodeID initiatorPubk("fda1cff674c90c9a197539fe3dfb53086ace64f83ed7c6eabec741f7f381cc803e52ab2cd55d5569bce4347107a310dfd5f88a010cd2ffd1005ca406f1842877");
+    shared_ptr<TestHandshake> h = TestHandshake::runWithInput(keyA, ack, initiatorPubk);
+    BOOST_REQUIRE(h->completedKeyEstablishment());
+    h->checkAckValuesEIP8(4);
 }
 #endif // !defined(_WIN32)
 
@@ -273,26 +273,26 @@ BOOST_AUTO_TEST_CASE(test_handshake_eip8_ack_plain)
 #if !defined(_WIN32)
 BOOST_AUTO_TEST_CASE(test_handshake_eip8_ack1)
 {
-	Secret keyA("49a7b37aa6f6645917e7b807e9d1c00d4fa71f18343b0d4122a4d2df64dd6fee");
-	bytes ack(fromHex(
-		"01ea0451958701280a56482929d3b0757da8f7fbe5286784beead59d95089c217c9b917788989470"
-		"b0e330cc6e4fb383c0340ed85fab836ec9fb8a49672712aeabbdfd1e837c1ff4cace34311cd7f4de"
-		"05d59279e3524ab26ef753a0095637ac88f2b499b9914b5f64e143eae548a1066e14cd2f4bd7f814"
-		"c4652f11b254f8a2d0191e2f5546fae6055694aed14d906df79ad3b407d94692694e259191cde171"
-		"ad542fc588fa2b7333313d82a9f887332f1dfc36cea03f831cb9a23fea05b33deb999e85489e645f"
-		"6aab1872475d488d7bd6c7c120caf28dbfc5d6833888155ed69d34dbdc39c1f299be1057810f34fb"
-		"e754d021bfca14dc989753d61c413d261934e1a9c67ee060a25eefb54e81a4d14baff922180c395d"
-		"3f998d70f46f6b58306f969627ae364497e73fc27f6d17ae45a413d322cb8814276be6ddd13b885b"
-		"201b943213656cde498fa0e9ddc8e0b8f8a53824fbd82254f3e2c17e8eaea009c38b4aa0a3f306e8"
-		"797db43c25d68e86f262e564086f59a2fc60511c42abfb3057c247a8a8fe4fb3ccbadde17514b7ac"
-		"8000cdb6a912778426260c47f38919a91f25f4b5ffb455d6aaaf150f7e5529c100ce62d6d92826a7"
-		"1778d809bdf60232ae21ce8a437eca8223f45ac37f6487452ce626f549b3b5fdee26afd2072e4bc7"
-		"5833c2464c805246155289f4"
-	));
-	NodeID initiatorPubk("fda1cff674c90c9a197539fe3dfb53086ace64f83ed7c6eabec741f7f381cc803e52ab2cd55d5569bce4347107a310dfd5f88a010cd2ffd1005ca406f1842877");
-	shared_ptr<TestHandshake> h = TestHandshake::runWithInput(keyA, ack, initiatorPubk);
-	BOOST_REQUIRE(h->completedKeyEstablishment());
-	h->checkAckValuesEIP8(4);
+    Secret keyA("49a7b37aa6f6645917e7b807e9d1c00d4fa71f18343b0d4122a4d2df64dd6fee");
+    bytes ack(fromHex(
+        "01ea0451958701280a56482929d3b0757da8f7fbe5286784beead59d95089c217c9b917788989470"
+        "b0e330cc6e4fb383c0340ed85fab836ec9fb8a49672712aeabbdfd1e837c1ff4cace34311cd7f4de"
+        "05d59279e3524ab26ef753a0095637ac88f2b499b9914b5f64e143eae548a1066e14cd2f4bd7f814"
+        "c4652f11b254f8a2d0191e2f5546fae6055694aed14d906df79ad3b407d94692694e259191cde171"
+        "ad542fc588fa2b7333313d82a9f887332f1dfc36cea03f831cb9a23fea05b33deb999e85489e645f"
+        "6aab1872475d488d7bd6c7c120caf28dbfc5d6833888155ed69d34dbdc39c1f299be1057810f34fb"
+        "e754d021bfca14dc989753d61c413d261934e1a9c67ee060a25eefb54e81a4d14baff922180c395d"
+        "3f998d70f46f6b58306f969627ae364497e73fc27f6d17ae45a413d322cb8814276be6ddd13b885b"
+        "201b943213656cde498fa0e9ddc8e0b8f8a53824fbd82254f3e2c17e8eaea009c38b4aa0a3f306e8"
+        "797db43c25d68e86f262e564086f59a2fc60511c42abfb3057c247a8a8fe4fb3ccbadde17514b7ac"
+        "8000cdb6a912778426260c47f38919a91f25f4b5ffb455d6aaaf150f7e5529c100ce62d6d92826a7"
+        "1778d809bdf60232ae21ce8a437eca8223f45ac37f6487452ce626f549b3b5fdee26afd2072e4bc7"
+        "5833c2464c805246155289f4"
+    ));
+    NodeID initiatorPubk("fda1cff674c90c9a197539fe3dfb53086ace64f83ed7c6eabec741f7f381cc803e52ab2cd55d5569bce4347107a310dfd5f88a010cd2ffd1005ca406f1842877");
+    shared_ptr<TestHandshake> h = TestHandshake::runWithInput(keyA, ack, initiatorPubk);
+    BOOST_REQUIRE(h->completedKeyEstablishment());
+    h->checkAckValuesEIP8(4);
 }
 #endif // !defined(_WIN32)
 
@@ -306,94 +306,97 @@ BOOST_AUTO_TEST_CASE(test_handshake_eip8_ack1)
 #if !defined(_WIN32)
 BOOST_AUTO_TEST_CASE(test_handshake_eip8_ack2)
 {
-	Secret keyA("49a7b37aa6f6645917e7b807e9d1c00d4fa71f18343b0d4122a4d2df64dd6fee");
-	bytes ack(fromHex(
-		"01f004076e58aae772bb101ab1a8e64e01ee96e64857ce82b1113817c6cdd52c09d26f7b90981cd7"
-		"ae835aeac72e1573b8a0225dd56d157a010846d888dac7464baf53f2ad4e3d584531fa203658fab0"
-		"3a06c9fd5e35737e417bc28c1cbf5e5dfc666de7090f69c3b29754725f84f75382891c561040ea1d"
-		"dc0d8f381ed1b9d0d4ad2a0ec021421d847820d6fa0ba66eaf58175f1b235e851c7e2124069fbc20"
-		"2888ddb3ac4d56bcbd1b9b7eab59e78f2e2d400905050f4a92dec1c4bdf797b3fc9b2f8e84a482f3"
-		"d800386186712dae00d5c386ec9387a5e9c9a1aca5a573ca91082c7d68421f388e79127a5177d4f8"
-		"590237364fd348c9611fa39f78dcdceee3f390f07991b7b47e1daa3ebcb6ccc9607811cb17ce51f1"
-		"c8c2c5098dbdd28fca547b3f58c01a424ac05f869f49c6a34672ea2cbbc558428aa1fe48bbfd6115"
-		"8b1b735a65d99f21e70dbc020bfdface9f724a0d1fb5895db971cc81aa7608baa0920abb0a565c9c"
-		"436e2fd13323428296c86385f2384e408a31e104670df0791d93e743a3a5194ee6b076fb6323ca59"
-		"3011b7348c16cf58f66b9633906ba54a2ee803187344b394f75dd2e663a57b956cb830dd7a908d4f"
-		"39a2336a61ef9fda549180d4ccde21514d117b6c6fd07a9102b5efe710a32af4eeacae2cb3b1dec0"
-		"35b9593b48b9d3ca4c13d245d5f04169b0b1"
-	));
-	NodeID initiatorPubk("fda1cff674c90c9a197539fe3dfb53086ace64f83ed7c6eabec741f7f381cc803e52ab2cd55d5569bce4347107a310dfd5f88a010cd2ffd1005ca406f1842877");
-	shared_ptr<TestHandshake> h = TestHandshake::runWithInput(keyA, ack, initiatorPubk);
-	BOOST_REQUIRE(h->completedKeyEstablishment());
-	h->checkAckValuesEIP8(57);
+    Secret keyA("49a7b37aa6f6645917e7b807e9d1c00d4fa71f18343b0d4122a4d2df64dd6fee");
+    bytes ack(fromHex(
+        "01f004076e58aae772bb101ab1a8e64e01ee96e64857ce82b1113817c6cdd52c09d26f7b90981cd7"
+        "ae835aeac72e1573b8a0225dd56d157a010846d888dac7464baf53f2ad4e3d584531fa203658fab0"
+        "3a06c9fd5e35737e417bc28c1cbf5e5dfc666de7090f69c3b29754725f84f75382891c561040ea1d"
+        "dc0d8f381ed1b9d0d4ad2a0ec021421d847820d6fa0ba66eaf58175f1b235e851c7e2124069fbc20"
+        "2888ddb3ac4d56bcbd1b9b7eab59e78f2e2d400905050f4a92dec1c4bdf797b3fc9b2f8e84a482f3"
+        "d800386186712dae00d5c386ec9387a5e9c9a1aca5a573ca91082c7d68421f388e79127a5177d4f8"
+        "590237364fd348c9611fa39f78dcdceee3f390f07991b7b47e1daa3ebcb6ccc9607811cb17ce51f1"
+        "c8c2c5098dbdd28fca547b3f58c01a424ac05f869f49c6a34672ea2cbbc558428aa1fe48bbfd6115"
+        "8b1b735a65d99f21e70dbc020bfdface9f724a0d1fb5895db971cc81aa7608baa0920abb0a565c9c"
+        "436e2fd13323428296c86385f2384e408a31e104670df0791d93e743a3a5194ee6b076fb6323ca59"
+        "3011b7348c16cf58f66b9633906ba54a2ee803187344b394f75dd2e663a57b956cb830dd7a908d4f"
+        "39a2336a61ef9fda549180d4ccde21514d117b6c6fd07a9102b5efe710a32af4eeacae2cb3b1dec0"
+        "35b9593b48b9d3ca4c13d245d5f04169b0b1"
+    ));
+    NodeID initiatorPubk("fda1cff674c90c9a197539fe3dfb53086ace64f83ed7c6eabec741f7f381cc803e52ab2cd55d5569bce4347107a310dfd5f88a010cd2ffd1005ca406f1842877");
+    shared_ptr<TestHandshake> h = TestHandshake::runWithInput(keyA, ack, initiatorPubk);
+    BOOST_REQUIRE(h->completedKeyEstablishment());
+    h->checkAckValuesEIP8(57);
 }
 #endif // !defined(_WIN32)
 
 void TestHandshake::checkAuthValuesEIP8(uint64_t _expectedRemoteVersion)
 {
-	BOOST_CHECK_EQUAL(m_remote, Public("fda1cff674c90c9a197539fe3dfb53086ace64f83ed7c6eabec741f7f381cc803e52ab2cd55d5569bce4347107a310dfd5f88a010cd2ffd1005ca406f1842877"));
-	BOOST_CHECK_EQUAL(m_remoteNonce, h256("7e968bba13b6c50e2c4cd7f241cc0d64d1ac25c7f5952df231ac6a2bda8ee5d6"));
-	BOOST_CHECK_EQUAL(m_ecdheRemote, Public("654d1044b69c577a44e5f01a1209523adb4026e70c62d1c13a067acabc09d2667a49821a0ad4b634554d330a15a58fe61f8a8e0544b310c6de7b0c8da7528a8d"));
-	BOOST_CHECK_EQUAL(m_remoteVersion, _expectedRemoteVersion);
+    BOOST_CHECK_EQUAL(m_remote, Public("fda1cff674c90c9a197539fe3dfb53086ace64f83ed7c6eabec741f7f381cc803e52ab2cd55d5569bce4347107a310dfd5f88a010cd2ffd1005ca406f1842877"));
+    BOOST_CHECK_EQUAL(m_remoteNonce, h256("7e968bba13b6c50e2c4cd7f241cc0d64d1ac25c7f5952df231ac6a2bda8ee5d6"));
+    BOOST_CHECK_EQUAL(m_ecdheRemote, Public("654d1044b69c577a44e5f01a1209523adb4026e70c62d1c13a067acabc09d2667a49821a0ad4b634554d330a15a58fe61f8a8e0544b310c6de7b0c8da7528a8d"));
+    BOOST_CHECK_EQUAL(m_remoteVersion, _expectedRemoteVersion);
 }
 
 void TestHandshake::checkAckValuesEIP8(uint64_t _expectedRemoteVersion)
 {
-	BOOST_CHECK_EQUAL(m_remoteNonce, h256("559aead08264d5795d3909718cdd05abd49572e84fe55590eef31a88a08fdffd"));
-	BOOST_CHECK_EQUAL(m_ecdheRemote, Public("b6d82fa3409da933dbf9cb0140c5dde89f4e64aec88d476af648880f4a10e1e49fe35ef3e69e93dd300b4797765a747c6384a6ecf5db9c2690398607a86181e4"));
-	BOOST_CHECK_EQUAL(m_remoteVersion, _expectedRemoteVersion);
+    BOOST_CHECK_EQUAL(m_remoteNonce, h256("559aead08264d5795d3909718cdd05abd49572e84fe55590eef31a88a08fdffd"));
+    BOOST_CHECK_EQUAL(m_ecdheRemote, Public("b6d82fa3409da933dbf9cb0140c5dde89f4e64aec88d476af648880f4a10e1e49fe35ef3e69e93dd300b4797765a747c6384a6ecf5db9c2690398607a86181e4"));
+    BOOST_CHECK_EQUAL(m_remoteVersion, _expectedRemoteVersion);
 }
 
-#define throwErrorCode(what, error) \
-	{ if (error) BOOST_THROW_EXCEPTION(Exception(what + _ec.message())); }
+#define throwErrorCode(what, error)                                                      \
+    {                                                                                    \
+        if (error)                                                                       \
+            BOOST_THROW_EXCEPTION(Exception() << errinfo_comment(what + _ec.message())); \
+    }
 
 shared_ptr<TestHandshake> TestHandshake::runWithInput(Secret _hostAlias, bytes _packet, NodeID _remoteID)
 {
-	// Spawn a listener which sends the packet to any client.
-	ba::io_service io;
-	bi::tcp::acceptor acceptor(io);
-	bi::tcp::endpoint endpoint(bi::address::from_string("127.0.0.1"), 0);
-	acceptor.open(endpoint.protocol());
-	acceptor.bind(endpoint);
-	acceptor.listen();
-	auto server = std::make_shared<RLPXSocket>(io);
-	acceptor.async_accept(server->ref(), [_packet,server](boost::system::error_code const& _ec)
-	{
-		throwErrorCode("accept error: ", _ec);
-		ba::async_write(server->ref(), ba::buffer(_packet), [](const boost::system::error_code& _ec, std::size_t)
-		{
-			throwErrorCode("write error: ", _ec);
-		});
-	});
+    // Spawn a listener which sends the packet to any client.
+    ba::io_service io;
+    bi::tcp::acceptor acceptor(io);
+    bi::tcp::endpoint endpoint(bi::address::from_string("127.0.0.1"), 0);
+    acceptor.open(endpoint.protocol());
+    acceptor.bind(endpoint);
+    acceptor.listen();
+    auto server = std::make_shared<RLPXSocket>(io);
+    acceptor.async_accept(server->ref(), [_packet,server](boost::system::error_code const& _ec)
+    {
+        throwErrorCode("accept error: ", _ec);
+        ba::async_write(server->ref(), ba::buffer(_packet), [](const boost::system::error_code& _ec, std::size_t)
+        {
+            throwErrorCode("write error: ", _ec);
+        });
+    });
 
-	// Spawn a client to execute the handshake.
-	auto host = make_shared<Host>("peer name", KeyPair(_hostAlias));
-	auto client = make_shared<RLPXSocket>(io);
-	shared_ptr<TestHandshake> handshake;
-	if (_remoteID == NodeID())
-		handshake.reset(new TestHandshake(host.get(), client));
-	else
-		handshake.reset(new TestHandshake(host.get(), client, _remoteID));
+    // Spawn a client to execute the handshake.
+    auto host = make_shared<Host>("peer name", KeyPair(_hostAlias));
+    auto client = make_shared<RLPXSocket>(io);
+    shared_ptr<TestHandshake> handshake;
+    if (_remoteID == NodeID())
+        handshake.reset(new TestHandshake(host.get(), client));
+    else
+        handshake.reset(new TestHandshake(host.get(), client, _remoteID));
 
-	client->ref().async_connect(acceptor.local_endpoint(), [handshake](boost::system::error_code const& _ec)
-	{
-		throwErrorCode("connect error: ", _ec);
-		handshake->start();
-	});
+    client->ref().async_connect(acceptor.local_endpoint(), [handshake](boost::system::error_code const& _ec)
+    {
+        throwErrorCode("connect error: ", _ec);
+        handshake->start();
+    });
 
-	// Run all I/O to completion and return the finished handshake.
-	io.run();
-	return handshake;
+    // Run all I/O to completion and return the finished handshake.
+    io.run();
+    return handshake;
 }
 
 void TestHandshake::transition(boost::system::error_code _ec)
 {
-	if (!_ec && m_nextState == ReadHello)
-	{
-		cancel();
-		return;
-	}
-	RLPXHandshake::transition(_ec);
+    if (!_ec && m_nextState == ReadHello)
+    {
+        cancel();
+        return;
+    }
+    RLPXHandshake::transition(_ec);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Fixes https://github.com/ethereum/cpp-ethereum/issues/4845

Having a `std::string` member in an exception class goes against boost recommendations (see http://www.boost.org/doc/libs/1_39_0/libs/exception/doc/exception_types_as_simple_semantic_tags.html and http://www.boost.org/community/error_handling.html)
and leads to weird behaviour.
(`boost::enable_current_exception()` copies the exception object provided to `BOOST_THROW_EXCEPTION` macro, but this string member is not copied; `boost::enable_current_exception()` actually requires copy constructor to never throw)

Also there's no point in storing additional error string as a `std::string` member because `error_info` mechanism of boost exceptions can and should be used to store any additional info about the error.

First commit here was changing `Exception` constructor to store the string in `error_info` instead of a member variable.
Then I decided to get rid of all exception constructors taking a parameter string and use the approach more natural to boost execption with using `operator<<` at the point of throw.