### PR TITLE
Improve DB exception handling

### DIFF
--- a/libdevcore/Exceptions.h
+++ b/libdevcore/Exceptions.h
@@ -88,4 +88,5 @@ using Hash256RequirementError = boost::tuple<errinfo_required_h256, errinfo_got_
 using errinfo_extraData = boost::error_info<struct tag_extraData, bytes>;
 using errinfo_externalFunction = boost::errinfo_api_function;
 using errinfo_interface = boost::error_info<struct tag_interface, std::string>;
+using errinfo_path = boost::error_info<struct tag_path, std::string>;
 }

--- a/libdevcore/db.h
+++ b/libdevcore/db.h
@@ -70,34 +70,16 @@ public:
     virtual void forEach(std::function<bool(Slice, Slice)> f) const = 0;
 };
 
-struct FailedToOpenDB : virtual Exception
-{
-    using Exception::Exception;
-};
-struct FailedInsertInDB : virtual Exception
-{
-    using Exception::Exception;
-};
-struct FailedLookupInDB : virtual Exception
-{
-    using Exception::Exception;
-};
-struct FailedDeleteInDB : virtual Exception
-{
-    using Exception::Exception;
-};
-struct FailedCommitInDB : virtual Exception
-{
-    using Exception::Exception;
-};
-struct FailedRollbackInDB : virtual Exception
-{
-    using Exception::Exception;
-};
-struct FailedIterateDB : virtual Exception
-{
-    using Exception::Exception;
-};
+DEV_SIMPLE_EXCEPTION(FailedToOpenDB);
+DEV_SIMPLE_EXCEPTION(FailedInsertInDB);
+DEV_SIMPLE_EXCEPTION(FailedLookupInDB);
+DEV_SIMPLE_EXCEPTION(FailedDeleteInDB);
+DEV_SIMPLE_EXCEPTION(FailedCommitInDB);
+DEV_SIMPLE_EXCEPTION(FailedIterateDB);
+DEV_SIMPLE_EXCEPTION(DBCorruption);
+DEV_SIMPLE_EXCEPTION(DBIOError);
+
+using errinfo_db = boost::error_info<struct tag_db, std::string>;
 
 }  // namespace db
 }  // namespace dev

--- a/libethereum/BlockChain.cpp
+++ b/libethereum/BlockChain.cpp
@@ -259,13 +259,7 @@ unsigned BlockChain::open(fs::path const& _path, WithExisting _we)
         m_blocksDB.reset(new db::DBImpl(chainPath / fs::path("blocks")));
         m_extrasDB.reset(new db::DBImpl(extrasPath / fs::path("extras")));
     }
-    catch (db::FailedToOpenDB const&)
-    {
-        // Do nothing, handled below
-    }
-
-
-    if (!m_blocksDB || !m_extrasDB)
+    catch (db::DBIOError const&)
     {
         if (fs::space(chainPath / fs::path("blocks")).available < 1024)
         {


### PR DESCRIPTION
I've got LevelDB corruption on my Ropsten node, but the error message was always reporting `Database already open` error.

With this change it looks like this
```
ubuntu@cpp-ropsten-node ~/E/c/build> eth/eth --ropsten
cpp-ethereum, a C++ Ethereum client
terminate called after throwing an instance of 'boost::exception_detail::clone_impl<dev::db::DBCorruption>'
  what():  /home/ubuntu/Ethereum/cpp-ethereum/libdevcore/LevelDB.cpp(87): Throw in function dev::db::LevelDB::LevelDB(const boost::filesystem::path&, leveldb::ReadOptions, leveldb::WriteOptions, leveldb::Options)
Dynamic exception type: boost::exception_detail::clone_impl<dev::db::DBCorruption>
[dev::db::tag_db*] = Corruption: bad block contents
[dev::tag_path*] = /home/ubuntu/.ethereum/41941023/blocks
```