### PR TITLE
 evm: Pass the "is CREATE" information to EVM-C VM

### DIFF
--- a/libethereum/Executive.cpp
+++ b/libethereum/Executive.cpp
@@ -299,7 +299,9 @@ bool Executive::call(CallParameters const& _p, u256 const& _gasPrice, Address co
         {
             bytes const& c = m_s.code(_p.codeAddress);
             h256 codeHash = m_s.codeHash(_p.codeAddress);
-            m_ext = make_shared<ExtVM>(m_s, m_envInfo, m_sealEngine, _p.receiveAddress, _p.senderAddress, _origin, _p.apparentValue, _gasPrice, _p.data, &c, codeHash, m_depth, _p.staticCall);
+            m_ext = make_shared<ExtVM>(m_s, m_envInfo, m_sealEngine, _p.receiveAddress,
+                _p.senderAddress, _origin, _p.apparentValue, _gasPrice, _p.data, &c, codeHash,
+                m_depth, false, _p.staticCall);
         }
     }
 
@@ -362,7 +364,8 @@ bool Executive::executeCreate(Address const& _sender, u256 const& _endowment, u2
 
     // Schedule _init execution if not empty.
     if (!_init.empty())
-        m_ext = make_shared<ExtVM>(m_s, m_envInfo, m_sealEngine, m_newAddress, _sender, _origin, _endowment, _gasPrice, bytesConstRef(), _init, sha3(_init), m_depth);
+        m_ext = make_shared<ExtVM>(m_s, m_envInfo, m_sealEngine, m_newAddress, _sender, _origin,
+            _endowment, _gasPrice, bytesConstRef(), _init, sha3(_init), m_depth, true, false);
 
     return !m_ext;
 }

--- a/libethereum/Executive.h
+++ b/libethereum/Executive.h
@@ -11,19 +11,17 @@
     You should have received a copy of the GNU General Public License
     along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** @file Executive.h
- * @author Gav Wood <i@gavwood.com>
- * @date 2014
- */
 
 #pragma once
 
-#include <functional>
-#include <json/json.h>
+#include "Transaction.h"
+
 #include <libdevcore/Log.h>
 #include <libethcore/Common.h>
 #include <libevm/VMFace.h>
-#include "Transaction.h"
+
+#include <json/json.h>
+#include <functional>
 
 namespace Json
 {
@@ -72,7 +70,6 @@ public:
 private:
     bool m_showMnemonics = false;
     std::vector<Instruction> m_lastInst;
-    bytes m_lastCallData;
     Json::Value m_trace;
     DebugOptions m_options;
 };

--- a/libethereum/ExtVM.h
+++ b/libethereum/ExtVM.h
@@ -14,20 +14,18 @@
 	You should have received a copy of the GNU General Public License
 	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** @file ExtVM.h
- * @author Gav Wood <i@gavwood.com>
- * @date 2014
- */
 
 #pragma once
 
-#include <map>
-#include <functional>
-#include <libethcore/Common.h>
-#include <libevm/ExtVMFace.h>
-#include <libethcore/SealEngine.h>
-#include "State.h"
 #include "Executive.h"
+#include "State.h"
+
+#include <libethcore/Common.h>
+#include <libethcore/SealEngine.h>
+#include <libevm/ExtVMFace.h>
+
+#include <functional>
+#include <map>
 
 namespace dev
 {
@@ -36,21 +34,25 @@ namespace eth
 
 class SealEngineFace;
 
-/**
- * @brief Externality interface for the Virtual Machine providing access to world state.
- */
-class ExtVM: public ExtVMFace
+/// Externality interface for the Virtual Machine providing access to world state.
+class ExtVM : public ExtVMFace
 {
 public:
-	/// Full constructor.
-	ExtVM(State& _s, EnvInfo const& _envInfo, SealEngineFace const& _sealEngine, Address _myAddress, Address _caller, Address _origin, u256 _value, u256 _gasPrice, bytesConstRef _data, bytesConstRef _code, h256 const& _codeHash, unsigned _depth = 0, bool _staticCall = false):
-		ExtVMFace(_envInfo, _myAddress, _caller, _origin, _value, _gasPrice, _data, _code.toBytes(), _codeHash, _depth, _staticCall), m_s(_s), m_sealEngine(_sealEngine)
-	{
-		// Contract: processing account must exist. In case of CALL, the ExtVM
-		// is created only if an account has code (so exist). In case of CREATE
-		// the account must be created first.
-		assert(m_s.addressInUse(_myAddress));
-	}
+    /// Full constructor.
+    ExtVM(State& _s, EnvInfo const& _envInfo, SealEngineFace const& _sealEngine, Address _myAddress,
+        Address _caller, Address _origin, u256 _value, u256 _gasPrice, bytesConstRef _data,
+        bytesConstRef _code, h256 const& _codeHash, unsigned _depth, bool _isCreate,
+        bool _staticCall)
+      : ExtVMFace(_envInfo, _myAddress, _caller, _origin, _value, _gasPrice, _data, _code.toBytes(),
+            _codeHash, _depth, _isCreate, _staticCall),
+        m_s(_s),
+        m_sealEngine(_sealEngine)
+    {
+        // Contract: processing account must exist. In case of CALL, the ExtVM
+        // is created only if an account has code (so exist). In case of CREATE
+        // the account must be created first.
+        assert(m_s.addressInUse(_myAddress));
+    }
 
 	/// Read storage location.
 	virtual u256 store(u256 _n) override final { return m_s.storage(myAddress, _n); }

--- a/libevm/EVMC.h
+++ b/libevm/EVMC.h
@@ -70,14 +70,14 @@ public:
     Result execute(ExtVMFace& _ext, int64_t gas)
     {
         auto mode = toRevision(_ext.evmSchedule());
+        evm_call_kind kind = _ext.isCreate ? EVM_CREATE : EVM_CALL;
         uint32_t flags = _ext.staticCall ? EVM_STATIC : 0;
-        evm_message msg = {toEvmC(_ext.myAddress), toEvmC(_ext.caller),
-                           toEvmC(_ext.value), _ext.data.data(),
-                           _ext.data.size(), toEvmC(_ext.codeHash), gas,
-                           static_cast<int32_t>(_ext.depth), EVM_CALL, flags};
-        return Result{m_instance->execute(
-            m_instance, &_ext, mode, &msg, _ext.code.data(), _ext.code.size()
-        )};
+        assert(flags != EVM_STATIC || kind == EVM_CALL);  // STATIC implies a CALL.
+        evm_message msg = {toEvmC(_ext.myAddress), toEvmC(_ext.caller), toEvmC(_ext.value),
+            _ext.data.data(), _ext.data.size(), toEvmC(_ext.codeHash), gas,
+            static_cast<int32_t>(_ext.depth), kind, flags};
+        return Result{
+            m_instance->execute(m_instance, &_ext, mode, &msg, _ext.code.data(), _ext.code.size())};
     }
 
 private:

--- a/libevm/ExtVMFace.cpp
+++ b/libevm/ExtVMFace.cpp
@@ -270,31 +270,22 @@ evm_context_fn_table const fnTable = {
 
 }
 
-ExtVMFace::ExtVMFace(
-	EnvInfo const& _envInfo,
-	Address _myAddress,
-	Address _caller,
-	Address _origin,
-	u256 _value,
-	u256 _gasPrice,
-	bytesConstRef _data,
-	bytes _code,
-	h256 const& _codeHash,
-	unsigned _depth,
-	bool _staticCall
-):
-	evm_context{&fnTable},
-	m_envInfo(_envInfo),
-	myAddress(_myAddress),
-	caller(_caller),
-	origin(_origin),
-	value(_value),
-	gasPrice(_gasPrice),
-	data(_data),
-	code(std::move(_code)),
-	codeHash(_codeHash),
-	depth(_depth),
-	staticCall(_staticCall)
+ExtVMFace::ExtVMFace(EnvInfo const& _envInfo, Address _myAddress, Address _caller, Address _origin,
+    u256 _value, u256 _gasPrice, bytesConstRef _data, bytes _code, h256 const& _codeHash,
+    unsigned _depth, bool _isCreate, bool _staticCall)
+  : evm_context{&fnTable},
+    m_envInfo(_envInfo),
+    myAddress(_myAddress),
+    caller(_caller),
+    origin(_origin),
+    value(_value),
+    gasPrice(_gasPrice),
+    data(_data),
+    code(std::move(_code)),
+    codeHash(_codeHash),
+    depth(_depth),
+    isCreate(_isCreate),
+    staticCall(_staticCall)
 {}
 
 }

--- a/libevm/ExtVMFace.h
+++ b/libevm/ExtVMFace.h
@@ -1,18 +1,18 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 #pragma once
@@ -55,55 +55,55 @@ namespace eth
 class owning_bytes_ref: public vector_ref<byte const>
 {
 public:
-	owning_bytes_ref() = default;
+    owning_bytes_ref() = default;
 
-	/// @param _bytes  The buffer.
-	/// @param _begin  The index of the first referenced byte.
-	/// @param _size   The number of referenced bytes.
-	owning_bytes_ref(bytes&& _bytes, size_t _begin, size_t _size):
-			m_bytes(std::move(_bytes))
-	{
-		// Set the reference *after* the buffer is moved to avoid
-		// pointer invalidation.
-		retarget(&m_bytes[_begin], _size);
-	}
+    /// @param _bytes  The buffer.
+    /// @param _begin  The index of the first referenced byte.
+    /// @param _size   The number of referenced bytes.
+    owning_bytes_ref(bytes&& _bytes, size_t _begin, size_t _size):
+            m_bytes(std::move(_bytes))
+    {
+        // Set the reference *after* the buffer is moved to avoid
+        // pointer invalidation.
+        retarget(&m_bytes[_begin], _size);
+    }
 
-	owning_bytes_ref(owning_bytes_ref const&) = delete;
-	owning_bytes_ref(owning_bytes_ref&&) = default;
-	owning_bytes_ref& operator=(owning_bytes_ref const&) = delete;
-	owning_bytes_ref& operator=(owning_bytes_ref&&) = default;
+    owning_bytes_ref(owning_bytes_ref const&) = delete;
+    owning_bytes_ref(owning_bytes_ref&&) = default;
+    owning_bytes_ref& operator=(owning_bytes_ref const&) = delete;
+    owning_bytes_ref& operator=(owning_bytes_ref&&) = default;
 
-	/// Moves the bytes vector out of here. The object cannot be used any more.
-	bytes&& takeBytes()
-	{
-		reset();  // Reset reference just in case.
-		return std::move(m_bytes);
-	}
+    /// Moves the bytes vector out of here. The object cannot be used any more.
+    bytes&& takeBytes()
+    {
+        reset();  // Reset reference just in case.
+        return std::move(m_bytes);
+    }
 
 private:
-	bytes m_bytes;
+    bytes m_bytes;
 };
 
 struct SubState
 {
-	std::set<Address> suicides;	///< Any accounts that have suicided.
-	LogEntries logs;			///< Any logs.
-	u256 refunds;				///< Refund counter of SSTORE nonzero->zero.
+    std::set<Address> suicides;    ///< Any accounts that have suicided.
+    LogEntries logs;            ///< Any logs.
+    u256 refunds;                ///< Refund counter of SSTORE nonzero->zero.
 
-	SubState& operator+=(SubState const& _s)
-	{
-		suicides += _s.suicides;
-		refunds += _s.refunds;
-		logs += _s.logs;
-		return *this;
-	}
+    SubState& operator+=(SubState const& _s)
+    {
+        suicides += _s.suicides;
+        refunds += _s.refunds;
+        logs += _s.logs;
+        return *this;
+    }
 
-	void clear()
-	{
-		suicides.clear();
-		logs.clear();
-		refunds = 0;
-	}
+    void clear()
+    {
+        suicides.clear();
+        logs.clear();
+        refunds = 0;
+    }
 };
 
 class ExtVMFace;
@@ -114,58 +114,58 @@ using OnOpFunc = std::function<void(uint64_t /*steps*/, uint64_t /* PC */, Instr
 
 struct CallParameters
 {
-	CallParameters() = default;
-	CallParameters(
-		Address _senderAddress,
-		Address _codeAddress,
-		Address _receiveAddress,
-		u256 _valueTransfer,
-		u256 _apparentValue,
-		u256 _gas,
-		bytesConstRef _data,
-		OnOpFunc _onOpFunc
-	):	senderAddress(_senderAddress), codeAddress(_codeAddress), receiveAddress(_receiveAddress),
-		valueTransfer(_valueTransfer), apparentValue(_apparentValue), gas(_gas), data(_data), onOp(_onOpFunc)  {}
-	Address senderAddress;
-	Address codeAddress;
-	Address receiveAddress;
-	u256 valueTransfer;
-	u256 apparentValue;
-	u256 gas;
-	bytesConstRef data;
-	bool staticCall = false;
-	OnOpFunc onOp;
+    CallParameters() = default;
+    CallParameters(
+        Address _senderAddress,
+        Address _codeAddress,
+        Address _receiveAddress,
+        u256 _valueTransfer,
+        u256 _apparentValue,
+        u256 _gas,
+        bytesConstRef _data,
+        OnOpFunc _onOpFunc
+    ):    senderAddress(_senderAddress), codeAddress(_codeAddress), receiveAddress(_receiveAddress),
+        valueTransfer(_valueTransfer), apparentValue(_apparentValue), gas(_gas), data(_data), onOp(_onOpFunc)  {}
+    Address senderAddress;
+    Address codeAddress;
+    Address receiveAddress;
+    u256 valueTransfer;
+    u256 apparentValue;
+    u256 gas;
+    bytesConstRef data;
+    bool staticCall = false;
+    OnOpFunc onOp;
 };
 
 class EnvInfo
 {
 public:
-	EnvInfo(BlockHeader const& _current, LastBlockHashesFace const& _lh, u256 const& _gasUsed):
-		m_headerInfo(_current),
-		m_lastHashes(_lh),
-		m_gasUsed(_gasUsed)
-	{}
-	// Constructor with custom gasLimit - used in some synthetic scenarios like eth_estimateGas	RPC method
-	EnvInfo(BlockHeader const& _current, LastBlockHashesFace const& _lh, u256 const& _gasUsed, u256 const& _gasLimit):
-		EnvInfo(_current, _lh, _gasUsed)
-	{
-		m_headerInfo.setGasLimit(_gasLimit);
-	}
+    EnvInfo(BlockHeader const& _current, LastBlockHashesFace const& _lh, u256 const& _gasUsed):
+        m_headerInfo(_current),
+        m_lastHashes(_lh),
+        m_gasUsed(_gasUsed)
+    {}
+    // Constructor with custom gasLimit - used in some synthetic scenarios like eth_estimateGas    RPC method
+    EnvInfo(BlockHeader const& _current, LastBlockHashesFace const& _lh, u256 const& _gasUsed, u256 const& _gasLimit):
+        EnvInfo(_current, _lh, _gasUsed)
+    {
+        m_headerInfo.setGasLimit(_gasLimit);
+    }
 
-	BlockHeader const& header() const { return m_headerInfo;  }
+    BlockHeader const& header() const { return m_headerInfo;  }
 
-	int64_t number() const { return m_headerInfo.number(); }
-	Address const& author() const { return m_headerInfo.author(); }
-	int64_t timestamp() const { return m_headerInfo.timestamp(); }
-	u256 const& difficulty() const { return m_headerInfo.difficulty(); }
-	u256 const& gasLimit() const { return m_headerInfo.gasLimit(); }
-	LastBlockHashesFace const& lastHashes() const { return m_lastHashes; }
-	u256 const& gasUsed() const { return m_gasUsed; }
+    int64_t number() const { return m_headerInfo.number(); }
+    Address const& author() const { return m_headerInfo.author(); }
+    int64_t timestamp() const { return m_headerInfo.timestamp(); }
+    u256 const& difficulty() const { return m_headerInfo.difficulty(); }
+    u256 const& gasLimit() const { return m_headerInfo.gasLimit(); }
+    LastBlockHashesFace const& lastHashes() const { return m_lastHashes; }
+    u256 const& gasUsed() const { return m_gasUsed; }
 
 private:
-	BlockHeader m_headerInfo;
-	LastBlockHashesFace const& m_lastHashes;
-	u256 m_gasUsed;
+    BlockHeader m_headerInfo;
+    LastBlockHashesFace const& m_lastHashes;
+    u256 m_gasUsed;
 };
 
 /**
@@ -174,83 +174,82 @@ private:
 class ExtVMFace: public evm_context
 {
 public:
-	/// Null constructor.
-	ExtVMFace() = default;
+    /// Full constructor.
+    ExtVMFace(EnvInfo const& _envInfo, Address _myAddress, Address _caller, Address _origin,
+        u256 _value, u256 _gasPrice, bytesConstRef _data, bytes _code, h256 const& _codeHash,
+        unsigned _depth, bool _staticCall);
 
-	/// Full constructor.
-	ExtVMFace(EnvInfo const& _envInfo, Address _myAddress, Address _caller, Address _origin, u256 _value, u256 _gasPrice, bytesConstRef _data, bytes _code, h256 const& _codeHash, unsigned _depth, bool _staticCall);
+    virtual ~ExtVMFace() = default;
 
-	virtual ~ExtVMFace() = default;
+    ExtVMFace(ExtVMFace const&) = delete;
+    ExtVMFace& operator=(ExtVMFace const&) = delete;
 
-	ExtVMFace(ExtVMFace const&) = delete;
-	ExtVMFace& operator=(ExtVMFace const&) = delete;
+    /// Read storage location.
+    virtual u256 store(u256) { return 0; }
 
-	/// Read storage location.
-	virtual u256 store(u256) { return 0; }
+    /// Write a value in storage.
+    virtual void setStore(u256, u256) {}
 
-	/// Write a value in storage.
-	virtual void setStore(u256, u256) {}
+    /// Read address's balance.
+    virtual u256 balance(Address) { return 0; }
 
-	/// Read address's balance.
-	virtual u256 balance(Address) { return 0; }
+    /// Read address's code.
+    virtual bytes const& codeAt(Address) { return NullBytes; }
 
-	/// Read address's code.
-	virtual bytes const& codeAt(Address) { return NullBytes; }
+    /// @returns the size of the code in bytes at the given address.
+    virtual size_t codeSizeAt(Address) { return 0; }
 
-	/// @returns the size of the code in bytes at the given address.
-	virtual size_t codeSizeAt(Address) { return 0; }
+    /// Does the account exist?
+    virtual bool exists(Address) { return false; }
 
-	/// Does the account exist?
-	virtual bool exists(Address) { return false; }
+    /// Suicide the associated contract and give proceeds to the given address.
+    virtual void suicide(Address) { sub.suicides.insert(myAddress); }
 
-	/// Suicide the associated contract and give proceeds to the given address.
-	virtual void suicide(Address) { sub.suicides.insert(myAddress); }
+    /// Create a new (contract) account.
+    virtual std::pair<h160, owning_bytes_ref> create(u256, u256&, bytesConstRef, Instruction, u256, OnOpFunc const&) = 0;
 
-	/// Create a new (contract) account.
-	virtual std::pair<h160, owning_bytes_ref> create(u256, u256&, bytesConstRef, Instruction, u256, OnOpFunc const&) = 0;
+    /// Make a new message call.
+    /// @returns success flag and output data, if any.
+    virtual std::pair<bool, owning_bytes_ref> call(CallParameters&) = 0;
 
-	/// Make a new message call.
-	/// @returns success flag and output data, if any.
-	virtual std::pair<bool, owning_bytes_ref> call(CallParameters&) = 0;
+    /// Revert any changes made (by any of the other calls).
+    virtual void log(h256s&& _topics, bytesConstRef _data) { sub.logs.push_back(LogEntry(myAddress, std::move(_topics), _data.toBytes())); }
 
-	/// Revert any changes made (by any of the other calls).
-	virtual void log(h256s&& _topics, bytesConstRef _data) { sub.logs.push_back(LogEntry(myAddress, std::move(_topics), _data.toBytes())); }
+    /// Hash of a block if within the last 256 blocks, or h256() otherwise.
+    virtual h256 blockHash(u256 _number) = 0;
 
-	/// Hash of a block if within the last 256 blocks, or h256() otherwise.
-	virtual h256 blockHash(u256 _number) = 0;
+    /// Get the execution environment information.
+    EnvInfo const& envInfo() const { return m_envInfo; }
 
-	/// Get the execution environment information.
-	EnvInfo const& envInfo() const { return m_envInfo; }
-
-	/// Return the EVM gas-price schedule for this execution context.
-	virtual EVMSchedule const& evmSchedule() const { return DefaultSchedule; }
+    /// Return the EVM gas-price schedule for this execution context.
+    virtual EVMSchedule const& evmSchedule() const { return DefaultSchedule; }
 
 private:
-	EnvInfo const& m_envInfo;
+    EnvInfo const& m_envInfo;
 
 public:
-	// TODO: make private
-	Address myAddress;			///< Address associated with executing code (a contract, or contract-to-be).
-	Address caller;				///< Address which sent the message (either equal to origin or a contract).
-	Address origin;				///< Original transactor.
-	u256 value;					///< Value (in Wei) that was passed to this address.
-	u256 gasPrice;				///< Price of gas (that we already paid).
-	bytesConstRef data;			///< Current input data.
-	bytes code;					///< Current code that is executing.
-	h256 codeHash;				///< SHA3 hash of the executing code
-	SubState sub;				///< Sub-band VM state (suicides, refund counter, logs).
-	unsigned depth = 0;			///< Depth of the present call.
-	bool staticCall = false;	///< Throw on state changing.
+    // TODO: make private
+    Address myAddress;  ///< Address associated with executing code (a contract, or contract-to-be).
+    Address caller;     ///< Address which sent the message (either equal to origin or a contract).
+    Address origin;     ///< Original transactor.
+    u256 value;         ///< Value (in Wei) that was passed to this address.
+    u256 gasPrice;      ///< Price of gas (that we already paid).
+    bytesConstRef data;       ///< Current input data.
+    bytes code;               ///< Current code that is executing.
+    h256 codeHash;            ///< SHA3 hash of the executing code
+    SubState sub;             ///< Sub-band VM state (suicides, refund counter, logs).
+    unsigned depth = 0;       ///< Depth of the present call.
+    bool staticCall = false;  ///< Throw on state changing.
 };
 
 inline evm_address toEvmC(Address const& _addr)
 {
-	return reinterpret_cast<evm_address const&>(_addr);
+    return reinterpret_cast<evm_address const&>(_addr);
 }
 
 inline evm_uint256be toEvmC(h256 const& _h)
 {
-	return reinterpret_cast<evm_uint256be const&>(_h);
+    return reinterpret_cast<evm_uint256be const&>(_h);
 }
 
 }

--- a/libevm/ExtVMFace.h
+++ b/libevm/ExtVMFace.h
@@ -177,7 +177,7 @@ public:
     /// Full constructor.
     ExtVMFace(EnvInfo const& _envInfo, Address _myAddress, Address _caller, Address _origin,
         u256 _value, u256 _gasPrice, bytesConstRef _data, bytes _code, h256 const& _codeHash,
-        unsigned _depth, bool _staticCall);
+        unsigned _depth, bool _isCreate, bool _staticCall);
 
     virtual ~ExtVMFace() = default;
 
@@ -239,6 +239,7 @@ public:
     h256 codeHash;            ///< SHA3 hash of the executing code
     SubState sub;             ///< Sub-band VM state (suicides, refund counter, logs).
     unsigned depth = 0;       ///< Depth of the present call.
+    bool isCreate = false;    ///< Is this a CREATE call?
     bool staticCall = false;  ///< Throw on state changing.
 };
 

--- a/test/tools/jsontests/vm.cpp
+++ b/test/tools/jsontests/vm.cpp
@@ -36,7 +36,7 @@ using namespace dev::test;
 namespace fs = boost::filesystem;
 
 FakeExtVM::FakeExtVM(EnvInfo const& _envInfo, unsigned _depth):			/// TODO: XXX: remove the default argument & fix.
-    ExtVMFace(_envInfo, Address(), Address(), Address(), 0, 1, bytesConstRef(), bytes(), EmptySHA3, false, _depth)
+    ExtVMFace(_envInfo, Address(), Address(), Address(), 0, 1, bytesConstRef(), bytes(), EmptySHA3, false, false, _depth)
 {}
 
 std::pair<h160, eth::owning_bytes_ref> FakeExtVM::create(u256 _endowment, u256& io_gas, bytesConstRef _init, Instruction , u256, OnOpFunc const&)

--- a/test/unittests/libethereum/ExtVMTest.cpp
+++ b/test/unittests/libethereum/ExtVMTest.cpp
@@ -1,21 +1,19 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** @file ExtVMTest.cpp
- */
 
 #include <test/tools/libtesteth/BlockChainHelper.h>
 #include <test/tools/libtesteth/TestHelper.h>
@@ -24,90 +22,93 @@
 #include <libethereum/Block.h>
 #include <libethereum/ExtVM.h>
 
-using namespace std;
 using namespace dev;
 using namespace dev::eth;
 using namespace dev::test;
 
-class ExtVMTestFixture: public TestOutputHelperFixture
+class ExtVMTestFixture : public TestOutputHelperFixture
 {
 public:
-	ExtVMTestFixture():
-		networkSelector(eth::Network::ConstantinopleTransitionTest),
-		testBlockchain(TestBlockChain::defaultGenesisBlock()),
-		genesisBlock(testBlockchain.testGenesis()),
-		genesisDB(genesisBlock.state().db()),
-		blockchain(testBlockchain.getInterface())
-	{
-		TestBlock testBlock;
-		// block 1 - before Constantinople
-		testBlock.mine(testBlockchain);
-		testBlockchain.addBlock(testBlock);
+    ExtVMTestFixture()
+      : networkSelector(eth::Network::ConstantinopleTransitionTest),
+        testBlockchain(TestBlockChain::defaultGenesisBlock()),
+        genesisBlock(testBlockchain.testGenesis()),
+        genesisDB(genesisBlock.state().db()),
+        blockchain(testBlockchain.getInterface())
+    {
+        TestBlock testBlock;
+        // block 1 - before Constantinople
+        testBlock.mine(testBlockchain);
+        testBlockchain.addBlock(testBlock);
 
-		// block 2 - first Constantinople block
-		testBlock.mine(testBlockchain);
-		testBlockchain.addBlock(testBlock);
-	}
+        // block 2 - first Constantinople block
+        testBlock.mine(testBlockchain);
+        testBlockchain.addBlock(testBlock);
+    }
 
-	NetworkSelector networkSelector;
-	TestBlockChain testBlockchain;
-	TestBlock const& genesisBlock;
-	OverlayDB const& genesisDB;
-	BlockChain const& blockchain;
+    NetworkSelector networkSelector;
+    TestBlockChain testBlockchain;
+    TestBlock const& genesisBlock;
+    OverlayDB const& genesisDB;
+    BlockChain const& blockchain;
 };
 
 BOOST_FIXTURE_TEST_SUITE(ExtVmSuite, ExtVMTestFixture)
 
 BOOST_AUTO_TEST_CASE(BlockhashOutOfBoundsRetunsZero)
 {
-	Block block = blockchain.genesisBlock(genesisDB);
-	block.sync(blockchain);
+    Block block = blockchain.genesisBlock(genesisDB);
+    block.sync(blockchain);
 
-	TestLastBlockHashes lastBlockHashes({});
-	EnvInfo envInfo(block.info(), lastBlockHashes, 0);
-	Address addr("0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b");
-	ExtVM extVM(block.mutableState(), envInfo, *blockchain.sealEngine(), addr, addr, addr, 0, 0, bytesConstRef(), bytesConstRef(), h256());
+    TestLastBlockHashes lastBlockHashes({});
+    EnvInfo envInfo(block.info(), lastBlockHashes, 0);
+    Address addr("0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b");
+    ExtVM extVM(block.mutableState(), envInfo, *blockchain.sealEngine(), addr, addr, addr, 0, 0, {},
+        {}, {}, 0, false, false);
 
-	BOOST_CHECK_EQUAL(extVM.blockHash(100), h256());
+    BOOST_CHECK_EQUAL(extVM.blockHash(100), h256());
 }
 
 BOOST_AUTO_TEST_CASE(BlockhashBeforeConstantinopleReliesOnLastHashes)
 {
-	Block block = blockchain.genesisBlock(genesisDB);
-	block.sync(blockchain);
-	
-	h256s lastHashes{h256("0xaaabbbccc"), h256("0xdddeeefff")};
-	TestLastBlockHashes lastBlockHashes(lastHashes);
-	EnvInfo envInfo(block.info(), lastBlockHashes, 0);
-	Address addr("0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b");
-	ExtVM extVM(block.mutableState(), envInfo, *blockchain.sealEngine(), addr, addr, addr, 0, 0, bytesConstRef(), bytesConstRef(), h256());
-	h256 hash = extVM.blockHash(1);
-	BOOST_REQUIRE_EQUAL(hash, lastHashes[0]);
+    Block block = blockchain.genesisBlock(genesisDB);
+    block.sync(blockchain);
+
+    h256s lastHashes{h256("0xaaabbbccc"), h256("0xdddeeefff")};
+    TestLastBlockHashes lastBlockHashes(lastHashes);
+    EnvInfo envInfo(block.info(), lastBlockHashes, 0);
+    Address addr("0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b");
+    ExtVM extVM(block.mutableState(), envInfo, *blockchain.sealEngine(), addr, addr, addr, 0, 0, {},
+        {}, {}, 0, false, false);
+    h256 hash = extVM.blockHash(1);
+    BOOST_REQUIRE_EQUAL(hash, lastHashes[0]);
 }
 
 BOOST_AUTO_TEST_CASE(BlockhashDoesntNeedLastHashesInConstantinople)
 {
-	// BLOCKHASH starts to work through the call to a contract 256 block after Constantinople fork block
-	TestBlock testBlock;
-	for (int i = 0; i < 256; ++i)
-	{
-		testBlock.mine(testBlockchain);
-		testBlockchain.addBlock(testBlock);
-	}
+    // BLOCKHASH starts to work through the call to a contract 256 block after Constantinople fork
+    // block
+    TestBlock testBlock;
+    for (int i = 0; i < 256; ++i)
+    {
+        testBlock.mine(testBlockchain);
+        testBlockchain.addBlock(testBlock);
+    }
 
-	Block block = blockchain.genesisBlock(genesisDB);
-	block.sync(blockchain);
+    Block block = blockchain.genesisBlock(genesisDB);
+    block.sync(blockchain);
 
-	TestLastBlockHashes lastBlockHashes({});
-	EnvInfo envInfo(block.info(), lastBlockHashes, 0);
-	Address addr("0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b");
-	ExtVM extVM(block.mutableState(), envInfo, *blockchain.sealEngine(), addr, addr, addr, 0, 0, bytesConstRef(), bytesConstRef(), h256());
+    TestLastBlockHashes lastBlockHashes({});
+    EnvInfo envInfo(block.info(), lastBlockHashes, 0);
+    Address addr("0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b");
+    ExtVM extVM(block.mutableState(), envInfo, *blockchain.sealEngine(), addr, addr, addr, 0, 0, {},
+        {}, {}, 0, false, false);
 
-	// older than 256 not available
-	BOOST_CHECK_EQUAL(extVM.blockHash(1), h256());
+    // older than 256 not available
+    BOOST_CHECK_EQUAL(extVM.blockHash(1), h256());
 
-	h256 hash = extVM.blockHash(200);
-	BOOST_REQUIRE_EQUAL(hash, blockchain.numberHash(200));
+    h256 hash = extVM.blockHash(200);
+    BOOST_REQUIRE_EQUAL(hash, blockchain.numberHash(200));
 }
 
 


### PR DESCRIPTION
Main feature: pass information whatever a call is a CREATE to the EVM-C VMs.
This PR also contains a lot of code formatting and cleanups. Sorry for that, but that was not avoidable. You can review commit by commit.

@axic @hugo-dc 