### PR TITLE
 ethvm: Do not chenge VM selection depending on tracing

### DIFF
--- a/ethvm/main.cpp
+++ b/ethvm/main.cpp
@@ -330,7 +330,7 @@ int main(int argc, char** argv)
             counts[(byte)inst].first++;
             counts[(byte)inst].second += gasCost;
             total++;
-            if (m > 0)
+            if (m > memTotal)
                 memTotal = m;
         };
     }

--- a/ethvm/main.cpp
+++ b/ethvm/main.cpp
@@ -14,29 +14,29 @@
     You should have received a copy of the GNU General Public License
     along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** @file main.cpp
- * @author Gav Wood <i@gavwood.com>
- * @date 2014
- * EVM Execution tool.
- */
+
+/// @file
+/// EVM Execution tool.
 
 #include <libdevcore/CommonIO.h>
 #include <libdevcore/SHA3.h>
+#include <libethashseal/Ethash.h>
+#include <libethashseal/GenesisInfo.h>
 #include <libethcore/SealEngine.h>
 #include <libethereum/Block.h>
-#include <libethereum/Executive.h>
 #include <libethereum/ChainParams.h>
+#include <libethereum/Executive.h>
 #include <libethereum/LastBlockHashesFace.h>
-#include <libethashseal/GenesisInfo.h>
-#include <libethashseal/Ethash.h>
 #include <libevm/VM.h>
 #include <libevm/VMFactory.h>
+
 #include <boost/algorithm/string.hpp>
 #include <boost/program_options.hpp>
-#include <boost/program_options/options_description.hpp>
+
+#include <ctime>
 #include <fstream>
 #include <iostream>
-#include <ctime>
+
 using namespace std;
 using namespace dev;
 using namespace eth;
@@ -44,12 +44,12 @@ namespace po = boost::program_options;
 
 namespace
 {
-
 unsigned const c_lineWidth = 160;
 
 int64_t maxBlockGasLimit()
 {
-    static int64_t limit = ChainParams(genesisInfo(Network::MainNetwork)).maxGasLimit.convert_to<int64_t>();
+    static int64_t limit =
+        ChainParams(genesisInfo(Network::MainNetwork)).maxGasLimit.convert_to<int64_t>();
     return limit;
 }
 
@@ -57,7 +57,8 @@ void version()
 {
     cout << "ethvm version " << dev::Version << "\n";
     cout << "By Gav Wood, 2015.\n";
-    cout << "Build: " << DEV_QUOTED(ETH_BUILD_PLATFORM) << "/" << DEV_QUOTED(ETH_BUILD_TYPE) << "\n";
+    cout << "Build: " << DEV_QUOTED(ETH_BUILD_PLATFORM) << "/" << DEV_QUOTED(ETH_BUILD_TYPE)
+         << "\n";
     exit(0);
 }
 
@@ -95,13 +96,15 @@ enum class Mode
     /// performance.
     Test
 };
-
 }
 
-class LastBlockHashes: public eth::LastBlockHashesFace
+class LastBlockHashes : public eth::LastBlockHashesFace
 {
 public:
-    h256s precedingHashes(h256 const& /* _mostRecentHash */) const override { return h256s(256, h256()); }
+    h256s precedingHashes(h256 const& /* _mostRecentHash */) const override
+    {
+        return h256s(256, h256());
+    }
     void clear() override {}
 };
 
@@ -119,7 +122,7 @@ int main(int argc, char** argv)
     bool styledJson = true;
     StandardTrace st;
     Network networkName = Network::MainNetworkTest;
-    BlockHeader blockHeader; // fake block to be executed in
+    BlockHeader blockHeader;  // fake block to be executed in
     blockHeader.setGasLimit(maxBlockGasLimit());
     blockHeader.setTimestamp(0);
     bytes data;
@@ -129,7 +132,8 @@ int main(int argc, char** argv)
     NoProof::init();
 
     po::options_description transactionOptions("Transaction options", c_lineWidth);
-    string const gasLimitDescription = "<n> Block gas limit (default: " + to_string(maxBlockGasLimit()) + ").";
+    string const gasLimitDescription =
+        "<n> Block gas limit (default: " + to_string(maxBlockGasLimit()) + ").";
     auto addTransactionOption = transactionOptions.add_options();
     addTransactionOption(
         "value", po::value<u256>(), "<n> Transaction should transfer the <n> wei (default: 0).");
@@ -147,8 +151,8 @@ int main(int argc, char** argv)
         "<d> Contract code <d>. Makes transaction a call to this contract");
 
     po::options_description networkOptions("Network options", c_lineWidth);
-    networkOptions.add_options()
-        ("network",  po::value<string>(), "Main|Ropsten|Homestead|Frontier|Byzantium|Constantinople\n");
+    networkOptions.add_options()("network", po::value<string>(),
+        "Main|Ropsten|Homestead|Frontier|Byzantium|Constantinople\n");
 
     po::options_description optionsForTrace("Options for trace", c_lineWidth);
     auto addTraceOption = optionsForTrace.add_options();
@@ -189,9 +193,8 @@ int main(int argc, char** argv)
     po::notify(vm);
 
     // handling mode and input file options separately, as they don't have option name
-    for (size_t i = 0; i < unrecognisedOptions.size(); ++i)
+    for (auto const& arg : unrecognisedOptions)
     {
-        string arg = unrecognisedOptions[i];
         if (arg == "stats")
             mode = Mode::Statistics;
         else if (arg == "output")
@@ -211,7 +214,7 @@ int main(int argc, char** argv)
     if (vm.count("help"))
     {
         cout << allowedOptions;
-        exit(0);
+        return 0;
     }
     if (vm.count("version"))
     {
@@ -272,7 +275,7 @@ int main(int argc, char** argv)
 
         if (inputFile == "-")
             for (int i = cin.get(); i != -1; i = cin.get())
-                code.push_back((char)i);
+                code.push_back(static_cast<byte>(i));
         else
             code = contents(inputFile);
 
@@ -282,7 +285,9 @@ int main(int argc, char** argv)
             strCode.erase(strCode.find_last_not_of(" \t\n\r") + 1);  // Right trim.
             code = fromHex(strCode, WhenError::Throw);
         }
-        catch (BadHexCharacter const&) {}  // Ignore decoding errors.
+        catch (BadHexCharacter const&)
+        {
+        }  // Ignore decoding errors.
     }
 
     Transaction t;
@@ -327,8 +332,9 @@ int main(int argc, char** argv)
     {
         onOp = [&](uint64_t, uint64_t, Instruction inst, bigint m, bigint gasCost, bigint,
                    VMFace const*, ExtVMFace const*) {
-            counts[(byte)inst].first++;
-            counts[(byte)inst].second += gasCost;
+            byte b = static_cast<byte>(inst);
+            counts[b].first++;
+            counts[b].second += gasCost;
             total++;
             if (m > memTotal)
                 memTotal = m;
@@ -345,23 +351,31 @@ int main(int argc, char** argv)
 
     if (mode == Mode::Statistics)
     {
-        cout << "Gas used: " << res.gasUsed << " (+" << t.baseGasRequired(se->evmSchedule(envInfo.number())) << " for transaction, -" << res.gasRefunded << " refunded)\n";
+        cout << "Gas used: " << res.gasUsed << " (+"
+             << t.baseGasRequired(se->evmSchedule(envInfo.number())) << " for transaction, -"
+             << res.gasRefunded << " refunded)\n";
         cout << "Output: " << toHex(output) << "\n";
         LogEntries logs = executive.logs();
         cout << logs.size() << " logs" << (logs.empty() ? "." : ":") << "\n";
-        for (LogEntry const& l: logs)
+        for (LogEntry const& l : logs)
         {
             cout << "  " << l.address.hex() << ": " << toHex(t.data()) << "\n";
-            for (h256 const& t: l.topics)
-                cout << "    " << t.hex() << "\n";
+            for (h256 const& topic : l.topics)
+                cout << "    " << topic.hex() << "\n";
         }
 
         cout << total << " operations in " << execTime << " seconds.\n";
         cout << "Maximum memory usage: " << memTotal * 32 << " bytes\n";
         cout << "Expensive operations:\n";
-        for (auto const& c: {Instruction::SSTORE, Instruction::SLOAD, Instruction::CALL, Instruction::CREATE, Instruction::CALLCODE, Instruction::DELEGATECALL, Instruction::MSTORE8, Instruction::MSTORE, Instruction::MLOAD, Instruction::SHA3})
-            if (!!counts[(byte)c].first)
-                cout << "  " << instructionInfo(c).name << " x " << counts[(byte)c].first << " (" << counts[(byte)c].second << " gas)\n";
+        for (auto const inst : {Instruction::SSTORE, Instruction::SLOAD, Instruction::CALL,
+                 Instruction::CREATE, Instruction::CALLCODE, Instruction::DELEGATECALL,
+                 Instruction::MSTORE8, Instruction::MSTORE, Instruction::MLOAD, Instruction::SHA3})
+        {
+            auto const& count = counts[static_cast<byte>(inst)];
+            if (count.first != 0)
+                cout << "  " << instructionInfo(inst).name << " x " << count.first << " ("
+                     << count.second << " gas)\n";
+        }
     }
     else if (mode == Mode::Trace)
         cout << st.json(styledJson);
@@ -375,7 +389,8 @@ int main(int argc, char** argv)
         cout << "output: '" << toHex(output) << "'\n";
         cout << "exception: " << boolalpha << exception << '\n';
         cout << "gas used: " << res.gasUsed << '\n';
-        cout << "gas/sec: " << scientific << setprecision(3) << uint64_t(res.gasUsed)/execTime << '\n';
+        cout << "gas/sec: " << scientific << setprecision(3) << uint64_t(res.gasUsed) / execTime
+             << '\n';
         cout << "exec time: " << fixed << setprecision(6) << execTime << '\n';
     }
     return 0;

--- a/libethereum/Executive.cpp
+++ b/libethereum/Executive.cpp
@@ -411,7 +411,7 @@ bool Executive::go(OnOpFunc const& _onOp)
         try
         {
             // Create VM instance. Force Interpreter if tracing requested.
-            auto vm = _onOp ? VMFactory::create(VMKind::Legacy) : VMFactory::create();
+            auto vm = VMFactory::create();
             if (m_isCreation)
             {
                 m_s.clearStorage(m_ext->myAddress);


### PR DESCRIPTION
Mostly: do not force Interpreter if VM tracing is required. Also cleanups some parts of ethvm.

Fixes https://github.com/ethereum/cpp-ethereum/issues/4899.
Fixes https://github.com/ethereum/cpp-ethereum/issues/4795.