### PR TITLE
Unify the condition variables in Client and Worker

### DIFF
--- a/libdevcore/Worker.h
+++ b/libdevcore/Worker.h
@@ -96,15 +96,15 @@ protected:
 	/// It's OK to call terminate() in destructors of multiple derived classes.
 	void terminate();
 
+protected:
+    mutable Mutex x_work;  ///< Lock for the network existance and m_state_notifier.
+    mutable std::condition_variable m_state_notifier;  //< Notification when m_state changes.
+
 private:
-
-	std::string m_name;
-
+    std::string m_name;
 	unsigned m_idleWaitMs = 0;
-	
-	mutable Mutex x_work;						///< Lock for the network existance and m_state_notifier.
-	std::unique_ptr<std::thread> m_work;		///< The network thread.
-    mutable std::condition_variable m_state_notifier; //< Notification when m_state changes.
+
+    std::unique_ptr<std::thread> m_work;		///< The network thread.
 	std::atomic<WorkerState> m_state = {WorkerState::Starting};
 };
 

--- a/libethereum/Client.h
+++ b/libethereum/Client.h
@@ -281,10 +281,18 @@ protected:
     void syncTransactionQueue();
 
     /// Magically called when m_tq needs syncing. Be nice and don't block.
-    void onTransactionQueueReady() { m_syncTransactionQueue = true; m_signalled.notify_all(); }
+    void onTransactionQueueReady()
+    {
+        m_syncTransactionQueue = true;
+        m_state_notifier.notify_all();
+    }
 
     /// Magically called when m_bq needs syncing. Be nice and don't block.
-    void onBlockQueueReady() { m_syncBlockQueue = true; m_signalled.notify_all(); }
+    void onBlockQueueReady()
+    {
+        m_syncBlockQueue = true;
+        m_state_notifier.notify_all();
+    }
 
     /// Called when the post state has changed (i.e. when more transactions are in it or we're sealing on a new block).
     /// This updates m_sealingInfo.
@@ -324,9 +332,6 @@ protected:
 
     std::weak_ptr<EthereumHost> m_host;     ///< Our Ethereum Host. Don't do anything if we can't lock.
     std::weak_ptr<WarpHostCapability> m_warpHost;
-
-    std::condition_variable m_signalled;
-    Mutex x_signalled;
 
     Handler<> m_tqReady;
     Handler<h256 const&> m_tqReplaced;


### PR DESCRIPTION
A Client object had two condition variables in Client class and in
Worker class.  This commit unifies these.  Then, I can revert the quick
workaround to make `eth --test` terminate quicker:

https://github.com/ethereum/cpp-ethereum/commit/ccfa8c705cc5dd144765d21fcb53804f34207d24

~Some tests fail, but it's Friday evening, so I file it~

Tests pass in CircleCI.  Maybe my local machine was busy syncing Ropsten.