### PR TITLE
Interpreter using EVM-C

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -109,6 +109,12 @@ defaults:
     - *store-testeth
     - *restore-ethash-dag
     - *test
+    - run:
+        name: "Test EVM-C Interpreter"
+        working_directory: ~/build
+        command: |
+          ETHEREUM_TEST_PATH=~/project/test/jsontests \
+          test/testeth -t GeneralStateTests -- --vm interpreter
     - *save-ethash-dag
     - *upload-coverage-data
 

--- a/libevm/CMakeLists.txt
+++ b/libevm/CMakeLists.txt
@@ -1,7 +1,9 @@
 
 set(sources
+    EVMC.cpp EVMC.h
     ExtVMFace.cpp ExtVMFace.h
     Instruction.cpp Instruction.h
+    interpreter.h
     LegacyVM.cpp LegacyVM.h
     LegacyVMCalls.cpp
     LegacyVMOpt.cpp
@@ -14,12 +16,6 @@ set(sources
     VMValidate.cpp
     VMFactory.cpp VMFactory.h
 )
-
-if(EVMJIT OR HERA)
-    list(APPEND sources
-        EVMC.cpp EVMC.h
-    )
-endif()
 
 add_library(evm ${sources})
 

--- a/libevm/VM.cpp
+++ b/libevm/VM.cpp
@@ -18,20 +18,16 @@
 #include "interpreter.h"
 #include "VM.h"
 
-using namespace std;
-using namespace dev;
-using namespace dev::eth;
-
 extern "C" evm_instance* interpreter_create() noexcept
 {
-    return new (std::nothrow) VM;
+    return new (std::nothrow) dev::eth::VM;
 }
 
 namespace
 {
 void destroy(evm_instance* _instance)
 {
-    delete static_cast<VM*>(_instance);
+    delete static_cast<dev::eth::VM*>(_instance);
 }
 
 void delete_output(const evm_result* result)
@@ -42,7 +38,7 @@ void delete_output(const evm_result* result)
 evm_result execute(evm_instance* _instance, evm_context* _context, evm_revision _rev,
     const evm_message* _msg, uint8_t const* _code, size_t _codeSize) noexcept
 {
-    auto vm = static_cast<VM*>(_instance);
+    auto vm = static_cast<dev::eth::VM*>(_instance);
     evm_result result = {};
     dev::eth::owning_bytes_ref output;
 
@@ -52,13 +48,13 @@ evm_result execute(evm_instance* _instance, evm_context* _context, evm_revision 
         result.status_code = EVM_SUCCESS;
         result.gas_left = vm->m_io_gas;
     }
-    catch (RevertInstruction& ex)
+    catch (dev::eth::RevertInstruction& ex)
     {
         result.status_code = EVM_REVERT;
         result.gas_left = vm->m_io_gas;
         output = ex.output();  // This moves the output from the exception!
     }
-    catch (VMException const&)
+    catch (dev::eth::VMException const&)
     {
         result.status_code = EVM_FAILURE;
     }
@@ -326,8 +322,8 @@ void VM::interpretCases()
 
             uint64_t b = (uint64_t)m_SP[0];
             uint64_t s = (uint64_t)m_SP[1];
-            owning_bytes_ref output{move(m_mem), b, s};
-            throwRevertInstruction(move(output));
+            owning_bytes_ref output{std::move(m_mem), b, s};
+            throwRevertInstruction(std::move(output));
         }
         BREAK;
 

--- a/libevm/VM.cpp
+++ b/libevm/VM.cpp
@@ -174,13 +174,12 @@ void VM::fetchInstruction()
 //
 // interpreter entry point
 
-owning_bytes_ref VM::exec(u256& _io_gas, ExtVMFace& _ext, OnOpFunc const& _onOp)
+owning_bytes_ref VM::exec(u256& _io_gas, ExtVMFace& _ext)
 {
     m_io_gas_p = &_io_gas;
     m_io_gas = uint64_t(_io_gas);
     m_ext = &_ext;
     m_schedule = &m_ext->evmSchedule();
-    m_onOp = _onOp;
     m_onFail = nullptr;  // TODO: Check if ever used.
     m_PC = 0;
 

--- a/libevm/VM.cpp
+++ b/libevm/VM.cpp
@@ -15,11 +15,33 @@
     along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include "interpreter.h"
 #include "VM.h"
 
 using namespace std;
 using namespace dev;
 using namespace dev::eth;
+
+extern "C" evm_instance* interpreter_create() noexcept
+{
+    return new (std::nothrow) VM;
+}
+
+namespace
+{
+void destroy(evm_instance* _instance)
+{
+    delete static_cast<VM*>(_instance);
+}
+}
+
+
+namespace dev
+{
+namespace eth
+{
+VM::VM() : evm_instance{EVM_ABI_VERSION, ::destroy, nullptr, nullptr}
+{}
 
 uint64_t VM::memNeed(u256 _offset, u256 _size)
 {
@@ -1627,4 +1649,6 @@ void VM::interpretCases()
         }
     }
     WHILE_CASES
+}
+}
 }

--- a/libevm/VM.cpp
+++ b/libevm/VM.cpp
@@ -33,6 +33,18 @@ void destroy(evm_instance* _instance)
 {
     delete static_cast<VM*>(_instance);
 }
+
+evm_result execute(evm_instance* _instance, evm_context* _context, evm_revision _rev,
+    const evm_message* _msg, uint8_t const* _code, size_t _codeSize)
+{
+    auto vm = static_cast<VM*>(_instance);
+    u256 gas = _msg->gas;
+    (void)_rev;
+    (void)_code;
+    (void)_codeSize;
+    vm->exec(gas, *(ExtVMFace*)(_context));
+    return {};
+}
 }
 
 
@@ -40,8 +52,7 @@ namespace dev
 {
 namespace eth
 {
-VM::VM() : evm_instance{EVM_ABI_VERSION, ::destroy, nullptr, nullptr}
-{}
+VM::VM() : evm_instance{EVM_ABI_VERSION, ::destroy, ::execute, nullptr} {}
 
 uint64_t VM::memNeed(u256 _offset, u256 _size)
 {

--- a/libevm/VM.cpp
+++ b/libevm/VM.cpp
@@ -34,16 +34,50 @@ void destroy(evm_instance* _instance)
     delete static_cast<VM*>(_instance);
 }
 
+void delete_output(const evm_result* result)
+{
+    delete[] result->output_data;
+}
+
 evm_result execute(evm_instance* _instance, evm_context* _context, evm_revision _rev,
-    const evm_message* _msg, uint8_t const* _code, size_t _codeSize)
+    const evm_message* _msg, uint8_t const* _code, size_t _codeSize) noexcept
 {
     auto vm = static_cast<VM*>(_instance);
-    u256 gas = _msg->gas;
-    (void)_rev;
-    (void)_code;
-    (void)_codeSize;
-    vm->exec(gas, *(ExtVMFace*)(_context));
-    return {};
+    evm_result result = {};
+    dev::eth::owning_bytes_ref output;
+
+    try
+    {
+        output = vm->exec(_context, _rev, _msg, _code, _codeSize);
+        result.status_code = EVM_SUCCESS;
+        result.gas_left = vm->m_io_gas;
+    }
+    catch (RevertInstruction& ex)
+    {
+        result.status_code = EVM_REVERT;
+        result.gas_left = vm->m_io_gas;
+        output = ex.output();  // This moves the output from the exception!
+    }
+    catch (VMException const&)
+    {
+        result.status_code = EVM_FAILURE;
+    }
+    catch (...)
+    {
+        result.status_code = EVM_INTERNAL_ERROR;
+    }
+
+    if (!output.empty())
+    {
+        // Make a copy of the output.
+        auto outputData = new uint8_t[output.size()];
+        std::memcpy(outputData, output.data(), output.size());
+        result.output_data = outputData;
+        result.output_size = output.size();
+        result.release = delete_output;
+    }
+
+    return result;
 }
 }
 
@@ -119,22 +153,20 @@ void VM::adjustStack(unsigned _removed, unsigned _added)
 
 void VM::updateSSGas()
 {
-    if (!m_ext->store(m_SP[0]) && m_SP[1])
-        m_runGas = toInt63(m_schedule->sstoreSetGas);
-    else if (m_ext->store(m_SP[0]) && !m_SP[1])
-    {
-        m_runGas = toInt63(m_schedule->sstoreResetGas);
-        m_ext->sub.refunds += m_schedule->sstoreRefundGas;
-    }
+    evm_uint256be key = toEvmC(m_SP[0]);
+    evm_uint256be rawValue;
+    m_context->fn_table->get_storage(&rawValue, m_context, &m_message->destination, &key);
+    u256 value = fromEvmC(rawValue);
+    if (!value && m_SP[1])
+        m_runGas = VMSchedule::sstoreSetGas;
     else
-        m_runGas = toInt63(m_schedule->sstoreResetGas);
+        m_runGas = toInt63(VMSchedule::sstoreResetGas);
 }
-
 
 uint64_t VM::gasForMem(u512 _size)
 {
     u512 s = _size / 32;
-    return toInt63((u512)m_schedule->memoryGas * s + s * s / m_schedule->quadCoeffDiv);
+    return toInt63((u512) VMSchedule::memoryGas * s + s * s / VMSchedule::quadCoeffDiv);
 }
 
 void VM::updateIOGas()
@@ -148,7 +180,7 @@ void VM::updateGas()
 {
     if (m_newMemSize > m_mem.size())
         m_runGas += toInt63(gasForMem(m_newMemSize) - gasForMem(m_mem.size()));
-    m_runGas += (m_schedule->copyGas * ((m_copyMemSize + 31) / 32));
+    m_runGas += (VMSchedule::copyGas * ((m_copyMemSize + 31) / 32));
     if (m_io_gas < m_runGas)
         throwOutOfGas();
 }
@@ -163,8 +195,9 @@ void VM::updateMem(uint64_t _newMem)
 
 void VM::logGasMem()
 {
-    unsigned n = (unsigned)m_OP - (unsigned)Instruction::LOG0;
-    m_runGas = toInt63(m_schedule->logGas + m_schedule->logTopicGas * n + u512(m_schedule->logDataGas) * m_SP[1]);
+    unsigned n = (unsigned) m_OP - (unsigned) Instruction::LOG0;
+    m_runGas = toInt63(
+        VMSchedule::logGas + VMSchedule::logTopicGas * n + u512(VMSchedule::logDataGas) * m_SP[1]);
     updateMem(memNeed(m_SP[0], m_SP[1]));
 }
 
@@ -175,9 +208,20 @@ void VM::fetchInstruction()
     adjustStack(metric.args, metric.ret);
 
     // FEES...
-    m_runGas = toInt63(m_schedule->tierStepGas[static_cast<unsigned>(metric.gasPriceTier)]);
+    std::array<int64_t, 9> tierStepGas{{0, 2, 3, 5, 8, 10, 20, 0, 0}};
+    m_runGas = tierStepGas[static_cast<unsigned>(metric.gasPriceTier)];
     m_newMemSize = m_mem.size();
     m_copyMemSize = 0;
+}
+
+evm_tx_context const& VM::getTxContext()
+{
+    if (!m_tx_context)
+    {
+        m_tx_context.emplace();
+        m_context->fn_table->get_tx_context(&m_tx_context.value(), m_context);
+    }
+    return m_tx_context.value();
 }
 
 
@@ -185,31 +229,23 @@ void VM::fetchInstruction()
 //
 // interpreter entry point
 
-owning_bytes_ref VM::exec(u256& _io_gas, ExtVMFace& _ext)
+owning_bytes_ref VM::exec(evm_context* _context, evm_revision _rev, const evm_message* _msg,
+    uint8_t const* _code, size_t _codeSize)
 {
-    m_io_gas_p = &_io_gas;
-    m_io_gas = uint64_t(_io_gas);
-    m_ext = &_ext;
-    m_schedule = &m_ext->evmSchedule();
-    m_onFail = nullptr;  // TODO: Check if ever used.
+    m_context = _context;
+    m_rev = _rev;
+    m_message = _msg;
+    m_io_gas = uint64_t(_msg->gas);
     m_PC = 0;
+    m_pCode = _code;
+    m_codeSize = _codeSize;
 
-    try
-    {
-        // trampoline to minimize depth of call stack when calling out
-        m_bounce = &VM::initEntry;
-        do
-            (this->*m_bounce)();
-        while (m_bounce);
+    // trampoline to minimize depth of call stack when calling out
+    m_bounce = &VM::initEntry;
+    do
+        (this->*m_bounce)();
+    while (m_bounce);
 
-    }
-    catch (...)
-    {
-        *m_io_gas_p = m_io_gas;
-        throw;
-    }
-
-    *m_io_gas_p = m_io_gas;
     return std::move(m_output);
 }
 
@@ -228,8 +264,8 @@ void VM::interpretCases()
         CASE(CREATE2)
         {
             ON_OP();
-            if (!m_schedule->haveCreate2)
-                throwBadInstruction();
+            // TODO: Bring back support for CREATE2.
+            throwBadInstruction();
 
             m_bounce = &VM::caseCreate;
         }
@@ -238,7 +274,7 @@ void VM::interpretCases()
         CASE(CREATE)
         {
             ON_OP();
-            if (m_ext->staticCall)
+            if (m_message->flags & EVM_STATIC)
                 throwDisallowedStateChange();
 
             m_bounce = &VM::caseCreate;
@@ -251,11 +287,11 @@ void VM::interpretCases()
         CASE(CALLCODE)
         {
             ON_OP();
-            if (m_OP == Instruction::DELEGATECALL && !m_schedule->haveDelegateCall)
+            if (m_OP == Instruction::DELEGATECALL && m_rev < EVM_HOMESTEAD)
                 throwBadInstruction();
-            if (m_OP == Instruction::STATICCALL && !m_schedule->haveStaticCall)
+            if (m_OP == Instruction::STATICCALL && m_rev < EVM_BYZANTIUM)
                 throwBadInstruction();
-            if (m_OP == Instruction::CALL && m_ext->staticCall && m_SP[2] != 0)
+            if (m_OP == Instruction::CALL && m_message->flags & EVM_STATIC && m_SP[2] != 0)
                 throwDisallowedStateChange();
             m_bounce = &VM::caseCall;
         }
@@ -278,7 +314,7 @@ void VM::interpretCases()
         CASE(REVERT)
         {
             // Pre-byzantium
-            if (!m_schedule->haveRevert)
+            if (m_rev < EVM_BYZANTIUM)
                 throwBadInstruction();
 
             ON_OP();
@@ -296,22 +332,29 @@ void VM::interpretCases()
         CASE(SUICIDE)
         {
             ON_OP();
-            if (m_ext->staticCall)
+            if (m_message->flags & EVM_STATIC)
                 throwDisallowedStateChange();
 
-            m_runGas = toInt63(m_schedule->suicideGas);
-            Address dest = asAddress(m_SP[0]);
+            m_runGas = m_rev >= EVM_TANGERINE_WHISTLE ? 5000 : 0;
+            evm_address destination = toEvmC(asAddress(m_SP[0]));
 
             // After EIP158 zero-value suicides do not have to pay account creation gas.
-            if (m_ext->balance(m_ext->myAddress) > 0 || m_schedule->zeroValueTransferChargesNewAccountGas())
+            evm_uint256be rawBalance;
+            m_context->fn_table->get_balance(&rawBalance, m_context, &m_message->destination);
+            u256 balance = fromEvmC(rawBalance);
+            if (balance > 0 || m_rev < EVM_SPURIOUS_DRAGON)
+            {
                 // After EIP150 hard fork charge additional cost of sending
                 // ethers to non-existing account.
-                if (m_schedule->suicideChargesNewAccountGas() && !m_ext->exists(dest))
-                    m_runGas += m_schedule->callNewAccountGas;
+                int destinationExists =
+                    m_context->fn_table->account_exists(m_context, &destination);
+                if (m_rev >= EVM_TANGERINE_WHISTLE && !destinationExists)
+                    m_runGas += VMSchedule::callNewAccount;
+            }
 
             updateIOGas();
-            m_ext->suicide(dest);
-            m_bounce = 0;
+            m_context->fn_table->selfdestruct(m_context, &m_message->destination, &destination);
+            m_bounce = nullptr;
         }
         BREAK
 
@@ -361,7 +404,7 @@ void VM::interpretCases()
         CASE(SHA3)
         {
             ON_OP();
-            m_runGas = toInt63(m_schedule->sha3Gas + (u512(m_SP[1]) + 31) / 32 * m_schedule->sha3WordGas);
+            m_runGas = toInt63(VMSchedule::sha3Gas + (u512(m_SP[1]) + 31) / 32 * VMSchedule::sha3WordGas);
             updateMem(memNeed(m_SP[0], m_SP[1]));
             updateIOGas();
 
@@ -374,72 +417,106 @@ void VM::interpretCases()
         CASE(LOG0)
         {
             ON_OP();
-            if (m_ext->staticCall)
+            if (m_message->flags & EVM_STATIC)
                 throwDisallowedStateChange();
 
             logGasMem();
             updateIOGas();
 
-            m_ext->log({}, bytesConstRef(m_mem.data() + (uint64_t)m_SP[0], (uint64_t)m_SP[1]));
+            uint8_t const* data = m_mem.data() + size_t(m_SP[0]);
+            size_t dataSize = size_t(m_SP[1]);
+
+            m_context->fn_table->emit_log(
+                m_context, &m_message->destination, data, dataSize, nullptr, 0);
         }
         NEXT
 
         CASE(LOG1)
         {
             ON_OP();
-            if (m_ext->staticCall)
+            if (m_message->flags & EVM_STATIC)
                 throwDisallowedStateChange();
 
             logGasMem();
             updateIOGas();
 
-            m_ext->log({m_SP[2]}, bytesConstRef(m_mem.data() + (uint64_t)m_SP[0], (uint64_t)m_SP[1]));
+            uint8_t const* data = m_mem.data() + size_t(m_SP[0]);
+            size_t dataSize = size_t(m_SP[1]);
+
+            evm_uint256be topics[] = {toEvmC(m_SP[2])};
+            size_t numTopics = sizeof(topics) / sizeof(topics[0]);
+
+            m_context->fn_table->emit_log(
+                m_context, &m_message->destination, data, dataSize, topics, numTopics);
         }
         NEXT
 
         CASE(LOG2)
         {
             ON_OP();
-            if (m_ext->staticCall)
+            if (m_message->flags & EVM_STATIC)
                 throwDisallowedStateChange();
 
             logGasMem();
             updateIOGas();
 
-            m_ext->log({m_SP[2], m_SP[3]}, bytesConstRef(m_mem.data() + (uint64_t)m_SP[0], (uint64_t)m_SP[1]));
+            uint8_t const* data = m_mem.data() + size_t(m_SP[0]);
+            size_t dataSize = size_t(m_SP[1]);
+
+            evm_uint256be topics[] = {toEvmC(m_SP[2]), toEvmC(m_SP[3])};
+            size_t numTopics = sizeof(topics) / sizeof(topics[0]);
+
+            m_context->fn_table->emit_log(
+                m_context, &m_message->destination, data, dataSize, topics, numTopics);
         }
         NEXT
 
         CASE(LOG3)
         {
             ON_OP();
-            if (m_ext->staticCall)
+            if (m_message->flags & EVM_STATIC)
                 throwDisallowedStateChange();
 
             logGasMem();
             updateIOGas();
 
-            m_ext->log({m_SP[2], m_SP[3], m_SP[4]}, bytesConstRef(m_mem.data() + (uint64_t)m_SP[0], (uint64_t)m_SP[1]));
+            uint8_t const* data = m_mem.data() + size_t(m_SP[0]);
+            size_t dataSize = size_t(m_SP[1]);
+
+            evm_uint256be topics[] = {toEvmC(m_SP[2]), toEvmC(m_SP[3]), toEvmC(m_SP[4])};
+            size_t numTopics = sizeof(topics) / sizeof(topics[0]);
+
+            m_context->fn_table->emit_log(
+                m_context, &m_message->destination, data, dataSize, topics, numTopics);
         }
         NEXT
 
         CASE(LOG4)
         {
             ON_OP();
-            if (m_ext->staticCall)
+            if (m_message->flags & EVM_STATIC)
                 throwDisallowedStateChange();
 
             logGasMem();
             updateIOGas();
 
-            m_ext->log({m_SP[2], m_SP[3], m_SP[4], m_SP[5]}, bytesConstRef(m_mem.data() + (uint64_t)m_SP[0], (uint64_t)m_SP[1]));
+            uint8_t const* data = m_mem.data() + size_t(m_SP[0]);
+            size_t dataSize = size_t(m_SP[1]);
+
+            evm_uint256be topics[] = {
+                toEvmC(m_SP[2]), toEvmC(m_SP[3]), toEvmC(m_SP[4]), toEvmC(m_SP[5])};
+            size_t numTopics = sizeof(topics) / sizeof(topics[0]);
+
+            m_context->fn_table->emit_log(
+                m_context, &m_message->destination, data, dataSize, topics, numTopics);
         }
         NEXT
 
         CASE(EXP)
         {
             u256 expon = m_SP[1];
-            m_runGas = toInt63(m_schedule->expGas + m_schedule->expByteGas * (32 - (h256(expon).firstBitSet() / 8)));
+            const int64_t byteCost = m_rev >= EVM_SPURIOUS_DRAGON ? 50 : 10;
+            m_runGas = toInt63(VMSchedule::stepGas5 + byteCost * (32 - (h256(expon).firstBitSet() / 8)));
             ON_OP();
             updateIOGas();
 
@@ -620,7 +697,7 @@ void VM::interpretCases()
         CASE(SHL)
         {
             // Pre-constantinople
-            if (!m_schedule->haveBitwiseShifting)
+            if (m_rev < EVM_CONSTANTINOPLE)
                 throwBadInstruction();
 
             ON_OP();
@@ -636,7 +713,7 @@ void VM::interpretCases()
         CASE(SHR)
         {
             // Pre-constantinople
-            if (!m_schedule->haveBitwiseShifting)
+            if (m_rev < EVM_CONSTANTINOPLE)
                 throwBadInstruction();
 
             ON_OP();
@@ -652,7 +729,7 @@ void VM::interpretCases()
         CASE(SAR)
         {
             // Pre-constantinople
-            if (!m_schedule->haveBitwiseShifting)
+            if (m_rev < EVM_CONSTANTINOPLE)
                 throwBadInstruction();
 
             ON_OP();
@@ -1051,7 +1128,7 @@ void VM::interpretCases()
 
         CASE(XSSTORE)
         {
-            if (m_ext->staticCall)
+            if (m_message->flags & EVM_STATIC)
                 throwDisallowedStateChange();
 
             updateSSGas();
@@ -1175,7 +1252,7 @@ void VM::interpretCases()
             ON_OP();
             updateIOGas();
 
-            m_SPP[0] = fromAddress(m_ext->myAddress);
+            m_SPP[0] = fromAddress(fromEvmC(m_message->destination));
         }
         NEXT
 
@@ -1184,17 +1261,20 @@ void VM::interpretCases()
             ON_OP();
             updateIOGas();
 
-            m_SPP[0] = fromAddress(m_ext->origin);
+            m_SPP[0] = fromAddress(fromEvmC(getTxContext().tx_origin));
         }
         NEXT
 
         CASE(BALANCE)
         {
-            m_runGas = toInt63(m_schedule->balanceGas);
+            m_runGas = m_rev >= EVM_TANGERINE_WHISTLE ? 400 : 20;
             ON_OP();
             updateIOGas();
 
-            m_SPP[0] = m_ext->balance(asAddress(m_SP[0]));
+            evm_address address = toEvmC(asAddress(m_SP[0]));
+            evm_uint256be rawBalance;
+            m_context->fn_table->get_balance(&rawBalance, m_context, &address);
+            m_SPP[0] = fromEvmC(rawBalance);
         }
         NEXT
 
@@ -1204,7 +1284,7 @@ void VM::interpretCases()
             ON_OP();
             updateIOGas();
 
-            m_SPP[0] = fromAddress(m_ext->caller);
+            m_SPP[0] = fromAddress(fromEvmC(m_message->sender));
         }
         NEXT
 
@@ -1213,7 +1293,7 @@ void VM::interpretCases()
             ON_OP();
             updateIOGas();
 
-            m_SPP[0] = m_ext->value;
+            m_SPP[0] = fromEvmC(m_message->value);
         }
         NEXT
 
@@ -1223,14 +1303,17 @@ void VM::interpretCases()
             ON_OP();
             updateIOGas();
 
-            if (u512(m_SP[0]) + 31 < m_ext->data.size())
-                m_SP[0] = (u256)*(h256 const*)(m_ext->data.data() + (size_t)m_SP[0]);
-            else if (m_SP[0] >= m_ext->data.size())
+            size_t const dataSize = m_message->input_size;
+            uint8_t const* const data = m_message->input_data;
+
+            if (u512(m_SP[0]) + 31 < dataSize)
+                m_SP[0] = (u256)*(h256 const*)(data + (size_t)m_SP[0]);
+            else if (m_SP[0] >= dataSize)
                 m_SP[0] = u256(0);
             else
             {     h256 r;
                 for (uint64_t i = (uint64_t)m_SP[0], e = (uint64_t)m_SP[0] + (uint64_t)32, j = 0; i < e; ++i, ++j)
-                    r[j] = i < m_ext->data.size() ? m_ext->data[i] : 0;
+                    r[j] = i < dataSize ? data[i] : 0;
                 m_SP[0] = (u256)r;
             };
         }
@@ -1242,13 +1325,13 @@ void VM::interpretCases()
             ON_OP();
             updateIOGas();
 
-            m_SPP[0] = m_ext->data.size();
+            m_SPP[0] = m_message->input_size;
         }
         NEXT
 
         CASE(RETURNDATASIZE)
         {
-            if (!m_schedule->haveReturnData)
+            if (m_rev < EVM_BYZANTIUM)
                 throwBadInstruction();
 
             ON_OP();
@@ -1263,17 +1346,19 @@ void VM::interpretCases()
             ON_OP();
             updateIOGas();
 
-            m_SPP[0] = m_ext->code.size();
+            m_SPP[0] = m_codeSize;
         }
         NEXT
 
         CASE(EXTCODESIZE)
         {
-            m_runGas = toInt63(m_schedule->extcodesizeGas);
+            m_runGas = m_rev >= EVM_TANGERINE_WHISTLE ? 700 : 20;
             ON_OP();
             updateIOGas();
 
-            m_SPP[0] = m_ext->codeSizeAt(asAddress(m_SP[0]));
+            evm_address address = toEvmC(asAddress(m_SP[0]));
+
+            m_SPP[0] = m_context->fn_table->get_code(nullptr, m_context, &address);
         }
         NEXT
 
@@ -1284,14 +1369,15 @@ void VM::interpretCases()
             updateMem(memNeed(m_SP[0], m_SP[2]));
             updateIOGas();
 
-            copyDataToMemory(m_ext->data, m_SP);
+            bytesConstRef data{m_message->input_data, m_message->input_size};
+            copyDataToMemory(data, m_SP);
         }
         NEXT
 
         CASE(RETURNDATACOPY)
         {
             ON_OP();
-            if (!m_schedule->haveReturnData)
+            if (m_rev < EVM_BYZANTIUM)
                 throwBadInstruction();
             bigint const endOfAccess = bigint(m_SP[1]) + bigint(m_SP[2]);
             if (m_returnData.size() < endOfAccess)
@@ -1312,20 +1398,22 @@ void VM::interpretCases()
             updateMem(memNeed(m_SP[0], m_SP[2]));
             updateIOGas();
 
-            copyDataToMemory(&m_ext->code, m_SP);
+            copyDataToMemory({m_pCode, m_codeSize}, m_SP);
         }
         NEXT
 
         CASE(EXTCODECOPY)
         {
             ON_OP();
-            m_runGas = toInt63(m_schedule->extcodecopyGas);
+            m_runGas = m_rev >= EVM_TANGERINE_WHISTLE ? 700 : 20;
             m_copyMemSize = toInt63(m_SP[3]);
             updateMem(memNeed(m_SP[1], m_SP[3]));
             updateIOGas();
 
-            Address a = asAddress(m_SP[0]);
-            copyDataToMemory(&m_ext->codeAt(a), m_SP + 1);
+            evm_address address = toEvmC(asAddress(m_SP[0]));
+            uint8_t const* pCode = nullptr;
+            size_t codeSize = m_context->fn_table->get_code(&pCode, m_context, &address);
+            copyDataToMemory({pCode, codeSize}, m_SP + 1);
         }
         NEXT
 
@@ -1335,17 +1423,27 @@ void VM::interpretCases()
             ON_OP();
             updateIOGas();
 
-            m_SPP[0] = m_ext->gasPrice;
+            m_SPP[0] = fromEvmC(getTxContext().tx_gas_price);
         }
         NEXT
 
         CASE(BLOCKHASH)
         {
             ON_OP();
-            m_runGas = toInt63(m_schedule->blockhashGas);
+            m_runGas = VMSchedule::stepGas6;
             updateIOGas();
 
-            m_SPP[0] = (u256)m_ext->blockHash(m_SP[0]);
+            const int64_t blockNumber = getTxContext().block_number;
+            u256 number = m_SP[0];
+
+            if (number < blockNumber && number >= std::max(int64_t(256), blockNumber) - 256)
+            {
+                evm_uint256be hash;
+                m_context->fn_table->get_block_hash(&hash, m_context, int64_t(number));
+                m_SPP[0] = fromEvmC(hash);
+            }
+            else
+                m_SPP[0] = 0;
         }
         NEXT
 
@@ -1354,7 +1452,7 @@ void VM::interpretCases()
             ON_OP();
             updateIOGas();
 
-            m_SPP[0] = (u160)m_ext->envInfo().author();
+            m_SPP[0] = fromAddress(fromEvmC(getTxContext().block_coinbase));
         }
         NEXT
 
@@ -1363,7 +1461,7 @@ void VM::interpretCases()
             ON_OP();
             updateIOGas();
 
-            m_SPP[0] = m_ext->envInfo().timestamp();
+            m_SPP[0] = getTxContext().block_timestamp;
         }
         NEXT
 
@@ -1372,7 +1470,7 @@ void VM::interpretCases()
             ON_OP();
             updateIOGas();
 
-            m_SPP[0] = m_ext->envInfo().number();
+            m_SPP[0] = getTxContext().block_number;
         }
         NEXT
 
@@ -1381,7 +1479,7 @@ void VM::interpretCases()
             ON_OP();
             updateIOGas();
 
-            m_SPP[0] = m_ext->envInfo().difficulty();
+            m_SPP[0] = fromEvmC(getTxContext().block_difficulty);
         }
         NEXT
 
@@ -1390,7 +1488,7 @@ void VM::interpretCases()
             ON_OP();
             updateIOGas();
 
-            m_SPP[0] = m_ext->envInfo().gasLimit();
+            m_SPP[0] = getTxContext().block_gas_limit;
         }
         NEXT
 
@@ -1585,24 +1683,29 @@ void VM::interpretCases()
 
         CASE(SLOAD)
         {
-            m_runGas = toInt63(m_schedule->sloadGas);
+            m_runGas = m_rev >= EVM_TANGERINE_WHISTLE ? 200 : 50;
             ON_OP();
             updateIOGas();
 
-            m_SPP[0] = m_ext->store(m_SP[0]);
+            evm_uint256be key = toEvmC(m_SP[0]);
+            evm_uint256be value;
+            m_context->fn_table->get_storage(&value, m_context, &m_message->destination, &key);
+            m_SPP[0] = fromEvmC(value);
         }
         NEXT
 
         CASE(SSTORE)
         {
             ON_OP();
-            if (m_ext->staticCall)
+            if (m_message->flags & EVM_STATIC)
                 throwDisallowedStateChange();
 
             updateSSGas();
             updateIOGas();
 
-            m_ext->setStore(m_SP[0], m_SP[1]);
+            evm_uint256be key = toEvmC(m_SP[0]);
+            evm_uint256be value = toEvmC(m_SP[1]);
+            m_context->fn_table->set_storage(m_context, &m_message->destination, &key, &value);
         }
         NEXT
 

--- a/libevm/VM.cpp
+++ b/libevm/VM.cpp
@@ -91,17 +91,6 @@ uint64_t VM::decodeJumpvDest(const byte* const _code, uint64_t& _pc, byte _voff)
 
 
 //
-// for tracing, checking, metering, measuring ...
-//
-void VM::onOperation()
-{
-    if (m_onOp)
-        (m_onOp)(++m_nSteps, m_PC, m_OP,
-            m_newMemSize > m_mem.size() ? (m_newMemSize - m_mem.size()) / 32 : uint64_t(0),
-            m_runGas, m_io_gas, this, m_ext);
-}
-
-//
 // set current SP to SP', adjust SP' per _removed and _added items
 //
 void VM::adjustStack(unsigned _removed, unsigned _added)
@@ -192,7 +181,7 @@ owning_bytes_ref VM::exec(u256& _io_gas, ExtVMFace& _ext, OnOpFunc const& _onOp)
     m_ext = &_ext;
     m_schedule = &m_ext->evmSchedule();
     m_onOp = _onOp;
-    m_onFail = &VM::onOperation; // this results in operations that fail being logged twice in the trace
+    m_onFail = nullptr;  // TODO: Check if ever used.
     m_PC = 0;
 
     try

--- a/libevm/VM.h
+++ b/libevm/VM.h
@@ -30,7 +30,35 @@ namespace dev
 namespace eth
 {
 
-class VM: public evm_instance
+struct VMSchedule
+{
+    static constexpr int64_t stackLimit = 1024;
+    static constexpr int64_t stepGas0 = 0;
+    static constexpr int64_t stepGas1 = 2;
+    static constexpr int64_t stepGas2 = 3;
+    static constexpr int64_t stepGas3 = 5;
+    static constexpr int64_t stepGas4 = 8;
+    static constexpr int64_t stepGas5 = 10;
+    static constexpr int64_t stepGas6 = 20;
+    static constexpr int64_t sha3Gas = 30;
+    static constexpr int64_t sha3WordGas = 6;
+    static constexpr int64_t sloadGas = 50;
+    static constexpr int64_t sstoreSetGas = 20000;
+    static constexpr int64_t sstoreResetGas = 5000;
+    static constexpr int64_t jumpdestGas = 1;
+    static constexpr int64_t logGas = 375;
+    static constexpr int64_t logDataGas = 8;
+    static constexpr int64_t logTopicGas = 375;
+    static constexpr int64_t createGas = 32000;
+    static constexpr int64_t memoryGas = 3;
+    static constexpr int64_t quadCoeffDiv = 512;
+    static constexpr int64_t copyGas = 3;
+    static constexpr int64_t valueTransferGas = 9000;
+    static constexpr int64_t callStipend = 2300;
+    static constexpr int64_t callNewAccount = 25000;
+};
+
+class VM : public evm_instance
 {
 public:
     VM();
@@ -63,7 +91,7 @@ private:
     static u256 exp256(u256 _base, u256 _exponent);
     void copyCode(int);
     typedef void (VM::*MemFnPtr)();
-    MemFnPtr m_bounce = 0;
+    MemFnPtr m_bounce = nullptr;
     uint64_t m_nSteps = 0;
 
     // return bytes
@@ -81,8 +109,8 @@ private:
     bytes m_returnData;
 
     // space for data stack, grows towards smaller addresses from the end
-    u256 m_stack[1024];
-    u256 *m_stackEnd = &m_stack[1024];
+    u256 m_stack[VMSchedule::stackLimit];
+    u256 *m_stackEnd = &m_stack[VMSchedule::stackLimit];
     size_t stackSize() { return m_stackEnd - m_SP; }
     
 #if EIP_615
@@ -222,35 +250,6 @@ private:
     }
 
 #endif
-};
-
-struct VMSchedule
-{
-    static constexpr int64_t stackLimit = 1024;
-    static constexpr int64_t stepGas0 = 0;
-    static constexpr int64_t stepGas1 = 2;
-    static constexpr int64_t stepGas2 = 3;
-    static constexpr int64_t stepGas3 = 5;
-    static constexpr int64_t stepGas4 = 8;
-    static constexpr int64_t stepGas5 = 10;
-    static constexpr int64_t stepGas6 = 20;
-    static constexpr int64_t sha3Gas = 30;
-    static constexpr int64_t sha3WordGas = 6;
-    static constexpr int64_t sloadGas = 50;
-    static constexpr int64_t sstoreSetGas = 20000;
-    static constexpr int64_t sstoreResetGas = 5000;
-    static constexpr int64_t sstoreClearGas = 5000;
-    static constexpr int64_t jumpdestGas = 1;
-    static constexpr int64_t logGas = 375;
-    static constexpr int64_t logDataGas = 8;
-    static constexpr int64_t logTopicGas = 375;
-    static constexpr int64_t createGas = 32000;
-    static constexpr int64_t memoryGas = 3;
-    static constexpr int64_t quadCoeffDiv = 512;
-    static constexpr int64_t copyGas = 3;
-    static constexpr int64_t valueTransferGas = 9000;
-    static constexpr int64_t callStipend = 2300;
-    static constexpr int64_t callNewAccount = 25000;
 };
 
 }

--- a/libevm/VM.h
+++ b/libevm/VM.h
@@ -20,15 +20,18 @@
 #include "Instruction.h"
 #include "VMConfig.h"
 #include "VMFace.h"
+#include <evm.h>
 
 namespace dev
 {
 namespace eth
 {
 
-class VM: public VMFace
+class VM: public VMFace, public evm_instance
 {
 public:
+    VM();
+
     owning_bytes_ref exec(u256& _io_gas, ExtVMFace& _ext, OnOpFunc const& _onOp) final;
 
 #if EIP_615

--- a/libevm/VM.h
+++ b/libevm/VM.h
@@ -32,7 +32,7 @@ class VM: public evm_instance
 public:
     VM();
 
-    owning_bytes_ref exec(u256& _io_gas, ExtVMFace& _ext, OnOpFunc const& _onOp);
+    owning_bytes_ref exec(u256& _io_gas, ExtVMFace& _ext);
 
 #if EIP_615
     // invalid code will throw an exeption
@@ -48,18 +48,18 @@ public:
     };
 
 private:
+
     u256* m_io_gas_p = 0;
     uint64_t m_io_gas = 0;
     ExtVMFace* m_ext = 0;
-    OnOpFunc m_onOp;
 
     static std::array<InstructionMetric, 256> c_metrics;
     static void initMetrics();
     static u256 exp256(u256 _base, u256 _exponent);
     void copyCode(int);
     typedef void (VM::*MemFnPtr)();
-    MemFnPtr m_bounce = nullptr;
-    MemFnPtr m_onFail = nullptr;
+    MemFnPtr m_bounce = 0;
+    MemFnPtr m_onFail = 0;
     uint64_t m_nSteps = 0;
     EVMSchedule const* m_schedule = nullptr;
 

--- a/libevm/VM.h
+++ b/libevm/VM.h
@@ -27,12 +27,12 @@ namespace dev
 namespace eth
 {
 
-class VM: public VMFace, public evm_instance
+class VM: public evm_instance
 {
 public:
     VM();
 
-    owning_bytes_ref exec(u256& _io_gas, ExtVMFace& _ext, OnOpFunc const& _onOp) final;
+    owning_bytes_ref exec(u256& _io_gas, ExtVMFace& _ext, OnOpFunc const& _onOp);
 
 #if EIP_615
     // invalid code will throw an exeption
@@ -132,7 +132,7 @@ private:
     std::vector<uint64_t> m_jumpDests;
     int64_t verifyJumpDest(u256 const& _dest, bool _throw = true);
 
-    void onOperation();
+    void onOperation() {}
     void adjustStack(unsigned _removed, unsigned _added);
     uint64_t gasForMem(u512 _size);
     void updateSSGas();

--- a/libevm/VMCalls.cpp
+++ b/libevm/VMCalls.cpp
@@ -17,11 +17,10 @@
 
 #include "VM.h"
 
-using namespace std;
-using namespace dev;
-using namespace dev::eth;
-
-
+namespace dev
+{
+namespace eth
+{
 void VM::copyDataToMemory(bytesConstRef _data, u256*_sp)
 {
     auto offset = static_cast<size_t>(_sp[0]);
@@ -74,8 +73,9 @@ void VM::throwBadStack(unsigned _removed, unsigned _added)
 
 void VM::throwRevertInstruction(owning_bytes_ref&& _output)
 {
-    // We can't use BOOST_THROW_EXCEPTION here because it makes a copy of exception inside and RevertInstruction has no copy constructor 
-    throw RevertInstruction(move(_output));
+    // We can't use BOOST_THROW_EXCEPTION here because it makes a copy of exception inside and
+    // RevertInstruction has no copy constructor
+    throw RevertInstruction(std::move(_output));
 }
 
 void VM::throwBufferOverrun(bigint const& _endOfAccess)
@@ -301,4 +301,6 @@ bool VM::caseCallSetup(evm_message& o_msg, bytesRef& o_output)
         return true;
     }
     return false;
+}
+}
 }

--- a/libevm/VMCalls.cpp
+++ b/libevm/VMCalls.cpp
@@ -160,7 +160,7 @@ void VM::caseCreate()
 
         h160 addr;
         owning_bytes_ref output;
-        std::tie(addr, output) = m_ext->create(endowment, gas, initCode, m_OP, salt, m_onOp);
+        std::tie(addr, output) = m_ext->create(endowment, gas, initCode, m_OP, salt, {});
         m_SPP[0] = (u160)addr;  // Convert address to integer.
         m_returnData = output.toBytes();
 
@@ -276,7 +276,7 @@ bool VM::caseCallSetup(CallParameters *callParams, bytesRef& o_output)
 
     if (m_ext->balance(m_ext->myAddress) >= callParams->valueTransfer && m_ext->depth < 1024)
     {
-        callParams->onOp = m_onOp;
+        callParams->onOp = {};
         callParams->senderAddress = m_OP == Instruction::DELEGATECALL ? m_ext->caller : m_ext->myAddress;
         callParams->receiveAddress = (m_OP == Instruction::CALL || m_OP == Instruction::STATICCALL) ? callParams->codeAddress : m_ext->myAddress;
         callParams->data = bytesConstRef(m_mem.data() + inOff, inSize);

--- a/libevm/VMCalls.cpp
+++ b/libevm/VMCalls.cpp
@@ -67,17 +67,9 @@ void VM::throwBadStack(unsigned _removed, unsigned _added)
 {
     bigint size = m_stackEnd - m_SPP;
     if (size < _removed)
-    {
-        if (m_onFail)
-            (this->*m_onFail)();
         BOOST_THROW_EXCEPTION(StackUnderflow() << RequirementError((bigint)_removed, size));
-    }
     else
-    {
-        if (m_onFail)
-            (this->*m_onFail)();
         BOOST_THROW_EXCEPTION(OutOfStack() << RequirementError((bigint)(_added - _removed), size));
-    }
 }
 
 void VM::throwRevertInstruction(owning_bytes_ref&& _output)
@@ -88,9 +80,6 @@ void VM::throwRevertInstruction(owning_bytes_ref&& _output)
 
 void VM::throwBufferOverrun(bigint const& _endOfAccess)
 {
-    // todo: disable this m_onFail, may result in duplicate log step in the trace
-    if (m_onFail)
-        (this->*m_onFail)();
     BOOST_THROW_EXCEPTION(BufferOverrun() << RequirementError(_endOfAccess, bigint(m_returnData.size())));
 }
 
@@ -118,7 +107,7 @@ int64_t VM::verifyJumpDest(u256 const& _dest, bool _throw)
 void VM::caseCreate()
 {
     m_bounce = &VM::interpretCases;
-    m_runGas = toInt63(m_schedule->createGas);
+    m_runGas = VMSchedule::createGas;
 
     // Collect arguments.
     u256 endowment = m_SP[0];
@@ -144,28 +133,40 @@ void VM::caseCreate()
     // Clear the return data buffer. This will not free the memory.
     m_returnData.clear();
 
-    if (m_ext->balance(m_ext->myAddress) >= endowment && m_ext->depth < 1024)
+    evm_uint256be rawBalance;
+    m_context->fn_table->get_balance(&rawBalance, m_context, &m_message->destination);
+    u256 balance = fromEvmC(rawBalance);
+    if (balance >= endowment && m_message->depth < 1024)
     {
-        *m_io_gas_p = m_io_gas;
-        u256 createGas = *m_io_gas_p;
-        if (!m_schedule->staticCallDepthLimit())
-            createGas -= createGas / 64;
-        u256 gas = createGas;
+        evm_message msg = {};
+        msg.gas = m_io_gas;
+        if (m_rev >= EVM_TANGERINE_WHISTLE)
+            msg.gas -= msg.gas / 64;
 
         // Get init code. Casts are safe because the memory cost has been paid.
         auto off = static_cast<size_t>(initOff);
         auto size = static_cast<size_t>(initSize);
-        bytesConstRef initCode{m_mem.data() + off, size};
 
+        msg.input_data = &m_mem[off];
+        msg.input_size = size;
+        msg.sender = m_message->destination;
+        msg.depth = m_message->depth + 1;
+        msg.kind = EVM_CREATE;  // FIXME: In EVM-C move the kind to the top.
+        msg.value = toEvmC(endowment);
 
-        h160 addr;
-        owning_bytes_ref output;
-        std::tie(addr, output) = m_ext->create(endowment, gas, initCode, m_OP, salt, {});
-        m_SPP[0] = (u160)addr;  // Convert address to integer.
-        m_returnData = output.toBytes();
+        evm_result result;
+        m_context->fn_table->call(&result, m_context, &msg);
 
-        *m_io_gas_p -= (createGas - gas);
-        m_io_gas = uint64_t(*m_io_gas_p);
+        if (result.status_code == EVM_SUCCESS)
+            m_SPP[0] = fromAddress(fromEvmC(result.create_address));
+        else
+            m_SPP[0] = 0;
+        m_returnData.assign(result.output_data, result.output_data + result.output_size);
+
+        m_io_gas -= (msg.gas - result.gas_left);
+
+        if (result.release)
+            result.release(&result);
     }
     else
         m_SPP[0] = 0;
@@ -176,56 +177,69 @@ void VM::caseCall()
 {
     m_bounce = &VM::interpretCases;
 
-    // TODO: Please check if that does not actually increases the stack size.
-    //       That was the case before.
-    unique_ptr<CallParameters> callParams(new CallParameters());
+    evm_message msg = {};
 
     // Clear the return data buffer. This will not free the memory.
     m_returnData.clear();
 
     bytesRef output;
-    if (caseCallSetup(callParams.get(), output))
+    if (caseCallSetup(msg, output))
     {
-        bool success = false;
-        owning_bytes_ref outputRef;
-        std::tie(success, outputRef) = m_ext->call(*callParams);
-        outputRef.copyTo(output);
+        evm_result result;
+        m_context->fn_table->call(&result, m_context, &msg);
 
-        // Here we have 2 options:
-        // 1. Keep the whole returned memory buffer (owning_bytes_ref):
-        //    higher memory footprint, no memory copy.
-        // 2. Copy only the return data from the returned memory buffer:
-        //    minimal memory footprint, additional memory copy.
-        // Option 2 used:
-        m_returnData = outputRef.toBytes();
+        m_returnData.assign(result.output_data, result.output_data + result.output_size);
+        bytesConstRef{&m_returnData}.copyTo(output);
 
-        m_SPP[0] = success ? 1 : 0;
+        m_SPP[0] = result.status_code == EVM_SUCCESS ? 1 : 0;
+        m_io_gas += result.gas_left;
+
+        if (result.release)
+            result.release(&result);
     }
     else
+    {
         m_SPP[0] = 0;
-    m_io_gas += uint64_t(callParams->gas);
+        m_io_gas += msg.gas;
+    }
     ++m_PC;
 }
 
-bool VM::caseCallSetup(CallParameters *callParams, bytesRef& o_output)
+bool VM::caseCallSetup(evm_message& o_msg, bytesRef& o_output)
 {
-    // Make sure the params were properly initialized.
-    assert(callParams->valueTransfer == 0);
-    assert(callParams->apparentValue == 0);
+    m_runGas = m_rev >= EVM_TANGERINE_WHISTLE ? 700 : 40;
 
-    m_runGas = toInt63(m_schedule->callGas);
+    switch (m_OP)
+    {
+    case Instruction::CALL:
+    case Instruction::STATICCALL:
+    default:
+        o_msg.kind = EVM_CALL;
+        break;
+    case Instruction::CALLCODE:
+        o_msg.kind = EVM_CALLCODE;
+        break;
+    case Instruction::DELEGATECALL:
+        o_msg.kind = EVM_DELEGATECALL;
+        break;
+    }
 
-    callParams->staticCall = (m_OP == Instruction::STATICCALL || m_ext->staticCall);
+    if (m_OP == Instruction::STATICCALL || m_message->flags & EVM_STATIC)
+        o_msg.flags = EVM_STATIC;
 
     bool const haveValueArg = m_OP == Instruction::CALL || m_OP == Instruction::CALLCODE;
 
-    Address destinationAddr = asAddress(m_SP[1]);
-    if (m_OP == Instruction::CALL && !m_ext->exists(destinationAddr))
-        if (m_SP[2] > 0 || m_schedule->zeroValueTransferChargesNewAccountGas())
-            m_runGas += toInt63(m_schedule->callNewAccountGas);
+    evm_address destination = toEvmC(asAddress(m_SP[1]));
+    int destinationExists = m_context->fn_table->account_exists(m_context, &destination);
+
+    if (m_OP == Instruction::CALL && !destinationExists)
+    {
+        if (m_SP[2] > 0 || m_rev < EVM_SPURIOUS_DRAGON)
+            m_runGas += VMSchedule::callNewAccount;
+    }
 
     if (haveValueArg && m_SP[2] > 0)
-        m_runGas += toInt63(m_schedule->callValueTransferGas);
+        m_runGas += VMSchedule::valueTransferGas;
 
     size_t const sizesOffset = haveValueArg ? 3 : 2;
     u256 inputOffset  = m_SP[sizesOffset];
@@ -240,46 +254,49 @@ bool VM::caseCallSetup(CallParameters *callParams, bytesRef& o_output)
     updateIOGas();
 
     // "Static" costs already applied. Calculate call gas.
-    if (m_schedule->staticCallDepthLimit())
-    {
-        // With static call depth limit we just charge the provided gas amount.
-        callParams->gas = m_SP[0];
-    }
-    else
+    u256 callGas = m_SP[0];
+    if (m_rev >= EVM_TANGERINE_WHISTLE)
     {
         // Apply "all but one 64th" rule.
         u256 maxAllowedCallGas = m_io_gas - m_io_gas / 64;
-        callParams->gas = std::min(m_SP[0], maxAllowedCallGas);
+        callGas = std::min(callGas, maxAllowedCallGas);
     }
 
-    m_runGas = toInt63(callParams->gas);
+    o_msg.gas = toInt63(callGas);
+    m_runGas = o_msg.gas;
     updateIOGas();
 
-    if (haveValueArg && m_SP[2] > 0)
-        callParams->gas += m_schedule->callStipend;
+    o_msg.destination = destination;
+    o_msg.sender = m_message->destination;
+    o_msg.input_data = m_mem.data() + size_t(inputOffset);
+    o_msg.input_size = size_t(inputSize);
 
-    callParams->codeAddress = destinationAddr;
-
+    bool balanceOk = true;
     if (haveValueArg)
     {
-        callParams->valueTransfer = m_SP[2];
-        callParams->apparentValue = m_SP[2];
+        u256 value = m_SP[2];
+        if (value > 0)
+        {
+            o_msg.value = toEvmC(m_SP[2]);
+            o_msg.gas += VMSchedule::callStipend;
+            {
+                evm_uint256be rawBalance;
+                m_context->fn_table->get_balance(&rawBalance, m_context, &m_message->destination);
+                u256 balance = fromEvmC(rawBalance);
+                balanceOk = balance >= value;
+            }
+        }
     }
     else if (m_OP == Instruction::DELEGATECALL)
-        // Forward VALUE.
-        callParams->apparentValue = m_ext->value;
-
-    uint64_t inOff = (uint64_t)inputOffset;
-    uint64_t inSize = (uint64_t)inputSize;
-    uint64_t outOff = (uint64_t)outputOffset;
-    uint64_t outSize = (uint64_t)outputSize;
-
-    if (m_ext->balance(m_ext->myAddress) >= callParams->valueTransfer && m_ext->depth < 1024)
     {
-        callParams->onOp = {};
-        callParams->senderAddress = m_OP == Instruction::DELEGATECALL ? m_ext->caller : m_ext->myAddress;
-        callParams->receiveAddress = (m_OP == Instruction::CALL || m_OP == Instruction::STATICCALL) ? callParams->codeAddress : m_ext->myAddress;
-        callParams->data = bytesConstRef(m_mem.data() + inOff, inSize);
+        o_msg.sender = m_message->sender;
+        o_msg.value = m_message->value;
+    }
+
+    if (balanceOk && m_message->depth < 1024)
+    {
+        size_t outOff = size_t(outputOffset);
+        size_t outSize = size_t(outputSize);
         o_output = bytesRef(m_mem.data() + outOff, outSize);
         return true;
     }

--- a/libevm/VMFactory.cpp
+++ b/libevm/VMFactory.cpp
@@ -18,7 +18,7 @@
 #include "VMFactory.h"
 #include "EVMC.h"
 #include "LegacyVM.h"
-#include "VM.h"
+#include "interpreter.h"
 #include <evmjit.h>
 #include <hera.h>
 
@@ -170,7 +170,7 @@ std::unique_ptr<VMFace> VMFactory::create(VMKind _kind)
         return std::unique_ptr<VMFace>(new EVMC{hera_create()});
 #endif
     case VMKind::Interpreter:
-        return std::unique_ptr<VMFace>(new VM);
+        return std::unique_ptr<VMFace>(new EVMC{interpreter_create()});
     case VMKind::Legacy:
     default:
         return std::unique_ptr<VMFace>(new LegacyVM);

--- a/libevm/VMOpt.cpp
+++ b/libevm/VMOpt.cpp
@@ -44,9 +44,9 @@ void VM::copyCode(int _extraBytes)
     // Copy code so that it can be safely modified and extend code by
     // _extraBytes zero bytes to allow reading virtual data at the end
     // of the code without bounds checks.
-    auto extendedSize = m_ext->code.size() + _extraBytes;
+    auto extendedSize = m_codeSize + _extraBytes;
     m_code.reserve(extendedSize);
-    m_code = m_ext->code;
+    m_code.assign(m_pCode, m_pCode + m_codeSize);
     m_code.resize(extendedSize);
 }
 
@@ -54,7 +54,7 @@ void VM::optimize()
 {
     copyCode(33);
 
-    size_t const nBytes = m_ext->code.size();
+    size_t const nBytes = m_codeSize;
 
     // build a table of jump destinations for use in verifyJumpDest
     

--- a/libevm/VMOpt.cpp
+++ b/libevm/VMOpt.cpp
@@ -17,16 +17,14 @@
 
 #include "VM.h"
 
-using namespace std;
-using namespace dev;
-using namespace dev::eth;
-
+namespace dev
+{
+namespace eth
+{
 std::array<InstructionMetric, 256> VM::c_metrics;
 void VM::initMetrics()
 {
-    static bool done =
-    []()
-    {
+    static bool done = []() {
         for (unsigned i = 0; i < 256; ++i)
         {
             InstructionInfo op = instructionInfo((Instruction)i);
@@ -35,7 +33,7 @@ void VM::initMetrics()
             c_metrics[i].ret = op.ret;
         }
         return true;
-    } ();
+    }();
     (void)done;
 }
 
@@ -217,4 +215,6 @@ u256 VM::exp256(u256 _base, u256 _exponent)
         _exponent >>= 1;
     }
     return result;
+}
+}
 }

--- a/libevm/interpreter.h
+++ b/libevm/interpreter.h
@@ -1,0 +1,6 @@
+
+#pragma once
+
+#include <evm.h>
+
+extern "C" evm_instance* interpreter_create() noexcept;


### PR DESCRIPTION
Finally we have the Interpreter using EVM-C interface. The old interface is available as `--vm legacy` and is the default one. The new is available as `--vm interpreter`.

I can split the last commit that does the essential changes into another PR if needed.

Part of #4882.