### PR TITLE
Fix Pong packet of discovery protocol

### DIFF
--- a/libp2p/NodeTable.cpp
+++ b/libp2p/NodeTable.cpp
@@ -517,7 +517,7 @@ void NodeTable::onReceived(UDPSocketFace*, bi::udp::endpoint const& _from, bytes
 				addNode(Node(in.sourceid, in.source));
 				
 				Pong p(in.source);
-				p.echo = sha3(in.echo);
+				p.echo = in.echo;
 				p.sign(m_secret);
 				m_socketPointer->send(p);
 				break;


### PR DESCRIPTION
Fixes https://github.com/ethereum/cpp-ethereum/issues/4911

We seem to have connectivity problems lately, this possibly can be the reason (my understanding is that  Geth started to validate this hash in recent releases)