### PR TITLE
notify Client class's condition variable before terminating the thread

### DIFF
--- a/libethashseal/EthashClient.cpp
+++ b/libethashseal/EthashClient.cpp
@@ -57,6 +57,7 @@ EthashClient::EthashClient(ChainParams const& _params, int _networkID, p2p::Host
 
 EthashClient::~EthashClient()
 {
+    m_signalled.notify_all(); // to wake up the thread from Client::doWork()
     terminate();
 }
 

--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -695,7 +695,7 @@ void Client::doWork(bool _doWait)
     if (!m_syncBlockQueue && !m_syncTransactionQueue && (_doWait || isSealed))
     {
         std::unique_lock<std::mutex> l(x_signalled);
-        m_signalled.wait_for(l, chrono::milliseconds(30));
+        m_signalled.wait_for(l, chrono::seconds(1));
     }
 }
 

--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -80,6 +80,7 @@ Client::Client(ChainParams const& _params, int _networkID, p2p::Host* _host,
 
 Client::~Client()
 {
+    m_signalled.notify_all(); // to wake up the thread from Client::doWork()
     stopWorking();
     terminate();
 }

--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -693,7 +693,7 @@ void Client::doWork(bool _doWait)
         isSealed = m_working.isSealed();
     // If the block is sealed, we have to wait for it to tickle through the block queue
     // (which only signals as wanting to be synced if it is ready).
-    if (!m_syncBlockQueue && !m_syncTransactionQueue && (_doWait || isSealed))
+    if (!m_syncBlockQueue && !m_syncTransactionQueue && (_doWait || isSealed) && isWorking())
     {
         std::unique_lock<std::mutex> l(x_signalled);
         m_signalled.wait_for(l, chrono::seconds(1));

--- a/libethereum/ClientTest.cpp
+++ b/libethereum/ClientTest.cpp
@@ -48,6 +48,7 @@ ClientTest::ClientTest(ChainParams const& _params, int _networkID, p2p::Host* _h
 
 ClientTest::~ClientTest()
 {
+    m_signalled.notify_all(); // to wake up the thread from Client::doWork()
     terminate();
 }
 


### PR DESCRIPTION
This reverts https://github.com/ethereum/cpp-ethereum/commit/ccfa8c705cc5dd144765d21fcb53804f34207d24 and applies a cleaner way to terminate `eth --test` faster.

This comes after a discussion in https://github.com/ethereum/cpp-ethereum/pull/4944