### PR TITLE
Quicker termination for eth --test

### DIFF
--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -695,7 +695,7 @@ void Client::doWork(bool _doWait)
     if (!m_syncBlockQueue && !m_syncTransactionQueue && (_doWait || isSealed))
     {
         std::unique_lock<std::mutex> l(x_signalled);
-        m_signalled.wait_for(l, chrono::seconds(1));
+        m_signalled.wait_for(l, chrono::milliseconds(30));
     }
 }
 


### PR DESCRIPTION
Before this commit, `eth --test` took half seconds to terminate after a SIGINT.
```
14:03:40.627|eth  Terminate worker 965 ms
```

After this commit, the termination takes less than 100 milliseconds (so
the timecount does not appear on the console).

Since retesteth required this after every test, most of the testing time
was spent during this half seconds.  ping @winsvega