### PR TITLE
test bitwise shifting

### DIFF
--- a/test/tools/jsontests/BlockChainTests.cpp
+++ b/test/tools/jsontests/BlockChainTests.cpp
@@ -1085,6 +1085,10 @@ BOOST_AUTO_TEST_CASE(stZeroKnowledge){}
 BOOST_AUTO_TEST_CASE(stZeroKnowledge2){}
 BOOST_AUTO_TEST_CASE(stBugs){}
 
+//Constantinople Tests
+BOOST_AUTO_TEST_CASE(stShift){}
+
+
 //Stress Tests
 BOOST_AUTO_TEST_CASE(stAttackTest){}
 BOOST_AUTO_TEST_CASE(stMemoryStressTest){}

--- a/test/tools/jsontests/StateTests.cpp
+++ b/test/tools/jsontests/StateTests.cpp
@@ -203,6 +203,9 @@ BOOST_AUTO_TEST_CASE(stZeroKnowledge2){}
 BOOST_AUTO_TEST_CASE(stCodeCopyTest){}
 BOOST_AUTO_TEST_CASE(stBugs){}
 
+//Constantinople Tests
+BOOST_AUTO_TEST_CASE(stShift){}
+
 //Stress Tests
 BOOST_AUTO_TEST_CASE(stAttackTest){}
 BOOST_AUTO_TEST_CASE(stMemoryStressTest){}

--- a/test/tools/libtesteth/TestHelper.cpp
+++ b/test/tools/libtesteth/TestHelper.cpp
@@ -153,8 +153,6 @@ bool isDisabledNetwork(eth::Network _net)
     Options const& opt = Options::get();
     if (opt.all || opt.filltests || opt.createRandomTest || !opt.singleTestNet.empty())
     {
-        if (_net == eth::Network::ConstantinopleTest)
-            return true;
         return false;
     }
     switch (_net)


### PR DESCRIPTION
This PR updates the jsontests submodule and enables `stShift` tests (for bitwise shifting being planned http://eips.ethereum.org/EIPS/eip-145).