### PR TITLE
Delete destructor to avoid aggregate initialization

### DIFF
--- a/libevm/VMFactory.h
+++ b/libevm/VMFactory.h
@@ -44,6 +44,7 @@ class VMFactory
 {
 public:
 	VMFactory() = delete;
+	~VMFactory() = delete;
 
 	/// Creates a VM instance of global kind (controlled by setKind() function).
 	static std::unique_ptr<VMFace> create();


### PR DESCRIPTION
Delete destructor so that VMFactory can't be instantiated via aggregate initialization (e.g. `VMFactory f{}` is valid)