### PR TITLE
~WebThreeDirect() destroys m_net before m_ethereum

### DIFF
--- a/libwebthree/WebThree.cpp
+++ b/libwebthree/WebThree.cpp
@@ -79,7 +79,6 @@ WebThreeDirect::~WebThreeDirect()
     // the guarantee is that m_ethereum is only reset *after* all sessions have ended (sessions are allowed to
     // use bits of data owned by m_ethereum).
     m_net.stop();
-    m_ethereum.reset();
 }
 
 std::string WebThreeDirect::composeClientVersion(std::string const& _client)

--- a/libwebthree/WebThree.h
+++ b/libwebthree/WebThree.h
@@ -211,9 +211,9 @@ public:
 private:
     std::string m_clientVersion;                    ///< Our end-application client's name/version.
 
-    p2p::Host m_net;                                ///< Should run in background and send us events when blocks found and allow us to send blocks as required.
-
     std::unique_ptr<eth::Client> m_ethereum;        ///< Client for Ethereum ("eth") protocol.
+
+    p2p::Host m_net;                                ///< Should run in background and send us events when blocks found and allow us to send blocks as required.
 };
 
 


### PR DESCRIPTION
This fixes https://github.com/ethereum/cpp-ethereum/issues/4942, a thread sanitizer warning.