### PR TITLE
Fix badge image URLs for "open issues" and "chat on gitter".

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ of operating systems and hardware.
 
 ## Contact
 
-[![Gitter](https://img.shields.io/gitter/room/nwjs/nw.js.svg)](https://gitter.im/ethereum/cpp-ethereum)
-[![GitHub Issues](https://img.shields.io/github/issues-raw/badges/shields.svg)](https://github.com/ethereum/cpp-ethereum/issues)
+[![Gitter](https://img.shields.io/gitter/room/ethereum/cpp-ethereum.svg)](https://gitter.im/ethereum/cpp-ethereum)
+[![GitHub Issues](https://img.shields.io/github/issues-raw/ethereum/cpp-ethereum.svg)](https://github.com/ethereum/cpp-ethereum/issues)
 
 - Chat in [cpp-ethereum channel on Gitter](https://gitter.im/ethereum/cpp-ethereum).
 - Report bugs, issues or feature requests using [GitHub issues](issues/new).
@@ -121,7 +121,7 @@ cmake .. -G "Visual Studio 14 2015 Win64"
 ## Contributing
 
 [![Contributors](https://img.shields.io/github/contributors/ethereum/cpp-ethereum.svg)](https://github.com/ethereum/cpp-ethereum/graphs/contributors)
-[![Gitter](https://img.shields.io/gitter/room/nwjs/nw.js.svg)](https://gitter.im/ethereum/cpp-ethereum)
+[![Gitter](https://img.shields.io/gitter/room/ethereum/cpp-ethereum.svg)](https://gitter.im/ethereum/cpp-ethereum)
 [![up-for-grabs](https://img.shields.io/github/issues-raw/ethereum/cpp-ethereum/up-for-grabs.svg)](https://github.com/ethereum/cpp-ethereum/labels/up-for-grabs)
 
 The current codebase is the work of many, many hands, with nearly 100


### PR DESCRIPTION
The original "open issues" counts the opened issues for [https://github.com/badges/shields]() instead of cpp-ethereum. This commit fix the image URLs for "open issues" as well as "chat on gitter" (although the change does not reflect on the appearance of "chat on gitter").