### PR TITLE
Always print state root upon completion of transaction

### DIFF
--- a/test/tools/libtesteth/ImportTest.cpp
+++ b/test/tools/libtesteth/ImportTest.cpp
@@ -273,10 +273,11 @@ std::tuple<eth::State, ImportTest::ExecOutput, eth::ChangeLog> ImportTest::execu
 			st.setOptions(Options::get().jsontraceOptions);
 			out = initialState.execute(_env, *se.get(), _tr, Permanence::Committed, st.onOp());
 			cout << st.json();
-			cout << "{\"stateRoot\": \"" << initialState.rootHash().hex() << "\"}";
 		}
 		else
 			out = initialState.execute(_env, *se.get(), _tr, Permanence::Uncommitted);
+
+    cout << "{\"stateRoot\": \"" << initialState.rootHash().hex() << "\"}\n";
 
 		// the changeLog might be broken under --jsontrace, because it uses intialState.execute with Permanence::Committed rather than Permanence::Uncommitted
 		eth::ChangeLog changeLog = initialState.changeLog();

--- a/test/tools/libtesteth/ImportTest.cpp
+++ b/test/tools/libtesteth/ImportTest.cpp
@@ -275,7 +275,7 @@ std::tuple<eth::State, ImportTest::ExecOutput, eth::ChangeLog> ImportTest::execu
 			cout << st.json();
 		}
 		else
-			out = initialState.execute(_env, *se.get(), _tr, Permanence::Uncommitted);
+			out = initialState.execute(_env, *se.get(), _tr, Permanence::Committed);
 
     cout << "{\"stateRoot\": \"" << initialState.rootHash().hex() << "\"}\n";
 


### PR DESCRIPTION
EWASM is not compatible with the `--jsontrace` option and we need this feature for the trace equivalence tester.