### PR TITLE
add test_addTransaction

### DIFF
--- a/libweb3jsonrpc/Test.cpp
+++ b/libweb3jsonrpc/Test.cpp
@@ -25,6 +25,7 @@
 #include <jsonrpccpp/common/exception.h>
 #include <libethereum/ClientTest.h>
 #include <libethereum/ChainParams.h>
+#include <libweb3jsonrpc/JsonHelper.h>
 
 using namespace std;
 using namespace dev;
@@ -32,6 +33,21 @@ using namespace dev::rpc;
 using namespace jsonrpc;
 
 Test::Test(eth::Client& _eth): m_eth(_eth) {}
+
+string Test::test_addTransaction(Json::Value const& param1)
+{
+    try
+    {
+        eth::TransactionSkeleton tr = eth::toTransactionSkeleton(param1);
+        m_eth.submitTransaction(tr, Secret(param1["secretKey"].asString()));
+    }
+    catch (...)
+    {
+        BOOST_THROW_EXCEPTION(JsonRpcException(Errors::ERROR_RPC_INVALID_PARAMS));
+    }
+
+    return "";
+}
 
 bool Test::test_setChainParams(Json::Value const& param1)
 {

--- a/libweb3jsonrpc/Test.h
+++ b/libweb3jsonrpc/Test.h
@@ -43,7 +43,8 @@ public:
 		return RPCModules{RPCModule{"test", "1.0"}};
 	}
 
-	virtual bool test_setChainParams(const Json::Value &param1) override;
+    virtual std::string test_addTransaction(const Json::Value& param1) override;
+    virtual bool test_setChainParams(const Json::Value &param1) override;
 	virtual bool test_mineBlocks(int _number) override;
 	virtual bool test_modifyTimestamp(int _timestamp) override;
 	virtual bool test_addBlock(std::string const& _rlp) override;

--- a/libweb3jsonrpc/TestFace.h
+++ b/libweb3jsonrpc/TestFace.h
@@ -14,6 +14,10 @@ namespace dev {
             public:
                 TestFace()
                 {
+                    this->bindAndAddMethod(
+                        jsonrpc::Procedure("test_addTransaction", jsonrpc::PARAMS_BY_POSITION,
+                            jsonrpc::JSON_STRING, "param1", jsonrpc::JSON_OBJECT, NULL),
+                        &dev::rpc::TestFace::test_addTransactionI);
                     this->bindAndAddMethod(jsonrpc::Procedure("test_setChainParams", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_BOOLEAN, "param1",jsonrpc::JSON_OBJECT, NULL), &dev::rpc::TestFace::test_setChainParamsI);
                     this->bindAndAddMethod(jsonrpc::Procedure("test_mineBlocks", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_BOOLEAN, "param1",jsonrpc::JSON_INTEGER, NULL), &dev::rpc::TestFace::test_mineBlocksI);
                     this->bindAndAddMethod(jsonrpc::Procedure("test_modifyTimestamp", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_BOOLEAN, "param1",jsonrpc::JSON_INTEGER, NULL), &dev::rpc::TestFace::test_modifyTimestampI);
@@ -21,6 +25,11 @@ namespace dev {
                     this->bindAndAddMethod(jsonrpc::Procedure("test_rewindToBlock", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_BOOLEAN, "param1",jsonrpc::JSON_INTEGER, NULL), &dev::rpc::TestFace::test_rewindToBlockI);
                 }
 
+                inline virtual void test_addTransactionI(
+                    const Json::Value& request, Json::Value& response)
+                {
+                    response = this->test_addTransaction(request[0u]);
+                }
                 inline virtual void test_setChainParamsI(const Json::Value &request, Json::Value &response)
                 {
                     response = this->test_setChainParams(request[0u]);
@@ -41,6 +50,8 @@ namespace dev {
                 {
                     response = this->test_rewindToBlock(request[0u].asInt());
                 }
+
+                virtual std::string test_addTransaction(const Json::Value& param1) = 0;
                 virtual bool test_setChainParams(const Json::Value& param1) = 0;
                 virtual bool test_mineBlocks(int param1) = 0;
                 virtual bool test_modifyTimestamp(int param1) = 0;

--- a/libweb3jsonrpc/test.json
+++ b/libweb3jsonrpc/test.json
@@ -1,4 +1,5 @@
 [
+{ "name": "test_addTransaction", "params": [{}], "order": [], "returns": ""},
 { "name": "test_setChainParams", "params": [{}], "order": [], "returns": false},
 { "name": "test_mineBlocks", "params": [0], "returns": false },
 { "name": "test_modifyTimestamp", "params": [0], "returns": false },


### PR DESCRIPTION
test method that allows to import unsigned transactions with explicit private key field that will be used to sign it.  

https://github.com/ethereum/retesteth/issues/6