### PR TITLE
Further improve DB exceptions

### DIFF
--- a/libdevcore/LevelDB.cpp
+++ b/libdevcore/LevelDB.cpp
@@ -29,6 +29,32 @@ inline leveldb::Slice toLDBSlice(Slice _slice)
     return leveldb::Slice(_slice.data(), _slice.size());
 }
 
+template <class _T>
+void throwDatabaseError(leveldb::Status const& _status, boost::filesystem::path const& _path)
+{
+    _T ex;
+    ex << errinfo_db(_status.ToString());
+    if (!_path.empty())
+        ex << errinfo_path(_path.string());
+
+    BOOST_THROW_EXCEPTION(ex);
+}
+
+void checkStatus(leveldb::Status const& _status, boost::filesystem::path const& _path = {})
+{
+    if (_status.ok())
+        return;
+
+    if (_status.IsCorruption())
+        throwDatabaseError<DBCorruption>(_status, _path);
+    else if (_status.IsIOError())
+        throwDatabaseError<IOError>(_status, _path);
+    else if (_status.IsNotFound())
+        throwDatabaseError<NotFound>(_status, _path);
+    else
+        throwDatabaseError<DatabaseError>(_status, _path);
+}
+
 class LevelDBWriteBatch : public WriteBatchFace
 {
 public:
@@ -76,20 +102,10 @@ LevelDB::LevelDB(boost::filesystem::path const& _path, leveldb::ReadOptions _rea
     leveldb::WriteOptions _writeOptions, leveldb::Options _dbOptions)
   : m_db(nullptr), m_readOptions(std::move(_readOptions)), m_writeOptions(std::move(_writeOptions))
 {
-    std::string const path = _path.string();
     auto db = static_cast<leveldb::DB*>(nullptr);
-    auto const status = leveldb::DB::Open(_dbOptions, path, &db);
-    if (!status.ok())
-    {
-        std::string const statusStr = status.ToString();
+    auto const status = leveldb::DB::Open(_dbOptions, _path.string(), &db);
+    checkStatus(status, _path);
 
-        if (status.IsCorruption())
-            BOOST_THROW_EXCEPTION(DBCorruption() << errinfo_db(statusStr) << errinfo_path(path));
-        else if (status.IsIOError())
-            BOOST_THROW_EXCEPTION(DBIOError() << errinfo_db(statusStr) << errinfo_path(path));
-        else
-            BOOST_THROW_EXCEPTION(FailedToOpenDB() << errinfo_db(statusStr) << errinfo_path(path));
-    }
     assert(db);
     m_db.reset(db);
 }
@@ -99,10 +115,7 @@ std::string LevelDB::lookup(Slice _key) const
     leveldb::Slice const key(_key.data(), _key.size());
     std::string value;
     auto const status = m_db->Get(m_readOptions, key, &value);
-    if (!status.ok())
-    {
-        BOOST_THROW_EXCEPTION(FailedLookupInDB() << errinfo_db(status.ToString()));
-    }
+    checkStatus(status);
     return value;
 }
 
@@ -111,7 +124,11 @@ bool LevelDB::exists(Slice _key) const
     std::string value;
     leveldb::Slice const key(_key.data(), _key.size());
     auto const status = m_db->Get(m_readOptions, key, &value);
-    return status.ok();
+    if (status.IsNotFound())
+        return false;
+
+    checkStatus(status);
+    return true;
 }
 
 void LevelDB::insert(Slice _key, Slice _value)
@@ -119,20 +136,14 @@ void LevelDB::insert(Slice _key, Slice _value)
     leveldb::Slice const key(_key.data(), _key.size());
     leveldb::Slice const value(_value.data(), _value.size());
     auto const status = m_db->Put(m_writeOptions, key, value);
-    if (!status.ok())
-    {
-        BOOST_THROW_EXCEPTION(FailedInsertInDB() << errinfo_db(status.ToString()));
-    }
+    checkStatus(status);
 }
 
 void LevelDB::kill(Slice _key)
 {
     leveldb::Slice const key(_key.data(), _key.size());
     auto const status = m_db->Delete(m_writeOptions, key);
-    if (!status.ok())
-    {
-        BOOST_THROW_EXCEPTION(FailedDeleteInDB() << errinfo_db(status.ToString()));
-    }
+    checkStatus(status);
 }
 
 std::unique_ptr<WriteBatchFace> LevelDB::createWriteBatch() const
@@ -144,19 +155,16 @@ void LevelDB::commit(std::unique_ptr<WriteBatchFace> _batch)
 {
     if (!_batch)
     {
-        BOOST_THROW_EXCEPTION(FailedCommitInDB() << errinfo_comment("Cannot commit null batch"));
+        BOOST_THROW_EXCEPTION(DatabaseError() << errinfo_comment("Cannot commit null batch"));
     }
     auto* batchPtr = dynamic_cast<LevelDBWriteBatch*>(_batch.get());
     if (!batchPtr)
     {
         BOOST_THROW_EXCEPTION(
-            FailedCommitInDB() << errinfo_comment("Invalid batch type passed to LevelDB::commit"));
+            DatabaseError() << errinfo_comment("Invalid batch type passed to LevelDB::commit"));
     }
     auto const status = m_db->Write(m_writeOptions, &batchPtr->writeBatch());
-    if (!status.ok())
-    {
-        BOOST_THROW_EXCEPTION(FailedCommitInDB() << errinfo_db(status.ToString()));
-    }
+    checkStatus(status);
 }
 
 void LevelDB::forEach(std::function<bool(Slice, Slice)> f) const
@@ -164,7 +172,7 @@ void LevelDB::forEach(std::function<bool(Slice, Slice)> f) const
     std::unique_ptr<leveldb::Iterator> itr(m_db->NewIterator(m_readOptions));
     if (itr == nullptr)
     {
-        BOOST_THROW_EXCEPTION(FailedIterateDB() << errinfo_comment("null iterator"));
+        BOOST_THROW_EXCEPTION(DatabaseError() << errinfo_comment("null iterator"));
     }
     auto keepIterating = true;
     for (itr->SeekToFirst(); keepIterating && itr->Valid(); itr->Next())

--- a/libdevcore/LevelDB.cpp
+++ b/libdevcore/LevelDB.cpp
@@ -49,8 +49,6 @@ void checkStatus(leveldb::Status const& _status, boost::filesystem::path const& 
         throwDatabaseError<DBCorruption>(_status, _path);
     else if (_status.IsIOError())
         throwDatabaseError<IOError>(_status, _path);
-    else if (_status.IsNotFound())
-        throwDatabaseError<NotFound>(_status, _path);
     else
         throwDatabaseError<DatabaseError>(_status, _path);
 }
@@ -115,6 +113,9 @@ std::string LevelDB::lookup(Slice _key) const
     leveldb::Slice const key(_key.data(), _key.size());
     std::string value;
     auto const status = m_db->Get(m_readOptions, key, &value);
+    if (status.IsNotFound())
+        return std::string();
+
     checkStatus(status);
     return value;
 }

--- a/libdevcore/OverlayDB.cpp
+++ b/libdevcore/OverlayDB.cpp
@@ -104,17 +104,13 @@ bytes OverlayDB::lookupAux(h256 const& _h) const
     bytes ret = MemoryDB::lookupAux(_h);
     if (!ret.empty() || !m_db)
         return ret;
-    std::string v;
+
     bytes b = _h.asBytes();
     b.push_back(255);   // for aux
-    try
-    {
-        v = m_db->lookup(toSlice(b));
-    }
-    catch (db::NotFound const&)
-    {
+    std::string const v = m_db->lookup(toSlice(b));
+    if (v.empty())
         cwarn << "Aux not found: " << _h;
-    }
+
     return asBytes(v);
 }
 
@@ -132,14 +128,7 @@ std::string OverlayDB::lookup(h256 const& _h) const
     if (!ret.empty() || !m_db)
         return ret;
 
-    try
-    {
-        ret = m_db->lookup(toSlice(_h));
-    }
-    catch (db::NotFound const&)
-    {
-    }
-    return ret;
+    return m_db->lookup(toSlice(_h));
 }
 
 bool OverlayDB::exists(h256 const& _h) const

--- a/libdevcore/db.h
+++ b/libdevcore/db.h
@@ -70,14 +70,16 @@ public:
     virtual void forEach(std::function<bool(Slice, Slice)> f) const = 0;
 };
 
-DEV_SIMPLE_EXCEPTION(FailedToOpenDB);
-DEV_SIMPLE_EXCEPTION(FailedInsertInDB);
-DEV_SIMPLE_EXCEPTION(FailedLookupInDB);
-DEV_SIMPLE_EXCEPTION(FailedDeleteInDB);
-DEV_SIMPLE_EXCEPTION(FailedCommitInDB);
-DEV_SIMPLE_EXCEPTION(FailedIterateDB);
-DEV_SIMPLE_EXCEPTION(DBCorruption);
-DEV_SIMPLE_EXCEPTION(DBIOError);
+DEV_SIMPLE_EXCEPTION(DatabaseError);
+struct DBCorruption : virtual DatabaseError
+{
+};
+struct IOError : virtual DatabaseError
+{
+};
+struct NotFound : virtual DatabaseError
+{
+};
 
 using errinfo_db = boost::error_info<struct tag_db, std::string>;
 

--- a/libdevcore/db.h
+++ b/libdevcore/db.h
@@ -77,9 +77,6 @@ struct DBCorruption : virtual DatabaseError
 struct IOError : virtual DatabaseError
 {
 };
-struct NotFound : virtual DatabaseError
-{
-};
 
 using errinfo_db = boost::error_info<struct tag_db, std::string>;
 

--- a/libdevcore/db.h
+++ b/libdevcore/db.h
@@ -71,14 +71,20 @@ public:
 };
 
 DEV_SIMPLE_EXCEPTION(DatabaseError);
-struct DBCorruption : virtual DatabaseError
+
+enum class DatabaseStatus
 {
-};
-struct IOError : virtual DatabaseError
-{
+    Ok,
+    NotFound,
+    Corruption,
+    NotSupported,
+    InvalidArgument,
+    IOError,
+    Unknown
 };
 
-using errinfo_db = boost::error_info<struct tag_db, std::string>;
+using errinfo_dbStatusCode = boost::error_info<struct tag_dbStatusCode, DatabaseStatus>;
+using errinfo_dbStatusString = boost::error_info<struct tag_dbStatusString, std::string>;
 
 }  // namespace db
 }  // namespace dev

--- a/libethereum/BlockChain.cpp
+++ b/libethereum/BlockChain.cpp
@@ -256,8 +256,12 @@ unsigned BlockChain::open(fs::path const& _path, WithExisting _we)
         m_blocksDB.reset(new db::DBImpl(chainPath / fs::path("blocks")));
         m_extrasDB.reset(new db::DBImpl(extrasPath / fs::path("extras")));
     }
-    catch (db::IOError const&)
+    catch (db::DatabaseError const& ex)
     {
+        // Check the exact reason of errror, in case of IOError we can display user-friendly message
+        if (*boost::get_error_info<db::errinfo_dbStatusCode>(ex) != db::DatabaseStatus::IOError)
+            throw;
+
         if (fs::space(chainPath / fs::path("blocks")).available < 1024)
         {
             cwarn << "Not enough available space found on hard drive. Please free some up and then re-run. Bailing.";

--- a/libethereum/BlockChain.h
+++ b/libethereum/BlockChain.h
@@ -351,7 +351,7 @@ private:
         {
             s = (_extrasDB ? _extrasDB : m_extrasDB.get())->lookup(toSlice(_h, N));
         }
-        catch (const db::FailedLookupInDB& /* ex */)
+        catch (db::NotFound& /* ex */)
         {
             return _n;
         }

--- a/libethereum/BlockChain.h
+++ b/libethereum/BlockChain.h
@@ -346,15 +346,9 @@ private:
                 return it->second;
         }
 
-        std::string s;
-        try
-        {
-            s = (_extrasDB ? _extrasDB : m_extrasDB.get())->lookup(toSlice(_h, N));
-        }
-        catch (db::NotFound& /* ex */)
-        {
+        std::string const s = (_extrasDB ? _extrasDB : m_extrasDB.get())->lookup(toSlice(_h, N));
+        if (s.empty())
             return _n;
-        }
 
         noteUsed(_h, N);
 

--- a/libethereum/State.cpp
+++ b/libethereum/State.cpp
@@ -98,9 +98,9 @@ OverlayDB State::openDB(fs::path const& _basePath, h256 const& _genesisHash, Wit
         clog(StateDetail) << "Opened state DB.";
         return OverlayDB(std::move(db));
     }
-    catch (db::FailedToOpenDB const& ex)
+    catch (boost::exception const& ex)
     {
-        cwarn << ex.what() << '\n';
+        cwarn << boost::diagnostic_information(ex) << '\n';
         if (fs::space(path / fs::path("state")).available < 1024)
         {
             cwarn << "Not enough available space found on hard drive. Please free some up and then re-run. Bailing.";

--- a/test/unittests/libethereum/BlockChain.cpp
+++ b/test/unittests/libethereum/BlockChain.cpp
@@ -1,18 +1,18 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file fullblockchain.cpp
  * @author Dimitry Khokhlov <dimitry@ethdev.com>
@@ -37,64 +37,64 @@ BOOST_FIXTURE_TEST_SUITE(BlockChainFrontierSuite, FrontierNoProofTestFixture)
 
 BOOST_AUTO_TEST_CASE(output)
 {
-	BOOST_WARN(string(BlockChainDebug::name()) == string(EthBlue "☍" EthWhite " ◇"));
-	BOOST_WARN(string(BlockChainWarn::name()) == string(EthBlue "☍" EthOnRed EthBlackBold " ✘"));
-	BOOST_WARN(string(BlockChainNote::name()) == string(EthBlue "☍" EthBlue " ℹ"));
-	BOOST_WARN(string(BlockChainChat::name()) == string(EthBlue "☍" EthWhite " ◌"));
+    BOOST_WARN(string(BlockChainDebug::name()) == string(EthBlue "☍" EthWhite " ◇"));
+    BOOST_WARN(string(BlockChainWarn::name()) == string(EthBlue "☍" EthOnRed EthBlackBold " ✘"));
+    BOOST_WARN(string(BlockChainNote::name()) == string(EthBlue "☍" EthBlue " ℹ"));
+    BOOST_WARN(string(BlockChainChat::name()) == string(EthBlue "☍" EthWhite " ◌"));
 
-	TestBlock genesis = TestBlockChain::defaultGenesisBlock();
-	TestBlockChain bc(genesis);
+    TestBlock genesis = TestBlockChain::defaultGenesisBlock();
+    TestBlockChain bc(genesis);
 
-	TestBlock block;
-	block.mine(bc);
-	bc.addBlock(block);
+    TestBlock block;
+    block.mine(bc);
+    bc.addBlock(block);
 
-	std::stringstream buffer;
-	buffer << bc.getInterface();
-	BOOST_REQUIRE(buffer.str().size() == 139);
-	buffer.str(std::string());
+    std::stringstream buffer;
+    buffer << bc.getInterface();
+    BOOST_REQUIRE(buffer.str().size() == 139);
+    buffer.str(std::string());
 }
 
 BOOST_AUTO_TEST_CASE(opendb)
 {
-	TestBlock genesis = TestBlockChain::defaultGenesisBlock();
-	TransientDirectory tempDirBlockchain;
-	ChainParams p(genesisInfo(eth::Network::TransitionnetTest), genesis.bytes(), genesis.accountMap());
-	BlockChain bc(p, tempDirBlockchain.path(), WithExisting::Kill);
-	auto is_critical = []( std::exception const& _e) { return string(_e.what()).find("DatabaseAlreadyOpen") != string::npos; };
-	BOOST_CHECK_EXCEPTION(BlockChain bc2(p, tempDirBlockchain.path(), WithExisting::Verify), DatabaseAlreadyOpen, is_critical);
+    TestBlock genesis = TestBlockChain::defaultGenesisBlock();
+    TransientDirectory tempDirBlockchain;
+    ChainParams p(genesisInfo(eth::Network::TransitionnetTest), genesis.bytes(), genesis.accountMap());
+    BlockChain bc(p, tempDirBlockchain.path(), WithExisting::Kill);
+    auto is_critical = []( std::exception const& _e) { return string(_e.what()).find("DatabaseAlreadyOpen") != string::npos; };
+    BOOST_CHECK_EXCEPTION(BlockChain bc2(p, tempDirBlockchain.path(), WithExisting::Verify), DatabaseAlreadyOpen, is_critical);
 }
 
 BOOST_AUTO_TEST_CASE(Mining_1_mineBlockWithTransaction)
 {
-	TestBlockChain bc(TestBlockChain::defaultGenesisBlock());
-	TestTransaction tr = TestTransaction::defaultTransaction(1); //nonce = 1
-	TestBlock block;
-	block.addTransaction(tr);
-	block.mine(bc);
-	bc.addBlock(block);
-	BOOST_REQUIRE(bc.getInterface().transactions().size() > 0);
+    TestBlockChain bc(TestBlockChain::defaultGenesisBlock());
+    TestTransaction tr = TestTransaction::defaultTransaction(1); //nonce = 1
+    TestBlock block;
+    block.addTransaction(tr);
+    block.mine(bc);
+    bc.addBlock(block);
+    BOOST_REQUIRE(bc.getInterface().transactions().size() > 0);
 }
 
 BOOST_AUTO_TEST_CASE(Mining_2_mineUncles)
 {
-	TestBlockChain bc(TestBlockChain::defaultGenesisBlock());
-	TestTransaction tr = TestTransaction::defaultTransaction(1); //nonce = 1
-	TestBlock block;
-	block.addTransaction(tr);
-	block.mine(bc);
-	bc.addBlock(block);
+    TestBlockChain bc(TestBlockChain::defaultGenesisBlock());
+    TestTransaction tr = TestTransaction::defaultTransaction(1); //nonce = 1
+    TestBlock block;
+    block.addTransaction(tr);
+    block.mine(bc);
+    bc.addBlock(block);
 
-	TestBlock uncleBlock;
-	uncleBlock.mine(bc);
-	TestBlock uncleBlock2;
-	uncleBlock2.mine(bc);
+    TestBlock uncleBlock;
+    uncleBlock.mine(bc);
+    TestBlock uncleBlock2;
+    uncleBlock2.mine(bc);
 
-	TestTransaction tr2 = TestTransaction::defaultTransaction(2);
-	TestBlock block2;
-	block2.addTransaction(tr2);
-	block2.mine(bc);
-	bc.addBlock(block2);
+    TestTransaction tr2 = TestTransaction::defaultTransaction(2);
+    TestBlock block2;
+    block2.addTransaction(tr2);
+    block2.mine(bc);
+    bc.addBlock(block2);
 }
 
 
@@ -107,33 +107,33 @@ See https://github.com/ethereum/cpp-ethereum/issues/3256.
 
 (Mining_3_mineBlockWithUncles)
 {
-	TestBlockChain bc(TestBlockChain::defaultGenesisBlock());
-	TestTransaction tr = TestTransaction::defaultTransaction(1); //nonce = 1
-	TestBlock block;
-	block.addTransaction(tr);
-	block.mine(bc);
-	bc.addBlock(block);
+    TestBlockChain bc(TestBlockChain::defaultGenesisBlock());
+    TestTransaction tr = TestTransaction::defaultTransaction(1); //nonce = 1
+    TestBlock block;
+    block.addTransaction(tr);
+    block.mine(bc);
+    bc.addBlock(block);
 
-	TestBlock uncleBlock;
-	uncleBlock.mine(bc);
-	TestBlock uncleBlock2;
-	uncleBlock2.mine(bc);
+    TestBlock uncleBlock;
+    uncleBlock.mine(bc);
+    TestBlock uncleBlock2;
+    uncleBlock2.mine(bc);
 
-	TestTransaction tr2 = TestTransaction::defaultTransaction(2);
-	TestBlock block2;
-	block2.addTransaction(tr2);
-	block2.mine(bc);
-	bc.addBlock(block2);
+    TestTransaction tr2 = TestTransaction::defaultTransaction(2);
+    TestBlock block2;
+    block2.addTransaction(tr2);
+    block2.mine(bc);
+    bc.addBlock(block2);
 
-	TestTransaction tr3 = TestTransaction::defaultTransaction(3);
-	TestBlock block3;
-	block3.addUncle(uncleBlock);
-	bc.syncUncles(block3.uncles());
-	block3.addTransaction(tr3);
-	block3.mine(bc);
-	bc.addBlock(block3);
-	BOOST_REQUIRE(bc.interface().info().number() == 3);
-	BOOST_REQUIRE(bc.interface().info(uncleBlock.blockHeader().hash()) == uncleBlock.blockHeader());
+    TestTransaction tr3 = TestTransaction::defaultTransaction(3);
+    TestBlock block3;
+    block3.addUncle(uncleBlock);
+    bc.syncUncles(block3.uncles());
+    block3.addTransaction(tr3);
+    block3.mine(bc);
+    bc.addBlock(block3);
+    BOOST_REQUIRE(bc.interface().info().number() == 3);
+    BOOST_REQUIRE(bc.interface().info(uncleBlock.blockHeader().hash()) == uncleBlock.blockHeader());
 }
 */
 
@@ -147,58 +147,58 @@ See https://github.com/ethereum/cpp-ethereum/issues/3059.
 
 (Mining_4_BlockQueueSyncing)
 {
-	TestBlockChain bc(TestBlockChain::defaultGenesisBlock());
-	TestBlockChain bc2(TestBlockChain::defaultGenesisBlock());
+    TestBlockChain bc(TestBlockChain::defaultGenesisBlock());
+    TestBlockChain bc2(TestBlockChain::defaultGenesisBlock());
 
-	TestBlock block;
-	block.mine(bc2);
-	bc2.addBlock(block);
-	TestBlock block2;
-	block2.mine(bc2);
+    TestBlock block;
+    block.mine(bc2);
+    bc2.addBlock(block);
+    TestBlock block2;
+    block2.mine(bc2);
 
-	BlockQueue uncleBlockQueue;
-	uncleBlockQueue.setChain(bc2.interface());
-	ImportResult importIntoQueue = uncleBlockQueue.import(&block2.bytes(), false);
-	BOOST_REQUIRE(importIntoQueue == ImportResult::Success);
-	this_thread::sleep_for(chrono::seconds(2));
+    BlockQueue uncleBlockQueue;
+    uncleBlockQueue.setChain(bc2.interface());
+    ImportResult importIntoQueue = uncleBlockQueue.import(&block2.bytes(), false);
+    BOOST_REQUIRE(importIntoQueue == ImportResult::Success);
+    this_thread::sleep_for(chrono::seconds(2));
 
-	BlockChain& bcRef = bc.interfaceUnsafe();
-	bcRef.sync(uncleBlockQueue, bc.testGenesis().state().db(), unsigned(4));
+    BlockChain& bcRef = bc.interfaceUnsafe();
+    bcRef.sync(uncleBlockQueue, bc.testGenesis().state().db(), unsigned(4));
 
-	//Attempt import block5 to another blockchain
-	pair<ImportResult, ImportRoute> importAttempt;
-	importAttempt = bcRef.attemptImport(block2.bytes(), bc.testGenesis().state().db());
-	BOOST_REQUIRE(importAttempt.first == ImportResult::UnknownParent);
+    //Attempt import block5 to another blockchain
+    pair<ImportResult, ImportRoute> importAttempt;
+    importAttempt = bcRef.attemptImport(block2.bytes(), bc.testGenesis().state().db());
+    BOOST_REQUIRE(importAttempt.first == ImportResult::UnknownParent);
 
-	//Insert block5 to another blockchain
-	auto is_critical = []( std::exception const& _e) { cnote << _e.what(); return true; };
-	BOOST_CHECK_EXCEPTION(bcRef.insert(block2.bytes(), block2.receipts()), UnknownParent, is_critical);
+    //Insert block5 to another blockchain
+    auto is_critical = []( std::exception const& _e) { cnote << _e.what(); return true; };
+    BOOST_CHECK_EXCEPTION(bcRef.insert(block2.bytes(), block2.receipts()), UnknownParent, is_critical);
 
-	//Get status of block5 in the block queue based on block5's chain (block5 imported into queue but not imported into chain)
-	//BlockQueue(bc2) changed by sync function of original bc
-	QueueStatus status = uncleBlockQueue.blockStatus(block2.blockHeader().hash());
-	BOOST_REQUIRE_MESSAGE(status == QueueStatus::Bad, "Received Queue Status: " + toString(status) + " Expected Queue Status: " + toString(QueueStatus::Bad));
+    //Get status of block5 in the block queue based on block5's chain (block5 imported into queue but not imported into chain)
+    //BlockQueue(bc2) changed by sync function of original bc
+    QueueStatus status = uncleBlockQueue.blockStatus(block2.blockHeader().hash());
+    BOOST_REQUIRE_MESSAGE(status == QueueStatus::Bad, "Received Queue Status: " + toString(status) + " Expected Queue Status: " + toString(QueueStatus::Bad));
 }
 */
 
 BOOST_AUTO_TEST_CASE(insertWithoutParent)
 {
-	TestBlockChain bc(TestBlockChain::defaultGenesisBlock());
-	TestTransaction tr = TestTransaction::defaultTransaction();
-	TestBlock block;
-	block.mine(bc);
+    TestBlockChain bc(TestBlockChain::defaultGenesisBlock());
+    TestTransaction tr = TestTransaction::defaultTransaction();
+    TestBlock block;
+    block.mine(bc);
 
-	BlockHeader header = block.blockHeader();
-	header.setNumber(10);
-	block.setBlockHeader(header);
+    BlockHeader header = block.blockHeader();
+    header.setNumber(10);
+    block.setBlockHeader(header);
 
-	BlockChain& bcRef = bc.interfaceUnsafe();
+    BlockChain& bcRef = bc.interfaceUnsafe();
 
-	bcRef.insertWithoutParent(block.bytes(), block.receipts(), 0x040000);
-	BOOST_CHECK_EQUAL(bcRef.number(), 10);
+    bcRef.insertWithoutParent(block.bytes(), block.receipts(), 0x040000);
+    BOOST_CHECK_EQUAL(bcRef.number(), 10);
 
-	bcRef.setChainStartBlockNumber(10);
-	BOOST_REQUIRE_EQUAL(bcRef.chainStartBlockNumber(), 10);
+    bcRef.setChainStartBlockNumber(10);
+    BOOST_REQUIRE_EQUAL(bcRef.chainStartBlockNumber(), 10);
 }
 
 
@@ -208,148 +208,149 @@ BOOST_FIXTURE_TEST_SUITE(BlockChainMainNetworkSuite, MainNetworkNoProofTestFixtu
 
 BOOST_AUTO_TEST_CASE(Mining_5_BlockFutureTime)
 {
-	TestBlockChain bc(TestBlockChain::defaultGenesisBlock());
+    TestBlockChain bc(TestBlockChain::defaultGenesisBlock());
 
-	TestBlock uncleBlock;
-	uncleBlock.mine(bc);
+    TestBlock uncleBlock;
+    uncleBlock.mine(bc);
 
-	BlockHeader uncleHeader = uncleBlock.blockHeader();
-	uncleHeader.setTimestamp(uncleHeader.timestamp() + 10000);
-	uncleBlock.setBlockHeader(uncleHeader);
-	uncleBlock.updateNonce(bc);
+    BlockHeader uncleHeader = uncleBlock.blockHeader();
+    uncleHeader.setTimestamp(uncleHeader.timestamp() + 10000);
+    uncleBlock.setBlockHeader(uncleHeader);
+    uncleBlock.updateNonce(bc);
 
-	BlockQueue uncleBlockQueue;
-	uncleBlockQueue.setChain(bc.getInterface());
-	uncleBlockQueue.import(&uncleBlock.bytes(), false);
-	std::this_thread::sleep_for(std::chrono::seconds(2));
+    BlockQueue uncleBlockQueue;
+    uncleBlockQueue.setChain(bc.getInterface());
+    uncleBlockQueue.import(&uncleBlock.bytes(), false);
+    std::this_thread::sleep_for(std::chrono::seconds(2));
 
-	BlockChain& bcRef = bc.interfaceUnsafe();
-	bcRef.sync(uncleBlockQueue, bc.testGenesis().state().db(), unsigned(4));
-	BOOST_REQUIRE(uncleBlockQueue.blockStatus(uncleBlock.blockHeader().hash()) == QueueStatus::Unknown);
+    BlockChain& bcRef = bc.interfaceUnsafe();
+    bcRef.sync(uncleBlockQueue, bc.testGenesis().state().db(), unsigned(4));
+    BOOST_REQUIRE(uncleBlockQueue.blockStatus(uncleBlock.blockHeader().hash()) == QueueStatus::Unknown);
 
-	pair<ImportResult, ImportRoute> importAttempt;
-	importAttempt = bcRef.attemptImport(uncleBlock.bytes(), bc.testGenesis().state().db());
-	BOOST_REQUIRE(importAttempt.first == ImportResult::FutureTimeKnown);
+    pair<ImportResult, ImportRoute> importAttempt;
+    importAttempt = bcRef.attemptImport(uncleBlock.bytes(), bc.testGenesis().state().db());
+    BOOST_REQUIRE(importAttempt.first == ImportResult::FutureTimeKnown);
 
-	auto is_critical = []( std::exception const& _e) { cnote << _e.what(); return true; };
-	BOOST_CHECK_EXCEPTION(bcRef.insert(uncleBlock.bytes(), uncleBlock.receipts()), FutureTime, is_critical);
+    auto is_critical = []( std::exception const& _e) { cnote << _e.what(); return true; };
+    BOOST_CHECK_EXCEPTION(bcRef.insert(uncleBlock.bytes(), uncleBlock.receipts()), FutureTime, is_critical);
 }
 
 bool onBadwasCalled = false;
-void onBad(Exception& _ex)
+void onBad(Exception&)
 {
-	cout << _ex.what();
-	onBadwasCalled = true;
+    onBadwasCalled = true;
 }
 
 BOOST_AUTO_TEST_CASE(attemptImport)
 {
-	//UnknownParent
-	//Success
-	//AlreadyKnown
-	//FutureTimeKnown
-	//Malformed
+    //UnknownParent
+    //Success
+    //AlreadyKnown
+    //FutureTimeKnown
+    //Malformed
 
-	TestBlockChain bc(TestBlockChain::defaultGenesisBlock());
+    TestBlockChain bc(TestBlockChain::defaultGenesisBlock());
 
-	TestTransaction tr = TestTransaction::defaultTransaction();
-	TestBlock block;
-	block.addTransaction(tr);
-	block.mine(bc);
+    TestTransaction tr = TestTransaction::defaultTransaction();
+    TestBlock block;
+    block.addTransaction(tr);
+    block.mine(bc);
 
-	pair<ImportResult, ImportRoute> importAttempt;
-	BlockChain& bcRef = bc.interfaceUnsafe();
-	bcRef.setOnBad(onBad);
+    pair<ImportResult, ImportRoute> importAttempt;
+    BlockChain& bcRef = bc.interfaceUnsafe();
+    bcRef.setOnBad(onBad);
 
-	importAttempt = bcRef.attemptImport(block.bytes(), bc.testGenesis().state().db());
-	BOOST_REQUIRE(importAttempt.first == ImportResult::Success);
+    importAttempt = bcRef.attemptImport(block.bytes(), bc.testGenesis().state().db());
+    BOOST_REQUIRE(importAttempt.first == ImportResult::Success);
 
-	importAttempt = bcRef.attemptImport(block.bytes(), bc.testGenesis().state().db());
-	BOOST_REQUIRE(importAttempt.first == ImportResult::AlreadyKnown);
+    importAttempt = bcRef.attemptImport(block.bytes(), bc.testGenesis().state().db());
+    BOOST_REQUIRE(importAttempt.first == ImportResult::AlreadyKnown);
 
-	bytes blockBytes = block.bytes();
-	blockBytes[0] = 0;
-	importAttempt = bcRef.attemptImport(blockBytes, bc.testGenesis().state().db());
-	BOOST_REQUIRE(importAttempt.first == ImportResult::Malformed);
-	BOOST_REQUIRE(onBadwasCalled == true);
+    bytes blockBytes = block.bytes();
+    blockBytes[0] = 0;
+    importAttempt = bcRef.attemptImport(blockBytes, bc.testGenesis().state().db());
+    BOOST_REQUIRE(importAttempt.first == ImportResult::Malformed);
+    BOOST_REQUIRE(onBadwasCalled == true);
 }
 
 BOOST_AUTO_TEST_CASE(insert)
 {
-	TestBlockChain bc(TestBlockChain::defaultGenesisBlock());
-	TestTransaction tr = TestTransaction::defaultTransaction();
-	TestBlock block;
-	block.addTransaction(tr);
-	block.mine(bc);
+    TestBlockChain bc(TestBlockChain::defaultGenesisBlock());
+    TestTransaction tr = TestTransaction::defaultTransaction();
+    TestBlock block;
+    block.addTransaction(tr);
+    block.mine(bc);
 
-	BlockChain& bcRef = bc.interfaceUnsafe();
+    BlockChain& bcRef = bc.interfaceUnsafe();
 
-	//Incorrect Receipt
-	ZeroGasPricer gp;
-	Block bl = bcRef.genesisBlock(bc.testGenesis().state().db());
-	bl.sync(bcRef);
-	bl.sync(bcRef, block.transactionQueue(), gp);
+    //Incorrect Receipt
+    ZeroGasPricer gp;
+    Block bl = bcRef.genesisBlock(bc.testGenesis().state().db());
+    bl.sync(bcRef);
+    bl.sync(bcRef, block.transactionQueue(), gp);
 
-	//Receipt should be RLPStream
-	const bytes receipt = bl.receipt(0).rlp();
-	bytesConstRef receiptRef(&receipt[0], receipt.size());
+    //Receipt should be RLPStream
+    const bytes receipt = bl.receipt(0).rlp();
+    bytesConstRef receiptRef(&receipt[0], receipt.size());
 
-	auto is_critical = [](std::exception const& _e) { return string(_e.what()).find("InvalidBlockFormat") != string::npos; };
-	BOOST_CHECK_EXCEPTION(bcRef.insert(bl.blockData(), receiptRef), InvalidBlockFormat, is_critical);
-	auto is_critical2 = [](std::exception const& _e) { return string(_e.what()).find("InvalidReceiptsStateRoot") != string::npos; };
-	BOOST_CHECK_EXCEPTION(bcRef.insert(block.bytes(), receiptRef), InvalidReceiptsStateRoot, is_critical2);
+    auto is_critical = [](std::exception const& _e) { return string(_e.what()).find("InvalidBlockFormat") != string::npos; };
+    BOOST_CHECK_EXCEPTION(bcRef.insert(bl.blockData(), receiptRef), InvalidBlockFormat, is_critical);
+    auto is_critical2 = [](std::exception const& _e) { return string(_e.what()).find("InvalidReceiptsStateRoot") != string::npos; };
+    BOOST_CHECK_EXCEPTION(bcRef.insert(block.bytes(), receiptRef), InvalidReceiptsStateRoot, is_critical2);
 
-	BOOST_REQUIRE(bcRef.number() == 0);
+    BOOST_REQUIRE(bcRef.number() == 0);
 
-	bcRef.insert(block.bytes(), block.receipts());
+    bcRef.insert(block.bytes(), block.receipts());
 }
 
 BOOST_AUTO_TEST_CASE(insertException)
 {
-	TestBlockChain bc(TestBlockChain::defaultGenesisBlock());
-	BlockChain& bcRef = bc.interfaceUnsafe();
+    TestBlockChain bc(TestBlockChain::defaultGenesisBlock());
+    BlockChain& bcRef = bc.interfaceUnsafe();
 
-	TestTransaction tr = TestTransaction::defaultTransaction();
-	TestBlock block;
-	block.addTransaction(tr);
-	block.mine(bc);
-	bc.addBlock(block);
+    TestTransaction tr = TestTransaction::defaultTransaction();
+    TestBlock block;
+    block.addTransaction(tr);
+    block.mine(bc);
+    bc.addBlock(block);
 
-	auto is_critical = [](std::exception const& _e) { cnote << _e.what(); return true; };
-	BOOST_CHECK_EXCEPTION(bcRef.insert(block.bytes(), block.receipts()), AlreadyHaveBlock, is_critical);
+    auto is_critical = [](std::exception const& _e) { cnote << _e.what(); return true; };
+    BOOST_CHECK_EXCEPTION(bcRef.insert(block.bytes(), block.receipts()), AlreadyHaveBlock, is_critical);
 }
 
 BOOST_AUTO_TEST_CASE(rescue, *utf::expected_failures(1))
 {
-	TestBlockChain bc(TestBlockChain::defaultGenesisBlock());
+    cout << "BlockChainMainNetworkSuite/rescue test - failure is expected\n";
 
-	{
-		TestTransaction tr = TestTransaction::defaultTransaction();
-		TestBlock block;
-		block.addTransaction(tr);
-		block.mine(bc);
-		bc.addBlock(block);
-	}
+    TestBlockChain bc(TestBlockChain::defaultGenesisBlock());
 
-	{
-		TestTransaction tr = TestTransaction::defaultTransaction(1);
-		TestBlock block;
-		block.addTransaction(tr);
-		block.mine(bc);
-		bc.addBlock(block);
-	}
+    {
+        TestTransaction tr = TestTransaction::defaultTransaction();
+        TestBlock block;
+        block.addTransaction(tr);
+        block.mine(bc);
+        bc.addBlock(block);
+    }
 
-	{
-		TestTransaction tr = TestTransaction::defaultTransaction(2);
-		TestBlock block;
-		block.addTransaction(tr);
-		block.mine(bc);
-		bc.addBlock(block);
-	}
+    {
+        TestTransaction tr = TestTransaction::defaultTransaction(1);
+        TestBlock block;
+        block.addTransaction(tr);
+        block.mine(bc);
+        bc.addBlock(block);
+    }
 
-	BlockChain& bcRef = bc.interfaceUnsafe();
-	bcRef.rescue(bc.testGenesis().state().db());
-	BOOST_CHECK_EQUAL(bcRef.number(), 3);
+    {
+        TestTransaction tr = TestTransaction::defaultTransaction(2);
+        TestBlock block;
+        block.addTransaction(tr);
+        block.mine(bc);
+        bc.addBlock(block);
+    }
+
+    BlockChain& bcRef = bc.interfaceUnsafe();
+    bcRef.rescue(bc.testGenesis().state().db());
+    BOOST_CHECK_EQUAL(bcRef.number(), 3);
 }
 
 BOOST_AUTO_TEST_SUITE_END()
@@ -358,50 +359,50 @@ BOOST_FIXTURE_TEST_SUITE(BlockChainSuite, TestOutputHelperFixture)
 
 BOOST_AUTO_TEST_CASE(updateStats)
 {
-	TestBlockChain bc(TestBlockChain::defaultGenesisBlock());
-	BlockChain& bcRef = bc.interfaceUnsafe();
+    TestBlockChain bc(TestBlockChain::defaultGenesisBlock());
+    BlockChain& bcRef = bc.interfaceUnsafe();
 
-	BlockChain::Statistics stat = bcRef.usage();
-	//Absolutely random values here!
-	//BOOST_REQUIRE(stat.memBlockHashes == 0);
-	//BOOST_REQUIRE(stat.memBlocks == 1); //incorrect value here
-	//BOOST_REQUIRE(stat.memDetails == 0);
-	//BOOST_REQUIRE(stat.memLogBlooms == 0);
-	//BOOST_REQUIRE(stat.memReceipts == 0);
-	//BOOST_REQUIRE(stat.memTotal() == 0);
-	//BOOST_REQUIRE(stat.memTransactionAddresses == 0); //incorrect value here
+    BlockChain::Statistics stat = bcRef.usage();
+    //Absolutely random values here!
+    //BOOST_REQUIRE(stat.memBlockHashes == 0);
+    //BOOST_REQUIRE(stat.memBlocks == 1); //incorrect value here
+    //BOOST_REQUIRE(stat.memDetails == 0);
+    //BOOST_REQUIRE(stat.memLogBlooms == 0);
+    //BOOST_REQUIRE(stat.memReceipts == 0);
+    //BOOST_REQUIRE(stat.memTotal() == 0);
+    //BOOST_REQUIRE(stat.memTransactionAddresses == 0); //incorrect value here
 
-	TestTransaction tr = TestTransaction::defaultTransaction();
-	TestBlock block;
-	block.addTransaction(tr);
-	block.mine(bc);
-	bc.addBlock(block);
+    TestTransaction tr = TestTransaction::defaultTransaction();
+    TestBlock block;
+    block.addTransaction(tr);
+    block.mine(bc);
+    bc.addBlock(block);
 
-	stat = bcRef.usage(true);
-	BOOST_REQUIRE_EQUAL(stat.memBlockHashes, 0);
-	BOOST_REQUIRE_EQUAL(stat.memBlocks, 675);
-	BOOST_REQUIRE_EQUAL(stat.memDetails, 138);
-	BOOST_REQUIRE_EQUAL(stat.memLogBlooms, 8422);
-	BOOST_REQUIRE_EQUAL(stat.memReceipts, 0);
-	BOOST_REQUIRE_EQUAL(stat.memTotal(), 9235);
-	BOOST_REQUIRE_EQUAL(stat.memTransactionAddresses, 0);
+    stat = bcRef.usage(true);
+    BOOST_REQUIRE_EQUAL(stat.memBlockHashes, 0);
+    BOOST_REQUIRE_EQUAL(stat.memBlocks, 675);
+    BOOST_REQUIRE_EQUAL(stat.memDetails, 138);
+    BOOST_REQUIRE_EQUAL(stat.memLogBlooms, 8422);
+    BOOST_REQUIRE_EQUAL(stat.memReceipts, 0);
+    BOOST_REQUIRE_EQUAL(stat.memTotal(), 9235);
+    BOOST_REQUIRE_EQUAL(stat.memTransactionAddresses, 0);
 
-	//memchache size 33554432 - 3500 blocks before cache to be cleared
-	bcRef.garbageCollect(true);
+    //memchache size 33554432 - 3500 blocks before cache to be cleared
+    bcRef.garbageCollect(true);
 }
 
 BOOST_AUTO_TEST_CASE(invalidJsonThrows)
 {
-	h256 emptyStateRoot;
-	/* Below, a comma is missing between fields. */
-	BOOST_CHECK_THROW(ChainParams("{ \"sealEngine\" : \"unknown\" \"accountStartNonce\" : \"3\" }", emptyStateRoot), json_spirit::Error_position);
+    h256 emptyStateRoot;
+    /* Below, a comma is missing between fields. */
+    BOOST_CHECK_THROW(ChainParams("{ \"sealEngine\" : \"unknown\" \"accountStartNonce\" : \"3\" }", emptyStateRoot), json_spirit::Error_position);
 }
 
 BOOST_AUTO_TEST_CASE(unknownFieldThrows)
 {
-	h256 emptyStateRoot;
-	/* Below, an unknown field is passed. */
-	BOOST_CHECK_THROW(ChainParams("{ \"usuallyNotThere\" : \"unknown\" }", emptyStateRoot), UnknownField);
+    h256 emptyStateRoot;
+    /* Below, an unknown field is passed. */
+    BOOST_CHECK_THROW(ChainParams("{ \"usuallyNotThere\" : \"unknown\" }", emptyStateRoot), UnknownField);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/unittests/libtesteth/blockchainTest.cpp
+++ b/test/unittests/libtesteth/blockchainTest.cpp
@@ -1,18 +1,18 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file blockchainTest.cpp
  * Unit tests for blockchain test filling/execution.
@@ -31,118 +31,118 @@ BOOST_FIXTURE_TEST_SUITE(BlockChainTestSuite, TestOutputHelperFixture)
 BOOST_AUTO_TEST_CASE(fillingExpectationOnMultipleNetworks)
 {
     std::string const s = R"(
-		{
-			"fillingExpectationOnMultipleNetworks" : {
-				"blocks" : [
-				],
-				"expect" : [
-					{
-						"network" : ["EIP150", "EIP158"],
-						"result" : {
-							"0x1000000000000000000000000000000000000000" : {
-								"balance" : "0x00"
-							},
-							"0x1000000000000000000000000000000000000001" : {
-								"balance" : "0x00"
-							}
-						}
-					}
-				],
-				"genesisBlockHeader" : {
-					"bloom" : "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-					"coinbase" : "2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
-					"difficulty" : "131072",
-					"extraData" : "0x42",
-					"gasLimit" : "0x7fffffffffffffff",
-					"gasUsed" : "0",
-					"mixHash" : "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
-					"nonce" : "0x0102030405060708",
-					"number" : "0",
-					"parentHash" : "0x0000000000000000000000000000000000000000000000000000000000000000",
-					"receiptTrie" : "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
-					"stateRoot" : "0xf99eb1626cfa6db435c0836235942d7ccaa935f1ae247d3f1c21e495685f903a",
-					"timestamp" : "0x03b6",
-					"transactionsTrie" : "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
-					"uncleHash" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
-				},
-				"pre" : {
-					"0x1000000000000000000000000000000000000000" : {
-						"balance" : "0x00",
-						"code" : "0x60004060005563ffffffff4060015567ffffffffffffffff406002556fffffffffffffffffffffffffffffffff406003557fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff40600455",
-						"nonce" : "0x00",
-						"storage" : {
-						}
-					},
-				"0x1000000000000000000000000000000000000001" : {
-					"balance" : "0x00",
-					"code" : "0x60004060005563ffffffff4060015567ffffffffffffffff406002556fffffffffffffffffffffffffffffffff406003557fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff40600455",
-					"nonce" : "0x00",
-					"storage" : {
-					}
-				}
-		}
-	)";
+        {
+            "fillingExpectationOnMultipleNetworks" : {
+                "blocks" : [
+                ],
+                "expect" : [
+                    {
+                        "network" : ["EIP150", "EIP158"],
+                        "result" : {
+                            "0x1000000000000000000000000000000000000000" : {
+                                "balance" : "0x00"
+                            },
+                            "0x1000000000000000000000000000000000000001" : {
+                                "balance" : "0x00"
+                            }
+                        }
+                    }
+                ],
+                "genesisBlockHeader" : {
+                    "bloom" : "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                    "coinbase" : "2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+                    "difficulty" : "131072",
+                    "extraData" : "0x42",
+                    "gasLimit" : "0x7fffffffffffffff",
+                    "gasUsed" : "0",
+                    "mixHash" : "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+                    "nonce" : "0x0102030405060708",
+                    "number" : "0",
+                    "parentHash" : "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "receiptTrie" : "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+                    "stateRoot" : "0xf99eb1626cfa6db435c0836235942d7ccaa935f1ae247d3f1c21e495685f903a",
+                    "timestamp" : "0x03b6",
+                    "transactionsTrie" : "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+                    "uncleHash" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+                },
+                "pre" : {
+                    "0x1000000000000000000000000000000000000000" : {
+                        "balance" : "0x00",
+                        "code" : "0x60004060005563ffffffff4060015567ffffffffffffffff406002556fffffffffffffffffffffffffffffffff406003557fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff40600455",
+                        "nonce" : "0x00",
+                        "storage" : {
+                        }
+                    },
+                "0x1000000000000000000000000000000000000001" : {
+                    "balance" : "0x00",
+                    "code" : "0x60004060005563ffffffff4060015567ffffffffffffffff406002556fffffffffffffffffffffffffffffffff406003557fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff40600455",
+                    "nonce" : "0x00",
+                    "storage" : {
+                    }
+                }
+        }
+    )";
     json_spirit::mValue input;
-	json_spirit::read_string(s, input);
-	BlockchainTestSuite suite;
-	json_spirit::mValue output = suite.doTests(input, true);
+    json_spirit::read_string(s, input);
+    BlockchainTestSuite suite;
+    json_spirit::mValue output = suite.doTests(input, true);
     BOOST_CHECK_MESSAGE(output.get_obj().size() == 2, "A wrong number of tests were generated.");
 }
 
 BOOST_AUTO_TEST_CASE(fillingExpectationOnSingleNetwork)
 {
     std::string const s = R"(
-		{
-			"fillingExpectationOnSingleNetwork" : {
-				"blocks" : [
-				],
-				"expect" : [
-					{
-						"network" : "EIP150",
-						"result" : {
-							"0x1000000000000000000000000000000000000000" : {
-								"balance" : "0x00"
-							},
-							"0x1000000000000000000000000000000000000001" : {
-								"balance" : "0x00"
-							}
-						}
-					}
-				],
-				"genesisBlockHeader" : {
-					"bloom" : "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-					"coinbase" : "2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
-					"difficulty" : "131072",
-					"extraData" : "0x42",
-					"gasLimit" : "0x7fffffffffffffff",
-					"gasUsed" : "0",
-					"mixHash" : "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
-					"nonce" : "0x0102030405060708",
-					"number" : "0",
-					"parentHash" : "0x0000000000000000000000000000000000000000000000000000000000000000",
-					"receiptTrie" : "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
-					"stateRoot" : "0xf99eb1626cfa6db435c0836235942d7ccaa935f1ae247d3f1c21e495685f903a",
-					"timestamp" : "0x03b6",
-					"transactionsTrie" : "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
-					"uncleHash" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
-				},
-				"pre" : {
-					"0x1000000000000000000000000000000000000000" : {
-						"balance" : "0x00",
-						"code" : "0x60004060005563ffffffff4060015567ffffffffffffffff406002556fffffffffffffffffffffffffffffffff406003557fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff40600455",
-						"nonce" : "0x00",
-						"storage" : {
-						}
-					},
-				"0x1000000000000000000000000000000000000001" : {
-					"balance" : "0x00",
-					"code" : "0x60004060005563ffffffff4060015567ffffffffffffffff406002556fffffffffffffffffffffffffffffffff406003557fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff40600455",
-					"nonce" : "0x00",
-					"storage" : {
-					}
-				}
-		}
-	)";
+        {
+            "fillingExpectationOnSingleNetwork" : {
+                "blocks" : [
+                ],
+                "expect" : [
+                    {
+                        "network" : "EIP150",
+                        "result" : {
+                            "0x1000000000000000000000000000000000000000" : {
+                                "balance" : "0x00"
+                            },
+                            "0x1000000000000000000000000000000000000001" : {
+                                "balance" : "0x00"
+                            }
+                        }
+                    }
+                ],
+                "genesisBlockHeader" : {
+                    "bloom" : "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                    "coinbase" : "2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+                    "difficulty" : "131072",
+                    "extraData" : "0x42",
+                    "gasLimit" : "0x7fffffffffffffff",
+                    "gasUsed" : "0",
+                    "mixHash" : "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+                    "nonce" : "0x0102030405060708",
+                    "number" : "0",
+                    "parentHash" : "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "receiptTrie" : "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+                    "stateRoot" : "0xf99eb1626cfa6db435c0836235942d7ccaa935f1ae247d3f1c21e495685f903a",
+                    "timestamp" : "0x03b6",
+                    "transactionsTrie" : "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+                    "uncleHash" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+                },
+                "pre" : {
+                    "0x1000000000000000000000000000000000000000" : {
+                        "balance" : "0x00",
+                        "code" : "0x60004060005563ffffffff4060015567ffffffffffffffff406002556fffffffffffffffffffffffffffffffff406003557fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff40600455",
+                        "nonce" : "0x00",
+                        "storage" : {
+                        }
+                    },
+                "0x1000000000000000000000000000000000000001" : {
+                    "balance" : "0x00",
+                    "code" : "0x60004060005563ffffffff4060015567ffffffffffffffff406002556fffffffffffffffffffffffffffffffff406003557fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff40600455",
+                    "nonce" : "0x00",
+                    "storage" : {
+                    }
+                }
+        }
+    )";
     json_spirit::mValue input;
     json_spirit::read_string(s, input);
     BlockchainTestSuite suite;
@@ -154,62 +154,64 @@ BOOST_AUTO_TEST_CASE(fillingExpectationOnSingleNetwork)
 BOOST_AUTO_TEST_CASE_EXPECTED_FAILURES(fillingWithWrongExpectation, 2)
 BOOST_AUTO_TEST_CASE(fillingWithWrongExpectation)
 {
-    std::string const s = R"(
-		{
-			"fillingWithWrongExpectation" : {
-				"blocks" : [
-				],
-				"expect" : [
-					{
-						"network" : ["EIP150"],
-						"result" : {
-							"0x1000000000000000000000000000000000000000" : {
-								"balance" : "0x01"
-							},
-							"0x1000000000000000000000000000000000000001" : {
-								"balance" : "0x00"
-							}
-						}
-					}
-				],
-				"genesisBlockHeader" : {
-					"bloom" : "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-					"coinbase" : "2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
-					"difficulty" : "131072",
-					"extraData" : "0x42",
-					"gasLimit" : "0x7fffffffffffffff",
-					"gasUsed" : "0",
-					"mixHash" : "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
-					"nonce" : "0x0102030405060708",
-					"number" : "0",
-					"parentHash" : "0x0000000000000000000000000000000000000000000000000000000000000000",
-					"receiptTrie" : "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
-					"stateRoot" : "0xf99eb1626cfa6db435c0836235942d7ccaa935f1ae247d3f1c21e495685f903a",
-					"timestamp" : "0x03b6",
-					"transactionsTrie" : "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
-					"uncleHash" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
-				},
-				"pre" : {
-					"0x1000000000000000000000000000000000000000" : {
-						"balance" : "0x00",
-						"code" : "0x60004060005563ffffffff4060015567ffffffffffffffff406002556fffffffffffffffffffffffffffffffff406003557fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff40600455",
-						"nonce" : "0x00",
-						"storage" : {
-						}
-					},
-				"0x1000000000000000000000000000000000000001" : {
-					"balance" : "0x00",
-					"code" : "0x60004060005563ffffffff4060015567ffffffffffffffff406002556fffffffffffffffffffffffffffffffff406003557fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff40600455",
-					"nonce" : "0x00",
-					"storage" : {
-					}
-				}
-		}
-	)";
-    json_spirit::mValue input;
-	json_spirit::read_string(s, input);
+    cout << "BlockChainTestSuite/fillingWithWrongExpectation test - failure is expected\n";
 
-	BlockchainTestSuite suite;
+    std::string const s = R"(
+        {
+            "fillingWithWrongExpectation" : {
+                "blocks" : [
+                ],
+                "expect" : [
+                    {
+                        "network" : ["EIP150"],
+                        "result" : {
+                            "0x1000000000000000000000000000000000000000" : {
+                                "balance" : "0x01"
+                            },
+                            "0x1000000000000000000000000000000000000001" : {
+                                "balance" : "0x00"
+                            }
+                        }
+                    }
+                ],
+                "genesisBlockHeader" : {
+                    "bloom" : "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                    "coinbase" : "2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+                    "difficulty" : "131072",
+                    "extraData" : "0x42",
+                    "gasLimit" : "0x7fffffffffffffff",
+                    "gasUsed" : "0",
+                    "mixHash" : "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+                    "nonce" : "0x0102030405060708",
+                    "number" : "0",
+                    "parentHash" : "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "receiptTrie" : "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+                    "stateRoot" : "0xf99eb1626cfa6db435c0836235942d7ccaa935f1ae247d3f1c21e495685f903a",
+                    "timestamp" : "0x03b6",
+                    "transactionsTrie" : "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+                    "uncleHash" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+                },
+                "pre" : {
+                    "0x1000000000000000000000000000000000000000" : {
+                        "balance" : "0x00",
+                        "code" : "0x60004060005563ffffffff4060015567ffffffffffffffff406002556fffffffffffffffffffffffffffffffff406003557fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff40600455",
+                        "nonce" : "0x00",
+                        "storage" : {
+                        }
+                    },
+                "0x1000000000000000000000000000000000000001" : {
+                    "balance" : "0x00",
+                    "code" : "0x60004060005563ffffffff4060015567ffffffffffffffff406002556fffffffffffffffffffffffffffffffff406003557fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff40600455",
+                    "nonce" : "0x00",
+                    "storage" : {
+                    }
+                }
+        }
+    )";
+    json_spirit::mValue input;
+    json_spirit::read_string(s, input);
+
+    BlockchainTestSuite suite;
     json_spirit::mValue output = suite.doTests(input, true);
     BOOST_CHECK_MESSAGE(output.get_obj().size() == 1, "A wrong number of tests were generated.");
 }


### PR DESCRIPTION
This should improve the situation with lower-level DB errors being ignored during lookup/insert, leading to confusing assert failures like https://github.com/ethereum/cpp-ethereum/issues/4578 https://github.com/ethereum/cpp-ethereum/issues/4585 https://github.com/ethereum/cpp-ethereum/issues/4584