### PR TITLE
Refactor logging - all changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,8 +87,8 @@ include(EthUtils)
 
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
-hunter_add_package(Boost COMPONENTS program_options filesystem system thread context fiber)
-find_package(Boost CONFIG REQUIRED program_options filesystem system thread context fiber)
+hunter_add_package(Boost COMPONENTS program_options filesystem system thread context fiber log)
+find_package(Boost CONFIG REQUIRED program_options filesystem system thread context fiber log)
 
 hunter_add_package(jsoncpp)
 find_package(jsoncpp CONFIG REQUIRED)

--- a/eth/MinerAux.h
+++ b/eth/MinerAux.h
@@ -1,20 +1,20 @@
 #pragma once
 
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file MinerAux.cpp
  * @author Gav Wood <i@gavwood.com>
@@ -57,272 +57,265 @@ using namespace dev::eth;
 
 bool isTrue(std::string const& _m)
 {
-	return _m == "on" || _m == "yes" || _m == "true" || _m == "1";
+    return _m == "on" || _m == "yes" || _m == "true" || _m == "1";
 }
 
 bool isFalse(std::string const& _m)
 {
-	return _m == "off" || _m == "no" || _m == "false" || _m == "0";
+    return _m == "off" || _m == "no" || _m == "false" || _m == "0";
 }
 
 inline std::string credits()
 {
-	std::ostringstream out;
-	out
-		<< "cpp-ethereum " << dev::Version << endl
-		<< "  By cpp-ethereum contributors, (c) 2013-2018." << endl
-		<< "  See the README for contributors and credits." << endl;
-	return out.str();
+    std::ostringstream out;
+    out
+        << "cpp-ethereum " << dev::Version << endl
+        << "  By cpp-ethereum contributors, (c) 2013-2018." << endl
+        << "  See the README for contributors and credits." << endl;
+    return out.str();
 }
 
 class BadArgument: public Exception {};
-struct MiningChannel: public LogChannel
-{
-	static const char* name() { return EthGreen "miner"; }
-	static const int verbosity = 2;
-	static const bool debug = false;
-};
-#define minelog clog(MiningChannel)
 
 class MinerCLI
 {
 public:
-	enum class OperationMode
-	{
-		None,
-		DAGInit,
-		Benchmark
-	};
+    enum class OperationMode
+    {
+        None,
+        DAGInit,
+        Benchmark
+    };
 
 
-	explicit MinerCLI(OperationMode _mode = OperationMode::None): mode(_mode)
-	{
-		Ethash::init();
-		NoProof::init();
-		BasicAuthority::init();
-	}
+    explicit MinerCLI(OperationMode _mode = OperationMode::None): mode(_mode)
+    {
+        Ethash::init();
+        NoProof::init();
+        BasicAuthority::init();
+    }
 
-	bool interpretOption(size_t& i, vector<string> const& argv)
-	{
-		size_t argc = argv.size();
-		string arg = argv[i];
-		if (arg == "--benchmark-warmup" && i + 1 < argc)
-			try {
-				m_benchmarkWarmup = stol(argv[++i]);
-			}
-			catch (...)
-			{
-				cerr << "Bad " << arg << " option: " << argv[i] << endl;
-				BOOST_THROW_EXCEPTION(BadArgument());
-			}
-		else if (arg == "--benchmark-trial" && i + 1 < argc)
-			try {
-				m_benchmarkTrial = stol(argv[++i]);
-			}
-			catch (...)
-			{
-				cerr << "Bad " << arg << " option: " << argv[i] << endl;
-				BOOST_THROW_EXCEPTION(BadArgument());
-			}
-		else if (arg == "--benchmark-trials" && i + 1 < argc)
-			try {
-				m_benchmarkTrials = stol(argv[++i]);
-			}
-			catch (...)
-			{
-				cerr << "Bad " << arg << " option: " << argv[i] << endl;
-				BOOST_THROW_EXCEPTION(BadArgument());
-			}
-		else if (arg == "-C" || arg == "--cpu")
-			m_minerType = "cpu";
-		else if (arg == "--current-block" && i + 1 < argc)
-			m_currentBlock = stol(argv[++i]);
-		else if (arg == "--no-precompute")
-		{
-			m_precompute = false;
-		}
-		else if ((arg == "-D" || arg == "--create-dag") && i + 1 < argc)
-		{
-			string m = boost::to_lower_copy(string(argv[++i]));
-			mode = OperationMode::DAGInit;
-			try
-			{
-				m_initDAG = stol(m);
-			}
-			catch (...)
-			{
-				cerr << "Bad " << arg << " option: " << m << endl;
-				BOOST_THROW_EXCEPTION(BadArgument());
-			}
-		}
-		else if ((arg == "-w" || arg == "--check-pow") && i + 4 < argc)
-		{
-			string m;
-			try
-			{
-				BlockHeader bi;
-				m = boost::to_lower_copy(string(argv[++i]));
-				h256 powHash(m);
-				m = boost::to_lower_copy(string(argv[++i]));
-				h256 seedHash;
-				if (m.size() == 64 || m.size() == 66)
-					seedHash = h256(m);
-				else
-					seedHash = EthashAux::seedHash(stol(m));
-				m = boost::to_lower_copy(string(argv[++i]));
-				bi.setDifficulty(u256(m));
-				auto boundary = Ethash::boundary(bi);
-				m = boost::to_lower_copy(string(argv[++i]));
-				Ethash::setNonce(bi, h64(m));
-				auto r = EthashAux::eval(seedHash, powHash, h64(m));
-				bool valid = r.value < boundary;
-				cout << (valid ? "VALID :-)" : "INVALID :-(") << endl;
-				cout << r.value << (valid ? " < " : " >= ") << boundary << endl;
-				cout << "  where " << boundary << " = 2^256 / " << bi.difficulty() << endl;
-				cout << "  and " << r.value << " = ethash(" << powHash << ", " << h64(m) << ")" << endl;
-				cout << "  with seed as " << seedHash << endl;
-				if (valid)
-					cout << "(mixHash = " << r.mixHash << ")" << endl;
-				cout << "SHA3( light(seed) ) = " << sha3(EthashAux::light(Ethash::seedHash(bi))->data()) << endl;
-				exit(0);
-			}
-			catch (...)
-			{
-				cerr << "Bad " << arg << " option: " << m << endl;
-				BOOST_THROW_EXCEPTION(BadArgument());
-			}
-		}
-		else if (arg == "-M" || arg == "--benchmark")
-			mode = OperationMode::Benchmark;
-		else if ((arg == "-t" || arg == "--mining-threads") && i + 1 < argc)
-		{
-			try {
-				m_miningThreads = stol(argv[++i]);
-			}
-			catch (...)
-			{
-				cerr << "Bad " << arg << " option: " << argv[i] << endl;
-				BOOST_THROW_EXCEPTION(BadArgument());
-			}
-		}
-		else
-			return false;
-		return true;
-	}
+    bool interpretOption(size_t& i, vector<string> const& argv)
+    {
+        size_t argc = argv.size();
+        string arg = argv[i];
+        if (arg == "--benchmark-warmup" && i + 1 < argc)
+            try {
+                m_benchmarkWarmup = stol(argv[++i]);
+            }
+            catch (...)
+            {
+                cerr << "Bad " << arg << " option: " << argv[i] << endl;
+                BOOST_THROW_EXCEPTION(BadArgument());
+            }
+        else if (arg == "--benchmark-trial" && i + 1 < argc)
+            try {
+                m_benchmarkTrial = stol(argv[++i]);
+            }
+            catch (...)
+            {
+                cerr << "Bad " << arg << " option: " << argv[i] << endl;
+                BOOST_THROW_EXCEPTION(BadArgument());
+            }
+        else if (arg == "--benchmark-trials" && i + 1 < argc)
+            try {
+                m_benchmarkTrials = stol(argv[++i]);
+            }
+            catch (...)
+            {
+                cerr << "Bad " << arg << " option: " << argv[i] << endl;
+                BOOST_THROW_EXCEPTION(BadArgument());
+            }
+        else if (arg == "-C" || arg == "--cpu")
+            m_minerType = "cpu";
+        else if (arg == "--current-block" && i + 1 < argc)
+            m_currentBlock = stol(argv[++i]);
+        else if (arg == "--no-precompute")
+        {
+            m_precompute = false;
+        }
+        else if ((arg == "-D" || arg == "--create-dag") && i + 1 < argc)
+        {
+            string m = boost::to_lower_copy(string(argv[++i]));
+            mode = OperationMode::DAGInit;
+            try
+            {
+                m_initDAG = stol(m);
+            }
+            catch (...)
+            {
+                cerr << "Bad " << arg << " option: " << m << endl;
+                BOOST_THROW_EXCEPTION(BadArgument());
+            }
+        }
+        else if ((arg == "-w" || arg == "--check-pow") && i + 4 < argc)
+        {
+            string m;
+            try
+            {
+                BlockHeader bi;
+                m = boost::to_lower_copy(string(argv[++i]));
+                h256 powHash(m);
+                m = boost::to_lower_copy(string(argv[++i]));
+                h256 seedHash;
+                if (m.size() == 64 || m.size() == 66)
+                    seedHash = h256(m);
+                else
+                    seedHash = EthashAux::seedHash(stol(m));
+                m = boost::to_lower_copy(string(argv[++i]));
+                bi.setDifficulty(u256(m));
+                auto boundary = Ethash::boundary(bi);
+                m = boost::to_lower_copy(string(argv[++i]));
+                Ethash::setNonce(bi, h64(m));
+                auto r = EthashAux::eval(seedHash, powHash, h64(m));
+                bool valid = r.value < boundary;
+                cout << (valid ? "VALID :-)" : "INVALID :-(") << endl;
+                cout << r.value << (valid ? " < " : " >= ") << boundary << endl;
+                cout << "  where " << boundary << " = 2^256 / " << bi.difficulty() << endl;
+                cout << "  and " << r.value << " = ethash(" << powHash << ", " << h64(m) << ")" << endl;
+                cout << "  with seed as " << seedHash << endl;
+                if (valid)
+                    cout << "(mixHash = " << r.mixHash << ")" << endl;
+                cout << "SHA3( light(seed) ) = " << sha3(EthashAux::light(Ethash::seedHash(bi))->data()) << endl;
+                exit(0);
+            }
+            catch (...)
+            {
+                cerr << "Bad " << arg << " option: " << m << endl;
+                BOOST_THROW_EXCEPTION(BadArgument());
+            }
+        }
+        else if (arg == "-M" || arg == "--benchmark")
+            mode = OperationMode::Benchmark;
+        else if ((arg == "-t" || arg == "--mining-threads") && i + 1 < argc)
+        {
+            try {
+                m_miningThreads = stol(argv[++i]);
+            }
+            catch (...)
+            {
+                cerr << "Bad " << arg << " option: " << argv[i] << endl;
+                BOOST_THROW_EXCEPTION(BadArgument());
+            }
+        }
+        else
+            return false;
+        return true;
+    }
 
-	void execute()
-	{
-		if (m_minerType == "cpu")
-			EthashCPUMiner::setNumInstances(m_miningThreads);
-		if (mode == OperationMode::DAGInit)
-			doInitDAG(m_initDAG);
-		else if (mode == OperationMode::Benchmark)
-			doBenchmark(m_minerType, m_benchmarkWarmup, m_benchmarkTrial, m_benchmarkTrials);
-	}
+    void execute()
+    {
+        if (m_minerType == "cpu")
+            EthashCPUMiner::setNumInstances(m_miningThreads);
+        if (mode == OperationMode::DAGInit)
+            doInitDAG(m_initDAG);
+        else if (mode == OperationMode::Benchmark)
+            doBenchmark(m_minerType, m_benchmarkWarmup, m_benchmarkTrial, m_benchmarkTrials);
+    }
 
-	static void streamHelp(ostream& _out)
-	{
-		_out
-			<< "Work farming mode:" << endl
-			<< "    --no-precompute  Don't precompute the next epoch's DAG." << endl
-			<< "Ethash verify mode:" << endl
-			<< "    -w,--check-pow <headerHash> <seedHash> <difficulty> <nonce>  Check PoW credentials for validity." << endl
-			<< endl
-			<< "Benchmarking mode:" << endl
-			<< "    -M,--benchmark  Benchmark for mining and exit; use with --cpu and --opencl." << endl
-			<< "    --benchmark-warmup <seconds>  Set the duration of warmup for the benchmark tests (default: 3)." << endl
-			<< "    --benchmark-trial <seconds>  Set the duration for each trial for the benchmark tests (default: 3)." << endl
-			<< "    --benchmark-trials <n>  Set the number of trials for the benchmark tests (default: 5)." << endl
-			<< "DAG creation mode:" << endl
-			<< "    -D,--create-dag <number>  Create the DAG in preparation for mining on given block and exit." << endl
-			<< "Mining configuration:" << endl
-			<< "    -C,--cpu  When mining, use the CPU." << endl
-			<< "    -t, --mining-threads <n> Limit number of CPU/GPU miners to n (default: use everything available on selected platform)" << endl
-			<< "    --current-block Let the miner know the current block number at configuration time. Will help determine DAG size and required GPU memory." << endl
-			<< "    --disable-submit-hashrate  When mining, don't submit hashrate to node." << endl;
-	}
+    static void streamHelp(ostream& _out)
+    {
+        _out
+            << "Work farming mode:" << endl
+            << "    --no-precompute  Don't precompute the next epoch's DAG." << endl
+            << "Ethash verify mode:" << endl
+            << "    -w,--check-pow <headerHash> <seedHash> <difficulty> <nonce>  Check PoW credentials for validity." << endl
+            << endl
+            << "Benchmarking mode:" << endl
+            << "    -M,--benchmark  Benchmark for mining and exit; use with --cpu and --opencl." << endl
+            << "    --benchmark-warmup <seconds>  Set the duration of warmup for the benchmark tests (default: 3)." << endl
+            << "    --benchmark-trial <seconds>  Set the duration for each trial for the benchmark tests (default: 3)." << endl
+            << "    --benchmark-trials <n>  Set the number of trials for the benchmark tests (default: 5)." << endl
+            << "DAG creation mode:" << endl
+            << "    -D,--create-dag <number>  Create the DAG in preparation for mining on given block and exit." << endl
+            << "Mining configuration:" << endl
+            << "    -C,--cpu  When mining, use the CPU." << endl
+            << "    -t, --mining-threads <n> Limit number of CPU/GPU miners to n (default: use everything available on selected platform)" << endl
+            << "    --current-block Let the miner know the current block number at configuration time. Will help determine DAG size and required GPU memory." << endl
+            << "    --disable-submit-hashrate  When mining, don't submit hashrate to node." << endl;
+    }
 
-	std::string minerType() const { return m_minerType; }
-	bool shouldPrecompute() const { return m_precompute; }
+    std::string minerType() const { return m_minerType; }
+    bool shouldPrecompute() const { return m_precompute; }
 
 private:
-	void doInitDAG(unsigned _n)
-	{
-		h256 seedHash = EthashAux::seedHash(_n);
-		cout << "Initializing DAG for epoch beginning #" << (_n / 30000 * 30000) << " (seedhash " << seedHash.abridged() << "). This will take a while." << endl;
-		EthashAux::full(seedHash, true);
-		exit(0);
-	}
+    void doInitDAG(unsigned _n)
+    {
+        h256 seedHash = EthashAux::seedHash(_n);
+        cout << "Initializing DAG for epoch beginning #" << (_n / 30000 * 30000) << " (seedhash " << seedHash.abridged() << "). This will take a while." << endl;
+        EthashAux::full(seedHash, true);
+        exit(0);
+    }
 
-	void doBenchmark(std::string const& _m, unsigned _warmupDuration = 15, unsigned _trialDuration = 3, unsigned _trials = 5)
-	{
-		BlockHeader genesis;
-		genesis.setDifficulty(1 << 18);
-		cdebug << Ethash::boundary(genesis);
+    void doBenchmark(std::string const& _m, unsigned _warmupDuration = 15, unsigned _trialDuration = 3, unsigned _trials = 5)
+    {
+        BlockHeader genesis;
+        genesis.setDifficulty(1 << 18);
+        cdebug << Ethash::boundary(genesis);
 
-		GenericFarm<EthashProofOfWork> f;
-		map<string, GenericFarm<EthashProofOfWork>::SealerDescriptor> sealers;
-		sealers["cpu"] = GenericFarm<EthashProofOfWork>::SealerDescriptor{&EthashCPUMiner::instances, [](GenericMiner<EthashProofOfWork>::ConstructionInfo ci){ return new EthashCPUMiner(ci); }};
-		f.setSealers(sealers);
-		f.onSolutionFound([&](EthashProofOfWork::Solution) { return false; });
+        GenericFarm<EthashProofOfWork> f;
+        map<string, GenericFarm<EthashProofOfWork>::SealerDescriptor> sealers;
+        sealers["cpu"] = GenericFarm<EthashProofOfWork>::SealerDescriptor{&EthashCPUMiner::instances, [](GenericMiner<EthashProofOfWork>::ConstructionInfo ci){ return new EthashCPUMiner(ci); }};
+        f.setSealers(sealers);
+        f.onSolutionFound([&](EthashProofOfWork::Solution) { return false; });
 
-		string platformInfo = EthashCPUMiner::platformInfo();
-		cout << "Benchmarking on platform: " << platformInfo << endl;
+        string platformInfo = EthashCPUMiner::platformInfo();
+        cout << "Benchmarking on platform: " << platformInfo << endl;
 
-		cout << "Preparing DAG..." << endl;
-		Ethash::ensurePrecomputed(0);
+        cout << "Preparing DAG..." << endl;
+        Ethash::ensurePrecomputed(0);
 
-		genesis.setDifficulty(u256(1) << 63);
-		f.setWork(genesis);
-		f.start(_m);
+        genesis.setDifficulty(u256(1) << 63);
+        f.setWork(genesis);
+        f.start(_m);
 
-		map<u256, WorkingProgress> results;
-		u256 mean = 0;
-		u256 innerMean = 0;
-		for (unsigned i = 0; i <= _trials; ++i)
-		{
-			if (!i)
-				cout << "Warming up..." << endl;
-			else
-				cout << "Trial " << i << "... " << flush;
-			this_thread::sleep_for(chrono::seconds(i ? _trialDuration : _warmupDuration));
+        map<u256, WorkingProgress> results;
+        u256 mean = 0;
+        u256 innerMean = 0;
+        for (unsigned i = 0; i <= _trials; ++i)
+        {
+            if (!i)
+                cout << "Warming up..." << endl;
+            else
+                cout << "Trial " << i << "... " << flush;
+            this_thread::sleep_for(chrono::seconds(i ? _trialDuration : _warmupDuration));
 
-			auto mp = f.miningProgress();
-			f.resetMiningProgress();
-			if (!i)
-				continue;
-			auto rate = mp.rate();
+            auto mp = f.miningProgress();
+            f.resetMiningProgress();
+            if (!i)
+                continue;
+            auto rate = mp.rate();
 
-			cout << rate << endl;
-			results[rate] = mp;
-			mean += rate;
-		}
-		f.stop();
-		int j = -1;
-		for (auto const& r: results)
-			if (++j > 0 && j < (int)_trials - 1)
-				innerMean += r.second.rate();
-		innerMean /= (_trials - 2);
-		cout << "min/mean/max: " << results.begin()->second.rate() << "/" << (mean / _trials) << "/" << results.rbegin()->second.rate() << " H/s" << endl;
-		cout << "inner mean: " << innerMean << " H/s" << endl;
-		exit(0);
-	}
+            cout << rate << endl;
+            results[rate] = mp;
+            mean += rate;
+        }
+        f.stop();
+        int j = -1;
+        for (auto const& r: results)
+            if (++j > 0 && j < (int)_trials - 1)
+                innerMean += r.second.rate();
+        innerMean /= (_trials - 2);
+        cout << "min/mean/max: " << results.begin()->second.rate() << "/" << (mean / _trials) << "/" << results.rbegin()->second.rate() << " H/s" << endl;
+        cout << "inner mean: " << innerMean << " H/s" << endl;
+        exit(0);
+    }
 
-	/// Operating mode.
-	OperationMode mode;
+    /// Operating mode.
+    OperationMode mode;
 
-	/// Mining options
-	std::string m_minerType = "cpu";
-	unsigned m_miningThreads = UINT_MAX;
-	uint64_t m_currentBlock = 0;
+    /// Mining options
+    std::string m_minerType = "cpu";
+    unsigned m_miningThreads = UINT_MAX;
+    uint64_t m_currentBlock = 0;
 
-	/// DAG initialisation param.
-	unsigned m_initDAG = 0;
+    /// DAG initialisation param.
+    unsigned m_initDAG = 0;
 
-	/// Benchmarking params
-	unsigned m_benchmarkWarmup = 3;
-	unsigned m_benchmarkTrial = 3;
-	unsigned m_benchmarkTrials = 5;
+    /// Benchmarking params
+    unsigned m_benchmarkWarmup = 3;
+    unsigned m_benchmarkTrial = 3;
+    unsigned m_benchmarkTrials = 5;
 
-	bool m_precompute = true;
+    bool m_precompute = true;
 };

--- a/eth/main.cpp
+++ b/eth/main.cpp
@@ -829,6 +829,7 @@ int main(int argc, char** argv)
         }
     }
 
+    setupLogging(g_logVerbosity);
 
     if (!privateChain.empty())
     {

--- a/eth/main.cpp
+++ b/eth/main.cpp
@@ -28,7 +28,6 @@
 #include <signal.h>
 
 #include <boost/algorithm/string.hpp>
-#include <boost/algorithm/string/trim_all.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/program_options.hpp>
 #include <boost/program_options/options_description.hpp>
@@ -67,7 +66,6 @@ using namespace std;
 using namespace dev;
 using namespace dev::p2p;
 using namespace dev::eth;
-using namespace boost::algorithm;
 namespace po = boost::program_options;
 namespace fs = boost::filesystem;
 

--- a/libdevcore/CMakeLists.txt
+++ b/libdevcore/CMakeLists.txt
@@ -12,4 +12,4 @@ target_link_libraries(devcore Boost::filesystem Boost::system Boost::thread Thre
 
 find_package(LevelDB)
 target_include_directories(devcore SYSTEM PUBLIC ${LEVELDB_INCLUDE_DIRS})
-target_link_libraries(devcore ${LEVELDB_LIBRARIES})
+target_link_libraries(devcore ${LEVELDB_LIBRARIES} Boost::log)

--- a/libdevcore/CMakeLists.txt
+++ b/libdevcore/CMakeLists.txt
@@ -8,8 +8,8 @@ add_dependencies(devcore BuildInfo.h)
 # Needed to prevent including system-level boost headers:
 target_include_directories(devcore SYSTEM PUBLIC ${Boost_INCLUDE_DIR} PRIVATE ../utils)
 
-target_link_libraries(devcore Boost::filesystem Boost::system Boost::thread Threads::Threads)
+target_link_libraries(devcore Boost::filesystem Boost::system Boost::log Boost::thread Threads::Threads)
 
 find_package(LevelDB)
 target_include_directories(devcore SYSTEM PUBLIC ${LEVELDB_INCLUDE_DIRS})
-target_link_libraries(devcore ${LEVELDB_LIBRARIES} Boost::log)
+target_link_libraries(devcore ${LEVELDB_LIBRARIES})

--- a/libdevcore/Common.cpp
+++ b/libdevcore/Common.cpp
@@ -42,19 +42,15 @@ void InvariantChecker::checkInvariants(HasInvariants const* _this, char const* _
     }
 }
 
-struct TimerChannel: public LogChannel { static const char* name(); static const int verbosity = 0; };
-
-#if defined(_WIN32)
-const char* TimerChannel::name() { return EthRed " ! "; }
-#else
-const char* TimerChannel::name() { return EthRed " ⚡ "; }
-#endif
-
 TimerHelper::~TimerHelper()
 {
     auto e = std::chrono::high_resolution_clock::now() - m_t;
     if (!m_ms || e > chrono::milliseconds(m_ms))
-        clog(TimerChannel) << m_id << chrono::duration_cast<chrono::milliseconds>(e).count() << "ms";
+    {
+        Logger logger{createLogger(0, "timer")};
+        BOOST_LOG(logger) << m_id << chrono::duration_cast<chrono::milliseconds>(e).count()
+                          << " ms";
+    }
 }
 
 int64_t utcTime()

--- a/libdevcore/Common.cpp
+++ b/libdevcore/Common.cpp
@@ -48,8 +48,8 @@ TimerHelper::~TimerHelper()
     if (!m_ms || e > chrono::milliseconds(m_ms))
     {
         Logger logger{createLogger(0, "timer")};
-        BOOST_LOG(logger) << m_id << " " << chrono::duration_cast<chrono::milliseconds>(e).count()
-                          << " ms";
+        LOG(logger) << m_id << " " << chrono::duration_cast<chrono::milliseconds>(e).count()
+                    << " ms";
     }
 }
 

--- a/libdevcore/Common.cpp
+++ b/libdevcore/Common.cpp
@@ -48,7 +48,7 @@ TimerHelper::~TimerHelper()
     if (!m_ms || e > chrono::milliseconds(m_ms))
     {
         Logger logger{createLogger(0, "timer")};
-        BOOST_LOG(logger) << m_id << chrono::duration_cast<chrono::milliseconds>(e).count()
+        BOOST_LOG(logger) << m_id << " " << chrono::duration_cast<chrono::milliseconds>(e).count()
                           << " ms";
     }
 }

--- a/libdevcore/Log.cpp
+++ b/libdevcore/Log.cpp
@@ -62,23 +62,6 @@ bool isChannelVisible(std::type_info const* _ch, bool _default)
     return _default;
 }
 
-LogOverrideAux::LogOverrideAux(std::type_info const* _ch, bool _value):
-    m_ch(_ch)
-{
-    Guard l(x_logOverride);
-    m_old = s_logOverride.count(_ch) ? (int)s_logOverride[_ch] : c_null;
-    s_logOverride[m_ch] = _value;
-}
-
-LogOverrideAux::~LogOverrideAux()
-{
-    Guard l(x_logOverride);
-    if (m_old == c_null)
-        s_logOverride.erase(m_ch);
-    else
-        s_logOverride[m_ch] = (bool)m_old;
-}
-
 #if defined(_WIN32)
 const char* LogChannel::name() { return EthGray "..."; }
 const char* LeftChannel::name() { return EthNavy "<--"; }

--- a/libdevcore/Log.cpp
+++ b/libdevcore/Log.cpp
@@ -54,14 +54,6 @@ mutex x_logOverride;
 /// or equal to the currently output verbosity (g_logVerbosity).
 static map<type_info const*, bool> s_logOverride;
 
-bool isChannelVisible(std::type_info const* _ch, bool _default)
-{
-    Guard l(x_logOverride);
-    if (s_logOverride.count(_ch))
-        return s_logOverride[_ch];
-    return _default;
-}
-
 #if defined(_WIN32)
 const char* LogChannel::name() { return EthGray "..."; }
 #else

--- a/libdevcore/Log.cpp
+++ b/libdevcore/Log.cpp
@@ -64,19 +64,8 @@ bool isChannelVisible(std::type_info const* _ch, bool _default)
 
 #if defined(_WIN32)
 const char* LogChannel::name() { return EthGray "..."; }
-const char* LeftChannel::name() { return EthNavy "<--"; }
-const char* RightChannel::name() { return EthGreen "-->"; }
-const char* WarnChannel::name() { return EthOnRed EthBlackBold "  X"; }
-const char* NoteChannel::name() { return EthBlue "  i"; }
-const char* DebugChannel::name() { return EthWhite "  D"; }
-
 #else
 const char* LogChannel::name() { return EthGray "···"; }
-const char* LeftChannel::name() { return EthNavy "◀▬▬"; }
-const char* RightChannel::name() { return EthGreen "▬▬▶"; }
-const char* WarnChannel::name() { return EthOnRed EthBlackBold "  ✘"; }
-const char* NoteChannel::name() { return EthBlue "  ℹ"; }
-const char* DebugChannel::name() { return EthWhite "  ◇"; }
 #endif
 
 LogOutputStreamBase::LogOutputStreamBase(char const* _id, std::type_info const* _info, unsigned _v, bool _autospacing):

--- a/libdevcore/Log.h
+++ b/libdevcore/Log.h
@@ -23,13 +23,14 @@
 
 #pragma once
 
-#include <ctime>
 #include <string>
 #include "CommonIO.h"
 #include "FixedHash.h"
 #include "Terminal.h"
 
-#include <boost/log/common.hpp>
+#include <boost/log/sources/global_logger_storage.hpp>
+#include <boost/log/sources/record_ostream.hpp>
+#include <boost/log/sources/severity_channel_logger.hpp>
 
 namespace dev
 {

--- a/libdevcore/Log.h
+++ b/libdevcore/Log.h
@@ -282,132 +282,120 @@ inline Logger createLogger(int _severity, std::string const& _channel)
 
 
 // Log stream output operators to apply special formatting to the values sent to log
-template <typename CharT, typename TraitsT, typename AllocatorT>
-inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operator<<(
-    boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& _strm, unsigned long _value)
+inline boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _strm, unsigned long _value)
 {
     _strm.stream() << EthBlue << _value << EthReset;
     return _strm;
 }
 
-template <typename CharT, typename TraitsT, typename AllocatorT>
-inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operator<<(
-    boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& _strm, long _value)
+inline boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _strm, long _value)
 {
     _strm.stream() << EthBlue << _value << EthReset;
     return _strm;
 }
 
-template <typename CharT, typename TraitsT, typename AllocatorT>
-inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operator<<(
-    boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& _strm, unsigned int _value)
+inline boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _strm, unsigned int _value)
 {
     _strm.stream() << EthBlue << _value << EthReset;
     return _strm;
 }
 
-template <typename CharT, typename TraitsT, typename AllocatorT>
-inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operator<<(
-    boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& _strm, int _value)
+inline boost::log::formatting_ostream& operator<<(boost::log::formatting_ostream& _strm, int _value)
 {
     _strm.stream() << EthBlue << _value << EthReset;
     return _strm;
 }
 
-template <typename CharT, typename TraitsT, typename AllocatorT>
-inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operator<<(
-    boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& _strm, double _value)
+inline boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _strm, double _value)
 {
     _strm.stream() << EthBlue << _value << EthReset;
     return _strm;
 }
 
-template <typename CharT, typename TraitsT, typename AllocatorT>
-inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operator<<(
-    boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& _strm, bigint const& _value)
+inline boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _strm, bigint const& _value)
 {
     _strm.stream() << EthNavy << _value << EthReset;
     return _strm;
 }
 
-template <typename CharT, typename TraitsT, typename AllocatorT>
-inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operator<<(
-    boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& _strm, u256 const& _value)
+inline boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _strm, u256 const& _value)
 {
     _strm.stream() << EthNavy << _value << EthReset;
     return _strm;
 }
 
-template <typename CharT, typename TraitsT, typename AllocatorT>
-inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operator<<(
-    boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& _strm, u160 const& _value)
+inline boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _strm, u160 const& _value)
 {
     _strm.stream() << EthNavy << _value << EthReset;
     return _strm;
 }
 
-template <typename CharT, typename TraitsT, typename AllocatorT, unsigned HashSize>
-inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operator<<(
-    boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& _strm,
-    FixedHash<HashSize> const& _value)
+template <unsigned N>
+inline boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _strm, FixedHash<N> const& _value)
 {
     _strm.stream() << EthTeal "#" << _value.abridged() << EthReset;
     return _strm;
 }
 
-template <typename CharT, typename TraitsT, typename AllocatorT>
-inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operator<<(
-    boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& _strm, h160 const& _value)
+inline boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _strm, h160 const& _value)
 {
     _strm.stream() << EthRed "@" << _value.abridged() << EthReset;
     return _strm;
 }
 
-template <typename CharT, typename TraitsT, typename AllocatorT>
-inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operator<<(
-    boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& _strm, h256 const& _value)
+inline boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _strm, h256 const& _value)
 {
     _strm.stream() << EthCyan "#" << _value.abridged() << EthReset;
     return _strm;
 }
+inline boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _strm, h256& _value)
+{
+    _strm << const_cast<h256 const&>(_value);
+    return _strm;
+}
 
-template <typename CharT, typename TraitsT, typename AllocatorT>
-inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operator<<(
-    boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& _strm, h512 const& _value)
+inline boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _strm, h512 const& _value)
 {
     _strm.stream() << EthTeal "##" << _value.abridged() << EthReset;
     return _strm;
 }
 
-template <typename CharT, typename TraitsT, typename AllocatorT>
-inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operator<<(
-    boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& _strm,
-    std::string const& _value)
+inline boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _strm, std::string const& _value)
 {
     _strm.stream() << EthGreen "\"" + _value + "\"" EthReset;
     return _strm;
 }
 
-template <typename CharT, typename TraitsT, typename AllocatorT>
-inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operator<<(
-    boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& _strm, bytes const& _value)
+inline boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _strm, bytes const& _value)
 {
     _strm.stream() << EthYellow "%" << toHex(_value) << EthReset;
     return _strm;
 }
 
-template <typename CharT, typename TraitsT, typename AllocatorT>
-inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operator<<(
-    boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& _strm, bytesConstRef _value)
+inline boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _strm, bytesConstRef _value)
 {
     _strm.stream() << EthYellow "%" << toHex(_value) << EthReset;
     return _strm;
 }
 
-template <typename CharT, typename TraitsT, typename AllocatorT, typename T>
-inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operator<<(
-    boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& _strm,
-    std::vector<T> const& _value)
+template <typename T>
+inline boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _strm, std::vector<T> const& _value)
 {
     _strm.stream() << EthWhite "[" EthReset;
     int n = 0;
@@ -420,10 +408,9 @@ inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operato
     return _strm;
 }
 
-template <typename CharT, typename TraitsT, typename AllocatorT, typename T>
-inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operator<<(
-    boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& _strm,
-    std::set<T> const& _value)
+template <typename T>
+inline boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _strm, std::set<T> const& _value)
 {
     _strm.stream() << EthYellow "{" EthReset;
     int n = 0;
@@ -436,10 +423,9 @@ inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operato
     return _strm;
 }
 
-template <typename CharT, typename TraitsT, typename AllocatorT, typename T>
-inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operator<<(
-    boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& _strm,
-    std::unordered_set<T> const& _value)
+template <typename T>
+inline boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _strm, std::unordered_set<T> const& _value)
 {
     _strm.stream() << EthYellow "{" EthReset;
     int n = 0;
@@ -452,10 +438,9 @@ inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operato
     return _strm;
 }
 
-template <typename CharT, typename TraitsT, typename AllocatorT, typename T, typename U>
-inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operator<<(
-    boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& _strm,
-    std::map<T, U> const& _value)
+template <typename T, typename U>
+inline boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _strm, std::map<T, U> const& _value)
 {
     _strm.stream() << EthLime "{" EthReset;
     int n = 0;
@@ -470,10 +455,9 @@ inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operato
     return _strm;
 }
 
-template <typename CharT, typename TraitsT, typename AllocatorT, typename T, typename U>
-inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operator<<(
-    boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& _strm,
-    std::unordered_map<T, U> const& _value)
+template <typename T, typename U>
+inline boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _strm, std::unordered_map<T, U> const& _value)
 {
     _strm << EthLime "{" EthReset;
     int n = 0;
@@ -488,10 +472,9 @@ inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operato
     return _strm;
 }
 
-template <typename CharT, typename TraitsT, typename AllocatorT, typename T, typename U>
-inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operator<<(
-    boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& _strm,
-    std::pair<T, U> const& _value)
+template <typename T, typename U>
+inline boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _strm, std::pair<T, U> const& _value)
 {
     _strm.stream() << EthPurple "(" EthReset;
     _strm << _value.first;

--- a/libdevcore/Log.h
+++ b/libdevcore/Log.h
@@ -24,7 +24,6 @@
 #pragma once
 
 #include <ctime>
-#include <chrono>
 #include <string>
 #include "CommonIO.h"
 #include "FixedHash.h"
@@ -34,9 +33,6 @@
 
 namespace dev
 {
-
-/// A simple log-output function that prints log messages to stdout.
-void debugOut(std::string const& _s);
 
 /// The logging system's current verbosity.
 extern int g_logVerbosity;
@@ -88,152 +84,6 @@ void setThreadName(std::string const& _n);
 
 /// Set the current thread's log name.
 std::string getThreadName();
-
-/// The default logging channels. Each has an associated verbosity and three-letter prefix (name() ).
-/// Channels should inherit from LogChannel and define name() and verbosity.
-struct LogChannel { static const char* name(); static const int verbosity = 1; static const bool debug = true; };
-
-enum class LogTag
-{
-    None,
-    Url,
-    Error,
-    Special
-};
-
-class LogOutputStreamBase
-{
-public:
-    LogOutputStreamBase(char const* _id, std::type_info const* _info, unsigned _v, bool _autospacing);
-
-    void comment(std::string const& _t)
-    {
-        switch (m_logTag)
-        {
-        case LogTag::Url: m_sstr << EthNavyUnder; break;
-        case LogTag::Error: m_sstr << EthRedBold; break;
-        case LogTag::Special: m_sstr << EthWhiteBold; break;
-        default:;
-        }
-        m_sstr << _t << EthReset;
-        m_logTag = LogTag::None;
-    }
-
-    void append(unsigned long _t) { m_sstr << EthBlue << _t << EthReset; }
-    void append(long _t) { m_sstr << EthBlue << _t << EthReset; }
-    void append(unsigned int _t) { m_sstr << EthBlue << _t << EthReset; }
-    void append(int _t) { m_sstr << EthBlue << _t << EthReset; }
-    void append(bigint const& _t) { m_sstr << EthNavy << _t << EthReset; }
-    void append(u256 const& _t) { m_sstr << EthNavy << _t << EthReset; }
-    void append(u160 const& _t) { m_sstr << EthNavy << _t << EthReset; }
-    void append(double _t) { m_sstr << EthBlue << _t << EthReset; }
-    template <unsigned N> void append(FixedHash<N> const& _t) { m_sstr << EthTeal "#" << _t.abridged() << EthReset; }
-    void append(h160 const& _t) { m_sstr << EthRed "@" << _t.abridged() << EthReset; }
-    void append(h256 const& _t) { m_sstr << EthCyan "#" << _t.abridged() << EthReset; }
-    void append(h512 const& _t) { m_sstr << EthTeal "##" << _t.abridged() << EthReset; }
-    void append(std::string const& _t) { m_sstr << EthGreen "\"" + _t + "\"" EthReset; }
-    void append(bytes const& _t) { m_sstr << EthYellow "%" << toHex(_t) << EthReset; }
-    void append(bytesConstRef _t) { m_sstr << EthYellow "%" << toHex(_t) << EthReset; }
-    template <class T> void append(std::vector<T> const& _t)
-    {
-        m_sstr << EthWhite "[" EthReset;
-        int n = 0;
-        for (T const& i: _t)
-        {
-            m_sstr << (n++ ? EthWhite ", " EthReset : "");
-            append(i);
-        }
-        m_sstr << EthWhite "]" EthReset;
-    }
-    template <class T> void append(std::set<T> const& _t)
-    {
-        m_sstr << EthYellow "{" EthReset;
-        int n = 0;
-        for (T const& i: _t)
-        {
-            m_sstr << (n++ ? EthYellow ", " EthReset : "");
-            append(i);
-        }
-        m_sstr << EthYellow "}" EthReset;
-    }
-    template <class T, class U> void append(std::map<T, U> const& _t)
-    {
-        m_sstr << EthLime "{" EthReset;
-        int n = 0;
-        for (auto const& i: _t)
-        {
-            m_sstr << (n++ ? EthLime ", " EthReset : "");
-            append(i.first);
-            m_sstr << (n++ ? EthLime ": " EthReset : "");
-            append(i.second);
-        }
-        m_sstr << EthLime "}" EthReset;
-    }
-    template <class T> void append(std::unordered_set<T> const& _t)
-    {
-        m_sstr << EthYellow "{" EthReset;
-        int n = 0;
-        for (T const& i: _t)
-        {
-            m_sstr << (n++ ? EthYellow ", " EthReset : "");
-            append(i);
-        }
-        m_sstr << EthYellow "}" EthReset;
-    }
-    template <class T, class U> void append(std::unordered_map<T, U> const& _t)
-    {
-        m_sstr << EthLime "{" EthReset;
-        int n = 0;
-        for (auto const& i: _t)
-        {
-            m_sstr << (n++ ? EthLime ", " EthReset : "");
-            append(i.first);
-            m_sstr << (n++ ? EthLime ": " EthReset : "");
-            append(i.second);
-        }
-        m_sstr << EthLime "}" EthReset;
-    }
-    template <class T, class U> void append(std::pair<T, U> const& _t)
-    {
-        m_sstr << EthPurple "(" EthReset;
-        append(_t.first);
-        m_sstr << EthPurple ", " EthReset;
-        append(_t.second);
-        m_sstr << EthPurple ")" EthReset;
-    }
-    template <class T> void append(T const& _t)
-    {
-        m_sstr << toString(_t);
-    }
-
-protected:
-    bool m_autospacing = false;
-    unsigned m_verbosity = 0;
-    std::stringstream m_sstr;   ///< The accrued log entry.
-    LogTag m_logTag = LogTag::None;
-};
-
-/// Logging class, iostream-like, that can be shifted to.
-template <class Id, bool _AutoSpacing = true>
-class LogOutputStream: LogOutputStreamBase
-{
-public:
-    /// Construct a new object.
-    /// If _term is true the the prefix info is terminated with a ']' character; if not it ends only with a '|' character.
-    LogOutputStream(): LogOutputStreamBase(Id::name(), &typeid(Id), Id::verbosity, _AutoSpacing) {}
-
-    /// Destructor. Posts the accrued log entry to the output stream.
-    ~LogOutputStream() { if (Id::verbosity <= g_logVerbosity) debugOut(m_sstr.str()); }
-
-    LogOutputStream& operator<<(std::string const& _t) { if (Id::verbosity <= g_logVerbosity) { if (_AutoSpacing && m_sstr.str().size() && m_sstr.str().back() != ' ') m_sstr << " "; comment(_t); } return *this; }
-
-    LogOutputStream& operator<<(LogTag _t) { m_logTag = _t; return *this; }
-
-    /// Shift arbitrary data to the log. Spaces will be added between items as required.
-    template <class T> LogOutputStream& operator<<(T const& _t) { if (Id::verbosity <= g_logVerbosity) { if (_AutoSpacing && m_sstr.str().size() && m_sstr.str().back() != ' ') m_sstr << " "; append(_t); } return *this; }
-};
-
-#define clog(X) dev::LogOutputStream<X>()
 
 #define LOG BOOST_LOG
 

--- a/libdevcore/Log.h
+++ b/libdevcore/Log.h
@@ -316,10 +316,19 @@ inline boost::log::formatting_ostream& operator<<(
     return _strm;
 }
 
+// Below overloads for both const and non-const references are needed, because without overload for
+// non-const reference generic operator<<(formatting_ostream& _strm, T& _value) will be preferred by
+// overload resolution.
 inline boost::log::formatting_ostream& operator<<(
     boost::log::formatting_ostream& _strm, bigint const& _value)
 {
     _strm.stream() << EthNavy << _value << EthReset;
+    return _strm;
+}
+inline boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _strm, bigint& _value)
+{
+    _strm << const_cast<bigint const&>(_value);
     return _strm;
 }
 
@@ -329,11 +338,23 @@ inline boost::log::formatting_ostream& operator<<(
     _strm.stream() << EthNavy << _value << EthReset;
     return _strm;
 }
+inline boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _strm, u256& _value)
+{
+    _strm << const_cast<u256 const&>(_value);
+    return _strm;
+}
 
 inline boost::log::formatting_ostream& operator<<(
     boost::log::formatting_ostream& _strm, u160 const& _value)
 {
     _strm.stream() << EthNavy << _value << EthReset;
+    return _strm;
+}
+inline boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _strm, u160& _value)
+{
+    _strm << const_cast<u160 const&>(_value);
     return _strm;
 }
 
@@ -344,11 +365,24 @@ inline boost::log::formatting_ostream& operator<<(
     _strm.stream() << EthTeal "#" << _value.abridged() << EthReset;
     return _strm;
 }
+template <unsigned N>
+inline boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _strm, FixedHash<N>& _value)
+{
+    _strm << const_cast<FixedHash<N> const&>(_value);
+    return _strm;
+}
 
 inline boost::log::formatting_ostream& operator<<(
     boost::log::formatting_ostream& _strm, h160 const& _value)
 {
     _strm.stream() << EthRed "@" << _value.abridged() << EthReset;
+    return _strm;
+}
+inline boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _strm, h160& _value)
+{
+    _strm << const_cast<h160 const&>(_value);
     return _strm;
 }
 
@@ -369,6 +403,12 @@ inline boost::log::formatting_ostream& operator<<(
     boost::log::formatting_ostream& _strm, h512 const& _value)
 {
     _strm.stream() << EthTeal "##" << _value.abridged() << EthReset;
+    return _strm;
+}
+inline boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _strm, h512& _value)
+{
+    _strm << const_cast<h512 const&>(_value);
     return _strm;
 }
 

--- a/libdevcore/Log.h
+++ b/libdevcore/Log.h
@@ -279,43 +279,10 @@ inline Logger createLogger(int _severity, std::string const& _channel)
     return Logger(
         boost::log::keywords::severity = _severity, boost::log::keywords::channel = _channel);
 }
-
-
-// Log stream output operators to apply special formatting to the values sent to log
-inline boost::log::formatting_ostream& operator<<(
-    boost::log::formatting_ostream& _strm, unsigned long _value)
-{
-    _strm.stream() << EthBlue << _value << EthReset;
-    return _strm;
 }
 
-inline boost::log::formatting_ostream& operator<<(
-    boost::log::formatting_ostream& _strm, long _value)
+namespace dev
 {
-    _strm.stream() << EthBlue << _value << EthReset;
-    return _strm;
-}
-
-inline boost::log::formatting_ostream& operator<<(
-    boost::log::formatting_ostream& _strm, unsigned int _value)
-{
-    _strm.stream() << EthBlue << _value << EthReset;
-    return _strm;
-}
-
-inline boost::log::formatting_ostream& operator<<(boost::log::formatting_ostream& _strm, int _value)
-{
-    _strm.stream() << EthBlue << _value << EthReset;
-    return _strm;
-}
-
-inline boost::log::formatting_ostream& operator<<(
-    boost::log::formatting_ostream& _strm, double _value)
-{
-    _strm.stream() << EthBlue << _value << EthReset;
-    return _strm;
-}
-
 // Below overloads for both const and non-const references are needed, because without overload for
 // non-const reference generic operator<<(formatting_ostream& _strm, T& _value) will be preferred by
 // overload resolution.
@@ -409,13 +376,6 @@ inline boost::log::formatting_ostream& operator<<(
     boost::log::formatting_ostream& _strm, h512& _value)
 {
     _strm << const_cast<h512 const&>(_value);
-    return _strm;
-}
-
-inline boost::log::formatting_ostream& operator<<(
-    boost::log::formatting_ostream& _strm, std::string const& _value)
-{
-    _strm.stream() << EthGreen "\"" + _value + "\"" EthReset;
     return _strm;
 }
 

--- a/libdevcore/Log.h
+++ b/libdevcore/Log.h
@@ -241,23 +241,22 @@ public:
 // Thread-safe
 BOOST_LOG_INLINE_GLOBAL_LOGGER_CTOR_ARGS(g_debugLogger,
     boost::log::sources::severity_channel_logger_mt<>,
-    (boost::log::keywords::severity = 0)(boost::log::keywords::channel = EthWhite "debug" EthReset))
+    (boost::log::keywords::severity = 0)(boost::log::keywords::channel = "debug"))
 #define cdebug LOG(dev::g_debugLogger::get())
 
 BOOST_LOG_INLINE_GLOBAL_LOGGER_CTOR_ARGS(g_noteLogger,
     boost::log::sources::severity_channel_logger_mt<>,
-    (boost::log::keywords::severity = 1)(boost::log::keywords::channel = EthBlue "note" EthReset))
+    (boost::log::keywords::severity = 1)(boost::log::keywords::channel = "note"))
 #define cnote LOG(dev::g_noteLogger::get())
 
 BOOST_LOG_INLINE_GLOBAL_LOGGER_CTOR_ARGS(g_warnLogger,
     boost::log::sources::severity_channel_logger_mt<>,
-    (boost::log::keywords::severity = 0)(
-        boost::log::keywords::channel = EthOnRed EthBlackBold "warn" EthReset))
+    (boost::log::keywords::severity = 0)(boost::log::keywords::channel = "warn"))
 #define cwarn LOG(dev::g_warnLogger::get())
 
 BOOST_LOG_INLINE_GLOBAL_LOGGER_CTOR_ARGS(g_traceLogger,
     boost::log::sources::severity_channel_logger_mt<>,
-    (boost::log::keywords::severity = 4)(boost::log::keywords::channel = EthGray "trace" EthReset))
+    (boost::log::keywords::severity = 4)(boost::log::keywords::channel = "trace"))
 #define ctrace LOG(dev::g_traceLogger::get())
 
 // Simple macro to log to any channel a message without creating a logger object
@@ -269,6 +268,7 @@ BOOST_LOG_INLINE_GLOBAL_LOGGER_DEFAULT(
     BOOST_LOG_STREAM_WITH_PARAMS(dev::g_clogLogger::get(), \
         (boost::log::keywords::severity = SEVERITY)(boost::log::keywords::channel = CHANNEL))
 
+
 // Should be called in every executable
 void setupLogging(int _verbosity);
 
@@ -278,5 +278,226 @@ inline Logger createLogger(int _severity, std::string const& _channel)
 {
     return Logger(
         boost::log::keywords::severity = _severity, boost::log::keywords::channel = _channel);
+}
+
+
+// Log stream output operators to apply special formatting to the values sent to log
+template <typename CharT, typename TraitsT, typename AllocatorT>
+inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operator<<(
+    boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& _strm, unsigned long _value)
+{
+    _strm.stream() << EthBlue << _value << EthReset;
+    return _strm;
+}
+
+template <typename CharT, typename TraitsT, typename AllocatorT>
+inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operator<<(
+    boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& _strm, long _value)
+{
+    _strm.stream() << EthBlue << _value << EthReset;
+    return _strm;
+}
+
+template <typename CharT, typename TraitsT, typename AllocatorT>
+inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operator<<(
+    boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& _strm, unsigned int _value)
+{
+    _strm.stream() << EthBlue << _value << EthReset;
+    return _strm;
+}
+
+template <typename CharT, typename TraitsT, typename AllocatorT>
+inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operator<<(
+    boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& _strm, int _value)
+{
+    _strm.stream() << EthBlue << _value << EthReset;
+    return _strm;
+}
+
+template <typename CharT, typename TraitsT, typename AllocatorT>
+inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operator<<(
+    boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& _strm, double _value)
+{
+    _strm.stream() << EthBlue << _value << EthReset;
+    return _strm;
+}
+
+template <typename CharT, typename TraitsT, typename AllocatorT>
+inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operator<<(
+    boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& _strm, bigint const& _value)
+{
+    _strm.stream() << EthNavy << _value << EthReset;
+    return _strm;
+}
+
+template <typename CharT, typename TraitsT, typename AllocatorT>
+inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operator<<(
+    boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& _strm, u256 const& _value)
+{
+    _strm.stream() << EthNavy << _value << EthReset;
+    return _strm;
+}
+
+template <typename CharT, typename TraitsT, typename AllocatorT>
+inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operator<<(
+    boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& _strm, u160 const& _value)
+{
+    _strm.stream() << EthNavy << _value << EthReset;
+    return _strm;
+}
+
+template <typename CharT, typename TraitsT, typename AllocatorT, unsigned HashSize>
+inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operator<<(
+    boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& _strm,
+    FixedHash<HashSize> const& _value)
+{
+    _strm.stream() << EthTeal "#" << _value.abridged() << EthReset;
+    return _strm;
+}
+
+template <typename CharT, typename TraitsT, typename AllocatorT>
+inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operator<<(
+    boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& _strm, h160 const& _value)
+{
+    _strm.stream() << EthRed "@" << _value.abridged() << EthReset;
+    return _strm;
+}
+
+template <typename CharT, typename TraitsT, typename AllocatorT>
+inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operator<<(
+    boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& _strm, h256 const& _value)
+{
+    _strm.stream() << EthCyan "#" << _value.abridged() << EthReset;
+    return _strm;
+}
+
+template <typename CharT, typename TraitsT, typename AllocatorT>
+inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operator<<(
+    boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& _strm, h512 const& _value)
+{
+    _strm.stream() << EthTeal "##" << _value.abridged() << EthReset;
+    return _strm;
+}
+
+template <typename CharT, typename TraitsT, typename AllocatorT>
+inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operator<<(
+    boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& _strm,
+    std::string const& _value)
+{
+    _strm.stream() << EthGreen "\"" + _value + "\"" EthReset;
+    return _strm;
+}
+
+template <typename CharT, typename TraitsT, typename AllocatorT>
+inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operator<<(
+    boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& _strm, bytes const& _value)
+{
+    _strm.stream() << EthYellow "%" << toHex(_value) << EthReset;
+    return _strm;
+}
+
+template <typename CharT, typename TraitsT, typename AllocatorT>
+inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operator<<(
+    boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& _strm, bytesConstRef _value)
+{
+    _strm.stream() << EthYellow "%" << toHex(_value) << EthReset;
+    return _strm;
+}
+
+template <typename CharT, typename TraitsT, typename AllocatorT, typename T>
+inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operator<<(
+    boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& _strm,
+    std::vector<T> const& _value)
+{
+    _strm.stream() << EthWhite "[" EthReset;
+    int n = 0;
+    for (T const& i : _value)
+    {
+        _strm.stream() << (n++ ? EthWhite ", " EthReset : "");
+        _strm << i;
+    }
+    _strm.stream() << EthWhite "]" EthReset;
+    return _strm;
+}
+
+template <typename CharT, typename TraitsT, typename AllocatorT, typename T>
+inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operator<<(
+    boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& _strm,
+    std::set<T> const& _value)
+{
+    _strm.stream() << EthYellow "{" EthReset;
+    int n = 0;
+    for (T const& i : _value)
+    {
+        _strm.stream() << (n++ ? EthYellow ", " EthReset : "");
+        _strm << i;
+    }
+    _strm.stream() << EthYellow "}" EthReset;
+    return _strm;
+}
+
+template <typename CharT, typename TraitsT, typename AllocatorT, typename T>
+inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operator<<(
+    boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& _strm,
+    std::unordered_set<T> const& _value)
+{
+    _strm.stream() << EthYellow "{" EthReset;
+    int n = 0;
+    for (T const& i : _value)
+    {
+        _strm.stream() << (n++ ? EthYellow ", " EthReset : "");
+        _strm << i;
+    }
+    _strm.stream() << EthYellow "}" EthReset;
+    return _strm;
+}
+
+template <typename CharT, typename TraitsT, typename AllocatorT, typename T, typename U>
+inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operator<<(
+    boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& _strm,
+    std::map<T, U> const& _value)
+{
+    _strm.stream() << EthLime "{" EthReset;
+    int n = 0;
+    for (auto const& i : _value)
+    {
+        _strm << (n++ ? EthLime ", " EthReset : "");
+        _strm << i.first;
+        _strm << (n++ ? EthLime ": " EthReset : "");
+        _strm << i.second;
+    }
+    _strm.stream() << EthLime "}" EthReset;
+    return _strm;
+}
+
+template <typename CharT, typename TraitsT, typename AllocatorT, typename T, typename U>
+inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operator<<(
+    boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& _strm,
+    std::unordered_map<T, U> const& _value)
+{
+    _strm << EthLime "{" EthReset;
+    int n = 0;
+    for (auto const& i : _value)
+    {
+        _strm.stream() << (n++ ? EthLime ", " EthReset : "");
+        _strm << i.first;
+        _strm.stream() << (n++ ? EthLime ": " EthReset : "");
+        _strm << i.second;
+    }
+    _strm << EthLime "}" EthReset;
+    return _strm;
+}
+
+template <typename CharT, typename TraitsT, typename AllocatorT, typename T, typename U>
+inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operator<<(
+    boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& _strm,
+    std::pair<T, U> const& _value)
+{
+    _strm.stream() << EthPurple "(" EthReset;
+    _strm << _value.first;
+    _strm.stream() << EthPurple ", " EthReset;
+    _strm << _value.second;
+    _strm.stream() << EthPurple ")" EthReset;
+    return _strm;
 }
 }

--- a/libdevcore/Log.h
+++ b/libdevcore/Log.h
@@ -380,16 +380,30 @@ inline boost::log::formatting_ostream& operator<<(
 }
 
 inline boost::log::formatting_ostream& operator<<(
-    boost::log::formatting_ostream& _strm, bytes const& _value)
+    boost::log::formatting_ostream& _strm, bytesConstRef _value)
 {
     _strm.stream() << EthYellow "%" << toHex(_value) << EthReset;
     return _strm;
 }
+}  // namespace dev
 
-inline boost::log::formatting_ostream& operator<<(
-    boost::log::formatting_ostream& _strm, bytesConstRef _value)
+// Overloads for types of std namespace can't be defined in dev namespace, because they won't be
+// found due to Argument-Dependent Lookup Placing anything into std is not allowed, but we can put
+// them into boost::log
+namespace boost
 {
-    _strm.stream() << EthYellow "%" << toHex(_value) << EthReset;
+namespace log
+{
+inline boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _strm, dev::bytes const& _value)
+{
+    _strm.stream() << EthYellow "%" << dev::toHex(_value) << EthReset;
+    return _strm;
+}
+inline boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _strm, dev::bytes& _value)
+{
+    _strm << const_cast<dev::bytes const&>(_value);
     return _strm;
 }
 
@@ -407,6 +421,13 @@ inline boost::log::formatting_ostream& operator<<(
     _strm.stream() << EthWhite "]" EthReset;
     return _strm;
 }
+template <typename T>
+inline boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _strm, std::vector<T>& _value)
+{
+    _strm << const_cast<std::vector<T> const&>(_value);
+    return _strm;
+}
 
 template <typename T>
 inline boost::log::formatting_ostream& operator<<(
@@ -422,6 +443,13 @@ inline boost::log::formatting_ostream& operator<<(
     _strm.stream() << EthYellow "}" EthReset;
     return _strm;
 }
+template <typename T>
+inline boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _strm, std::set<T>& _value)
+{
+    _strm << const_cast<std::set<T> const&>(_value);
+    return _strm;
+}
 
 template <typename T>
 inline boost::log::formatting_ostream& operator<<(
@@ -435,6 +463,13 @@ inline boost::log::formatting_ostream& operator<<(
         _strm << i;
     }
     _strm.stream() << EthYellow "}" EthReset;
+    return _strm;
+}
+template <typename T>
+inline boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _strm, std::unordered_set<T>& _value)
+{
+    _strm << const_cast<std::unordered_set<T> const&>(_value);
     return _strm;
 }
 
@@ -454,6 +489,13 @@ inline boost::log::formatting_ostream& operator<<(
     _strm.stream() << EthLime "}" EthReset;
     return _strm;
 }
+template <typename T, typename U>
+inline boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _strm, std::map<T, U>& _value)
+{
+    _strm << const_cast<std::map<T, U> const&>(_value);
+    return _strm;
+}
 
 template <typename T, typename U>
 inline boost::log::formatting_ostream& operator<<(
@@ -471,6 +513,13 @@ inline boost::log::formatting_ostream& operator<<(
     _strm << EthLime "}" EthReset;
     return _strm;
 }
+template <typename T, typename U>
+inline boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _strm, std::unordered_map<T, U>& _value)
+{
+    _strm << const_cast<std::unordered_map<T, U> const&>(_value);
+    return _strm;
+}
 
 template <typename T, typename U>
 inline boost::log::formatting_ostream& operator<<(
@@ -483,4 +532,12 @@ inline boost::log::formatting_ostream& operator<<(
     _strm.stream() << EthPurple ")" EthReset;
     return _strm;
 }
+template <typename T, typename U>
+inline boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _strm, std::pair<T, U>& _value)
+{
+    _strm << const_cast<std::pair<T, U> const&>(_value);
+    return _strm;
 }
+}
+}  // namespace boost

--- a/libdevcore/Log.h
+++ b/libdevcore/Log.h
@@ -238,7 +238,7 @@ public:
 #define LOG BOOST_LOG
 
 // Simple cout-like stream objects for accessing common log channels.
-// Dirties the global namespace, but oh so convenient...
+// Thread-safe
 BOOST_LOG_INLINE_GLOBAL_LOGGER_CTOR_ARGS(g_debugLogger,
     boost::log::sources::severity_channel_logger_mt<>,
     (boost::log::keywords::severity = 0)(boost::log::keywords::channel = EthWhite "debug" EthReset))
@@ -260,8 +260,19 @@ BOOST_LOG_INLINE_GLOBAL_LOGGER_CTOR_ARGS(g_traceLogger,
     (boost::log::keywords::severity = 4)(boost::log::keywords::channel = EthGray "trace" EthReset))
 #define ctrace LOG(dev::g_traceLogger::get())
 
+// Simple macro to log to any channel a message without creating a logger object
+// e.g. clog(0, "channel") << "message";
+// Thread-safe
+BOOST_LOG_INLINE_GLOBAL_LOGGER_DEFAULT(
+    g_clogLogger, boost::log::sources::severity_channel_logger_mt<>);
+#define clogSimple(SEVERITY, CHANNEL)                      \
+    BOOST_LOG_STREAM_WITH_PARAMS(dev::g_clogLogger::get(), \
+        (boost::log::keywords::severity = SEVERITY)(boost::log::keywords::channel = CHANNEL))
+
+// Should be called in every executable
 void setupLogging(int _verbosity);
 
+// Simple non-thread-safe logger with fixed severity and channel for each message
 using Logger = boost::log::sources::severity_channel_logger<>;
 inline Logger createLogger(int _severity, std::string const& _channel)
 {

--- a/libdevcore/Log.h
+++ b/libdevcore/Log.h
@@ -295,7 +295,8 @@ inline boost::log::formatting_ostream& operator<<(
 inline boost::log::formatting_ostream& operator<<(
     boost::log::formatting_ostream& _strm, bigint& _value)
 {
-    _strm << const_cast<bigint const&>(_value);
+    auto const& constValue = _value;
+    _strm << constValue;
     return _strm;
 }
 
@@ -308,7 +309,8 @@ inline boost::log::formatting_ostream& operator<<(
 inline boost::log::formatting_ostream& operator<<(
     boost::log::formatting_ostream& _strm, u256& _value)
 {
-    _strm << const_cast<u256 const&>(_value);
+    auto const& constValue = _value;
+    _strm << constValue;
     return _strm;
 }
 
@@ -321,7 +323,8 @@ inline boost::log::formatting_ostream& operator<<(
 inline boost::log::formatting_ostream& operator<<(
     boost::log::formatting_ostream& _strm, u160& _value)
 {
-    _strm << const_cast<u160 const&>(_value);
+    auto const& constValue = _value;
+    _strm << constValue;
     return _strm;
 }
 
@@ -336,7 +339,8 @@ template <unsigned N>
 inline boost::log::formatting_ostream& operator<<(
     boost::log::formatting_ostream& _strm, FixedHash<N>& _value)
 {
-    _strm << const_cast<FixedHash<N> const&>(_value);
+    auto const& constValue = _value;
+    _strm << constValue;
     return _strm;
 }
 
@@ -349,7 +353,8 @@ inline boost::log::formatting_ostream& operator<<(
 inline boost::log::formatting_ostream& operator<<(
     boost::log::formatting_ostream& _strm, h160& _value)
 {
-    _strm << const_cast<h160 const&>(_value);
+    auto const& constValue = _value;
+    _strm << constValue;
     return _strm;
 }
 
@@ -362,7 +367,8 @@ inline boost::log::formatting_ostream& operator<<(
 inline boost::log::formatting_ostream& operator<<(
     boost::log::formatting_ostream& _strm, h256& _value)
 {
-    _strm << const_cast<h256 const&>(_value);
+    auto const& constValue = _value;
+    _strm << constValue;
     return _strm;
 }
 
@@ -375,7 +381,8 @@ inline boost::log::formatting_ostream& operator<<(
 inline boost::log::formatting_ostream& operator<<(
     boost::log::formatting_ostream& _strm, h512& _value)
 {
-    _strm << const_cast<h512 const&>(_value);
+    auto const& constValue = _value;
+    _strm << constValue;
     return _strm;
 }
 
@@ -403,7 +410,8 @@ inline boost::log::formatting_ostream& operator<<(
 inline boost::log::formatting_ostream& operator<<(
     boost::log::formatting_ostream& _strm, dev::bytes& _value)
 {
-    _strm << const_cast<dev::bytes const&>(_value);
+    auto const& constValue = _value;
+    _strm << constValue;
     return _strm;
 }
 
@@ -425,7 +433,8 @@ template <typename T>
 inline boost::log::formatting_ostream& operator<<(
     boost::log::formatting_ostream& _strm, std::vector<T>& _value)
 {
-    _strm << const_cast<std::vector<T> const&>(_value);
+    auto const& constValue = _value;
+    _strm << constValue;
     return _strm;
 }
 
@@ -447,7 +456,8 @@ template <typename T>
 inline boost::log::formatting_ostream& operator<<(
     boost::log::formatting_ostream& _strm, std::set<T>& _value)
 {
-    _strm << const_cast<std::set<T> const&>(_value);
+    auto const& constValue = _value;
+    _strm << constValue;
     return _strm;
 }
 
@@ -469,7 +479,8 @@ template <typename T>
 inline boost::log::formatting_ostream& operator<<(
     boost::log::formatting_ostream& _strm, std::unordered_set<T>& _value)
 {
-    _strm << const_cast<std::unordered_set<T> const&>(_value);
+    auto const& constValue = _value;
+    _strm << constValue;
     return _strm;
 }
 
@@ -493,7 +504,8 @@ template <typename T, typename U>
 inline boost::log::formatting_ostream& operator<<(
     boost::log::formatting_ostream& _strm, std::map<T, U>& _value)
 {
-    _strm << const_cast<std::map<T, U> const&>(_value);
+    auto const& constValue = _value;
+    _strm << constValue;
     return _strm;
 }
 
@@ -517,7 +529,8 @@ template <typename T, typename U>
 inline boost::log::formatting_ostream& operator<<(
     boost::log::formatting_ostream& _strm, std::unordered_map<T, U>& _value)
 {
-    _strm << const_cast<std::unordered_map<T, U> const&>(_value);
+    auto const& constValue = _value;
+    _strm << constValue;
     return _strm;
 }
 
@@ -536,7 +549,8 @@ template <typename T, typename U>
 inline boost::log::formatting_ostream& operator<<(
     boost::log::formatting_ostream& _strm, std::pair<T, U>& _value)
 {
-    _strm << const_cast<std::pair<T, U> const&>(_value);
+    auto const& constValue = _value;
+    _strm << constValue;
     return _strm;
 }
 }

--- a/libdevcore/Log.h
+++ b/libdevcore/Log.h
@@ -41,9 +41,6 @@ void debugOut(std::string const& _s);
 /// The logging system's current verbosity.
 extern int g_logVerbosity;
 
-bool isChannelVisible(std::type_info const* _ch, bool _default);
-template <class Channel> bool isChannelVisible() { return isChannelVisible(&typeid(Channel), Channel::verbosity <= g_logVerbosity); }
-
 /// Temporary changes system's verbosity for specific function. Restores the old verbosity when function returns.
 /// Not thread-safe, use with caution!
 struct VerbosityHolder
@@ -52,8 +49,6 @@ struct VerbosityHolder
     ~VerbosityHolder() { g_logVerbosity = oldLogVerbosity; }
     int oldLogVerbosity;
 };
-
-#define ETH_THREAD_CONTEXT(name) for (std::pair<dev::ThreadContext, bool> __eth_thread_context(name, true); p.second; p.second = false)
 
 class ThreadContext
 {
@@ -238,20 +233,7 @@ public:
     template <class T> LogOutputStream& operator<<(T const& _t) { if (Id::verbosity <= g_logVerbosity) { if (_AutoSpacing && m_sstr.str().size() && m_sstr.str().back() != ' ') m_sstr << " "; append(_t); } return *this; }
 };
 
-/// A "hacky" way to execute the next statement on COND.
-/// We need such a thing due to the dangling else problem and the need
-/// for the logging macros to end with the stream object and not a closing brace '}'
-#define DEV_STATEMENT_IF(COND) for (bool i_eth_if_ = (COND); i_eth_if_; i_eth_if_ = false)
-/// A "hacky" way to skip the next statement.
-/// We need such a thing due to the dangling else problem and the need
-/// for the logging macros to end with the stream object and not a closing brace '}'
-#define DEV_STATEMENT_SKIP() while (/*CONSTCOND*/ false) /*NOTREACHED*/
-
-#if NDEBUG
-#define clog(X) DEV_STATEMENT_IF(!(X::debug)) dev::LogOutputStream<X>()
-#else
 #define clog(X) dev::LogOutputStream<X>()
-#endif
 
 // Simple cout-like stream objects for accessing common log channels.
 // Dirties the global namespace, but oh so convenient...

--- a/libdevcore/Log.h
+++ b/libdevcore/Log.h
@@ -97,11 +97,6 @@ std::string getThreadName();
 /// The default logging channels. Each has an associated verbosity and three-letter prefix (name() ).
 /// Channels should inherit from LogChannel and define name() and verbosity.
 struct LogChannel { static const char* name(); static const int verbosity = 1; static const bool debug = true; };
-struct LeftChannel: public LogChannel { static const char* name(); };
-struct RightChannel: public LogChannel { static const char* name(); };
-struct WarnChannel: public LogChannel { static const char* name(); static const int verbosity = 0; static const bool debug = false; };
-struct NoteChannel: public LogChannel { static const char* name(); static const bool debug = false; };
-struct DebugChannel : public LogChannel { static const char* name(); static const int verbosity = 0; };
 
 enum class LogTag
 {

--- a/libdevcore/Log.h
+++ b/libdevcore/Log.h
@@ -235,28 +235,30 @@ public:
 
 #define clog(X) dev::LogOutputStream<X>()
 
+#define LOG BOOST_LOG
+
 // Simple cout-like stream objects for accessing common log channels.
 // Dirties the global namespace, but oh so convenient...
 BOOST_LOG_INLINE_GLOBAL_LOGGER_CTOR_ARGS(g_debugLogger,
     boost::log::sources::severity_channel_logger_mt<>,
     (boost::log::keywords::severity = 0)(boost::log::keywords::channel = EthWhite "debug" EthReset))
-#define cdebug BOOST_LOG(dev::g_debugLogger::get())
+#define cdebug LOG(dev::g_debugLogger::get())
 
 BOOST_LOG_INLINE_GLOBAL_LOGGER_CTOR_ARGS(g_noteLogger,
     boost::log::sources::severity_channel_logger_mt<>,
     (boost::log::keywords::severity = 1)(boost::log::keywords::channel = EthBlue "note" EthReset))
-#define cnote BOOST_LOG(dev::g_noteLogger::get())
+#define cnote LOG(dev::g_noteLogger::get())
 
 BOOST_LOG_INLINE_GLOBAL_LOGGER_CTOR_ARGS(g_warnLogger,
     boost::log::sources::severity_channel_logger_mt<>,
     (boost::log::keywords::severity = 0)(
         boost::log::keywords::channel = EthOnRed EthBlackBold "warn" EthReset))
-#define cwarn BOOST_LOG(dev::g_warnLogger::get())
+#define cwarn LOG(dev::g_warnLogger::get())
 
 BOOST_LOG_INLINE_GLOBAL_LOGGER_CTOR_ARGS(g_traceLogger,
     boost::log::sources::severity_channel_logger_mt<>,
     (boost::log::keywords::severity = 4)(boost::log::keywords::channel = EthGray "trace" EthReset))
-#define ctrace BOOST_LOG(dev::g_traceLogger::get())
+#define ctrace LOG(dev::g_traceLogger::get())
 
 void setupLogging(int _verbosity);
 

--- a/libdevcore/MemoryDB.cpp
+++ b/libdevcore/MemoryDB.cpp
@@ -1,18 +1,18 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file MemoryDB.cpp
  * @author Gav Wood <i@gavwood.com>
@@ -28,165 +28,162 @@ using namespace dev;
 namespace dev
 {
 
-const char* DBChannel::name() { return "TDB"; }
-const char* DBWarn::name() { return "TDB"; }
-
 std::unordered_map<h256, std::string> MemoryDB::get() const
 {
 #if DEV_GUARDED_DB
-	ReadGuard l(x_this);
+    ReadGuard l(x_this);
 #endif
-	std::unordered_map<h256, std::string> ret;
-	for (auto const& i: m_main)
-		if (!m_enforceRefs || i.second.second > 0)
-			ret.insert(make_pair(i.first, i.second.first));
-	return ret;
+    std::unordered_map<h256, std::string> ret;
+    for (auto const& i: m_main)
+        if (!m_enforceRefs || i.second.second > 0)
+            ret.insert(make_pair(i.first, i.second.first));
+    return ret;
 }
 
 MemoryDB& MemoryDB::operator=(MemoryDB const& _c)
 {
-	if (this == &_c)
-		return *this;
+    if (this == &_c)
+        return *this;
 #if DEV_GUARDED_DB
-	ReadGuard l(_c.x_this);
-	WriteGuard l2(x_this);
+    ReadGuard l(_c.x_this);
+    WriteGuard l2(x_this);
 #endif
-	m_main = _c.m_main;
-	m_aux = _c.m_aux;
-	return *this;
+    m_main = _c.m_main;
+    m_aux = _c.m_aux;
+    return *this;
 }
 
 std::string MemoryDB::lookup(h256 const& _h) const
 {
 #if DEV_GUARDED_DB
-	ReadGuard l(x_this);
+    ReadGuard l(x_this);
 #endif
-	auto it = m_main.find(_h);
-	if (it != m_main.end())
-	{
-		if (!m_enforceRefs || it->second.second > 0)
-			return it->second.first;
-		else
-			cwarn << "Lookup required for value with refcount == 0. This is probably a critical trie issue" << _h;
-	}
-	return std::string();
+    auto it = m_main.find(_h);
+    if (it != m_main.end())
+    {
+        if (!m_enforceRefs || it->second.second > 0)
+            return it->second.first;
+        else
+            cwarn << "Lookup required for value with refcount == 0. This is probably a critical trie issue" << _h;
+    }
+    return std::string();
 }
 
 bool MemoryDB::exists(h256 const& _h) const
 {
 #if DEV_GUARDED_DB
-	ReadGuard l(x_this);
+    ReadGuard l(x_this);
 #endif
-	auto it = m_main.find(_h);
-	if (it != m_main.end() && (!m_enforceRefs || it->second.second > 0))
-		return true;
-	return false;
+    auto it = m_main.find(_h);
+    if (it != m_main.end() && (!m_enforceRefs || it->second.second > 0))
+        return true;
+    return false;
 }
 
 void MemoryDB::insert(h256 const& _h, bytesConstRef _v)
 {
 #if DEV_GUARDED_DB
-	WriteGuard l(x_this);
+    WriteGuard l(x_this);
 #endif
-	auto it = m_main.find(_h);
-	if (it != m_main.end())
-	{
-		it->second.first = _v.toString();
-		it->second.second++;
-	}
-	else
-		m_main[_h] = make_pair(_v.toString(), 1);
+    auto it = m_main.find(_h);
+    if (it != m_main.end())
+    {
+        it->second.first = _v.toString();
+        it->second.second++;
+    }
+    else
+        m_main[_h] = make_pair(_v.toString(), 1);
 #if ETH_PARANOIA
-	dbdebug << "INST" << _h << "=>" << m_main[_h].second;
+    cdebug << "INST" << _h << "=>" << m_main[_h].second;
 #endif
 }
 
 bool MemoryDB::kill(h256 const& _h)
 {
 #if DEV_GUARDED_DB
-	ReadGuard l(x_this);
+    ReadGuard l(x_this);
 #endif
-	if (m_main.count(_h))
-	{
-		if (m_main[_h].second > 0)
-		{
-			m_main[_h].second--;
-			return true;
-		}
+    if (m_main.count(_h))
+    {
+        if (m_main[_h].second > 0)
+        {
+            m_main[_h].second--;
+            return true;
+        }
 #if ETH_PARANOIA
-		else
-		{
-			// If we get to this point, then there was probably a node in the level DB which we need to remove and which we have previously
-			// used as part of the memory-based MemoryDB. Nothing to be worried about *as long as the node exists in the DB*.
-			dbdebug << "NOKILL-WAS" << _h;
-		}
-		dbdebug << "KILL" << _h << "=>" << m_main[_h].second;
-	}
-	else
-	{
-		dbdebug << "NOKILL" << _h;
+        else
+        {
+            // If we get to this point, then there was probably a node in the level DB which we need to remove and which we have previously
+            // used as part of the memory-based MemoryDB. Nothing to be worried about *as long as the node exists in the DB*.
+            cdebug << "NOKILL-WAS" << _h;
+        }
+        cdebug << "KILL" << _h << "=>" << m_main[_h].second;
+    }
+    else
+    {
+        cdebug << "NOKILL" << _h;
 #endif
-	}
-	return false;
+    }
+    return false;
 }
 
 bytes MemoryDB::lookupAux(h256 const& _h) const
 {
 #if DEV_GUARDED_DB
-	ReadGuard l(x_this);
+    ReadGuard l(x_this);
 #endif
-	auto it = m_aux.find(_h);
-	if (it != m_aux.end() && (!m_enforceRefs || it->second.second))
-		return it->second.first;
-	return bytes();
+    auto it = m_aux.find(_h);
+    if (it != m_aux.end() && (!m_enforceRefs || it->second.second))
+        return it->second.first;
+    return bytes();
 }
 
 void MemoryDB::removeAux(h256 const& _h)
 {
 #if DEV_GUARDED_DB
-	WriteGuard l(x_this);
+    WriteGuard l(x_this);
 #endif
-	m_aux[_h].second = false;
+    m_aux[_h].second = false;
 }
 
 void MemoryDB::insertAux(h256 const& _h, bytesConstRef _v)
 {
 #if DEV_GUARDED_DB
-	WriteGuard l(x_this);
+    WriteGuard l(x_this);
 #endif
-	m_aux[_h] = make_pair(_v.toBytes(), true);
+    m_aux[_h] = make_pair(_v.toBytes(), true);
 }
 
 void MemoryDB::purge()
 {
 #if DEV_GUARDED_DB
-	WriteGuard l(x_this);
+    WriteGuard l(x_this);
 #endif
-	// purge m_main
-	for (auto it = m_main.begin(); it != m_main.end(); )
-		if (it->second.second)
-			++it;
-		else
-			it = m_main.erase(it);
+    // purge m_main
+    for (auto it = m_main.begin(); it != m_main.end(); )
+        if (it->second.second)
+            ++it;
+        else
+            it = m_main.erase(it);
 
-	// purge m_aux
-	for (auto it = m_aux.begin(); it != m_aux.end(); )
-		if (it->second.second)
-			++it;
-		else
-			it = m_aux.erase(it);
+    // purge m_aux
+    for (auto it = m_aux.begin(); it != m_aux.end(); )
+        if (it->second.second)
+            ++it;
+        else
+            it = m_aux.erase(it);
 }
 
 h256Hash MemoryDB::keys() const
 {
 #if DEV_GUARDED_DB
-	ReadGuard l(x_this);
+    ReadGuard l(x_this);
 #endif
-	h256Hash ret;
-	for (auto const& i: m_main)
-		if (i.second.second)
-			ret.insert(i.first);
-	return ret;
+    h256Hash ret;
+    for (auto const& i: m_main)
+        if (i.second.second)
+            ret.insert(i.first);
+    return ret;
 }
 
 }

--- a/libdevcore/MemoryDB.h
+++ b/libdevcore/MemoryDB.h
@@ -29,12 +29,6 @@
 namespace dev
 {
 
-struct DBChannel: public LogChannel  { static const char* name(); static const int verbosity = 18; };
-struct DBWarn: public LogChannel  { static const char* name(); static const int verbosity = 1; };
-
-#define dbdebug clog(DBChannel)
-#define dbwarn clog(DBWarn)
-
 class MemoryDB
 {
     friend class EnforceRefs;

--- a/libdevcore/OverlayDB.h
+++ b/libdevcore/OverlayDB.h
@@ -30,14 +30,12 @@
 namespace dev
 {
 
-struct DBDetail: public LogChannel { static const char* name() { return "DBDetail"; } static const int verbosity = 14; };
-
 class OverlayDB: public MemoryDB
 {
 public:
     explicit OverlayDB(std::unique_ptr<db::DatabaseFace> _db = nullptr)
       : m_db(_db.release(), [](db::DatabaseFace* db) {
-            clog(DBDetail) << "Closing state DB";
+            clogSimple(14, "overlaydb") << "Closing state DB";
             delete db;
         })
     {}

--- a/libdevcore/TrieDB.h
+++ b/libdevcore/TrieDB.h
@@ -30,13 +30,6 @@
 namespace dev
 {
 
-struct TrieDBChannel: public LogChannel
-{
-    static const char* name() { return "-T-"; }
-    static const int verbosity = 17;
-};
-#define tdebug clog(TrieDBChannel)
-
 struct InvalidTrie: virtual dev::Exception {};
 
 enum class Verification {

--- a/libdevcore/Worker.cpp
+++ b/libdevcore/Worker.cpp
@@ -64,7 +64,7 @@ void Worker::startWorking()
 				}
 				catch (std::exception const& _e)
 				{
-					clog(WarnChannel) << "Exception thrown in Worker thread: " << _e.what();
+					cwarn << "Exception thrown in Worker thread: " << _e.what();
 				}
 
 //				ex = WorkerState::Stopping;

--- a/libethashseal/EthashAux.cpp
+++ b/libethashseal/EthashAux.cpp
@@ -1,18 +1,18 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file EthashAux.cpp
  * @author Gav Wood <i@gavwood.com>
@@ -40,8 +40,6 @@ using namespace chrono;
 using namespace dev;
 using namespace eth;
 
-const char* DAGChannel::name() { return EthGreen "DAG"; }
-
 EthashAux* dev::eth::EthashAux::s_this = nullptr;
 
 EthashAux::~EthashAux()
@@ -50,210 +48,210 @@ EthashAux::~EthashAux()
 
 EthashAux* EthashAux::get()
 {
-	static std::once_flag flag;
-	std::call_once(flag, []{s_this = new EthashAux();});
-	return s_this;
+    static std::once_flag flag;
+    std::call_once(flag, []{s_this = new EthashAux();});
+    return s_this;
 }
 
 uint64_t EthashAux::cacheSize(BlockHeader const& _header)
 {
-	return ethash_get_cachesize((uint64_t)_header.number());
+    return ethash_get_cachesize((uint64_t)_header.number());
 }
 
 uint64_t EthashAux::dataSize(uint64_t _blockNumber)
 {
-	return ethash_get_datasize(_blockNumber);
+    return ethash_get_datasize(_blockNumber);
 }
 
 h256 EthashAux::seedHash(unsigned _number)
 {
-	unsigned epoch = _number / ETHASH_EPOCH_LENGTH;
-	Guard l(get()->x_epochs);
-	if (epoch >= get()->m_seedHashes.size())
-	{
-		h256 ret;
-		unsigned n = 0;
-		if (!get()->m_seedHashes.empty())
-		{
-			ret = get()->m_seedHashes.back();
-			n = get()->m_seedHashes.size() - 1;
-		}
-		get()->m_seedHashes.resize(epoch + 1);
+    unsigned epoch = _number / ETHASH_EPOCH_LENGTH;
+    Guard l(get()->x_epochs);
+    if (epoch >= get()->m_seedHashes.size())
+    {
+        h256 ret;
+        unsigned n = 0;
+        if (!get()->m_seedHashes.empty())
+        {
+            ret = get()->m_seedHashes.back();
+            n = get()->m_seedHashes.size() - 1;
+        }
+        get()->m_seedHashes.resize(epoch + 1);
 //		cdebug << "Searching for seedHash of epoch " << epoch;
-		for (; n <= epoch; ++n, ret = sha3(ret))
-		{
-			get()->m_seedHashes[n] = ret;
+        for (; n <= epoch; ++n, ret = sha3(ret))
+        {
+            get()->m_seedHashes[n] = ret;
 //			cdebug << "Epoch" << n << "is" << ret;
-		}
-	}
-	return get()->m_seedHashes[epoch];
+        }
+    }
+    return get()->m_seedHashes[epoch];
 }
 
 uint64_t EthashAux::number(h256 const& _seedHash)
 {
-	Guard l(get()->x_epochs);
-	unsigned epoch = 0;
-	auto epochIter = get()->m_epochs.find(_seedHash);
-	if (epochIter == get()->m_epochs.end())
-	{
-		//		cdebug << "Searching for seedHash " << _seedHash;
-		for (h256 h; h != _seedHash && epoch < 2048; ++epoch, h = sha3(h), get()->m_epochs[h] = epoch) {}
-		if (epoch == 2048)
-		{
-			std::ostringstream error;
-			error << "apparent block number for " << _seedHash << " is too high; max is " << (ETHASH_EPOCH_LENGTH * 2048);
-			throw std::invalid_argument(error.str());
-		}
-	}
-	else
-		epoch = epochIter->second;
-	return epoch * ETHASH_EPOCH_LENGTH;
+    Guard l(get()->x_epochs);
+    unsigned epoch = 0;
+    auto epochIter = get()->m_epochs.find(_seedHash);
+    if (epochIter == get()->m_epochs.end())
+    {
+        //		cdebug << "Searching for seedHash " << _seedHash;
+        for (h256 h; h != _seedHash && epoch < 2048; ++epoch, h = sha3(h), get()->m_epochs[h] = epoch) {}
+        if (epoch == 2048)
+        {
+            std::ostringstream error;
+            error << "apparent block number for " << _seedHash << " is too high; max is " << (ETHASH_EPOCH_LENGTH * 2048);
+            throw std::invalid_argument(error.str());
+        }
+    }
+    else
+        epoch = epochIter->second;
+    return epoch * ETHASH_EPOCH_LENGTH;
 }
 
 void EthashAux::killCache(h256 const& _s)
 {
-	WriteGuard l(x_lights);
-	m_lights.erase(_s);
+    WriteGuard l(x_lights);
+    m_lights.erase(_s);
 }
 
 EthashAux::LightType EthashAux::light(h256 const& _seedHash)
 {
-	UpgradableGuard l(get()->x_lights);
-	if (get()->m_lights.count(_seedHash))
-		return get()->m_lights.at(_seedHash);
-	UpgradeGuard l2(l);
-	return (get()->m_lights[_seedHash] = make_shared<LightAllocation>(_seedHash));
+    UpgradableGuard l(get()->x_lights);
+    if (get()->m_lights.count(_seedHash))
+        return get()->m_lights.at(_seedHash);
+    UpgradeGuard l2(l);
+    return (get()->m_lights[_seedHash] = make_shared<LightAllocation>(_seedHash));
 }
 
 EthashAux::LightAllocation::LightAllocation(h256 const& _seedHash)
 {
-	uint64_t blockNumber = EthashAux::number(_seedHash);
-	light = ethash_light_new(blockNumber);
-	if (!light)
-		BOOST_THROW_EXCEPTION(ExternalFunctionFailure() << errinfo_externalFunction("ethash_light_new()"));
-	size = ethash_get_cachesize(blockNumber);
+    uint64_t blockNumber = EthashAux::number(_seedHash);
+    light = ethash_light_new(blockNumber);
+    if (!light)
+        BOOST_THROW_EXCEPTION(ExternalFunctionFailure() << errinfo_externalFunction("ethash_light_new()"));
+    size = ethash_get_cachesize(blockNumber);
 }
 
 EthashAux::LightAllocation::~LightAllocation()
 {
-	ethash_light_delete(light);
+    ethash_light_delete(light);
 }
 
 bytesConstRef EthashAux::LightAllocation::data() const
 {
-	return bytesConstRef((byte const*)light->cache, size);
+    return bytesConstRef((byte const*)light->cache, size);
 }
 
 EthashAux::FullAllocation::FullAllocation(ethash_light_t _light, ethash_callback_t _cb)
 {
 //	cdebug << "About to call ethash_full_new...";
-	full = ethash_full_new(_light, _cb);
+    full = ethash_full_new(_light, _cb);
 //	cdebug << "Called OK.";
-	if (!full)
-	{
-		clog(DAGChannel) << "DAG Generation Failure. Reason: "  << strerror(errno);
-		BOOST_THROW_EXCEPTION(ExternalFunctionFailure() << errinfo_externalFunction("ethash_full_new"));
-	}
+    if (!full)
+    {
+        clogSimple(1, "DAG") << "DAG Generation Failure. Reason: " << strerror(errno);
+        BOOST_THROW_EXCEPTION(ExternalFunctionFailure() << errinfo_externalFunction("ethash_full_new"));
+    }
 }
 
 EthashAux::FullAllocation::~FullAllocation()
 {
-	ethash_full_delete(full);
+    ethash_full_delete(full);
 }
 
 bytesConstRef EthashAux::FullAllocation::data() const
 {
-	return bytesConstRef((byte const*)ethash_full_dag(full), size());
+    return bytesConstRef((byte const*)ethash_full_dag(full), size());
 }
 
 static std::function<int(unsigned)> s_dagCallback;
 static int dagCallbackShim(unsigned _p)
 {
-	clog(DAGChannel) << "Generating DAG file. Progress: " << toString(_p) << "%";
-	return s_dagCallback ? s_dagCallback(_p) : 0;
+    clogSimple(1, "DAG") << "Generating DAG file. Progress: " << toString(_p) << "%";
+    return s_dagCallback ? s_dagCallback(_p) : 0;
 }
 
 EthashAux::FullType EthashAux::full(h256 const& _seedHash, bool _createIfMissing, function<int(unsigned)> const& _f)
 {
-	FullType ret;
-	auto l = light(_seedHash);
+    FullType ret;
+    auto l = light(_seedHash);
 
-	DEV_GUARDED(get()->x_fulls)
-		if ((ret = get()->m_fulls[_seedHash].lock()))
-		{
-			get()->m_lastUsedFull = ret;
-			return ret;
-		}
+    DEV_GUARDED(get()->x_fulls)
+        if ((ret = get()->m_fulls[_seedHash].lock()))
+        {
+            get()->m_lastUsedFull = ret;
+            return ret;
+        }
 
-	if (_createIfMissing || computeFull(_seedHash, false) == 100)
-	{
-		s_dagCallback = _f;
+    if (_createIfMissing || computeFull(_seedHash, false) == 100)
+    {
+        s_dagCallback = _f;
 //		cnote << "Loading from libethash...";
-		ret = make_shared<FullAllocation>(l->light, dagCallbackShim);
+        ret = make_shared<FullAllocation>(l->light, dagCallbackShim);
 //		cnote << "Done loading.";
 
-		DEV_GUARDED(get()->x_fulls)
-			get()->m_fulls[_seedHash] = get()->m_lastUsedFull = ret;
-	}
+        DEV_GUARDED(get()->x_fulls)
+            get()->m_fulls[_seedHash] = get()->m_lastUsedFull = ret;
+    }
 
-	return ret;
+    return ret;
 }
 
 unsigned EthashAux::computeFull(h256 const& _seedHash, bool _createIfMissing)
 {
-	Guard l(get()->x_fulls);
-	uint64_t blockNumber;
+    Guard l(get()->x_fulls);
+    uint64_t blockNumber;
 
-	DEV_IF_THROWS(blockNumber = EthashAux::number(_seedHash))
-	{
-		return 0;
-	}
+    DEV_IF_THROWS(blockNumber = EthashAux::number(_seedHash))
+    {
+        return 0;
+    }
 
-	if (FullType ret = get()->m_fulls[_seedHash].lock())
-	{
-		get()->m_lastUsedFull = ret;
-		return 100;
-	}
+    if (FullType ret = get()->m_fulls[_seedHash].lock())
+    {
+        get()->m_lastUsedFull = ret;
+        return 100;
+    }
 
-	if (_createIfMissing && (!get()->m_fullGenerator || !get()->m_fullGenerator->joinable()))
-	{
-		get()->m_fullProgress = 0;
-		get()->m_generatingFullNumber = blockNumber / ETHASH_EPOCH_LENGTH * ETHASH_EPOCH_LENGTH;
-		get()->m_fullGenerator = unique_ptr<thread>(new thread([=](){
-			cnote << "Loading full DAG of seedhash: " << _seedHash;
-			get()->full(_seedHash, true, [](unsigned p){ get()->m_fullProgress = p; return 0; });
-			cnote << "Full DAG loaded";
-			get()->m_fullProgress = 0;
-			get()->m_generatingFullNumber = NotGenerating;
-		}));
-	}
+    if (_createIfMissing && (!get()->m_fullGenerator || !get()->m_fullGenerator->joinable()))
+    {
+        get()->m_fullProgress = 0;
+        get()->m_generatingFullNumber = blockNumber / ETHASH_EPOCH_LENGTH * ETHASH_EPOCH_LENGTH;
+        get()->m_fullGenerator = unique_ptr<thread>(new thread([=](){
+            cnote << "Loading full DAG of seedhash: " << _seedHash;
+            get()->full(_seedHash, true, [](unsigned p){ get()->m_fullProgress = p; return 0; });
+            cnote << "Full DAG loaded";
+            get()->m_fullProgress = 0;
+            get()->m_generatingFullNumber = NotGenerating;
+        }));
+    }
 
-	return (get()->m_generatingFullNumber == blockNumber) ? get()->m_fullProgress : 0;
+    return (get()->m_generatingFullNumber == blockNumber) ? get()->m_fullProgress : 0;
 }
 
 EthashProofOfWork::Result EthashAux::FullAllocation::compute(h256 const& _headerHash, Nonce const& _nonce) const
 {
-	ethash_return_value_t r = ethash_full_compute(full, *(ethash_h256_t*)_headerHash.data(), (uint64_t)(u64)_nonce);
-	if (!r.success)
-		BOOST_THROW_EXCEPTION(DAGCreationFailure());
-	return EthashProofOfWork::Result{h256((uint8_t*)&r.result, h256::ConstructFromPointer), h256((uint8_t*)&r.mix_hash, h256::ConstructFromPointer)};
+    ethash_return_value_t r = ethash_full_compute(full, *(ethash_h256_t*)_headerHash.data(), (uint64_t)(u64)_nonce);
+    if (!r.success)
+        BOOST_THROW_EXCEPTION(DAGCreationFailure());
+    return EthashProofOfWork::Result{h256((uint8_t*)&r.result, h256::ConstructFromPointer), h256((uint8_t*)&r.mix_hash, h256::ConstructFromPointer)};
 }
 
 EthashProofOfWork::Result EthashAux::LightAllocation::compute(h256 const& _headerHash, Nonce const& _nonce) const
 {
-	ethash_return_value r = ethash_light_compute(light, *(ethash_h256_t*)_headerHash.data(), (uint64_t)(u64)_nonce);
-	if (!r.success)
-		BOOST_THROW_EXCEPTION(DAGCreationFailure());
-	return EthashProofOfWork::Result{h256((uint8_t*)&r.result, h256::ConstructFromPointer), h256((uint8_t*)&r.mix_hash, h256::ConstructFromPointer)};
+    ethash_return_value r = ethash_light_compute(light, *(ethash_h256_t*)_headerHash.data(), (uint64_t)(u64)_nonce);
+    if (!r.success)
+        BOOST_THROW_EXCEPTION(DAGCreationFailure());
+    return EthashProofOfWork::Result{h256((uint8_t*)&r.result, h256::ConstructFromPointer), h256((uint8_t*)&r.mix_hash, h256::ConstructFromPointer)};
 }
 
 EthashProofOfWork::Result EthashAux::eval(h256 const& _seedHash, h256 const& _headerHash, Nonce const& _nonce)
 {
-	DEV_GUARDED(get()->x_fulls)
-		if (FullType dag = get()->m_fulls[_seedHash].lock())
-			return dag->compute(_headerHash, _nonce);
-	DEV_IF_THROWS(return EthashAux::get()->light(_seedHash)->compute(_headerHash, _nonce))
-	{
-		return EthashProofOfWork::Result{ ~h256(), h256() };
-	}
+    DEV_GUARDED(get()->x_fulls)
+        if (FullType dag = get()->m_fulls[_seedHash].lock())
+            return dag->compute(_headerHash, _nonce);
+    DEV_IF_THROWS(return EthashAux::get()->light(_seedHash)->compute(_headerHash, _nonce))
+    {
+        return EthashProofOfWork::Result{ ~h256(), h256() };
+    }
 }

--- a/libethashseal/EthashAux.h
+++ b/libethashseal/EthashAux.h
@@ -1,18 +1,18 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file EthashAux.cpp
  * @author Gav Wood <i@gavwood.com>
@@ -33,80 +33,78 @@ namespace dev
 namespace eth
 {
 
-struct DAGChannel: public LogChannel { static const char* name(); static const int verbosity = 1; };
-
 class BlockHeader;
 
 class EthashAux
 {
 public:
-	~EthashAux();
+    ~EthashAux();
 
-	static EthashAux* get();
+    static EthashAux* get();
 
-	struct LightAllocation
-	{
-		LightAllocation(h256 const& _seedHash);
-		~LightAllocation();
-		bytesConstRef data() const;
-		EthashProofOfWork::Result compute(h256 const& _headerHash, Nonce const& _nonce) const;
-		ethash_light_t light;
-		uint64_t size;
-	};
+    struct LightAllocation
+    {
+        LightAllocation(h256 const& _seedHash);
+        ~LightAllocation();
+        bytesConstRef data() const;
+        EthashProofOfWork::Result compute(h256 const& _headerHash, Nonce const& _nonce) const;
+        ethash_light_t light;
+        uint64_t size;
+    };
 
-	struct FullAllocation
-	{
-		FullAllocation(ethash_light_t _light, ethash_callback_t _cb);
-		~FullAllocation();
-		EthashProofOfWork::Result compute(h256 const& _headerHash, Nonce const& _nonce) const;
-		bytesConstRef data() const;
-		uint64_t size() const { return ethash_full_dag_size(full); }
-		ethash_full_t full;
-	};
+    struct FullAllocation
+    {
+        FullAllocation(ethash_light_t _light, ethash_callback_t _cb);
+        ~FullAllocation();
+        EthashProofOfWork::Result compute(h256 const& _headerHash, Nonce const& _nonce) const;
+        bytesConstRef data() const;
+        uint64_t size() const { return ethash_full_dag_size(full); }
+        ethash_full_t full;
+    };
 
-	using LightType = std::shared_ptr<LightAllocation>;
-	using FullType = std::shared_ptr<FullAllocation>;
+    using LightType = std::shared_ptr<LightAllocation>;
+    using FullType = std::shared_ptr<FullAllocation>;
 
-	static h256 seedHash(unsigned _number);
-	static uint64_t number(h256 const& _seedHash);
-	static uint64_t cacheSize(BlockHeader const& _header);
-	static uint64_t dataSize(uint64_t _blockNumber);
+    static h256 seedHash(unsigned _number);
+    static uint64_t number(h256 const& _seedHash);
+    static uint64_t cacheSize(BlockHeader const& _header);
+    static uint64_t dataSize(uint64_t _blockNumber);
 
-	static LightType light(h256 const& _seedHash);
+    static LightType light(h256 const& _seedHash);
 
-	static const uint64_t NotGenerating = (uint64_t)-1;
-	/// Kicks off generation of DAG for @a _seedHash and @returns false or @returns true if ready.
-	static unsigned computeFull(h256 const& _seedHash, bool _createIfMissing = true);
-	/// Information on the generation progress.
-	static std::pair<uint64_t, unsigned> fullGeneratingProgress() { return std::make_pair(get()->m_generatingFullNumber, get()->m_fullProgress); }
-	/// Kicks off generation of DAG for @a _blocknumber and blocks until ready; @returns result or empty pointer if not existing and _createIfMissing is false.
-	static FullType full(h256 const& _seedHash, bool _createIfMissing = false, std::function<int(unsigned)> const& _f = std::function<int(unsigned)>());
+    static const uint64_t NotGenerating = (uint64_t)-1;
+    /// Kicks off generation of DAG for @a _seedHash and @returns false or @returns true if ready.
+    static unsigned computeFull(h256 const& _seedHash, bool _createIfMissing = true);
+    /// Information on the generation progress.
+    static std::pair<uint64_t, unsigned> fullGeneratingProgress() { return std::make_pair(get()->m_generatingFullNumber, get()->m_fullProgress); }
+    /// Kicks off generation of DAG for @a _blocknumber and blocks until ready; @returns result or empty pointer if not existing and _createIfMissing is false.
+    static FullType full(h256 const& _seedHash, bool _createIfMissing = false, std::function<int(unsigned)> const& _f = std::function<int(unsigned)>());
 
-	static EthashProofOfWork::Result eval(h256 const& _seedHash, h256 const& _headerHash, Nonce const& _nonce);
+    static EthashProofOfWork::Result eval(h256 const& _seedHash, h256 const& _headerHash, Nonce const& _nonce);
 
 private:
-	EthashAux() {}
+    EthashAux() {}
 
-	/// Kicks off generation of DAG for @a _blocknumber and blocks until ready; @returns result.
+    /// Kicks off generation of DAG for @a _blocknumber and blocks until ready; @returns result.
 
-	void killCache(h256 const& _s);
+    void killCache(h256 const& _s);
 
-	static EthashAux* s_this;
+    static EthashAux* s_this;
 
-	SharedMutex x_lights;
-	std::unordered_map<h256, std::shared_ptr<LightAllocation>> m_lights;
+    SharedMutex x_lights;
+    std::unordered_map<h256, std::shared_ptr<LightAllocation>> m_lights;
 
-	Mutex x_fulls;
-	std::condition_variable m_fullsChanged;
-	std::unordered_map<h256, std::weak_ptr<FullAllocation>> m_fulls;
-	FullType m_lastUsedFull;
-	std::unique_ptr<std::thread> m_fullGenerator;
-	uint64_t m_generatingFullNumber = NotGenerating;
-	unsigned m_fullProgress;
+    Mutex x_fulls;
+    std::condition_variable m_fullsChanged;
+    std::unordered_map<h256, std::weak_ptr<FullAllocation>> m_fulls;
+    FullType m_lastUsedFull;
+    std::unique_ptr<std::thread> m_fullGenerator;
+    uint64_t m_generatingFullNumber = NotGenerating;
+    unsigned m_fullProgress;
 
-	Mutex x_epochs;
-	std::unordered_map<h256, unsigned> m_epochs;
-	h256s m_seedHashes;
+    Mutex x_epochs;
+    std::unordered_map<h256, unsigned> m_epochs;
+    h256s m_seedHashes;
 };
 
 }

--- a/libethcore/BlockHeader.cpp
+++ b/libethcore/BlockHeader.cpp
@@ -1,18 +1,18 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file BlockHeader.cpp
  * @author Gav Wood <i@gavwood.com>
@@ -38,234 +38,232 @@ BlockHeader::BlockHeader()
 
 BlockHeader::BlockHeader(bytesConstRef _block, BlockDataType _bdt, h256 const& _hashWith)
 {
-	RLP header = _bdt == BlockData ? extractHeader(_block) : RLP(_block);
-	m_hash = _hashWith ? _hashWith : sha3(header.data());
-	populate(header);
+    RLP header = _bdt == BlockData ? extractHeader(_block) : RLP(_block);
+    m_hash = _hashWith ? _hashWith : sha3(header.data());
+    populate(header);
 }
 
 BlockHeader::BlockHeader(BlockHeader const& _other) :
-	m_parentHash(_other.parentHash()),
-	m_sha3Uncles(_other.sha3Uncles()),
-	m_stateRoot(_other.stateRoot()),
-	m_transactionsRoot(_other.transactionsRoot()),
-	m_receiptsRoot(_other.receiptsRoot()),
-	m_logBloom(_other.logBloom()),
-	m_number(_other.number()),
-	m_gasLimit(_other.gasLimit()),
-	m_gasUsed(_other.gasUsed()),
-	m_extraData(_other.extraData()),
-	m_timestamp(_other.timestamp()),
-	m_author(_other.author()),
-	m_difficulty(_other.difficulty()),
-	m_seal(_other.seal()),
-	m_hash(_other.hashRawRead()),
-	m_hashWithout(_other.hashWithoutRawRead())
+    m_parentHash(_other.parentHash()),
+    m_sha3Uncles(_other.sha3Uncles()),
+    m_stateRoot(_other.stateRoot()),
+    m_transactionsRoot(_other.transactionsRoot()),
+    m_receiptsRoot(_other.receiptsRoot()),
+    m_logBloom(_other.logBloom()),
+    m_number(_other.number()),
+    m_gasLimit(_other.gasLimit()),
+    m_gasUsed(_other.gasUsed()),
+    m_extraData(_other.extraData()),
+    m_timestamp(_other.timestamp()),
+    m_author(_other.author()),
+    m_difficulty(_other.difficulty()),
+    m_seal(_other.seal()),
+    m_hash(_other.hashRawRead()),
+    m_hashWithout(_other.hashWithoutRawRead())
 {
-	assert(*this == _other);
+    assert(*this == _other);
 }
 
 BlockHeader& BlockHeader::operator=(BlockHeader const& _other)
 {
-	if (this == &_other)
-		return *this;
-	m_parentHash = _other.parentHash();
-	m_sha3Uncles = _other.sha3Uncles();
-	m_stateRoot = _other.stateRoot();
-	m_transactionsRoot = _other.transactionsRoot();
-	m_receiptsRoot = _other.receiptsRoot();
-	m_logBloom = _other.logBloom();
-	m_number = _other.number();
-	m_gasLimit = _other.gasLimit();
-	m_gasUsed = _other.gasUsed();
-	m_extraData = _other.extraData();
-	m_timestamp = _other.timestamp();
-	m_author = _other.author();
-	m_difficulty = _other.difficulty();
-	std::vector<bytes> seal = _other.seal();
-	{
-		Guard l(m_sealLock);
-		m_seal = std::move(seal);
-	}
-	h256 hash = _other.hashRawRead();
-	h256 hashWithout = _other.hashWithoutRawRead();
-	{
-		Guard l(m_hashLock);
-		m_hash = std::move(hash);
-		m_hashWithout = std::move(hashWithout);
-	}
-	assert(*this == _other);
-	return *this;
+    if (this == &_other)
+        return *this;
+    m_parentHash = _other.parentHash();
+    m_sha3Uncles = _other.sha3Uncles();
+    m_stateRoot = _other.stateRoot();
+    m_transactionsRoot = _other.transactionsRoot();
+    m_receiptsRoot = _other.receiptsRoot();
+    m_logBloom = _other.logBloom();
+    m_number = _other.number();
+    m_gasLimit = _other.gasLimit();
+    m_gasUsed = _other.gasUsed();
+    m_extraData = _other.extraData();
+    m_timestamp = _other.timestamp();
+    m_author = _other.author();
+    m_difficulty = _other.difficulty();
+    std::vector<bytes> seal = _other.seal();
+    {
+        Guard l(m_sealLock);
+        m_seal = std::move(seal);
+    }
+    h256 hash = _other.hashRawRead();
+    h256 hashWithout = _other.hashWithoutRawRead();
+    {
+        Guard l(m_hashLock);
+        m_hash = std::move(hash);
+        m_hashWithout = std::move(hashWithout);
+    }
+    assert(*this == _other);
+    return *this;
 }
 
 void BlockHeader::clear()
 {
-	m_parentHash = h256();
-	m_sha3Uncles = EmptyListSHA3;
-	m_author = Address();
-	m_stateRoot = EmptyTrie;
-	m_transactionsRoot = EmptyTrie;
-	m_receiptsRoot = EmptyTrie;
-	m_logBloom = LogBloom();
-	m_difficulty = 0;
-	m_number = 0;
-	m_gasLimit = 0;
-	m_gasUsed = 0;
-	m_timestamp = -1;
-	m_extraData.clear();
-	m_seal.clear();
-	noteDirty();
+    m_parentHash = h256();
+    m_sha3Uncles = EmptyListSHA3;
+    m_author = Address();
+    m_stateRoot = EmptyTrie;
+    m_transactionsRoot = EmptyTrie;
+    m_receiptsRoot = EmptyTrie;
+    m_logBloom = LogBloom();
+    m_difficulty = 0;
+    m_number = 0;
+    m_gasLimit = 0;
+    m_gasUsed = 0;
+    m_timestamp = -1;
+    m_extraData.clear();
+    m_seal.clear();
+    noteDirty();
 }
 
 h256 BlockHeader::hash(IncludeSeal _i) const
 {
-	h256 dummy;
-	Guard l(m_hashLock);
-	h256& memo = _i == WithSeal ? m_hash : _i == WithoutSeal ? m_hashWithout : dummy;
-	if (!memo)
-	{
-		RLPStream s;
-		streamRLP(s, _i);
-		memo = sha3(s.out());
-	}
-	return memo;
+    h256 dummy;
+    Guard l(m_hashLock);
+    h256& memo = _i == WithSeal ? m_hash : _i == WithoutSeal ? m_hashWithout : dummy;
+    if (!memo)
+    {
+        RLPStream s;
+        streamRLP(s, _i);
+        memo = sha3(s.out());
+    }
+    return memo;
 }
 
 void BlockHeader::streamRLPFields(RLPStream& _s) const
 {
-	_s	<< m_parentHash << m_sha3Uncles << m_author << m_stateRoot << m_transactionsRoot << m_receiptsRoot << m_logBloom
-		<< m_difficulty << m_number << m_gasLimit << m_gasUsed << m_timestamp << m_extraData;
+    _s	<< m_parentHash << m_sha3Uncles << m_author << m_stateRoot << m_transactionsRoot << m_receiptsRoot << m_logBloom
+        << m_difficulty << m_number << m_gasLimit << m_gasUsed << m_timestamp << m_extraData;
 }
 
 void BlockHeader::streamRLP(RLPStream& _s, IncludeSeal _i) const
 {
-	if (_i != OnlySeal)
-	{
-		_s.appendList(BlockHeader::BasicFields + (_i == WithoutSeal ? 0 : m_seal.size()));
-		BlockHeader::streamRLPFields(_s);
-	}
-	if (_i != WithoutSeal)
-		for (unsigned i = 0; i < m_seal.size(); ++i)
-			_s.appendRaw(m_seal[i]);
+    if (_i != OnlySeal)
+    {
+        _s.appendList(BlockHeader::BasicFields + (_i == WithoutSeal ? 0 : m_seal.size()));
+        BlockHeader::streamRLPFields(_s);
+    }
+    if (_i != WithoutSeal)
+        for (unsigned i = 0; i < m_seal.size(); ++i)
+            _s.appendRaw(m_seal[i]);
 }
 
 h256 BlockHeader::headerHashFromBlock(bytesConstRef _block)
 {
-	return sha3(RLP(_block)[0].data());
+    return sha3(RLP(_block)[0].data());
 }
 
 RLP BlockHeader::extractHeader(bytesConstRef _block)
 {
-	RLP root(_block);
-	if (!root.isList())
-		BOOST_THROW_EXCEPTION(InvalidBlockFormat() << errinfo_comment("Block must be a list") << BadFieldError(0, _block.toString()));
-	RLP header = root[0];
-	if (!header.isList())
-		BOOST_THROW_EXCEPTION(InvalidBlockFormat() << errinfo_comment("Block header must be a list") << BadFieldError(0, header.data().toString()));
-	if (!root[1].isList())
-		BOOST_THROW_EXCEPTION(InvalidBlockFormat() << errinfo_comment("Block transactions must be a list") << BadFieldError(1, root[1].data().toString()));
-	if (!root[2].isList())
-		BOOST_THROW_EXCEPTION(InvalidBlockFormat() << errinfo_comment("Block uncles must be a list") << BadFieldError(2, root[2].data().toString()));
-	return header;
+    RLP root(_block);
+    if (!root.isList())
+        BOOST_THROW_EXCEPTION(InvalidBlockFormat() << errinfo_comment("Block must be a list") << BadFieldError(0, _block.toString()));
+    RLP header = root[0];
+    if (!header.isList())
+        BOOST_THROW_EXCEPTION(InvalidBlockFormat() << errinfo_comment("Block header must be a list") << BadFieldError(0, header.data().toString()));
+    if (!root[1].isList())
+        BOOST_THROW_EXCEPTION(InvalidBlockFormat() << errinfo_comment("Block transactions must be a list") << BadFieldError(1, root[1].data().toString()));
+    if (!root[2].isList())
+        BOOST_THROW_EXCEPTION(InvalidBlockFormat() << errinfo_comment("Block uncles must be a list") << BadFieldError(2, root[2].data().toString()));
+    return header;
 }
 
 void BlockHeader::populate(RLP const& _header)
 {
-	int field = 0;
-	try
-	{
-		m_parentHash = _header[field = 0].toHash<h256>(RLP::VeryStrict);
-		m_sha3Uncles = _header[field = 1].toHash<h256>(RLP::VeryStrict);
-		m_author = _header[field = 2].toHash<Address>(RLP::VeryStrict);
-		m_stateRoot = _header[field = 3].toHash<h256>(RLP::VeryStrict);
-		m_transactionsRoot = _header[field = 4].toHash<h256>(RLP::VeryStrict);
-		m_receiptsRoot = _header[field = 5].toHash<h256>(RLP::VeryStrict);
-		m_logBloom = _header[field = 6].toHash<LogBloom>(RLP::VeryStrict);
-		m_difficulty = _header[field = 7].toInt<u256>();
-		m_number = _header[field = 8].toPositiveInt64();
-		m_gasLimit = _header[field = 9].toInt<u256>();
-		m_gasUsed = _header[field = 10].toInt<u256>();
-		m_timestamp = _header[field = 11].toPositiveInt64();
-		m_extraData = _header[field = 12].toBytes();
-		m_seal.clear();
-		for (unsigned i = 13; i < _header.itemCount(); ++i)
-			m_seal.push_back(_header[i].data().toBytes());
-	}
-	catch (Exception const& _e)
-	{
-		_e << errinfo_name("invalid block header format") << BadFieldError(field, toHex(_header[field].data().toBytes()));
-		throw;
-	}
+    int field = 0;
+    try
+    {
+        m_parentHash = _header[field = 0].toHash<h256>(RLP::VeryStrict);
+        m_sha3Uncles = _header[field = 1].toHash<h256>(RLP::VeryStrict);
+        m_author = _header[field = 2].toHash<Address>(RLP::VeryStrict);
+        m_stateRoot = _header[field = 3].toHash<h256>(RLP::VeryStrict);
+        m_transactionsRoot = _header[field = 4].toHash<h256>(RLP::VeryStrict);
+        m_receiptsRoot = _header[field = 5].toHash<h256>(RLP::VeryStrict);
+        m_logBloom = _header[field = 6].toHash<LogBloom>(RLP::VeryStrict);
+        m_difficulty = _header[field = 7].toInt<u256>();
+        m_number = _header[field = 8].toPositiveInt64();
+        m_gasLimit = _header[field = 9].toInt<u256>();
+        m_gasUsed = _header[field = 10].toInt<u256>();
+        m_timestamp = _header[field = 11].toPositiveInt64();
+        m_extraData = _header[field = 12].toBytes();
+        m_seal.clear();
+        for (unsigned i = 13; i < _header.itemCount(); ++i)
+            m_seal.push_back(_header[i].data().toBytes());
+    }
+    catch (Exception const& _e)
+    {
+        _e << errinfo_name("invalid block header format") << BadFieldError(field, toHex(_header[field].data().toBytes()));
+        throw;
+    }
 }
-
-struct BlockInfoDiagnosticsChannel: public LogChannel { static const char* name() { return EthBlue "▧" EthWhite " ◌"; } static const int verbosity = 9; };
 
 void BlockHeader::populateFromParent(BlockHeader const& _parent)
 {
-	m_stateRoot = _parent.stateRoot();
-	m_number = _parent.m_number + 1;
-	m_parentHash = _parent.m_hash;
-	m_gasLimit = _parent.m_gasLimit;
+    m_stateRoot = _parent.stateRoot();
+    m_number = _parent.m_number + 1;
+    m_parentHash = _parent.m_hash;
+    m_gasLimit = _parent.m_gasLimit;
     m_difficulty = _parent.m_difficulty;
     m_gasUsed = 0;
 }
 
 void BlockHeader::verify(Strictness _s, BlockHeader const& _parent, bytesConstRef _block) const
 {
-	if (m_number > ~(unsigned)0)
-		BOOST_THROW_EXCEPTION(InvalidNumber());
+    if (m_number > ~(unsigned)0)
+        BOOST_THROW_EXCEPTION(InvalidNumber());
 
-	if (_s != CheckNothingNew && m_gasUsed > m_gasLimit)
-		BOOST_THROW_EXCEPTION(TooMuchGasUsed() << RequirementError(bigint(m_gasLimit), bigint(m_gasUsed)));
+    if (_s != CheckNothingNew && m_gasUsed > m_gasLimit)
+        BOOST_THROW_EXCEPTION(TooMuchGasUsed() << RequirementError(bigint(m_gasLimit), bigint(m_gasUsed)));
 
-	if (_parent)
-	{
-		if (m_parentHash && _parent.hash() != m_parentHash)
-			BOOST_THROW_EXCEPTION(InvalidParentHash());
+    if (_parent)
+    {
+        if (m_parentHash && _parent.hash() != m_parentHash)
+            BOOST_THROW_EXCEPTION(InvalidParentHash());
 
-		if (m_timestamp <= _parent.m_timestamp)
-			BOOST_THROW_EXCEPTION(InvalidTimestamp());
+        if (m_timestamp <= _parent.m_timestamp)
+            BOOST_THROW_EXCEPTION(InvalidTimestamp());
 
-		if (m_number != _parent.m_number + 1)
-			BOOST_THROW_EXCEPTION(InvalidNumber());
-	}
+        if (m_number != _parent.m_number + 1)
+            BOOST_THROW_EXCEPTION(InvalidNumber());
+    }
 
-	if (_block)
-	{
-		RLP root(_block);
+    if (_block)
+    {
+        RLP root(_block);
 
-		auto txList = root[1];
-		auto expectedRoot = trieRootOver(txList.itemCount(), [&](unsigned i){ return rlp(i); }, [&](unsigned i){ return txList[i].data().toBytes(); });
+        auto txList = root[1];
+        auto expectedRoot = trieRootOver(txList.itemCount(), [&](unsigned i){ return rlp(i); }, [&](unsigned i){ return txList[i].data().toBytes(); });
 
-		clog(BlockInfoDiagnosticsChannel) << "Expected trie root:" << toString(expectedRoot);
-		if (m_transactionsRoot != expectedRoot)
-		{
-			MemoryDB tm;
-			GenericTrieDB<MemoryDB> transactionsTrie(&tm);
-			transactionsTrie.init();
+        LOG(m_logger) << "Expected trie root: " << toString(expectedRoot);
+        if (m_transactionsRoot != expectedRoot)
+        {
+            MemoryDB tm;
+            GenericTrieDB<MemoryDB> transactionsTrie(&tm);
+            transactionsTrie.init();
 
-			vector<bytesConstRef> txs;
+            vector<bytesConstRef> txs;
 
-			for (unsigned i = 0; i < txList.itemCount(); ++i)
-			{
-				RLPStream k;
-				k << i;
+            for (unsigned i = 0; i < txList.itemCount(); ++i)
+            {
+                RLPStream k;
+                k << i;
 
-				transactionsTrie.insert(&k.out(), txList[i].data());
+                transactionsTrie.insert(&k.out(), txList[i].data());
 
-				txs.push_back(txList[i].data());
-				cdebug << toHex(k.out()) << toHex(txList[i].data());
-			}
-			cdebug << "trieRootOver" << expectedRoot;
-			cdebug << "orderedTrieRoot" << orderedTrieRoot(txs);
-			cdebug << "TrieDB" << transactionsTrie.root();
-			cdebug << "Contents:";
-			for (auto const& t: txs)
-				cdebug << toHex(t);
+                txs.push_back(txList[i].data());
+                cdebug << toHex(k.out()) << toHex(txList[i].data());
+            }
+            cdebug << "trieRootOver" << expectedRoot;
+            cdebug << "orderedTrieRoot" << orderedTrieRoot(txs);
+            cdebug << "TrieDB" << transactionsTrie.root();
+            cdebug << "Contents:";
+            for (auto const& t: txs)
+                cdebug << toHex(t);
 
-			BOOST_THROW_EXCEPTION(InvalidTransactionsRoot() << Hash256RequirementError(expectedRoot, m_transactionsRoot));
-		}
-		clog(BlockInfoDiagnosticsChannel) << "Expected uncle hash:" << toString(sha3(root[2].data()));
-		if (m_sha3Uncles != sha3(root[2].data()))
-			BOOST_THROW_EXCEPTION(InvalidUnclesHash() << Hash256RequirementError(sha3(root[2].data()), m_sha3Uncles));
-	}
+            BOOST_THROW_EXCEPTION(InvalidTransactionsRoot() << Hash256RequirementError(expectedRoot, m_transactionsRoot));
+        }
+        LOG(m_logger) << "Expected uncle hash: " << toString(sha3(root[2].data()));
+        if (m_sha3Uncles != sha3(root[2].data()))
+            BOOST_THROW_EXCEPTION(InvalidUnclesHash() << Hash256RequirementError(sha3(root[2].data()), m_sha3Uncles));
+    }
 }

--- a/libethcore/BlockHeader.h
+++ b/libethcore/BlockHeader.h
@@ -1,18 +1,18 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file BlockHeader.h
  * @author Gav Wood <i@gavwood.com>
@@ -21,14 +21,15 @@
 
 #pragma once
 
-#include <algorithm>
+#include "ChainOperationParams.h"
+#include "Common.h"
+#include "Exceptions.h"
 #include <libdevcore/Common.h>
+#include <libdevcore/Guards.h>
+#include <libdevcore/Log.h>
 #include <libdevcore/RLP.h>
 #include <libdevcore/SHA3.h>
-#include <libdevcore/Guards.h>
-#include "Common.h"
-#include "ChainOperationParams.h"
-#include "Exceptions.h"
+#include <algorithm>
 
 namespace dev
 {
@@ -37,37 +38,37 @@ namespace eth
 
 enum IncludeSeal
 {
-	WithoutSeal = 0,
-	WithSeal = 1,
-	OnlySeal = 2
+    WithoutSeal = 0,
+    WithSeal = 1,
+    OnlySeal = 2
 };
 
 enum Strictness
 {
-	CheckEverything,
-	JustSeal,
-	QuickNonce,
-	IgnoreSeal,
-	CheckNothingNew
+    CheckEverything,
+    JustSeal,
+    QuickNonce,
+    IgnoreSeal,
+    CheckNothingNew
 };
 
 // TODO: for implementing soon.
 /*enum Check
 {
-	CheckBasic,
-	CheckExtended,
-	CheckBlock,
-	CheckParent,
-	CheckSeal,
-	CheckSealQuickly,
-	CheckAll = CheckBasic | CheckExtended | CheckBlock | CheckParent | CheckSeal,
+    CheckBasic,
+    CheckExtended,
+    CheckBlock,
+    CheckParent,
+    CheckSeal,
+    CheckSealQuickly,
+    CheckAll = CheckBasic | CheckExtended | CheckBlock | CheckParent | CheckSeal,
 };
 using Checks = FlagSet<Check>;*/
 
 enum BlockDataType
 {
-	HeaderData,
-	BlockData
+    HeaderData,
+    BlockData
 };
 
 DEV_SIMPLE_EXCEPTION(NoHashRecorded);
@@ -95,129 +96,131 @@ DEV_SIMPLE_EXCEPTION(GenesisBlockCannotBeCalculated);
  */
 class BlockHeader
 {
-	friend class BlockChain;
+    friend class BlockChain;
 public:
-	static const unsigned BasicFields = 13;
+    static const unsigned BasicFields = 13;
 
-	BlockHeader();
-	explicit BlockHeader(bytesConstRef _data, BlockDataType _bdt = BlockData, h256 const& _hashWith = h256());
-	explicit BlockHeader(bytes const& _data, BlockDataType _bdt = BlockData, h256 const& _hashWith = h256()): BlockHeader(&_data, _bdt, _hashWith) {}
-	BlockHeader(BlockHeader const& _other);
-	BlockHeader& operator=(BlockHeader const& _other);
+    BlockHeader();
+    explicit BlockHeader(bytesConstRef _data, BlockDataType _bdt = BlockData, h256 const& _hashWith = h256());
+    explicit BlockHeader(bytes const& _data, BlockDataType _bdt = BlockData, h256 const& _hashWith = h256()): BlockHeader(&_data, _bdt, _hashWith) {}
+    BlockHeader(BlockHeader const& _other);
+    BlockHeader& operator=(BlockHeader const& _other);
 
-	static h256 headerHashFromBlock(bytes const& _block) { return headerHashFromBlock(&_block); }
-	static h256 headerHashFromBlock(bytesConstRef _block);
-	static RLP extractHeader(bytesConstRef _block);
+    static h256 headerHashFromBlock(bytes const& _block) { return headerHashFromBlock(&_block); }
+    static h256 headerHashFromBlock(bytesConstRef _block);
+    static RLP extractHeader(bytesConstRef _block);
 
-	explicit operator bool() const { return m_timestamp != Invalid256; }
+    explicit operator bool() const { return m_timestamp != Invalid256; }
 
-	bool operator==(BlockHeader const& _cmp) const
-	{
-		return m_parentHash == _cmp.parentHash() &&
-			m_sha3Uncles == _cmp.sha3Uncles() &&
-			m_author == _cmp.author() &&
-			m_stateRoot == _cmp.stateRoot() &&
-			m_transactionsRoot == _cmp.transactionsRoot() &&
-			m_receiptsRoot == _cmp.receiptsRoot() &&
-			m_logBloom == _cmp.logBloom() &&
-			m_difficulty == _cmp.difficulty() &&
-			m_number == _cmp.number() &&
-			m_gasLimit == _cmp.gasLimit() &&
-			m_gasUsed == _cmp.gasUsed() &&
-			m_timestamp == _cmp.timestamp() &&
-			m_extraData == _cmp.extraData();
-	}
-	bool operator!=(BlockHeader const& _cmp) const { return !operator==(_cmp); }
+    bool operator==(BlockHeader const& _cmp) const
+    {
+        return m_parentHash == _cmp.parentHash() &&
+            m_sha3Uncles == _cmp.sha3Uncles() &&
+            m_author == _cmp.author() &&
+            m_stateRoot == _cmp.stateRoot() &&
+            m_transactionsRoot == _cmp.transactionsRoot() &&
+            m_receiptsRoot == _cmp.receiptsRoot() &&
+            m_logBloom == _cmp.logBloom() &&
+            m_difficulty == _cmp.difficulty() &&
+            m_number == _cmp.number() &&
+            m_gasLimit == _cmp.gasLimit() &&
+            m_gasUsed == _cmp.gasUsed() &&
+            m_timestamp == _cmp.timestamp() &&
+            m_extraData == _cmp.extraData();
+    }
+    bool operator!=(BlockHeader const& _cmp) const { return !operator==(_cmp); }
 
-	void clear();
-	void noteDirty() const { Guard l(m_hashLock); m_hashWithout = m_hash = h256(); }
-	void populateFromParent(BlockHeader const& parent);
+    void clear();
+    void noteDirty() const { Guard l(m_hashLock); m_hashWithout = m_hash = h256(); }
+    void populateFromParent(BlockHeader const& parent);
 
-	// TODO: pull out into abstract class Verifier.
-	void verify(Strictness _s = CheckEverything, BlockHeader const& _parent = BlockHeader(), bytesConstRef _block = bytesConstRef()) const;
-	void verify(Strictness _s, bytesConstRef _block) const { verify(_s, BlockHeader(), _block); }
+    // TODO: pull out into abstract class Verifier.
+    void verify(Strictness _s = CheckEverything, BlockHeader const& _parent = BlockHeader(), bytesConstRef _block = bytesConstRef()) const;
+    void verify(Strictness _s, bytesConstRef _block) const { verify(_s, BlockHeader(), _block); }
 
-	h256 hash(IncludeSeal _i = WithSeal) const;
-	void streamRLP(RLPStream& _s, IncludeSeal _i = WithSeal) const;
+    h256 hash(IncludeSeal _i = WithSeal) const;
+    void streamRLP(RLPStream& _s, IncludeSeal _i = WithSeal) const;
 
-	void setParentHash(h256 const& _v) { m_parentHash = _v; noteDirty(); }
-	void setSha3Uncles(h256 const& _v) { m_sha3Uncles = _v; noteDirty(); }
-	void setTimestamp(int64_t _v) { m_timestamp = _v; noteDirty(); }
-	void setAuthor(Address const& _v) { m_author = _v; noteDirty(); }
-	void setRoots(h256 const& _t, h256 const& _r, h256 const& _u, h256 const& _s) { m_transactionsRoot = _t; m_receiptsRoot = _r; m_stateRoot = _s; m_sha3Uncles = _u; noteDirty(); }
-	void setGasUsed(u256 const& _v) { m_gasUsed = _v; noteDirty(); }
-	void setNumber(int64_t _v) { m_number = _v; noteDirty(); }
-	void setGasLimit(u256 const& _v) { m_gasLimit = _v; noteDirty(); }
-	void setExtraData(bytes const& _v) { m_extraData = _v; noteDirty(); }
-	void setLogBloom(LogBloom const& _v) { m_logBloom = _v; noteDirty(); }
-	void setDifficulty(u256 const& _v) { m_difficulty = _v; noteDirty(); }
-	template <class T> void setSeal(unsigned _offset, T const& _value) { Guard l(m_sealLock); if (m_seal.size() <= _offset) m_seal.resize(_offset + 1); m_seal[_offset] = rlp(_value); noteDirty(); }
-	template <class T> void setSeal(T const& _value) { setSeal(0, _value); }
+    void setParentHash(h256 const& _v) { m_parentHash = _v; noteDirty(); }
+    void setSha3Uncles(h256 const& _v) { m_sha3Uncles = _v; noteDirty(); }
+    void setTimestamp(int64_t _v) { m_timestamp = _v; noteDirty(); }
+    void setAuthor(Address const& _v) { m_author = _v; noteDirty(); }
+    void setRoots(h256 const& _t, h256 const& _r, h256 const& _u, h256 const& _s) { m_transactionsRoot = _t; m_receiptsRoot = _r; m_stateRoot = _s; m_sha3Uncles = _u; noteDirty(); }
+    void setGasUsed(u256 const& _v) { m_gasUsed = _v; noteDirty(); }
+    void setNumber(int64_t _v) { m_number = _v; noteDirty(); }
+    void setGasLimit(u256 const& _v) { m_gasLimit = _v; noteDirty(); }
+    void setExtraData(bytes const& _v) { m_extraData = _v; noteDirty(); }
+    void setLogBloom(LogBloom const& _v) { m_logBloom = _v; noteDirty(); }
+    void setDifficulty(u256 const& _v) { m_difficulty = _v; noteDirty(); }
+    template <class T> void setSeal(unsigned _offset, T const& _value) { Guard l(m_sealLock); if (m_seal.size() <= _offset) m_seal.resize(_offset + 1); m_seal[_offset] = rlp(_value); noteDirty(); }
+    template <class T> void setSeal(T const& _value) { setSeal(0, _value); }
 
-	h256 const& parentHash() const { return m_parentHash; }
-	h256 const& sha3Uncles() const { return m_sha3Uncles; }
-	bool hasUncles() const { return m_sha3Uncles != EmptyListSHA3; }
-	int64_t timestamp() const { return m_timestamp; }
-	Address const& author() const { return m_author; }
-	h256 const& stateRoot() const { return m_stateRoot; }
-	h256 const& transactionsRoot() const { return m_transactionsRoot; }
-	h256 const& receiptsRoot() const { return m_receiptsRoot; }
-	u256 const& gasUsed() const { return m_gasUsed; }
-	int64_t number() const { return m_number; }
-	u256 const& gasLimit() const { return m_gasLimit; }
-	bytes const& extraData() const { return m_extraData; }
-	LogBloom const& logBloom() const { return m_logBloom; }
-	u256 const& difficulty() const { return m_difficulty; }
-	template <class T> T seal(unsigned _offset = 0) const { T ret; Guard l(m_sealLock); if (_offset < m_seal.size()) ret = RLP(m_seal[_offset]).convert<T>(RLP::VeryStrict); return ret; }
+    h256 const& parentHash() const { return m_parentHash; }
+    h256 const& sha3Uncles() const { return m_sha3Uncles; }
+    bool hasUncles() const { return m_sha3Uncles != EmptyListSHA3; }
+    int64_t timestamp() const { return m_timestamp; }
+    Address const& author() const { return m_author; }
+    h256 const& stateRoot() const { return m_stateRoot; }
+    h256 const& transactionsRoot() const { return m_transactionsRoot; }
+    h256 const& receiptsRoot() const { return m_receiptsRoot; }
+    u256 const& gasUsed() const { return m_gasUsed; }
+    int64_t number() const { return m_number; }
+    u256 const& gasLimit() const { return m_gasLimit; }
+    bytes const& extraData() const { return m_extraData; }
+    LogBloom const& logBloom() const { return m_logBloom; }
+    u256 const& difficulty() const { return m_difficulty; }
+    template <class T> T seal(unsigned _offset = 0) const { T ret; Guard l(m_sealLock); if (_offset < m_seal.size()) ret = RLP(m_seal[_offset]).convert<T>(RLP::VeryStrict); return ret; }
 
 private:
-	void populate(RLP const& _header);
-	void streamRLPFields(RLPStream& _s) const;
-	std::vector<bytes> seal() const
-	{
-		Guard l(m_sealLock);
-		return m_seal;
-	}
-	h256 hashRawRead() const
-	{
-		Guard l(m_hashLock);
-		return m_hash;
-	}
-	h256 hashWithoutRawRead() const
-	{
-		Guard l(m_hashLock);
-		return m_hashWithout;
-	}
+    void populate(RLP const& _header);
+    void streamRLPFields(RLPStream& _s) const;
+    std::vector<bytes> seal() const
+    {
+        Guard l(m_sealLock);
+        return m_seal;
+    }
+    h256 hashRawRead() const
+    {
+        Guard l(m_hashLock);
+        return m_hash;
+    }
+    h256 hashWithoutRawRead() const
+    {
+        Guard l(m_hashLock);
+        return m_hashWithout;
+    }
 
-	h256 m_parentHash;
-	h256 m_sha3Uncles;
-	h256 m_stateRoot;
-	h256 m_transactionsRoot;
-	h256 m_receiptsRoot;
-	LogBloom m_logBloom;
-	int64_t m_number = 0;
-	u256 m_gasLimit;
-	u256 m_gasUsed;
-	bytes m_extraData;
-	int64_t m_timestamp = -1;
+    h256 m_parentHash;
+    h256 m_sha3Uncles;
+    h256 m_stateRoot;
+    h256 m_transactionsRoot;
+    h256 m_receiptsRoot;
+    LogBloom m_logBloom;
+    int64_t m_number = 0;
+    u256 m_gasLimit;
+    u256 m_gasUsed;
+    bytes m_extraData;
+    int64_t m_timestamp = -1;
 
-	Address m_author;
-	u256 m_difficulty;
+    Address m_author;
+    u256 m_difficulty;
 
-	std::vector<bytes> m_seal;		///< Additional (RLP-encoded) header fields.
-	mutable Mutex m_sealLock;
+    std::vector<bytes> m_seal;		///< Additional (RLP-encoded) header fields.
+    mutable Mutex m_sealLock;
 
-	mutable h256 m_hash;			///< (Memoised) SHA3 hash of the block header with seal.
-	mutable h256 m_hashWithout;		///< (Memoised) SHA3 hash of the block header without seal.
-	mutable Mutex m_hashLock;		///< A lock for both m_hash and m_hashWithout.
+    mutable h256 m_hash;			///< (Memoised) SHA3 hash of the block header with seal.
+    mutable h256 m_hashWithout;		///< (Memoised) SHA3 hash of the block header without seal.
+    mutable Mutex m_hashLock;		///< A lock for both m_hash and m_hashWithout.
+
+    mutable Logger m_logger{createLogger(9, "blockhdr")};
 };
 
 inline std::ostream& operator<<(std::ostream& _out, BlockHeader const& _bi)
 {
-	_out << _bi.hash(WithoutSeal) << " " << _bi.parentHash() << " " << _bi.sha3Uncles() << " " << _bi.author() << " " << _bi.stateRoot() << " " << _bi.transactionsRoot() << " " <<
-			_bi.receiptsRoot() << " " << _bi.logBloom() << " " << _bi.difficulty() << " " << _bi.number() << " " << _bi.gasLimit() << " " <<
-			_bi.gasUsed() << " " << _bi.timestamp();
-	return _out;
+    _out << _bi.hash(WithoutSeal) << " " << _bi.parentHash() << " " << _bi.sha3Uncles() << " " << _bi.author() << " " << _bi.stateRoot() << " " << _bi.transactionsRoot() << " " <<
+            _bi.receiptsRoot() << " " << _bi.logBloom() << " " << _bi.difficulty() << " " << _bi.number() << " " << _bi.gasLimit() << " " <<
+            _bi.gasUsed() << " " << _bi.timestamp();
+    return _out;
 }
 
 }

--- a/libethereum/Block.cpp
+++ b/libethereum/Block.cpp
@@ -489,7 +489,6 @@ u256 Block::enact(VerifiedBlockRef const& _block, BlockChain const& _bc)
         {
             try
             {
-                LogOverride<ExecutiveWarnChannel> o(false);
 //				cnote << "Enacting transaction: " << tr.nonce() << tr.from() << state().transactionsFrom(tr.from()) << tr.value();
                 execute(_bc.lastBlockHashes(), tr);
 //				cnote << "Now: " << tr.from() << state().transactionsFrom(tr.from());

--- a/libethereum/Block.cpp
+++ b/libethereum/Block.cpp
@@ -45,11 +45,6 @@ namespace fs = boost::filesystem;
 
 static const unsigned c_maxSyncTransactions = 1024;
 
-const char* BlockSafeExceptions::name() { return EthViolet "⚙" EthBlue " ℹ"; }
-const char* BlockDetail::name() { return EthViolet "⚙" EthWhite " ◌"; }
-const char* BlockTrace::name() { return EthViolet "⚙" EthGray " ◎"; }
-const char* BlockChat::name() { return EthViolet "⚙" EthWhite " ◌"; }
-
 namespace
 {
 
@@ -344,7 +339,7 @@ pair<TransactionReceipts, bool> Block::sync(BlockChain const& _bc, TransactionQu
                     }
                     else if (t.gasPrice() < _gp.ask(*this) * 9 / 10)
                     {
-                        clog(StateTrace) << t.sha3() << "Dropping El Cheapo transaction (<90% of ask price)";
+                        BOOST_LOG(m_logger) << t.sha3() << " Dropping El Cheapo transaction (<90% of ask price)";
                         _tq.drop(t.sha3());
                     }
                 }
@@ -356,13 +351,13 @@ pair<TransactionReceipts, bool> Block::sync(BlockChain const& _bc, TransactionQu
                     if (req > got)
                     {
                         // too old
-                        clog(StateTrace) << t.sha3() << "Dropping old transaction (nonce too low)";
+                        BOOST_LOG(m_logger) << t.sha3() << " Dropping old transaction (nonce too low)";
                         _tq.drop(t.sha3());
                     }
                     else if (got > req + _tq.waiting(t.sender()))
                     {
                         // too new
-                        clog(StateTrace) << t.sha3() << "Dropping new transaction (too many nonces ahead)";
+                        BOOST_LOG(m_logger) << t.sha3() << " Dropping new transaction (too many nonces ahead)";
                         _tq.drop(t.sha3());
                     }
                     else
@@ -373,13 +368,13 @@ pair<TransactionReceipts, bool> Block::sync(BlockChain const& _bc, TransactionQu
                     bigint const& got = *boost::get_error_info<errinfo_got>(e);
                     if (got > m_currentBlock.gasLimit())
                     {
-                        clog(StateTrace) << t.sha3() << "Dropping over-gassy transaction (gas > block's gas limit)";
-                        clog(StateTrace) << "got: " << got << " required: " << m_currentBlock.gasLimit();
+                        BOOST_LOG(m_logger) << t.sha3() << " Dropping over-gassy transaction (gas > block's gas limit)";
+                        BOOST_LOG(m_logger) << "got: " << got << " required: " << m_currentBlock.gasLimit();
                         _tq.drop(t.sha3());
                     }
                     else
                     {
-                        clog(StateTrace) << t.sha3() << "Temporarily no gas left in current block (txs gas > block's gas limit)";
+                        BOOST_LOG(m_logger) << t.sha3() << " Temporarily no gas left in current block (txs gas > block's gas limit)";
                         //_tq.drop(t.sha3());
                         // Temporarily no gas left in current block.
                         // OPTIMISE: could note this and then we don't evaluate until a block that does have the gas left.
@@ -389,7 +384,7 @@ pair<TransactionReceipts, bool> Block::sync(BlockChain const& _bc, TransactionQu
                 catch (Exception const& _e)
                 {
                     // Something else went wrong - drop it.
-                    clog(StateTrace) << t.sha3() << "Dropping invalid transaction:" << diagnostic_information(_e);
+                    BOOST_LOG(m_logger) << t.sha3() << " Dropping invalid transaction: " << diagnostic_information(_e);
                     _tq.drop(t.sha3());
                 }
                 catch (std::exception const&)
@@ -452,7 +447,7 @@ u256 Block::enactOn(VerifiedBlockRef const& _block, BlockChain const& _bc)
 #if ETH_TIMED_ENACTMENTS
     enactment = t.elapsed();
     if (populateVerify + populateGrand + syncReset + enactment > 0.5)
-        clog(StateChat) << "popVer/popGrand/syncReset/enactment = " << populateVerify << "/" << populateGrand << "/" << syncReset << "/" << enactment;
+        BOOST_LOG(m_logger) << "popVer/popGrand/syncReset/enactment = " << populateVerify << " / " << populateGrand << " / " << syncReset << " / " << enactment;
 #endif
     return ret;
 }
@@ -740,7 +735,7 @@ void Block::commitToSeal(BlockChain const& _bc, bytes const& _extraData)
     if (m_previousBlock.number() != 0)
     {
         // Find great-uncles (or second-cousins or whatever they are) - children of great-grandparents, great-great-grandparents... that were not already uncles in previous generations.
-        clog(StateDetail) << "Checking " << m_previousBlock.hash() << ", parent=" << m_previousBlock.parentHash();
+        BOOST_LOG(m_loggerDetailed) << "Checking " << m_previousBlock.hash() << ", parent = " << m_previousBlock.parentHash();
         h256Hash excluded = _bc.allKinFrom(m_currentBlock.parentHash(), 6);
         auto p = m_previousBlock.parentHash();
         for (unsigned gen = 0; gen < 6 && p != _bc.genesisHash() && unclesCount < 2; ++gen, p = _bc.details(p).parent)
@@ -795,8 +790,8 @@ void Block::commitToSeal(BlockChain const& _bc, bytes const& _extraData)
     DEV_TIMED_ABOVE("commit", 500)
         m_state.commit(removeEmptyAccounts ? State::CommitBehaviour::RemoveEmptyAccounts : State::CommitBehaviour::KeepEmptyAccounts);
 
-    clog(StateDetail) << "Post-reward stateRoot:" << m_state.rootHash();
-    clog(StateDetail) << m_state;
+    BOOST_LOG(m_loggerDetailed) << "Post-reward stateRoot: " << m_state.rootHash();
+    BOOST_LOG(m_loggerDetailed) << m_state;
 
     m_currentBlock.setLogBloom(logBloom());
     m_currentBlock.setGasUsed(gasUsed());
@@ -831,7 +826,7 @@ bool Block::sealBlock(bytesConstRef _header)
     if (BlockHeader(_header, HeaderData).hash(WithoutSeal) != m_currentBlock.hash(WithoutSeal))
         return false;
 
-    clog(StateDetail) << "Sealing block!";
+    BOOST_LOG(m_loggerDetailed) << "Sealing block!";
 
     // Compile block:
     RLPStream ret;
@@ -875,8 +870,7 @@ LogBloom Block::logBloom() const
 void Block::cleanup()
 {
     // Commit the new trie to disk.
-    if (isChannelVisible<StateTrace>()) // Avoid calling toHex if not needed
-        clog(StateTrace) << "Committing to disk: stateRoot" << m_currentBlock.stateRoot() << "=" << rootHash() << "=" << toHex(asBytes(db().lookup(rootHash())));
+    BOOST_LOG(m_logger) << "Committing to disk: stateRoot " << m_currentBlock.stateRoot() << " = " << rootHash() << " = " << toHex(asBytes(db().lookup(rootHash())));
 
     try
     {
@@ -885,19 +879,18 @@ void Block::cleanup()
     }
     catch (BadRoot const&)
     {
-        clog(StateChat) << "Trie corrupt! :-(";
+        cwarn << "Trie corrupt! :-(";
         throw;
     }
 
     m_state.db().commit();	// TODO: State API for this?
 
-    if (isChannelVisible<StateTrace>()) // Avoid calling toHex if not needed
-        clog(StateTrace) << "Committed: stateRoot" << m_currentBlock.stateRoot() << "=" << rootHash() << "=" << toHex(asBytes(db().lookup(rootHash())));
+    BOOST_LOG(m_logger) << "Committed: stateRoot " << m_currentBlock.stateRoot() << " = " << rootHash() << " = " << toHex(asBytes(db().lookup(rootHash())));
 
     m_previousBlock = m_currentBlock;
     sealEngine()->populateFromParent(m_currentBlock, m_previousBlock);
 
-    clog(StateTrace) << "finalising enactment. current -> previous, hash is" << m_previousBlock.hash();
+    BOOST_LOG(m_logger) << "finalising enactment. current -> previous, hash is " << m_previousBlock.hash();
 
     resetCurrent();
 }

--- a/libethereum/Block.cpp
+++ b/libethereum/Block.cpp
@@ -339,7 +339,8 @@ pair<TransactionReceipts, bool> Block::sync(BlockChain const& _bc, TransactionQu
                     }
                     else if (t.gasPrice() < _gp.ask(*this) * 9 / 10)
                     {
-                        BOOST_LOG(m_logger) << t.sha3() << " Dropping El Cheapo transaction (<90% of ask price)";
+                        LOG(m_logger)
+                            << t.sha3() << " Dropping El Cheapo transaction (<90% of ask price)";
                         _tq.drop(t.sha3());
                     }
                 }
@@ -351,13 +352,14 @@ pair<TransactionReceipts, bool> Block::sync(BlockChain const& _bc, TransactionQu
                     if (req > got)
                     {
                         // too old
-                        BOOST_LOG(m_logger) << t.sha3() << " Dropping old transaction (nonce too low)";
+                        LOG(m_logger) << t.sha3() << " Dropping old transaction (nonce too low)";
                         _tq.drop(t.sha3());
                     }
                     else if (got > req + _tq.waiting(t.sender()))
                     {
                         // too new
-                        BOOST_LOG(m_logger) << t.sha3() << " Dropping new transaction (too many nonces ahead)";
+                        LOG(m_logger)
+                            << t.sha3() << " Dropping new transaction (too many nonces ahead)";
                         _tq.drop(t.sha3());
                     }
                     else
@@ -368,13 +370,18 @@ pair<TransactionReceipts, bool> Block::sync(BlockChain const& _bc, TransactionQu
                     bigint const& got = *boost::get_error_info<errinfo_got>(e);
                     if (got > m_currentBlock.gasLimit())
                     {
-                        BOOST_LOG(m_logger) << t.sha3() << " Dropping over-gassy transaction (gas > block's gas limit)";
-                        BOOST_LOG(m_logger) << "got: " << got << " required: " << m_currentBlock.gasLimit();
+                        LOG(m_logger)
+                            << t.sha3()
+                            << " Dropping over-gassy transaction (gas > block's gas limit)";
+                        LOG(m_logger)
+                            << "got: " << got << " required: " << m_currentBlock.gasLimit();
                         _tq.drop(t.sha3());
                     }
                     else
                     {
-                        BOOST_LOG(m_logger) << t.sha3() << " Temporarily no gas left in current block (txs gas > block's gas limit)";
+                        LOG(m_logger) << t.sha3()
+                                      << " Temporarily no gas left in current block (txs gas > "
+                                         "block's gas limit)";
                         //_tq.drop(t.sha3());
                         // Temporarily no gas left in current block.
                         // OPTIMISE: could note this and then we don't evaluate until a block that does have the gas left.
@@ -384,7 +391,8 @@ pair<TransactionReceipts, bool> Block::sync(BlockChain const& _bc, TransactionQu
                 catch (Exception const& _e)
                 {
                     // Something else went wrong - drop it.
-                    BOOST_LOG(m_logger) << t.sha3() << " Dropping invalid transaction: " << diagnostic_information(_e);
+                    LOG(m_logger) << t.sha3() << " Dropping invalid transaction: "
+                                  << diagnostic_information(_e);
                     _tq.drop(t.sha3());
                 }
                 catch (std::exception const&)
@@ -447,7 +455,8 @@ u256 Block::enactOn(VerifiedBlockRef const& _block, BlockChain const& _bc)
 #if ETH_TIMED_ENACTMENTS
     enactment = t.elapsed();
     if (populateVerify + populateGrand + syncReset + enactment > 0.5)
-        BOOST_LOG(m_logger) << "popVer/popGrand/syncReset/enactment = " << populateVerify << " / " << populateGrand << " / " << syncReset << " / " << enactment;
+        LOG(m_logger) << "popVer/popGrand/syncReset/enactment = " << populateVerify << " / "
+                      << populateGrand << " / " << syncReset << " / " << enactment;
 #endif
     return ret;
 }
@@ -735,7 +744,8 @@ void Block::commitToSeal(BlockChain const& _bc, bytes const& _extraData)
     if (m_previousBlock.number() != 0)
     {
         // Find great-uncles (or second-cousins or whatever they are) - children of great-grandparents, great-great-grandparents... that were not already uncles in previous generations.
-        BOOST_LOG(m_loggerDetailed) << "Checking " << m_previousBlock.hash() << ", parent = " << m_previousBlock.parentHash();
+        LOG(m_loggerDetailed) << "Checking " << m_previousBlock.hash()
+                              << ", parent = " << m_previousBlock.parentHash();
         h256Hash excluded = _bc.allKinFrom(m_currentBlock.parentHash(), 6);
         auto p = m_previousBlock.parentHash();
         for (unsigned gen = 0; gen < 6 && p != _bc.genesisHash() && unclesCount < 2; ++gen, p = _bc.details(p).parent)
@@ -790,20 +800,21 @@ void Block::commitToSeal(BlockChain const& _bc, bytes const& _extraData)
     DEV_TIMED_ABOVE("commit", 500)
         m_state.commit(removeEmptyAccounts ? State::CommitBehaviour::RemoveEmptyAccounts : State::CommitBehaviour::KeepEmptyAccounts);
 
-    BOOST_LOG(m_loggerDetailed) << "Post-reward stateRoot: " << m_state.rootHash();
-    BOOST_LOG(m_loggerDetailed) << m_state;
+        LOG(m_loggerDetailed) << "Post-reward stateRoot: " << m_state.rootHash();
+        LOG(m_loggerDetailed) << m_state;
 
-    m_currentBlock.setLogBloom(logBloom());
-    m_currentBlock.setGasUsed(gasUsed());
-    m_currentBlock.setRoots(hash256(transactionsMap), hash256(receiptsMap), sha3(m_currentUncles), m_state.rootHash());
+        m_currentBlock.setLogBloom(logBloom());
+        m_currentBlock.setGasUsed(gasUsed());
+        m_currentBlock.setRoots(hash256(transactionsMap), hash256(receiptsMap),
+            sha3(m_currentUncles), m_state.rootHash());
 
-    m_currentBlock.setParentHash(m_previousBlock.hash());
-    m_currentBlock.setExtraData(_extraData);
-    if (m_currentBlock.extraData().size() > 32)
-    {
-        auto ed = m_currentBlock.extraData();
-        ed.resize(32);
-        m_currentBlock.setExtraData(ed);
+        m_currentBlock.setParentHash(m_previousBlock.hash());
+        m_currentBlock.setExtraData(_extraData);
+        if (m_currentBlock.extraData().size() > 32)
+        {
+            auto ed = m_currentBlock.extraData();
+            ed.resize(32);
+            m_currentBlock.setExtraData(ed);
     }
 
     m_committedToSeal = true;
@@ -826,7 +837,7 @@ bool Block::sealBlock(bytesConstRef _header)
     if (BlockHeader(_header, HeaderData).hash(WithoutSeal) != m_currentBlock.hash(WithoutSeal))
         return false;
 
-    BOOST_LOG(m_loggerDetailed) << "Sealing block!";
+    LOG(m_loggerDetailed) << "Sealing block!";
 
     // Compile block:
     RLPStream ret;
@@ -870,7 +881,8 @@ LogBloom Block::logBloom() const
 void Block::cleanup()
 {
     // Commit the new trie to disk.
-    BOOST_LOG(m_logger) << "Committing to disk: stateRoot " << m_currentBlock.stateRoot() << " = " << rootHash() << " = " << toHex(asBytes(db().lookup(rootHash())));
+    LOG(m_logger) << "Committing to disk: stateRoot " << m_currentBlock.stateRoot() << " = "
+                  << rootHash() << " = " << toHex(asBytes(db().lookup(rootHash())));
 
     try
     {
@@ -885,12 +897,14 @@ void Block::cleanup()
 
     m_state.db().commit();	// TODO: State API for this?
 
-    BOOST_LOG(m_logger) << "Committed: stateRoot " << m_currentBlock.stateRoot() << " = " << rootHash() << " = " << toHex(asBytes(db().lookup(rootHash())));
+    LOG(m_logger) << "Committed: stateRoot " << m_currentBlock.stateRoot() << " = " << rootHash()
+                  << " = " << toHex(asBytes(db().lookup(rootHash())));
 
     m_previousBlock = m_currentBlock;
     sealEngine()->populateFromParent(m_currentBlock, m_previousBlock);
 
-    BOOST_LOG(m_logger) << "finalising enactment. current -> previous, hash is " << m_previousBlock.hash();
+    LOG(m_logger) << "finalising enactment. current -> previous, hash is "
+                  << m_previousBlock.hash();
 
     resetCurrent();
 }

--- a/libethereum/Block.h
+++ b/libethereum/Block.h
@@ -51,11 +51,6 @@ class TransactionQueue;
 struct VerifiedBlockRef;
 class LastBlockHashesFace;
 
-struct BlockChat: public LogChannel { static const char* name(); static const int verbosity = 4; };
-struct BlockTrace: public LogChannel { static const char* name(); static const int verbosity = 5; };
-struct BlockDetail: public LogChannel { static const char* name(); static const int verbosity = 14; };
-struct BlockSafeExceptions: public LogChannel { static const char* name(); static const int verbosity = 21; };
-
 struct PopulationStatistics
 {
 	double verify;
@@ -316,6 +311,9 @@ private:
 	Address m_author;							///< Our address (i.e. the address to which fees go).
 
 	SealEngineFace* m_sealEngine = nullptr;		///< The chain's seal engine.
+
+    Logger m_logger{createLogger(5, "block")};
+    Logger m_loggerDetailed{createLogger(14, "block")};
 };
 
 

--- a/libethereum/Block.h
+++ b/libethereum/Block.h
@@ -1,18 +1,18 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file Block.h
  * @author Gav Wood <i@gavwood.com>
@@ -53,8 +53,8 @@ class LastBlockHashesFace;
 
 struct PopulationStatistics
 {
-	double verify;
-	double enact;
+    double verify;
+    double enact;
 };
 
 DEV_SIMPLE_EXCEPTION(ChainOperationWithUnknownBlockChain);
@@ -67,250 +67,250 @@ DEV_SIMPLE_EXCEPTION(InvalidOperationOnSealedBlock);
  */
 class Block
 {
-	friend class ExtVM;
-	friend class dev::test::ImportTest;
-	friend class dev::test::StateLoader;
-	friend class Executive;
-	friend class BlockChain;
+    friend class ExtVM;
+    friend class dev::test::ImportTest;
+    friend class dev::test::StateLoader;
+    friend class Executive;
+    friend class BlockChain;
 
 public:
-	// TODO: pass in ChainOperationParams rather than u256
+    // TODO: pass in ChainOperationParams rather than u256
 
-	/// Default constructor; creates with a blank database prepopulated with the genesis block.
-	Block(u256 const& _accountStartNonce): m_state(_accountStartNonce, OverlayDB(), BaseState::Empty), m_precommit(_accountStartNonce) {}
+    /// Default constructor; creates with a blank database prepopulated with the genesis block.
+    Block(u256 const& _accountStartNonce): m_state(_accountStartNonce, OverlayDB(), BaseState::Empty), m_precommit(_accountStartNonce) {}
 
-	/// Basic state object from database.
-	/// Use the default when you already have a database and you just want to make a Block object
-	/// which uses it. If you have no preexisting database then set BaseState to something other
-	/// than BaseState::PreExisting in order to prepopulate the Trie.
-	/// You can also set the author address.
-	Block(BlockChain const& _bc, OverlayDB const& _db, BaseState _bs = BaseState::PreExisting, Address const& _author = Address());
+    /// Basic state object from database.
+    /// Use the default when you already have a database and you just want to make a Block object
+    /// which uses it. If you have no preexisting database then set BaseState to something other
+    /// than BaseState::PreExisting in order to prepopulate the Trie.
+    /// You can also set the author address.
+    Block(BlockChain const& _bc, OverlayDB const& _db, BaseState _bs = BaseState::PreExisting, Address const& _author = Address());
 
-	/// Basic state object from database.
-	/// Use the default when you already have a database and you just want to make a Block object
-	/// which uses it.
-	/// Will throw InvalidRoot if the root passed is not in the database.
-	/// You can also set the author address.
-	Block(BlockChain const& _bc, OverlayDB const& _db, h256 const& _root, Address const& _author = Address());
+    /// Basic state object from database.
+    /// Use the default when you already have a database and you just want to make a Block object
+    /// which uses it.
+    /// Will throw InvalidRoot if the root passed is not in the database.
+    /// You can also set the author address.
+    Block(BlockChain const& _bc, OverlayDB const& _db, h256 const& _root, Address const& _author = Address());
 
-	enum NullType { Null };
-	Block(NullType): m_state(0, OverlayDB(), BaseState::Empty), m_precommit(0) {}
+    enum NullType { Null };
+    Block(NullType): m_state(0, OverlayDB(), BaseState::Empty), m_precommit(0) {}
 
-	/// Construct from a given blockchain. Empty, but associated with @a _bc 's chain params.
-	explicit Block(BlockChain const& _bc): Block(Null) { noteChain(_bc); }
+    /// Construct from a given blockchain. Empty, but associated with @a _bc 's chain params.
+    explicit Block(BlockChain const& _bc): Block(Null) { noteChain(_bc); }
 
-	/// Copy state object.
-	Block(Block const& _s);
+    /// Copy state object.
+    Block(Block const& _s);
 
-	/// Copy state object.
-	Block& operator=(Block const& _s);
+    /// Copy state object.
+    Block& operator=(Block const& _s);
 
-	/// Get the author address for any transactions we do and rewards we get.
-	Address author() const { return m_author; }
+    /// Get the author address for any transactions we do and rewards we get.
+    Address author() const { return m_author; }
 
-	/// Set the author address for any transactions we do and rewards we get.
-	/// This causes a complete reset of current block.
-	void setAuthor(Address const& _id) { m_author = _id; resetCurrent(); }
+    /// Set the author address for any transactions we do and rewards we get.
+    /// This causes a complete reset of current block.
+    void setAuthor(Address const& _id) { m_author = _id; resetCurrent(); }
 
-	/// Note the fact that this block is being used with a particular chain.
-	/// Call this before using any non-const methods.
-	void noteChain(BlockChain const& _bc);
+    /// Note the fact that this block is being used with a particular chain.
+    /// Call this before using any non-const methods.
+    void noteChain(BlockChain const& _bc);
 
-	// Account-getters. All operate on the final state.
+    // Account-getters. All operate on the final state.
 
-	/// Get an account's balance.
-	/// @returns 0 if the address has never been used.
-	u256 balance(Address const& _address) const { return m_state.balance(_address); }
+    /// Get an account's balance.
+    /// @returns 0 if the address has never been used.
+    u256 balance(Address const& _address) const { return m_state.balance(_address); }
 
-	/// Get the number of transactions a particular address has sent (used for the transaction nonce).
-	/// @returns 0 if the address has never been used.
-	u256 transactionsFrom(Address const& _address) const { return m_state.getNonce(_address); }
+    /// Get the number of transactions a particular address has sent (used for the transaction nonce).
+    /// @returns 0 if the address has never been used.
+    u256 transactionsFrom(Address const& _address) const { return m_state.getNonce(_address); }
 
-	/// Check if the address is in use.
-	bool addressInUse(Address const& _address) const { return m_state.addressInUse(_address); }
+    /// Check if the address is in use.
+    bool addressInUse(Address const& _address) const { return m_state.addressInUse(_address); }
 
-	/// Check if the address contains executable code.
-	bool addressHasCode(Address const& _address) const { return m_state.addressHasCode(_address); }
+    /// Check if the address contains executable code.
+    bool addressHasCode(Address const& _address) const { return m_state.addressHasCode(_address); }
 
-	/// Get the root of the storage of an account.
-	h256 storageRoot(Address const& _contract) const { return m_state.storageRoot(_contract); }
+    /// Get the root of the storage of an account.
+    h256 storageRoot(Address const& _contract) const { return m_state.storageRoot(_contract); }
 
-	/// Get the value of a storage position of an account.
-	/// @returns 0 if no account exists at that address.
-	u256 storage(Address const& _contract, u256 const& _memory) const { return m_state.storage(_contract, _memory); }
+    /// Get the value of a storage position of an account.
+    /// @returns 0 if no account exists at that address.
+    u256 storage(Address const& _contract, u256 const& _memory) const { return m_state.storage(_contract, _memory); }
 
-	/// Get the storage of an account.
-	/// @note This is expensive. Don't use it unless you need to.
-	/// @returns map of hashed keys to key-value pairs or empty map if no account exists at that address.
-	std::map<h256, std::pair<u256, u256>> storage(Address const& _contract) const { return m_state.storage(_contract); }
+    /// Get the storage of an account.
+    /// @note This is expensive. Don't use it unless you need to.
+    /// @returns map of hashed keys to key-value pairs or empty map if no account exists at that address.
+    std::map<h256, std::pair<u256, u256>> storage(Address const& _contract) const { return m_state.storage(_contract); }
 
-	/// Get the code of an account.
-	/// @returns bytes() if no account exists at that address.
-	bytes const& code(Address const& _contract) const { return m_state.code(_contract); }
+    /// Get the code of an account.
+    /// @returns bytes() if no account exists at that address.
+    bytes const& code(Address const& _contract) const { return m_state.code(_contract); }
 
-	/// Get the code hash of an account.
-	/// @returns EmptySHA3 if no account exists at that address or if there is no code associated with the address.
-	h256 codeHash(Address const& _contract) const { return m_state.codeHash(_contract); }
+    /// Get the code hash of an account.
+    /// @returns EmptySHA3 if no account exists at that address or if there is no code associated with the address.
+    h256 codeHash(Address const& _contract) const { return m_state.codeHash(_contract); }
 
-	// General information from state
+    // General information from state
 
-	/// Get the backing state object.
-	State const& state() const { return m_state; }
+    /// Get the backing state object.
+    State const& state() const { return m_state; }
 
-	/// Open a DB - useful for passing into the constructor & keeping for other states that are necessary.
-	OverlayDB const& db() const { return m_state.db(); }
+    /// Open a DB - useful for passing into the constructor & keeping for other states that are necessary.
+    OverlayDB const& db() const { return m_state.db(); }
 
-	/// The hash of the root of our state tree.
-	h256 rootHash() const { return m_state.rootHash(); }
+    /// The hash of the root of our state tree.
+    h256 rootHash() const { return m_state.rootHash(); }
 
-	/// @returns the set containing all addresses currently in use in Ethereum.
-	/// @throws InterfaceNotSupported if compiled without ETH_FATDB.
-	std::unordered_map<Address, u256> addresses() const { return m_state.addresses(); }
+    /// @returns the set containing all addresses currently in use in Ethereum.
+    /// @throws InterfaceNotSupported if compiled without ETH_FATDB.
+    std::unordered_map<Address, u256> addresses() const { return m_state.addresses(); }
 
-	// For altering accounts behind-the-scenes
+    // For altering accounts behind-the-scenes
 
-	/// Get a mutable State object which is backing this block.
-	/// @warning Only use this is you know what you're doing. If you use it while constructing a
-	/// normal sealable block, don't expect things to work right.
-	State& mutableState() { return m_state; }
+    /// Get a mutable State object which is backing this block.
+    /// @warning Only use this is you know what you're doing. If you use it while constructing a
+    /// normal sealable block, don't expect things to work right.
+    State& mutableState() { return m_state; }
 
-	// Information concerning ongoing transactions
+    // Information concerning ongoing transactions
 
-	/// Get the remaining gas limit in this block.
-	u256 gasLimitRemaining() const { return m_currentBlock.gasLimit() - gasUsed(); }
+    /// Get the remaining gas limit in this block.
+    u256 gasLimitRemaining() const { return m_currentBlock.gasLimit() - gasUsed(); }
 
-	/// Get the list of pending transactions.
-	Transactions const& pending() const { return m_transactions; }
+    /// Get the list of pending transactions.
+    Transactions const& pending() const { return m_transactions; }
 
-	/// Get the list of hashes of pending transactions.
-	h256Hash const& pendingHashes() const { return m_transactionSet; }
+    /// Get the list of hashes of pending transactions.
+    h256Hash const& pendingHashes() const { return m_transactionSet; }
 
-	/// Get the transaction receipt for the transaction of the given index.
-	TransactionReceipt const& receipt(unsigned _i) const { return m_receipts.at(_i); }
+    /// Get the transaction receipt for the transaction of the given index.
+    TransactionReceipt const& receipt(unsigned _i) const { return m_receipts.at(_i); }
 
-	/// Get the list of pending transactions.
-	LogEntries const& log(unsigned _i) const { return receipt(_i).log(); }
+    /// Get the list of pending transactions.
+    LogEntries const& log(unsigned _i) const { return receipt(_i).log(); }
 
-	/// Get the bloom filter of all logs that happened in the block.
-	LogBloom logBloom() const;
+    /// Get the bloom filter of all logs that happened in the block.
+    LogBloom logBloom() const;
 
-	/// Get the bloom filter of a particular transaction that happened in the block.
-	LogBloom const& logBloom(unsigned _i) const { return receipt(_i).bloom(); }
+    /// Get the bloom filter of a particular transaction that happened in the block.
+    LogBloom const& logBloom(unsigned _i) const { return receipt(_i).bloom(); }
 
-	/// Get the State root hash immediately after all previous transactions before transaction @a _i have been applied.
-	/// If (_i == 0) returns the initial state of the block.
-	/// If (_i == pending().size()) returns the final state of the block, prior to rewards.
-	/// Returns zero hash if intermediate state root is not available in the receipt (the case after EIP98)
-	h256 stateRootBeforeTx(unsigned _i) const;
+    /// Get the State root hash immediately after all previous transactions before transaction @a _i have been applied.
+    /// If (_i == 0) returns the initial state of the block.
+    /// If (_i == pending().size()) returns the final state of the block, prior to rewards.
+    /// Returns zero hash if intermediate state root is not available in the receipt (the case after EIP98)
+    h256 stateRootBeforeTx(unsigned _i) const;
 
-	// State-change operations
+    // State-change operations
 
-	/// Construct state object from arbitrary point in blockchain.
-	PopulationStatistics populateFromChain(BlockChain const& _bc, h256 const& _hash, ImportRequirements::value _ir = ImportRequirements::None);
+    /// Construct state object from arbitrary point in blockchain.
+    PopulationStatistics populateFromChain(BlockChain const& _bc, h256 const& _hash, ImportRequirements::value _ir = ImportRequirements::None);
 
-	/// Execute a given transaction.
-	/// This will append @a _t to the transaction list and change the state accordingly.
-	ExecutionResult execute(LastBlockHashesFace const& _lh, Transaction const& _t, Permanence _p = Permanence::Committed, OnOpFunc const& _onOp = OnOpFunc());
+    /// Execute a given transaction.
+    /// This will append @a _t to the transaction list and change the state accordingly.
+    ExecutionResult execute(LastBlockHashesFace const& _lh, Transaction const& _t, Permanence _p = Permanence::Committed, OnOpFunc const& _onOp = OnOpFunc());
 
-	/// Sync our transactions, killing those from the queue that we have and assimilating those that we don't.
-	/// @returns a list of receipts one for each transaction placed from the queue into the state and bool, true iff there are more transactions to be processed.
-	std::pair<TransactionReceipts, bool> sync(BlockChain const& _bc, TransactionQueue& _tq, GasPricer const& _gp, unsigned _msTimeout = 100);
+    /// Sync our transactions, killing those from the queue that we have and assimilating those that we don't.
+    /// @returns a list of receipts one for each transaction placed from the queue into the state and bool, true iff there are more transactions to be processed.
+    std::pair<TransactionReceipts, bool> sync(BlockChain const& _bc, TransactionQueue& _tq, GasPricer const& _gp, unsigned _msTimeout = 100);
 
-	/// Sync our state with the block chain.
-	/// This basically involves wiping ourselves if we've been superceded and rebuilding from the transaction queue.
-	bool sync(BlockChain const& _bc);
+    /// Sync our state with the block chain.
+    /// This basically involves wiping ourselves if we've been superceded and rebuilding from the transaction queue.
+    bool sync(BlockChain const& _bc);
 
-	/// Sync with the block chain, but rather than synching to the latest block, instead sync to the given block.
-	bool sync(BlockChain const& _bc, h256 const& _blockHash, BlockHeader const& _bi = BlockHeader());
+    /// Sync with the block chain, but rather than synching to the latest block, instead sync to the given block.
+    bool sync(BlockChain const& _bc, h256 const& _blockHash, BlockHeader const& _bi = BlockHeader());
 
-	/// Execute all transactions within a given block.
-	/// @returns the additional total difficulty.
-	u256 enactOn(VerifiedBlockRef const& _block, BlockChain const& _bc);
+    /// Execute all transactions within a given block.
+    /// @returns the additional total difficulty.
+    u256 enactOn(VerifiedBlockRef const& _block, BlockChain const& _bc);
 
-	/// Returns back to a pristine state after having done a playback.
-	void cleanup();
+    /// Returns back to a pristine state after having done a playback.
+    void cleanup();
 
-	/// Sets m_currentBlock to a clean state, (i.e. no change from m_previousBlock) and
-	/// optionally modifies the timestamp.
-	void resetCurrent(int64_t _timestamp = utcTime());
+    /// Sets m_currentBlock to a clean state, (i.e. no change from m_previousBlock) and
+    /// optionally modifies the timestamp.
+    void resetCurrent(int64_t _timestamp = utcTime());
 
-	// Sealing
+    // Sealing
 
-	/// Prepares the current state for mining.
-	/// Commits all transactions into the trie, compiles uncles and transactions list, applies all
-	/// rewards and populates the current block header with the appropriate hashes.
-	/// The only thing left to do after this is to actually mine().
-	///
-	/// This may be called multiple times and without issue.
-	void commitToSeal(BlockChain const& _bc, bytes const& _extraData = {});
+    /// Prepares the current state for mining.
+    /// Commits all transactions into the trie, compiles uncles and transactions list, applies all
+    /// rewards and populates the current block header with the appropriate hashes.
+    /// The only thing left to do after this is to actually mine().
+    ///
+    /// This may be called multiple times and without issue.
+    void commitToSeal(BlockChain const& _bc, bytes const& _extraData = {});
 
-	/// Pass in a properly sealed header matching this block.
-	/// @returns true iff we were previously committed to sealing, the header is valid and it
-	/// corresponds to this block.
-	/// TODO: verify it prior to calling this.
-	/** Commit to DB and build the final block if the previous call to mine()'s result is completion.
-	 * Typically looks like:
-	 * @code
-	 * while (!isSealed)
-	 * {
-	 * // lock
-	 * commitToSeal(_blockChain);  // will call uncommitToSeal if a repeat.
-	 * sealBlock(sealedHeader);
-	 * // unlock
-	 * @endcode
-	 */
-	bool sealBlock(bytes const& _header) { return sealBlock(&_header); }
-	bool sealBlock(bytesConstRef _header);
+    /// Pass in a properly sealed header matching this block.
+    /// @returns true iff we were previously committed to sealing, the header is valid and it
+    /// corresponds to this block.
+    /// TODO: verify it prior to calling this.
+    /** Commit to DB and build the final block if the previous call to mine()'s result is completion.
+     * Typically looks like:
+     * @code
+     * while (!isSealed)
+     * {
+     * // lock
+     * commitToSeal(_blockChain);  // will call uncommitToSeal if a repeat.
+     * sealBlock(sealedHeader);
+     * // unlock
+     * @endcode
+     */
+    bool sealBlock(bytes const& _header) { return sealBlock(&_header); }
+    bool sealBlock(bytesConstRef _header);
 
-	/// @returns true if sealed - in this case you can no longer append transactions.
-	bool isSealed() const { return !m_currentBytes.empty(); }
+    /// @returns true if sealed - in this case you can no longer append transactions.
+    bool isSealed() const { return !m_currentBytes.empty(); }
 
-	/// Get the complete current block, including valid nonce.
-	/// Only valid when isSealed() is true.
-	bytes const& blockData() const { return m_currentBytes; }
+    /// Get the complete current block, including valid nonce.
+    /// Only valid when isSealed() is true.
+    bytes const& blockData() const { return m_currentBytes; }
 
-	/// Get the header information on the present block.
-	BlockHeader const& info() const { return m_currentBlock; }
+    /// Get the header information on the present block.
+    BlockHeader const& info() const { return m_currentBlock; }
 
 private:
-	SealEngineFace* sealEngine() const;
+    SealEngineFace* sealEngine() const;
 
-	/// Undo the changes to the state for committing to mine.
-	void uncommitToSeal();
+    /// Undo the changes to the state for committing to mine.
+    void uncommitToSeal();
 
-	/// Execute the given block, assuming it corresponds to m_currentBlock.
-	/// Throws on failure.
-	u256 enact(VerifiedBlockRef const& _block, BlockChain const& _bc);
+    /// Execute the given block, assuming it corresponds to m_currentBlock.
+    /// Throws on failure.
+    u256 enact(VerifiedBlockRef const& _block, BlockChain const& _bc);
 
-	/// Finalise the block, applying the earned rewards.
-	void applyRewards(std::vector<BlockHeader> const& _uncleBlockHeaders, u256 const& _blockReward);
+    /// Finalise the block, applying the earned rewards.
+    void applyRewards(std::vector<BlockHeader> const& _uncleBlockHeaders, u256 const& _blockReward);
 
-	/// @returns gas used by transactions thus far executed.
-	u256 gasUsed() const { return m_receipts.size() ? m_receipts.back().cumulativeGasUsed() : 0; }
+    /// @returns gas used by transactions thus far executed.
+    u256 gasUsed() const { return m_receipts.size() ? m_receipts.back().cumulativeGasUsed() : 0; }
 
-	/// Performs irregular modifications right after initialization, e.g. to implement a hard fork.
-	void performIrregularModifications();
+    /// Performs irregular modifications right after initialization, e.g. to implement a hard fork.
+    void performIrregularModifications();
 
-	/// Creates and updates the special contract for storing block hashes according to EIP96
-	void updateBlockhashContract();
+    /// Creates and updates the special contract for storing block hashes according to EIP96
+    void updateBlockhashContract();
 
-	State m_state;								///< Our state tree, as an OverlayDB DB.
-	Transactions m_transactions;				///< The current list of transactions that we've included in the state.
-	TransactionReceipts m_receipts;				///< The corresponding list of transaction receipts.
-	h256Hash m_transactionSet;					///< The set of transaction hashes that we've included in the state.
-	State m_precommit;							///< State at the point immediately prior to rewards.
+    State m_state;								///< Our state tree, as an OverlayDB DB.
+    Transactions m_transactions;				///< The current list of transactions that we've included in the state.
+    TransactionReceipts m_receipts;				///< The corresponding list of transaction receipts.
+    h256Hash m_transactionSet;					///< The set of transaction hashes that we've included in the state.
+    State m_precommit;							///< State at the point immediately prior to rewards.
 
-	BlockHeader m_previousBlock;				///< The previous block's information.
-	BlockHeader m_currentBlock;					///< The current block's information.
-	bytes m_currentBytes;						///< The current block's bytes.
-	bool m_committedToSeal = false;				///< Have we committed to mine on the present m_currentBlock?
+    BlockHeader m_previousBlock;				///< The previous block's information.
+    BlockHeader m_currentBlock;					///< The current block's information.
+    bytes m_currentBytes;						///< The current block's bytes.
+    bool m_committedToSeal = false;				///< Have we committed to mine on the present m_currentBlock?
 
-	bytes m_currentTxs;							///< The RLP-encoded block of transactions.
-	bytes m_currentUncles;						///< The RLP-encoded block of uncles.
+    bytes m_currentTxs;							///< The RLP-encoded block of transactions.
+    bytes m_currentUncles;						///< The RLP-encoded block of uncles.
 
-	Address m_author;							///< Our address (i.e. the address to which fees go).
+    Address m_author;							///< Our address (i.e. the address to which fees go).
 
-	SealEngineFace* m_sealEngine = nullptr;		///< The chain's seal engine.
+    SealEngineFace* m_sealEngine = nullptr;		///< The chain's seal engine.
 
     Logger m_logger{createLogger(5, "block")};
     Logger m_loggerDetailed{createLogger(14, "block")};

--- a/libethereum/BlockChain.h
+++ b/libethereum/BlockChain.h
@@ -70,11 +70,6 @@ DEV_SIMPLE_EXCEPTION(TransientError);
 DEV_SIMPLE_EXCEPTION(FailedToWriteChainStart);
 DEV_SIMPLE_EXCEPTION(UnknownBlockNumber);
 
-struct BlockChainChat: public LogChannel { static const char* name(); static const int verbosity = 5; };
-struct BlockChainNote: public LogChannel { static const char* name(); static const int verbosity = 3; };
-struct BlockChainWarn: public LogChannel { static const char* name(); static const int verbosity = 1; };
-struct BlockChainDebug: public LogChannel { static const char* name(); static const int verbosity = 0; };
-
 // TODO: Move all this Genesis stuff into Genesis.h/.cpp
 std::unordered_map<Address, Account> const& genesisState();
 
@@ -421,6 +416,10 @@ private:
     std::function<void(BlockHeader const&)> m_onBlockImport;                                        ///< Called if we have imported a new block into the db
 
     boost::filesystem::path m_dbPath;
+
+    mutable Logger m_logger{createLogger(3, "chain")};
+    mutable Logger m_loggerDetail{createLogger(5, "chain")};
+    mutable Logger m_loggerDebug{createLogger(0, "chain")};
 
     friend std::ostream& operator<<(std::ostream& _out, BlockChain const& _bc);
 };

--- a/libethereum/BlockChainSync.cpp
+++ b/libethereum/BlockChainSync.cpp
@@ -1,18 +1,18 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file BlockChainSync.cpp
  * @author Gav Wood <i@gavwood.com>
@@ -44,11 +44,11 @@ unsigned const c_maxRequestBodies = 1024;
 
 std::ostream& dev::eth::operator<<(std::ostream& _out, SyncStatus const& _sync)
 {
-	_out << "protocol: " << _sync.protocolVersion << endl;
-	_out << "state: " << EthereumHost::stateName(_sync.state) << " ";
-	if (_sync.state == SyncState::Blocks)
-		_out << _sync.currentBlockNumber << "/" << _sync.highestBlockNumber;
-	return _out;
+    _out << "protocol: " << _sync.protocolVersion << endl;
+    _out << "state: " << EthereumHost::stateName(_sync.state) << " ";
+    if (_sync.state == SyncState::Blocks)
+        _out << _sync.currentBlockNumber << "/" << _sync.highestBlockNumber;
+    return _out;
 }
 
 namespace  // Helper functions.
@@ -56,872 +56,879 @@ namespace  // Helper functions.
 
 template<typename T> bool haveItem(std::map<unsigned, T>& _container, unsigned _number)
 {
-	if (_container.empty())
-		return false;
-	auto lower = _container.lower_bound(_number);
-	if (lower != _container.end() && lower->first == _number)
-		return true;
-	if (lower ==  _container.begin())
-		return false;
-	--lower;
-	return lower->first <= _number && (lower->first + lower->second.size()) > _number;
+    if (_container.empty())
+        return false;
+    auto lower = _container.lower_bound(_number);
+    if (lower != _container.end() && lower->first == _number)
+        return true;
+    if (lower ==  _container.begin())
+        return false;
+    --lower;
+    return lower->first <= _number && (lower->first + lower->second.size()) > _number;
 }
 
 template<typename T> T const* findItem(std::map<unsigned, std::vector<T>>& _container, unsigned _number)
 {
-	if (_container.empty())
-		return nullptr;
-	auto lower = _container.lower_bound(_number);
-	if (lower != _container.end() && lower->first == _number)
-		return &(*lower->second.begin());
-	if (lower ==  _container.begin())
-		return nullptr;
-	--lower;
-	if (lower->first <= _number && (lower->first + lower->second.size()) > _number)
-		return &lower->second.at(_number - lower->first);
-	return nullptr;
+    if (_container.empty())
+        return nullptr;
+    auto lower = _container.lower_bound(_number);
+    if (lower != _container.end() && lower->first == _number)
+        return &(*lower->second.begin());
+    if (lower ==  _container.begin())
+        return nullptr;
+    --lower;
+    if (lower->first <= _number && (lower->first + lower->second.size()) > _number)
+        return &lower->second.at(_number - lower->first);
+    return nullptr;
 }
 
 template<typename T> void removeItem(std::map<unsigned, std::vector<T>>& _container, unsigned _number)
 {
-	if (_container.empty())
-		return;
-	auto lower = _container.lower_bound(_number);
-	if (lower != _container.end() && lower->first == _number)
-	{
-		_container.erase(lower);
-		return;
-	}
-	if (lower ==  _container.begin())
-		return;
-	--lower;
-	if (lower->first <= _number && (lower->first + lower->second.size()) > _number)
-		lower->second.erase(lower->second.begin() + (_number - lower->first), lower->second.end());
+    if (_container.empty())
+        return;
+    auto lower = _container.lower_bound(_number);
+    if (lower != _container.end() && lower->first == _number)
+    {
+        _container.erase(lower);
+        return;
+    }
+    if (lower ==  _container.begin())
+        return;
+    --lower;
+    if (lower->first <= _number && (lower->first + lower->second.size()) > _number)
+        lower->second.erase(lower->second.begin() + (_number - lower->first), lower->second.end());
 }
 
 template<typename T> void removeAllStartingWith(std::map<unsigned, std::vector<T>>& _container, unsigned _number)
 {
-	if (_container.empty())
-		return;
-	auto lower = _container.lower_bound(_number);
-	if (lower != _container.end() && lower->first == _number)
-	{
-		_container.erase(lower, _container.end());
-		return;
-	}
-	if (lower == _container.begin())
-	{
-		_container.clear();
-		return;
-	}
-	--lower;
-	if (lower->first <= _number && (lower->first + lower->second.size()) > _number)
-		lower->second.erase(lower->second.begin() + (_number - lower->first), lower->second.end());
-	_container.erase(++lower, _container.end());
+    if (_container.empty())
+        return;
+    auto lower = _container.lower_bound(_number);
+    if (lower != _container.end() && lower->first == _number)
+    {
+        _container.erase(lower, _container.end());
+        return;
+    }
+    if (lower == _container.begin())
+    {
+        _container.clear();
+        return;
+    }
+    --lower;
+    if (lower->first <= _number && (lower->first + lower->second.size()) > _number)
+        lower->second.erase(lower->second.begin() + (_number - lower->first), lower->second.end());
+    _container.erase(++lower, _container.end());
 }
 
 template<typename T> void mergeInto(std::map<unsigned, std::vector<T>>& _container, unsigned _number, T&& _data)
 {
-	assert(!haveItem(_container, _number));
-	auto lower = _container.lower_bound(_number);
-	if (!_container.empty() && lower != _container.begin())
-		--lower;
-	if (lower != _container.end() && (lower->first + lower->second.size() == _number))
-	{
-		// extend existing chunk
-		lower->second.emplace_back(_data);
+    assert(!haveItem(_container, _number));
+    auto lower = _container.lower_bound(_number);
+    if (!_container.empty() && lower != _container.begin())
+        --lower;
+    if (lower != _container.end() && (lower->first + lower->second.size() == _number))
+    {
+        // extend existing chunk
+        lower->second.emplace_back(_data);
 
-		auto next = lower;
-		++next;
-		if (next != _container.end() && (lower->first + lower->second.size() == next->first))
-		{
-			// merge with the next chunk
-			std::move(next->second.begin(), next->second.end(), std::back_inserter(lower->second));
-			_container.erase(next);
-		}
+        auto next = lower;
+        ++next;
+        if (next != _container.end() && (lower->first + lower->second.size() == next->first))
+        {
+            // merge with the next chunk
+            std::move(next->second.begin(), next->second.end(), std::back_inserter(lower->second));
+            _container.erase(next);
+        }
 
-	}
-	else
-	{
-		// insert a new chunk
-		auto inserted = _container.insert(lower, std::make_pair(_number, std::vector<T> { _data }));
-		auto next = inserted;
-		++next;
-		if (next != _container.end() && next->first == _number + 1)
-		{
-			std::move(next->second.begin(), next->second.end(), std::back_inserter(inserted->second));
-			_container.erase(next);
-		}
-	}
+    }
+    else
+    {
+        // insert a new chunk
+        auto inserted = _container.insert(lower, std::make_pair(_number, std::vector<T> { _data }));
+        auto next = inserted;
+        ++next;
+        if (next != _container.end() && next->first == _number + 1)
+        {
+            std::move(next->second.begin(), next->second.end(), std::back_inserter(inserted->second));
+            _container.erase(next);
+        }
+    }
 }
 
 }  // Anonymous namespace -- helper functions.
 
 BlockChainSync::BlockChainSync(EthereumHost& _host):
-	m_host(_host),
-	m_chainStartBlock(_host.chain().chainStartBlockNumber()),
-	m_startingBlock(_host.chain().number()),
-	m_lastImportedBlock(m_startingBlock),
-	m_lastImportedBlockHash(_host.chain().currentHash())
+    m_host(_host),
+    m_chainStartBlock(_host.chain().chainStartBlockNumber()),
+    m_startingBlock(_host.chain().number()),
+    m_lastImportedBlock(m_startingBlock),
+    m_lastImportedBlockHash(_host.chain().currentHash())
 {
-	m_bqRoomAvailable = host().bq().onRoomAvailable([this]()
-	{
-		RecursiveGuard l(x_sync);
-		m_state = SyncState::Blocks;
-		continueSync();
-	});
+    m_bqRoomAvailable = host().bq().onRoomAvailable([this]()
+    {
+        RecursiveGuard l(x_sync);
+        m_state = SyncState::Blocks;
+        continueSync();
+    });
 }
 
 BlockChainSync::~BlockChainSync()
 {
-	RecursiveGuard l(x_sync);
-	abortSync();
+    RecursiveGuard l(x_sync);
+    abortSync();
 }
 
 void BlockChainSync::onBlockImported(BlockHeader const& _info)
 {
-	//if a block has been added via mining or other block import function
-	//through RPC, then we should count it as a last imported block
-	RecursiveGuard l(x_sync);
-	if (_info.number() > m_lastImportedBlock)
-	{
-		m_lastImportedBlock = static_cast<unsigned>(_info.number());
-		m_lastImportedBlockHash = _info.hash();
-		m_highestBlock = max(m_lastImportedBlock, m_highestBlock);
-	}
+    //if a block has been added via mining or other block import function
+    //through RPC, then we should count it as a last imported block
+    RecursiveGuard l(x_sync);
+    if (_info.number() > m_lastImportedBlock)
+    {
+        m_lastImportedBlock = static_cast<unsigned>(_info.number());
+        m_lastImportedBlockHash = _info.hash();
+        m_highestBlock = max(m_lastImportedBlock, m_highestBlock);
+    }
 }
 
 void BlockChainSync::abortSync()
 {
-	RecursiveGuard l(x_sync);
-	resetSync();
-	host().foreachPeer([&](std::shared_ptr<EthereumPeer> _p)
-	{
-		_p->abortSync();
-		return true;
-	});
+    RecursiveGuard l(x_sync);
+    resetSync();
+    host().foreachPeer([&](std::shared_ptr<EthereumPeer> _p)
+    {
+        _p->abortSync();
+        return true;
+    });
 }
 
 void BlockChainSync::onPeerStatus(std::shared_ptr<EthereumPeer> _peer)
 {
-	RecursiveGuard l(x_sync);
-	DEV_INVARIANT_CHECK;
-	std::shared_ptr<SessionFace> session = _peer->session();
-	if (!session)
-		return; // Expired
-	if (_peer->m_genesisHash != host().chain().genesisHash())
-		_peer->disable("Invalid genesis hash");
-	else if (_peer->m_protocolVersion != host().protocolVersion() && _peer->m_protocolVersion != EthereumHost::c_oldProtocolVersion)
-		_peer->disable("Invalid protocol version.");
-	else if (_peer->m_networkId != host().networkId())
-		_peer->disable("Invalid network identifier.");
-	else if (session->info().clientVersion.find("/v0.7.0/") != string::npos)
-		_peer->disable("Blacklisted client version.");
-	else if (host().isBanned(session->id()))
-		_peer->disable("Peer banned for previous bad behaviour.");
-	else if (_peer->m_asking != Asking::State && _peer->m_asking != Asking::Nothing)
-		_peer->disable("Peer banned for unexpected status message.");
-	else
-	{
-		// Before starting to exchange the data with the node, let's verify that it's on our chain
-		if (!requestDaoForkBlockHeader(_peer))
-			// DAO challenge not needed
-			syncPeer(_peer, true); 
-	}
+    RecursiveGuard l(x_sync);
+    DEV_INVARIANT_CHECK;
+    std::shared_ptr<SessionFace> session = _peer->session();
+    if (!session)
+        return; // Expired
+    if (_peer->m_genesisHash != host().chain().genesisHash())
+        _peer->disable("Invalid genesis hash");
+    else if (_peer->m_protocolVersion != host().protocolVersion() && _peer->m_protocolVersion != EthereumHost::c_oldProtocolVersion)
+        _peer->disable("Invalid protocol version.");
+    else if (_peer->m_networkId != host().networkId())
+        _peer->disable("Invalid network identifier.");
+    else if (session->info().clientVersion.find("/v0.7.0/") != string::npos)
+        _peer->disable("Blacklisted client version.");
+    else if (host().isBanned(session->id()))
+        _peer->disable("Peer banned for previous bad behaviour.");
+    else if (_peer->m_asking != Asking::State && _peer->m_asking != Asking::Nothing)
+        _peer->disable("Peer banned for unexpected status message.");
+    else
+    {
+        // Before starting to exchange the data with the node, let's verify that it's on our chain
+        if (!requestDaoForkBlockHeader(_peer))
+            // DAO challenge not needed
+            syncPeer(_peer, true); 
+    }
 }
 
 bool BlockChainSync::requestDaoForkBlockHeader(std::shared_ptr<EthereumPeer> _peer)
 {
-	// DAO challenge
-	unsigned const daoHardfork = static_cast<unsigned>(host().chain().sealEngine()->chainParams().daoHardforkBlock);
-	if (daoHardfork == 0)
-		return false;
+    // DAO challenge
+    unsigned const daoHardfork = static_cast<unsigned>(host().chain().sealEngine()->chainParams().daoHardforkBlock);
+    if (daoHardfork == 0)
+        return false;
 
-	m_daoChallengedPeers.insert(_peer);
-	_peer->requestBlockHeaders(daoHardfork, 1, 0, false);
-	return true;
+    m_daoChallengedPeers.insert(_peer);
+    _peer->requestBlockHeaders(daoHardfork, 1, 0, false);
+    return true;
 }
 
 void BlockChainSync::syncPeer(std::shared_ptr<EthereumPeer> _peer, bool _force)
 {
-	if (_peer->m_asking != Asking::Nothing)
-	{
-		clog(NetAllDetail) << "Can't sync with this peer - outstanding asks.";
-		return;
-	}
+    if (_peer->m_asking != Asking::Nothing)
+    {
+        LOG(m_loggerVerbose) << "Can't sync with this peer - outstanding asks.";
+        return;
+    }
 
-	if (m_state == SyncState::Waiting)
-		return;
+    if (m_state == SyncState::Waiting)
+        return;
 
-	u256 td = host().chain().details().totalDifficulty;
-	if (host().bq().isActive())
-		td += host().bq().difficulty();
+    u256 td = host().chain().details().totalDifficulty;
+    if (host().bq().isActive())
+        td += host().bq().difficulty();
 
-	u256 syncingDifficulty = std::max(m_syncingTotalDifficulty, td);
+    u256 syncingDifficulty = std::max(m_syncingTotalDifficulty, td);
 
-	if (_force || _peer->m_totalDifficulty > syncingDifficulty)
-	{
-		// start sync
-		m_syncingTotalDifficulty = _peer->m_totalDifficulty;
-		if (m_state == SyncState::Idle || m_state == SyncState::NotSynced)
-			m_state = SyncState::Blocks;
-		_peer->requestBlockHeaders(_peer->m_latestHash, 1, 0, false);
-		_peer->m_requireTransactions = true;
-		return;
-	}
+    if (_force || _peer->m_totalDifficulty > syncingDifficulty)
+    {
+        // start sync
+        m_syncingTotalDifficulty = _peer->m_totalDifficulty;
+        if (m_state == SyncState::Idle || m_state == SyncState::NotSynced)
+            m_state = SyncState::Blocks;
+        _peer->requestBlockHeaders(_peer->m_latestHash, 1, 0, false);
+        _peer->m_requireTransactions = true;
+        return;
+    }
 
-	if (m_state == SyncState::Blocks)
-	{
-		requestBlocks(_peer);
-		return;
-	}
+    if (m_state == SyncState::Blocks)
+    {
+        requestBlocks(_peer);
+        return;
+    }
 }
 
 void BlockChainSync::continueSync()
 {
-	host().foreachPeer([this](std::shared_ptr<EthereumPeer> _p)
-	{
-		syncPeer(_p, false);
-		return true;
-	});
+    host().foreachPeer([this](std::shared_ptr<EthereumPeer> _p)
+    {
+        syncPeer(_p, false);
+        return true;
+    });
 }
 
 void BlockChainSync::requestBlocks(std::shared_ptr<EthereumPeer> _peer)
 {
-	clearPeerDownload(_peer);
-	if (host().bq().knownFull())
-	{
-		clog(NetAllDetail) << "Waiting for block queue before downloading blocks";
-		pauseSync();
-		return;
-	}
-	// check to see if we need to download any block bodies first
-	auto header = m_headers.begin();
-	h256s neededBodies;
-	vector<unsigned> neededNumbers;
-	unsigned index = 0;
-	if (m_haveCommonHeader && !m_headers.empty() && m_headers.begin()->first == m_lastImportedBlock + 1)
-	{
-		while (header != m_headers.end() && neededBodies.size() < c_maxRequestBodies && index < header->second.size())
-		{
-			unsigned block = header->first + index;
-			if (m_downloadingBodies.count(block) == 0 && !haveItem(m_bodies, block))
-			{
-				neededBodies.push_back(header->second[index].hash);
-				neededNumbers.push_back(block);
-				m_downloadingBodies.insert(block);
-			}
+    clearPeerDownload(_peer);
+    if (host().bq().knownFull())
+    {
+        LOG(m_loggerVerbose) << "Waiting for block queue before downloading blocks";
+        pauseSync();
+        return;
+    }
+    // check to see if we need to download any block bodies first
+    auto header = m_headers.begin();
+    h256s neededBodies;
+    vector<unsigned> neededNumbers;
+    unsigned index = 0;
+    if (m_haveCommonHeader && !m_headers.empty() && m_headers.begin()->first == m_lastImportedBlock + 1)
+    {
+        while (header != m_headers.end() && neededBodies.size() < c_maxRequestBodies && index < header->second.size())
+        {
+            unsigned block = header->first + index;
+            if (m_downloadingBodies.count(block) == 0 && !haveItem(m_bodies, block))
+            {
+                neededBodies.push_back(header->second[index].hash);
+                neededNumbers.push_back(block);
+                m_downloadingBodies.insert(block);
+            }
 
-			++index;
-			if (index >= header->second.size())
-				break; // Download bodies only for validated header chain
-		}
-	}
-	if (neededBodies.size() > 0)
-	{
-		m_bodySyncPeers[_peer] = neededNumbers;
-		_peer->requestBlockBodies(neededBodies);
-	}
-	else
-	{
-		// check if need to download headers
-		unsigned start = 0;
-		if (!m_haveCommonHeader)
-		{
-			// download backwards until common block is found 1 header at a time
-			start = m_lastImportedBlock;
-			if (!m_headers.empty())
-				start = std::min(start, m_headers.begin()->first - 1);
-			m_lastImportedBlock = start;
-			m_lastImportedBlockHash = host().chain().numberHash(start);
+            ++index;
+            if (index >= header->second.size())
+                break; // Download bodies only for validated header chain
+        }
+    }
+    if (neededBodies.size() > 0)
+    {
+        m_bodySyncPeers[_peer] = neededNumbers;
+        _peer->requestBlockBodies(neededBodies);
+    }
+    else
+    {
+        // check if need to download headers
+        unsigned start = 0;
+        if (!m_haveCommonHeader)
+        {
+            // download backwards until common block is found 1 header at a time
+            start = m_lastImportedBlock;
+            if (!m_headers.empty())
+                start = std::min(start, m_headers.begin()->first - 1);
+            m_lastImportedBlock = start;
+            m_lastImportedBlockHash = host().chain().numberHash(start);
 
-			if (start <= m_chainStartBlock + 1)
-				m_haveCommonHeader = true; //reached chain start
-		}
-		if (m_haveCommonHeader)
-		{
-			start = m_lastImportedBlock + 1;
-			auto next = m_headers.begin();
-			unsigned count = 0;
-			if (!m_headers.empty() && start >= m_headers.begin()->first)
-			{
-				start = m_headers.begin()->first + m_headers.begin()->second.size();
-				++next;
-			}
+            if (start <= m_chainStartBlock + 1)
+                m_haveCommonHeader = true; //reached chain start
+        }
+        if (m_haveCommonHeader)
+        {
+            start = m_lastImportedBlock + 1;
+            auto next = m_headers.begin();
+            unsigned count = 0;
+            if (!m_headers.empty() && start >= m_headers.begin()->first)
+            {
+                start = m_headers.begin()->first + m_headers.begin()->second.size();
+                ++next;
+            }
 
-			while (count == 0 && next != m_headers.end())
-			{
-				count = std::min(c_maxRequestHeaders, next->first - start);
-				while(count > 0 && m_downloadingHeaders.count(start) != 0)
-				{
-					start++;
-					count--;
-				}
-				std::vector<unsigned> headers;
-				for (unsigned block = start; block < start + count; block++)
-					if (m_downloadingHeaders.count(block) == 0)
-					{
-						headers.push_back(block);
-						m_downloadingHeaders.insert(block);
-					}
-				count = headers.size();
-				if (count > 0)
-				{
-					m_headerSyncPeers[_peer] = headers;
-					assert(!haveItem(m_headers, start));
-					_peer->requestBlockHeaders(start, count, 0, false);
-				}
-				else if (start >= next->first)
-				{
-					start = next->first + next->second.size();
-					++next;
-				}
-			}
-		}
-		else
-			_peer->requestBlockHeaders(start, 1, 0, false);
-	}
+            while (count == 0 && next != m_headers.end())
+            {
+                count = std::min(c_maxRequestHeaders, next->first - start);
+                while(count > 0 && m_downloadingHeaders.count(start) != 0)
+                {
+                    start++;
+                    count--;
+                }
+                std::vector<unsigned> headers;
+                for (unsigned block = start; block < start + count; block++)
+                    if (m_downloadingHeaders.count(block) == 0)
+                    {
+                        headers.push_back(block);
+                        m_downloadingHeaders.insert(block);
+                    }
+                count = headers.size();
+                if (count > 0)
+                {
+                    m_headerSyncPeers[_peer] = headers;
+                    assert(!haveItem(m_headers, start));
+                    _peer->requestBlockHeaders(start, count, 0, false);
+                }
+                else if (start >= next->first)
+                {
+                    start = next->first + next->second.size();
+                    ++next;
+                }
+            }
+        }
+        else
+            _peer->requestBlockHeaders(start, 1, 0, false);
+    }
 }
 
 void BlockChainSync::clearPeerDownload(std::shared_ptr<EthereumPeer> _peer)
 {
-	auto syncPeer = m_headerSyncPeers.find(_peer);
-	if (syncPeer != m_headerSyncPeers.end())
-	{
-		for (unsigned block : syncPeer->second)
-			m_downloadingHeaders.erase(block);
-		m_headerSyncPeers.erase(syncPeer);
-	}
-	syncPeer = m_bodySyncPeers.find(_peer);
-	if (syncPeer != m_bodySyncPeers.end())
-	{
-		for (unsigned block : syncPeer->second)
-			m_downloadingBodies.erase(block);
-		m_bodySyncPeers.erase(syncPeer);
-	}
-	m_daoChallengedPeers.erase(_peer);
+    auto syncPeer = m_headerSyncPeers.find(_peer);
+    if (syncPeer != m_headerSyncPeers.end())
+    {
+        for (unsigned block : syncPeer->second)
+            m_downloadingHeaders.erase(block);
+        m_headerSyncPeers.erase(syncPeer);
+    }
+    syncPeer = m_bodySyncPeers.find(_peer);
+    if (syncPeer != m_bodySyncPeers.end())
+    {
+        for (unsigned block : syncPeer->second)
+            m_downloadingBodies.erase(block);
+        m_bodySyncPeers.erase(syncPeer);
+    }
+    m_daoChallengedPeers.erase(_peer);
 }
 
 void BlockChainSync::clearPeerDownload()
 {
-	for (auto s = m_headerSyncPeers.begin(); s != m_headerSyncPeers.end();)
-	{
-		if (s->first.expired())
-		{
-			for (unsigned block : s->second)
-				m_downloadingHeaders.erase(block);
-			m_headerSyncPeers.erase(s++);
-		}
-		else
-			++s;
-	}
-	for (auto s = m_bodySyncPeers.begin(); s != m_bodySyncPeers.end();)
-	{
-		if (s->first.expired())
-		{
-			for (unsigned block : s->second)
-				m_downloadingBodies.erase(block);
-			m_bodySyncPeers.erase(s++);
-		}
-		else
-			++s;
-	}
-	for (auto s = m_daoChallengedPeers.begin(); s != m_daoChallengedPeers.end();)
-	{
-		if (s->expired())
-			m_daoChallengedPeers.erase(s++);
-		else
-			++s;
-	}
+    for (auto s = m_headerSyncPeers.begin(); s != m_headerSyncPeers.end();)
+    {
+        if (s->first.expired())
+        {
+            for (unsigned block : s->second)
+                m_downloadingHeaders.erase(block);
+            m_headerSyncPeers.erase(s++);
+        }
+        else
+            ++s;
+    }
+    for (auto s = m_bodySyncPeers.begin(); s != m_bodySyncPeers.end();)
+    {
+        if (s->first.expired())
+        {
+            for (unsigned block : s->second)
+                m_downloadingBodies.erase(block);
+            m_bodySyncPeers.erase(s++);
+        }
+        else
+            ++s;
+    }
+    for (auto s = m_daoChallengedPeers.begin(); s != m_daoChallengedPeers.end();)
+    {
+        if (s->expired())
+            m_daoChallengedPeers.erase(s++);
+        else
+            ++s;
+    }
 }
 
 void BlockChainSync::logNewBlock(h256 const& _h)
 {
-	m_knownNewHashes.erase(_h);
+    m_knownNewHashes.erase(_h);
 }
 
 void BlockChainSync::onPeerBlockHeaders(std::shared_ptr<EthereumPeer> _peer, RLP const& _r)
 {
-	RecursiveGuard l(x_sync);
-	DEV_INVARIANT_CHECK;
-	size_t itemCount = _r.itemCount();
-	clog(NetMessageSummary) << "BlocksHeaders (" << dec << itemCount << "entries)" << (itemCount ? "" : ": NoMoreHeaders");
+    RecursiveGuard l(x_sync);
+    DEV_INVARIANT_CHECK;
+    size_t itemCount = _r.itemCount();
+    LOG(m_logger) << "BlocksHeaders (" << dec << itemCount << " entries) "
+                  << (itemCount ? "" : ": NoMoreHeaders");
 
-	if (m_daoChallengedPeers.find(_peer) != m_daoChallengedPeers.end())
-	{
-		if (verifyDaoChallengeResponse(_r))
-			syncPeer(_peer, false);
-		else
-			_peer->disable("Peer from another fork.");
+    if (m_daoChallengedPeers.find(_peer) != m_daoChallengedPeers.end())
+    {
+        if (verifyDaoChallengeResponse(_r))
+            syncPeer(_peer, false);
+        else
+            _peer->disable("Peer from another fork.");
 
-		m_daoChallengedPeers.erase(_peer);
-		return;
-	}
+        m_daoChallengedPeers.erase(_peer);
+        return;
+    }
 
-	clearPeerDownload(_peer);
-	if (m_state != SyncState::Blocks && m_state != SyncState::Waiting)
-	{
-		clog(NetMessageSummary) << "Ignoring unexpected blocks";
-		return;
-	}
-	if (m_state == SyncState::Waiting)
-	{
-		clog(NetAllDetail) << "Ignored blocks while waiting";
-		return;
-	}
-	if (itemCount == 0)
-	{
-		clog(NetAllDetail) << "Peer does not have the blocks requested";
-		_peer->addRating(-1);
-	}
-	for (unsigned i = 0; i < itemCount; i++)
-	{
-		BlockHeader info(_r[i].data(), HeaderData);
-		unsigned blockNumber = static_cast<unsigned>(info.number());
-		if (blockNumber < m_chainStartBlock)
-		{
-			clog(NetMessageSummary) << "Skipping too old header " << blockNumber;
-			continue;
-		}
-		if (haveItem(m_headers, blockNumber))
-		{
-			clog(NetMessageSummary) << "Skipping header " << blockNumber;
-			continue;
-		}
-		if (blockNumber <= m_lastImportedBlock && m_haveCommonHeader)
-		{
-			clog(NetMessageSummary) << "Skipping header " << blockNumber;
-			continue;
-		}
-		if (blockNumber > m_highestBlock)
-			m_highestBlock = blockNumber;
+    clearPeerDownload(_peer);
+    if (m_state != SyncState::Blocks && m_state != SyncState::Waiting)
+    {
+        LOG(m_logger) << "Ignoring unexpected blocks";
+        return;
+    }
+    if (m_state == SyncState::Waiting)
+    {
+        LOG(m_loggerVerbose) << "Ignored blocks while waiting";
+        return;
+    }
+    if (itemCount == 0)
+    {
+        LOG(m_loggerVerbose) << "Peer does not have the blocks requested";
+        _peer->addRating(-1);
+    }
+    for (unsigned i = 0; i < itemCount; i++)
+    {
+        BlockHeader info(_r[i].data(), HeaderData);
+        unsigned blockNumber = static_cast<unsigned>(info.number());
+        if (blockNumber < m_chainStartBlock)
+        {
+            LOG(m_logger) << "Skipping too old header " << blockNumber;
+            continue;
+        }
+        if (haveItem(m_headers, blockNumber))
+        {
+            LOG(m_logger) << "Skipping header " << blockNumber;
+            continue;
+        }
+        if (blockNumber <= m_lastImportedBlock && m_haveCommonHeader)
+        {
+            LOG(m_logger) << "Skipping header " << blockNumber;
+            continue;
+        }
+        if (blockNumber > m_highestBlock)
+            m_highestBlock = blockNumber;
 
-		auto status = host().bq().blockStatus(info.hash());
-		if (status == QueueStatus::Importing || status == QueueStatus::Ready || host().chain().isKnown(info.hash()))
-		{
-			m_haveCommonHeader = true;
-			m_lastImportedBlock = (unsigned)info.number();
-			m_lastImportedBlockHash = info.hash();
-		
-			if (!m_headers.empty() && m_headers.begin()->first == m_lastImportedBlock + 1 && 
-				m_headers.begin()->second[0].parent != m_lastImportedBlockHash)
-			{
-				// Start of the header chain in m_headers doesn't match our known chain,
-				// probably we've downloaded other fork
-				clog(NetWarn) << "Unknown parent of the downloaded headers, restarting sync";
-				restartSync();
-				return;
-			}
-		}
-		else
-		{
-			Header hdr { _r[i].data().toBytes(), info.hash(), info.parentHash() };
+        auto status = host().bq().blockStatus(info.hash());
+        if (status == QueueStatus::Importing || status == QueueStatus::Ready || host().chain().isKnown(info.hash()))
+        {
+            m_haveCommonHeader = true;
+            m_lastImportedBlock = (unsigned)info.number();
+            m_lastImportedBlockHash = info.hash();
+        
+            if (!m_headers.empty() && m_headers.begin()->first == m_lastImportedBlock + 1 && 
+                m_headers.begin()->second[0].parent != m_lastImportedBlockHash)
+            {
+                // Start of the header chain in m_headers doesn't match our known chain,
+                // probably we've downloaded other fork
+                clogSimple(0, "sync")
+                    << "Unknown parent of the downloaded headers, restarting sync";
+                restartSync();
+                return;
+            }
+        }
+        else
+        {
+            Header hdr { _r[i].data().toBytes(), info.hash(), info.parentHash() };
 
-			// validate chain
-			HeaderId headerId { info.transactionsRoot(), info.sha3Uncles() };
-			if (m_haveCommonHeader)
-			{
-				Header const* prevBlock = findItem(m_headers, blockNumber - 1);
-				if ((prevBlock && prevBlock->hash != info.parentHash()) || (blockNumber == m_lastImportedBlock + 1 && info.parentHash() != m_lastImportedBlockHash))
-				{
-					// mismatching parent id, delete the previous block and don't add this one
-					clog(NetImpolite) << "Unknown block header " << blockNumber << " " << info.hash() << " (Restart syncing)";
-					_peer->addRating(-1);
-					restartSync();
-					return ;
-				}
+            // validate chain
+            HeaderId headerId { info.transactionsRoot(), info.sha3Uncles() };
+            if (m_haveCommonHeader)
+            {
+                Header const* prevBlock = findItem(m_headers, blockNumber - 1);
+                if ((prevBlock && prevBlock->hash != info.parentHash()) || (blockNumber == m_lastImportedBlock + 1 && info.parentHash() != m_lastImportedBlockHash))
+                {
+                    // mismatching parent id, delete the previous block and don't add this one
+                    clogSimple(0, "sync") << "Unknown block header " << blockNumber << " "
+                                          << info.hash() << " (Restart syncing)";
+                    _peer->addRating(-1);
+                    restartSync();
+                    return ;
+                }
 
-				Header const* nextBlock = findItem(m_headers, blockNumber + 1);
-				if (nextBlock && nextBlock->parent != info.hash())
-				{
-					clog(NetImpolite) << "Unknown block header " << blockNumber + 1 << " " << nextBlock->hash;
-					// clear following headers
-					unsigned n = blockNumber + 1;
-					auto headers = m_headers.at(n);
-					for (auto const& h : headers)
-					{
-						BlockHeader deletingInfo(h.data, HeaderData);
-						m_headerIdToNumber.erase(headerId);
-						m_downloadingBodies.erase(n);
-						m_downloadingHeaders.erase(n);
-						++n;
-					}
-					removeAllStartingWith(m_headers, blockNumber + 1);
-					removeAllStartingWith(m_bodies, blockNumber + 1);
-				}
-			}
+                Header const* nextBlock = findItem(m_headers, blockNumber + 1);
+                if (nextBlock && nextBlock->parent != info.hash())
+                {
+                    LOG(m_loggerDetail)
+                        << "Unknown block header " << blockNumber + 1 << " " << nextBlock->hash;
+                    // clear following headers
+                    unsigned n = blockNumber + 1;
+                    auto headers = m_headers.at(n);
+                    for (auto const& h : headers)
+                    {
+                        BlockHeader deletingInfo(h.data, HeaderData);
+                        m_headerIdToNumber.erase(headerId);
+                        m_downloadingBodies.erase(n);
+                        m_downloadingHeaders.erase(n);
+                        ++n;
+                    }
+                    removeAllStartingWith(m_headers, blockNumber + 1);
+                    removeAllStartingWith(m_bodies, blockNumber + 1);
+                }
+            }
 
-			mergeInto(m_headers, blockNumber, std::move(hdr));
-			if (headerId.transactionsRoot == EmptyTrie && headerId.uncles == EmptyListSHA3)
-			{
-				//empty body, just mark as downloaded
-				RLPStream r(2);
-				r.appendRaw(RLPEmptyList);
-				r.appendRaw(RLPEmptyList);
-				bytes body;
-				r.swapOut(body);
-				mergeInto(m_bodies, blockNumber, std::move(body));
-			}
-			else
-				m_headerIdToNumber[headerId] = blockNumber;
-		}
-	}
-	collectBlocks();
-	continueSync();
+            mergeInto(m_headers, blockNumber, std::move(hdr));
+            if (headerId.transactionsRoot == EmptyTrie && headerId.uncles == EmptyListSHA3)
+            {
+                //empty body, just mark as downloaded
+                RLPStream r(2);
+                r.appendRaw(RLPEmptyList);
+                r.appendRaw(RLPEmptyList);
+                bytes body;
+                r.swapOut(body);
+                mergeInto(m_bodies, blockNumber, std::move(body));
+            }
+            else
+                m_headerIdToNumber[headerId] = blockNumber;
+        }
+    }
+    collectBlocks();
+    continueSync();
 }
 
 bool BlockChainSync::verifyDaoChallengeResponse(RLP const& _r)
 {
-	if (_r.itemCount() != 1)
-		return false;
+    if (_r.itemCount() != 1)
+        return false;
 
-	BlockHeader info(_r[0].data(), HeaderData);
-	return info.number() == host().chain().sealEngine()->chainParams().daoHardforkBlock &&
-		info.extraData() == fromHex("0x64616f2d686172642d666f726b");
+    BlockHeader info(_r[0].data(), HeaderData);
+    return info.number() == host().chain().sealEngine()->chainParams().daoHardforkBlock &&
+        info.extraData() == fromHex("0x64616f2d686172642d666f726b");
 }
 
 void BlockChainSync::onPeerBlockBodies(std::shared_ptr<EthereumPeer> _peer, RLP const& _r)
 {
-	RecursiveGuard l(x_sync);
-	DEV_INVARIANT_CHECK;
-	size_t itemCount = _r.itemCount();
-	clog(NetMessageSummary) << "BlocksBodies (" << dec << itemCount << "entries)" << (itemCount ? "" : ": NoMoreBodies");
-	clearPeerDownload(_peer);
-	if (m_state != SyncState::Blocks && m_state != SyncState::Waiting) {
-		clog(NetMessageSummary) << "Ignoring unexpected blocks";
-		return;
-	}
-	if (m_state == SyncState::Waiting)
-	{
-		clog(NetAllDetail) << "Ignored blocks while waiting";
-		return;
-	}
-	if (itemCount == 0)
-	{
-		clog(NetAllDetail) << "Peer does not have the blocks requested";
-		_peer->addRating(-1);
-	}
-	for (unsigned i = 0; i < itemCount; i++)
-	{
-		RLP body(_r[i]);
+    RecursiveGuard l(x_sync);
+    DEV_INVARIANT_CHECK;
+    size_t itemCount = _r.itemCount();
+    LOG(m_logger) << "BlocksBodies (" << dec << itemCount << " entries) "
+                  << (itemCount ? "" : ": NoMoreBodies");
+    clearPeerDownload(_peer);
+    if (m_state != SyncState::Blocks && m_state != SyncState::Waiting) {
+        LOG(m_logger) << "Ignoring unexpected blocks";
+        return;
+    }
+    if (m_state == SyncState::Waiting)
+    {
+        LOG(m_loggerVerbose) << "Ignored blocks while waiting";
+        return;
+    }
+    if (itemCount == 0)
+    {
+        LOG(m_loggerVerbose) << "Peer does not have the blocks requested";
+        _peer->addRating(-1);
+    }
+    for (unsigned i = 0; i < itemCount; i++)
+    {
+        RLP body(_r[i]);
 
-		auto txList = body[0];
-		h256 transactionRoot = trieRootOver(txList.itemCount(), [&](unsigned i){ return rlp(i); }, [&](unsigned i){ return txList[i].data().toBytes(); });
-		h256 uncles = sha3(body[1].data());
-		HeaderId id { transactionRoot, uncles };
-		auto iter = m_headerIdToNumber.find(id);
-		if (iter == m_headerIdToNumber.end() || !haveItem(m_headers, iter->second))
-		{
-			clog(NetAllDetail) << "Ignored unknown block body";
-			continue;
-		}
-		unsigned blockNumber = iter->second;
-		if (haveItem(m_bodies, blockNumber))
-		{
-			clog(NetMessageSummary) << "Skipping already downloaded block body " << blockNumber;
-			continue;
-		}
-		m_headerIdToNumber.erase(id);
-		mergeInto(m_bodies, blockNumber, body.data().toBytes());
-	}
-	collectBlocks();
-	continueSync();
+        auto txList = body[0];
+        h256 transactionRoot = trieRootOver(txList.itemCount(), [&](unsigned i){ return rlp(i); }, [&](unsigned i){ return txList[i].data().toBytes(); });
+        h256 uncles = sha3(body[1].data());
+        HeaderId id { transactionRoot, uncles };
+        auto iter = m_headerIdToNumber.find(id);
+        if (iter == m_headerIdToNumber.end() || !haveItem(m_headers, iter->second))
+        {
+            LOG(m_loggerVerbose) << "Ignored unknown block body";
+            continue;
+        }
+        unsigned blockNumber = iter->second;
+        if (haveItem(m_bodies, blockNumber))
+        {
+            LOG(m_logger) << "Skipping already downloaded block body " << blockNumber;
+            continue;
+        }
+        m_headerIdToNumber.erase(id);
+        mergeInto(m_bodies, blockNumber, body.data().toBytes());
+    }
+    collectBlocks();
+    continueSync();
 }
 
 void BlockChainSync::collectBlocks()
 {
-	if (!m_haveCommonHeader || m_headers.empty() || m_bodies.empty())
-		return;
+    if (!m_haveCommonHeader || m_headers.empty() || m_bodies.empty())
+        return;
 
-	// merge headers and bodies
-	auto& headers = *m_headers.begin();
-	auto& bodies = *m_bodies.begin();
-	if (headers.first != bodies.first || headers.first != m_lastImportedBlock + 1)
-		return;
+    // merge headers and bodies
+    auto& headers = *m_headers.begin();
+    auto& bodies = *m_bodies.begin();
+    if (headers.first != bodies.first || headers.first != m_lastImportedBlock + 1)
+        return;
 
-	unsigned success = 0;
-	unsigned future = 0;
-	unsigned got = 0;
-	unsigned unknown = 0;
-	size_t i = 0;
-	for (; i < headers.second.size() && i < bodies.second.size(); i++)
-	{
-		RLPStream blockStream(3);
-		blockStream.appendRaw(headers.second[i].data);
-		RLP body(bodies.second[i]);
-		blockStream.appendRaw(body[0].data());
-		blockStream.appendRaw(body[1].data());
-		bytes block;
-		blockStream.swapOut(block);
-		switch (host().bq().import(&block))
-		{
-		case ImportResult::Success:
-			success++;
-			if (headers.first + i > m_lastImportedBlock) 
-			{
-				m_lastImportedBlock = headers.first + (unsigned)i;
-				m_lastImportedBlockHash = headers.second[i].hash;
-			}
-			break;
-		case ImportResult::Malformed:
-		case ImportResult::BadChain:
-			restartSync();
-			return;
+    unsigned success = 0;
+    unsigned future = 0;
+    unsigned got = 0;
+    unsigned unknown = 0;
+    size_t i = 0;
+    for (; i < headers.second.size() && i < bodies.second.size(); i++)
+    {
+        RLPStream blockStream(3);
+        blockStream.appendRaw(headers.second[i].data);
+        RLP body(bodies.second[i]);
+        blockStream.appendRaw(body[0].data());
+        blockStream.appendRaw(body[1].data());
+        bytes block;
+        blockStream.swapOut(block);
+        switch (host().bq().import(&block))
+        {
+        case ImportResult::Success:
+            success++;
+            if (headers.first + i > m_lastImportedBlock) 
+            {
+                m_lastImportedBlock = headers.first + (unsigned)i;
+                m_lastImportedBlockHash = headers.second[i].hash;
+            }
+            break;
+        case ImportResult::Malformed:
+        case ImportResult::BadChain:
+            restartSync();
+            return;
 
-		case ImportResult::FutureTimeKnown:
-			future++;
-			break;
-		case ImportResult::AlreadyInChain:
-			break;
-		case ImportResult::AlreadyKnown:
-		case ImportResult::FutureTimeUnknown:
-		case ImportResult::UnknownParent:
-			if (headers.first + i > m_lastImportedBlock)
-			{
-				resetSync();
-				m_haveCommonHeader = false; // fork detected, search for common header again
-			}
-			return;
+        case ImportResult::FutureTimeKnown:
+            future++;
+            break;
+        case ImportResult::AlreadyInChain:
+            break;
+        case ImportResult::AlreadyKnown:
+        case ImportResult::FutureTimeUnknown:
+        case ImportResult::UnknownParent:
+            if (headers.first + i > m_lastImportedBlock)
+            {
+                resetSync();
+                m_haveCommonHeader = false; // fork detected, search for common header again
+            }
+            return;
 
-		default:;
-		}
-	}
+        default:;
+        }
+    }
 
-	clog(NetMessageSummary) << dec << success << "imported OK," << unknown << "with unknown parents," << future << "with future timestamps," << got << " already known received.";
+    LOG(m_logger) << dec << success << "imported OK, " << unknown << " with unknown parents, "
+                  << future << " with future timestamps, " << got << " already known received.";
 
-	if (host().bq().unknownFull())
-	{
-		clog(NetWarn) << "Too many unknown blocks, restarting sync";
-		restartSync();
-		return;
-	}
+    if (host().bq().unknownFull())
+    {
+        clogSimple(0, "sync") << "Too many unknown blocks, restarting sync";
+        restartSync();
+        return;
+    }
 
-	auto newHeaders = std::move(headers.second);
-	newHeaders.erase(newHeaders.begin(), newHeaders.begin() + i);
-	unsigned newHeaderHead = headers.first + i;
-	auto newBodies = std::move(bodies.second);
-	newBodies.erase(newBodies.begin(), newBodies.begin() + i);
-	unsigned newBodiesHead = bodies.first + i;
-	m_headers.erase(m_headers.begin());
-	m_bodies.erase(m_bodies.begin());
-	if (!newHeaders.empty())
-		m_headers[newHeaderHead] = newHeaders;
-	if (!newBodies.empty())
-		m_bodies[newBodiesHead] = newBodies;
+    auto newHeaders = std::move(headers.second);
+    newHeaders.erase(newHeaders.begin(), newHeaders.begin() + i);
+    unsigned newHeaderHead = headers.first + i;
+    auto newBodies = std::move(bodies.second);
+    newBodies.erase(newBodies.begin(), newBodies.begin() + i);
+    unsigned newBodiesHead = bodies.first + i;
+    m_headers.erase(m_headers.begin());
+    m_bodies.erase(m_bodies.begin());
+    if (!newHeaders.empty())
+        m_headers[newHeaderHead] = newHeaders;
+    if (!newBodies.empty())
+        m_bodies[newBodiesHead] = newBodies;
 
-	if (m_headers.empty())
-	{
-		assert(m_bodies.empty());
-		completeSync();
-	}
-	DEV_INVARIANT_CHECK_HERE;
+    if (m_headers.empty())
+    {
+        assert(m_bodies.empty());
+        completeSync();
+    }
+    DEV_INVARIANT_CHECK_HERE;
 }
 
 void BlockChainSync::onPeerNewBlock(std::shared_ptr<EthereumPeer> _peer, RLP const& _r)
 {
-	RecursiveGuard l(x_sync);
-	DEV_INVARIANT_CHECK;
+    RecursiveGuard l(x_sync);
+    DEV_INVARIANT_CHECK;
 
-	if (_r.itemCount() != 2)
-	{
-		_peer->disable("NewBlock without 2 data fields.");
-		return;
-	}
-	BlockHeader info(_r[0][0].data(), HeaderData);
-	auto h = info.hash();
-	DEV_GUARDED(_peer->x_knownBlocks)
-		_peer->m_knownBlocks.insert(h);
-	unsigned blockNumber = static_cast<unsigned>(info.number());
-	if (blockNumber > (m_lastImportedBlock + 1))
-	{
-		clog(NetAllDetail) << "Received unknown new block";
-		syncPeer(_peer, true);
-		return;
-	}
-	switch (host().bq().import(_r[0].data()))
-	{
-	case ImportResult::Success:
-		_peer->addRating(100);
-		logNewBlock(h);
-		if (blockNumber > m_lastImportedBlock) 
-		{
-			m_lastImportedBlock = max(m_lastImportedBlock, blockNumber);
-			m_lastImportedBlockHash = h;
-		}
-		m_highestBlock = max(m_lastImportedBlock, m_highestBlock);
-		m_downloadingBodies.erase(blockNumber);
-		m_downloadingHeaders.erase(blockNumber);
-		removeItem(m_headers, blockNumber);
-		removeItem(m_bodies, blockNumber);
-		if (m_headers.empty())
-		{
-			if (!m_bodies.empty())
-			{
-				clog(NetMessageDetail) << "Block headers map is empty, but block bodies map is not. Force-clearing.";
-				m_bodies.clear();
-			}
-			completeSync();
-		}
-		break;
-	case ImportResult::FutureTimeKnown:
-		//TODO: Rating dependent on how far in future it is.
-		break;
+    if (_r.itemCount() != 2)
+    {
+        _peer->disable("NewBlock without 2 data fields.");
+        return;
+    }
+    BlockHeader info(_r[0][0].data(), HeaderData);
+    auto h = info.hash();
+    DEV_GUARDED(_peer->x_knownBlocks)
+        _peer->m_knownBlocks.insert(h);
+    unsigned blockNumber = static_cast<unsigned>(info.number());
+    if (blockNumber > (m_lastImportedBlock + 1))
+    {
+        LOG(m_loggerVerbose) << "Received unknown new block";
+        syncPeer(_peer, true);
+        return;
+    }
+    switch (host().bq().import(_r[0].data()))
+    {
+    case ImportResult::Success:
+        _peer->addRating(100);
+        logNewBlock(h);
+        if (blockNumber > m_lastImportedBlock) 
+        {
+            m_lastImportedBlock = max(m_lastImportedBlock, blockNumber);
+            m_lastImportedBlockHash = h;
+        }
+        m_highestBlock = max(m_lastImportedBlock, m_highestBlock);
+        m_downloadingBodies.erase(blockNumber);
+        m_downloadingHeaders.erase(blockNumber);
+        removeItem(m_headers, blockNumber);
+        removeItem(m_bodies, blockNumber);
+        if (m_headers.empty())
+        {
+            if (!m_bodies.empty())
+            {
+                LOG(m_loggerDetail)
+                    << "Block headers map is empty, but block bodies map is not. Force-clearing.";
+                m_bodies.clear();
+            }
+            completeSync();
+        }
+        break;
+    case ImportResult::FutureTimeKnown:
+        //TODO: Rating dependent on how far in future it is.
+        break;
 
-	case ImportResult::Malformed:
-	case ImportResult::BadChain:
-		logNewBlock(h);
-		_peer->disable("Malformed block received.");
-		return;
+    case ImportResult::Malformed:
+    case ImportResult::BadChain:
+        logNewBlock(h);
+        _peer->disable("Malformed block received.");
+        return;
 
-	case ImportResult::AlreadyInChain:
-	case ImportResult::AlreadyKnown:
-		break;
+    case ImportResult::AlreadyInChain:
+    case ImportResult::AlreadyKnown:
+        break;
 
-	case ImportResult::FutureTimeUnknown:
-	case ImportResult::UnknownParent:
-	{
-		_peer->m_unknownNewBlocks++;
-		if (_peer->m_unknownNewBlocks > c_maxPeerUknownNewBlocks)
-		{
-			_peer->disable("Too many uknown new blocks");
-			restartSync();
-		}
-		logNewBlock(h);
-		u256 totalDifficulty = _r[1].toInt<u256>();
-		if (totalDifficulty > _peer->m_totalDifficulty)
-		{
-			clog(NetMessageDetail) << "Received block with no known parent. Peer needs syncing...";
-			syncPeer(_peer, true);
-		}
-		break;
-	}
-	default:;
-	}
+    case ImportResult::FutureTimeUnknown:
+    case ImportResult::UnknownParent:
+    {
+        _peer->m_unknownNewBlocks++;
+        if (_peer->m_unknownNewBlocks > c_maxPeerUknownNewBlocks)
+        {
+            _peer->disable("Too many uknown new blocks");
+            restartSync();
+        }
+        logNewBlock(h);
+        u256 totalDifficulty = _r[1].toInt<u256>();
+        if (totalDifficulty > _peer->m_totalDifficulty)
+        {
+            LOG(m_loggerDetail) << "Received block with no known parent. Peer needs syncing...";
+            syncPeer(_peer, true);
+        }
+        break;
+    }
+    default:;
+    }
 }
 
 SyncStatus BlockChainSync::status() const
 {
-	RecursiveGuard l(x_sync);
-	SyncStatus res;
-	res.state = m_state;
-	res.protocolVersion = 62;
-	res.startBlockNumber = m_startingBlock;
-	res.currentBlockNumber = host().chain().number();
-	res.highestBlockNumber = m_highestBlock;
-	return res;
+    RecursiveGuard l(x_sync);
+    SyncStatus res;
+    res.state = m_state;
+    res.protocolVersion = 62;
+    res.startBlockNumber = m_startingBlock;
+    res.currentBlockNumber = host().chain().number();
+    res.highestBlockNumber = m_highestBlock;
+    return res;
 }
 
 void BlockChainSync::resetSync()
 {
-	m_downloadingHeaders.clear();
-	m_downloadingBodies.clear();
-	m_headers.clear();
-	m_bodies.clear();
-	m_headerSyncPeers.clear();
-	m_bodySyncPeers.clear();
-	m_headerIdToNumber.clear();
-	m_syncingTotalDifficulty = 0;
-	m_state = SyncState::NotSynced;
+    m_downloadingHeaders.clear();
+    m_downloadingBodies.clear();
+    m_headers.clear();
+    m_bodies.clear();
+    m_headerSyncPeers.clear();
+    m_bodySyncPeers.clear();
+    m_headerIdToNumber.clear();
+    m_syncingTotalDifficulty = 0;
+    m_state = SyncState::NotSynced;
 }
 
 void BlockChainSync::restartSync()
 {
-	RecursiveGuard l(x_sync);
-	resetSync();
-	m_highestBlock = 0;
-	m_haveCommonHeader = false;
-	host().bq().clear();
-	m_startingBlock = host().chain().number();
-	m_lastImportedBlock = m_startingBlock;
-	m_lastImportedBlockHash = host().chain().currentHash();
+    RecursiveGuard l(x_sync);
+    resetSync();
+    m_highestBlock = 0;
+    m_haveCommonHeader = false;
+    host().bq().clear();
+    m_startingBlock = host().chain().number();
+    m_lastImportedBlock = m_startingBlock;
+    m_lastImportedBlockHash = host().chain().currentHash();
 }
 
 void BlockChainSync::completeSync()
 {
-	RecursiveGuard l(x_sync);
-	resetSync();
-	m_state = SyncState::Idle;
+    RecursiveGuard l(x_sync);
+    resetSync();
+    m_state = SyncState::Idle;
 }
 
 void BlockChainSync::pauseSync()
 {
-	m_state = SyncState::Waiting;
+    m_state = SyncState::Waiting;
 }
 
 bool BlockChainSync::isSyncing() const
 {
-	return m_state != SyncState::Idle;
+    return m_state != SyncState::Idle;
 }
 
 void BlockChainSync::onPeerNewHashes(std::shared_ptr<EthereumPeer> _peer, std::vector<std::pair<h256, u256>> const& _hashes)
 {
-	RecursiveGuard l(x_sync);
-	DEV_INVARIANT_CHECK;
-	if (_peer->isConversing())
-	{
-		clog(NetMessageDetail) << "Ignoring new hashes since we're already downloading.";
-		return;
-	}
-	clog(NetMessageDetail) << "Not syncing and new block hash discovered: syncing.";
-	unsigned knowns = 0;
-	unsigned unknowns = 0;
-	unsigned maxHeight = 0;
-	for (auto const& p: _hashes)
-	{
-		h256 const& h = p.first;
-		_peer->addRating(1);
-		DEV_GUARDED(_peer->x_knownBlocks)
-			_peer->m_knownBlocks.insert(h);
-		auto status = host().bq().blockStatus(h);
-		if (status == QueueStatus::Importing || status == QueueStatus::Ready || host().chain().isKnown(h))
-			knowns++;
-		else if (status == QueueStatus::Bad)
-		{
-			cwarn << "block hash bad!" << h << ". Bailing...";
-			return;
-		}
-		else if (status == QueueStatus::Unknown)
-		{
-			unknowns++;
-			if (p.second > maxHeight)
-			{
-				maxHeight = (unsigned)p.second;
-				_peer->m_latestHash = h;
-			}
-		}
-		else
-			knowns++;
-	}
-	clog(NetMessageSummary) << knowns << "knowns," << unknowns << "unknowns";
-	if (unknowns > 0)
-	{
-		clog(NetMessageDetail) << "Not syncing and new block hash discovered: syncing.";
-		syncPeer(_peer, true);
-	}
+    RecursiveGuard l(x_sync);
+    DEV_INVARIANT_CHECK;
+    if (_peer->isConversing())
+    {
+        LOG(m_loggerDetail) << "Ignoring new hashes since we're already downloading.";
+        return;
+    }
+    LOG(m_loggerDetail) << "Not syncing and new block hash discovered: syncing.";
+    unsigned knowns = 0;
+    unsigned unknowns = 0;
+    unsigned maxHeight = 0;
+    for (auto const& p: _hashes)
+    {
+        h256 const& h = p.first;
+        _peer->addRating(1);
+        DEV_GUARDED(_peer->x_knownBlocks)
+            _peer->m_knownBlocks.insert(h);
+        auto status = host().bq().blockStatus(h);
+        if (status == QueueStatus::Importing || status == QueueStatus::Ready || host().chain().isKnown(h))
+            knowns++;
+        else if (status == QueueStatus::Bad)
+        {
+            cwarn << "block hash bad!" << h << ". Bailing...";
+            return;
+        }
+        else if (status == QueueStatus::Unknown)
+        {
+            unknowns++;
+            if (p.second > maxHeight)
+            {
+                maxHeight = (unsigned)p.second;
+                _peer->m_latestHash = h;
+            }
+        }
+        else
+            knowns++;
+    }
+    LOG(m_logger) << knowns << " knowns, " << unknowns << " unknowns";
+    if (unknowns > 0)
+    {
+        LOG(m_loggerDetail) << "Not syncing and new block hash discovered: syncing.";
+        syncPeer(_peer, true);
+    }
 }
 
 void BlockChainSync::onPeerAborting()
 {
-	RecursiveGuard l(x_sync);
-	// Can't check invariants here since the peers is already removed from the list and the state is not updated yet.
-	clearPeerDownload();
-	continueSync();
-	DEV_INVARIANT_CHECK_HERE;
+    RecursiveGuard l(x_sync);
+    // Can't check invariants here since the peers is already removed from the list and the state is not updated yet.
+    clearPeerDownload();
+    continueSync();
+    DEV_INVARIANT_CHECK_HERE;
 }
 
 bool BlockChainSync::invariants() const
 {
-	if (!isSyncing() && !m_headers.empty())
-		BOOST_THROW_EXCEPTION(FailedInvariant() << errinfo_comment("Got headers while not syncing"));
-	if (!isSyncing() && !m_bodies.empty())
-		BOOST_THROW_EXCEPTION(FailedInvariant() << errinfo_comment("Got bodies while not syncing"));
-	if (isSyncing() && m_host.chain().number() > 0 && m_haveCommonHeader && m_lastImportedBlock == 0)
-		BOOST_THROW_EXCEPTION(FailedInvariant() << errinfo_comment("Common block not found"));
-	if (isSyncing() && !m_headers.empty() &&  m_lastImportedBlock >= m_headers.begin()->first)
-		BOOST_THROW_EXCEPTION(FailedInvariant() << errinfo_comment("Header is too old"));
-	if (m_headerSyncPeers.empty() != m_downloadingHeaders.empty())
-		BOOST_THROW_EXCEPTION(FailedInvariant() << errinfo_comment("Header download map mismatch"));
-	if (m_bodySyncPeers.empty() != m_downloadingBodies.empty() && m_downloadingBodies.size() <= m_headerIdToNumber.size())
-		BOOST_THROW_EXCEPTION(FailedInvariant() << errinfo_comment("Body download map mismatch"));
-	return true;
+    if (!isSyncing() && !m_headers.empty())
+        BOOST_THROW_EXCEPTION(FailedInvariant() << errinfo_comment("Got headers while not syncing"));
+    if (!isSyncing() && !m_bodies.empty())
+        BOOST_THROW_EXCEPTION(FailedInvariant() << errinfo_comment("Got bodies while not syncing"));
+    if (isSyncing() && m_host.chain().number() > 0 && m_haveCommonHeader && m_lastImportedBlock == 0)
+        BOOST_THROW_EXCEPTION(FailedInvariant() << errinfo_comment("Common block not found"));
+    if (isSyncing() && !m_headers.empty() &&  m_lastImportedBlock >= m_headers.begin()->first)
+        BOOST_THROW_EXCEPTION(FailedInvariant() << errinfo_comment("Header is too old"));
+    if (m_headerSyncPeers.empty() != m_downloadingHeaders.empty())
+        BOOST_THROW_EXCEPTION(FailedInvariant() << errinfo_comment("Header download map mismatch"));
+    if (m_bodySyncPeers.empty() != m_downloadingBodies.empty() && m_downloadingBodies.size() <= m_headerIdToNumber.size())
+        BOOST_THROW_EXCEPTION(FailedInvariant() << errinfo_comment("Body download map mismatch"));
+    return true;
 }

--- a/libethereum/BlockChainSync.h
+++ b/libethereum/BlockChainSync.h
@@ -1,18 +1,18 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file BlockChainSync.h
  * @author Gav Wood <i@gavwood.com>
@@ -49,121 +49,125 @@ class EthereumPeer;
 class BlockChainSync final: public HasInvariants
 {
 public:
-	BlockChainSync(EthereumHost& _host);
-	~BlockChainSync();
-	void abortSync(); ///< Abort all sync activity
+    BlockChainSync(EthereumHost& _host);
+    ~BlockChainSync();
+    void abortSync(); ///< Abort all sync activity
 
-	/// @returns true is Sync is in progress
-	bool isSyncing() const;
+    /// @returns true is Sync is in progress
+    bool isSyncing() const;
 
-	/// Restart sync
-	void restartSync();
+    /// Restart sync
+    void restartSync();
 
-	/// Called after all blocks have been downloaded
-	/// Public only for test mode
-	void completeSync();
+    /// Called after all blocks have been downloaded
+    /// Public only for test mode
+    void completeSync();
 
-	/// Called by peer to report status
-	void onPeerStatus(std::shared_ptr<EthereumPeer> _peer);
+    /// Called by peer to report status
+    void onPeerStatus(std::shared_ptr<EthereumPeer> _peer);
 
-	/// Called by peer once it has new block headers during sync
-	void onPeerBlockHeaders(std::shared_ptr<EthereumPeer> _peer, RLP const& _r);
+    /// Called by peer once it has new block headers during sync
+    void onPeerBlockHeaders(std::shared_ptr<EthereumPeer> _peer, RLP const& _r);
 
-	/// Called by peer once it has new block bodies
-	void onPeerBlockBodies(std::shared_ptr<EthereumPeer> _peer, RLP const& _r);
+    /// Called by peer once it has new block bodies
+    void onPeerBlockBodies(std::shared_ptr<EthereumPeer> _peer, RLP const& _r);
 
-	/// Called by peer once it has new block bodies
-	void onPeerNewBlock(std::shared_ptr<EthereumPeer> _peer, RLP const& _r);
+    /// Called by peer once it has new block bodies
+    void onPeerNewBlock(std::shared_ptr<EthereumPeer> _peer, RLP const& _r);
 
-	void onPeerNewHashes(std::shared_ptr<EthereumPeer> _peer, std::vector<std::pair<h256, u256>> const& _hashes);
+    void onPeerNewHashes(std::shared_ptr<EthereumPeer> _peer, std::vector<std::pair<h256, u256>> const& _hashes);
 
-	/// Called by peer when it is disconnecting
-	void onPeerAborting();
+    /// Called by peer when it is disconnecting
+    void onPeerAborting();
 
-	/// Called when a blockchain has imported a new block onto the DB
-	void onBlockImported(BlockHeader const& _info);
+    /// Called when a blockchain has imported a new block onto the DB
+    void onBlockImported(BlockHeader const& _info);
 
-	/// @returns Synchonization status
-	SyncStatus status() const;
+    /// @returns Synchonization status
+    SyncStatus status() const;
 
-	static char const* stateName(SyncState _s) { return s_stateNames[static_cast<int>(_s)]; }
-
-private:
-	/// Resume downloading after witing state
-	void continueSync();
-
-	/// Enter waiting state
-	void pauseSync();
-
-	EthereumHost& host() { return m_host; }
-	EthereumHost const& host() const { return m_host; }
-
-	void resetSync();
-	void syncPeer(std::shared_ptr<EthereumPeer> _peer, bool _force);
-	void requestBlocks(std::shared_ptr<EthereumPeer> _peer);
-	void clearPeerDownload(std::shared_ptr<EthereumPeer> _peer);
-	void clearPeerDownload();
-	void collectBlocks();
-	bool requestDaoForkBlockHeader(std::shared_ptr<EthereumPeer> _peer);
-	bool verifyDaoChallengeResponse(RLP const& _r);
+    static char const* stateName(SyncState _s) { return s_stateNames[static_cast<int>(_s)]; }
 
 private:
-	struct Header
-	{
-		bytes data;		///< Header data
-		h256 hash;		///< Block hash
-		h256 parent;	///< Parent hash
-	};
+    /// Resume downloading after witing state
+    void continueSync();
 
-	/// Used to identify header by transactions and uncles hashes
-	struct HeaderId
-	{
-		h256 transactionsRoot;
-		h256 uncles;
+    /// Enter waiting state
+    void pauseSync();
 
-		bool operator==(HeaderId const& _other) const
-		{
-			return transactionsRoot == _other.transactionsRoot && uncles == _other.uncles;
-		}
-	};
+    EthereumHost& host() { return m_host; }
+    EthereumHost const& host() const { return m_host; }
 
-	struct HeaderIdHash
-	{
-		std::size_t operator()(const HeaderId& _k) const
-		{
-			size_t seed = 0;
-			h256::hash hasher;
-			boost::hash_combine(seed, hasher(_k.transactionsRoot));
-			boost::hash_combine(seed, hasher(_k.uncles));
-			return seed;
-		}
-	};
-
-	EthereumHost& m_host;
-	Handler<> m_bqRoomAvailable;				///< Triggered once block queue has space for more blocks
-	mutable RecursiveMutex x_sync;
-	std::set<std::weak_ptr<EthereumPeer>, std::owner_less<std::weak_ptr<EthereumPeer>>> m_daoChallengedPeers; ///> Peers to which we've sent DAO challenge request
-	std::atomic<SyncState> m_state{SyncState::Idle};		///< Current sync state
-	h256Hash m_knownNewHashes; 					///< New hashes we know about use for logging only
-	unsigned m_chainStartBlock = 0;
-	unsigned m_startingBlock = 0;      	    	///< Last block number for the start of sync
-	unsigned m_highestBlock = 0;       	     	///< Highest block number seen
-	std::unordered_set<unsigned> m_downloadingHeaders;		///< Set of block body numbers being downloaded
-	std::unordered_set<unsigned> m_downloadingBodies;		///< Set of block header numbers being downloaded
-	std::map<unsigned, std::vector<Header>> m_headers;	    ///< Downloaded headers
-	std::map<unsigned, std::vector<bytes>> m_bodies;	    ///< Downloaded block bodies
-	std::map<std::weak_ptr<EthereumPeer>, std::vector<unsigned>, std::owner_less<std::weak_ptr<EthereumPeer>>> m_headerSyncPeers; ///< Peers to m_downloadingSubchain number map
-	std::map<std::weak_ptr<EthereumPeer>, std::vector<unsigned>, std::owner_less<std::weak_ptr<EthereumPeer>>> m_bodySyncPeers; ///< Peers to m_downloadingSubchain number map
-	std::unordered_map<HeaderId, unsigned, HeaderIdHash> m_headerIdToNumber;
-	bool m_haveCommonHeader = false;			///< True if common block for our and remote chain has been found
-	unsigned m_lastImportedBlock = 0; 			///< Last imported block number
-	h256 m_lastImportedBlockHash;				///< Last imported block hash
-	u256 m_syncingTotalDifficulty;				///< Highest peer difficulty
+    void resetSync();
+    void syncPeer(std::shared_ptr<EthereumPeer> _peer, bool _force);
+    void requestBlocks(std::shared_ptr<EthereumPeer> _peer);
+    void clearPeerDownload(std::shared_ptr<EthereumPeer> _peer);
+    void clearPeerDownload();
+    void collectBlocks();
+    bool requestDaoForkBlockHeader(std::shared_ptr<EthereumPeer> _peer);
+    bool verifyDaoChallengeResponse(RLP const& _r);
 
 private:
-	static char const* const s_stateNames[static_cast<int>(SyncState::Size)];
-	bool invariants() const override;
-	void logNewBlock(h256 const& _h);
+    struct Header
+    {
+        bytes data;		///< Header data
+        h256 hash;		///< Block hash
+        h256 parent;	///< Parent hash
+    };
+
+    /// Used to identify header by transactions and uncles hashes
+    struct HeaderId
+    {
+        h256 transactionsRoot;
+        h256 uncles;
+
+        bool operator==(HeaderId const& _other) const
+        {
+            return transactionsRoot == _other.transactionsRoot && uncles == _other.uncles;
+        }
+    };
+
+    struct HeaderIdHash
+    {
+        std::size_t operator()(const HeaderId& _k) const
+        {
+            size_t seed = 0;
+            h256::hash hasher;
+            boost::hash_combine(seed, hasher(_k.transactionsRoot));
+            boost::hash_combine(seed, hasher(_k.uncles));
+            return seed;
+        }
+    };
+
+    EthereumHost& m_host;
+    Handler<> m_bqRoomAvailable;				///< Triggered once block queue has space for more blocks
+    mutable RecursiveMutex x_sync;
+    std::set<std::weak_ptr<EthereumPeer>, std::owner_less<std::weak_ptr<EthereumPeer>>> m_daoChallengedPeers; ///> Peers to which we've sent DAO challenge request
+    std::atomic<SyncState> m_state{SyncState::Idle};		///< Current sync state
+    h256Hash m_knownNewHashes; 					///< New hashes we know about use for logging only
+    unsigned m_chainStartBlock = 0;
+    unsigned m_startingBlock = 0;      	    	///< Last block number for the start of sync
+    unsigned m_highestBlock = 0;       	     	///< Highest block number seen
+    std::unordered_set<unsigned> m_downloadingHeaders;		///< Set of block body numbers being downloaded
+    std::unordered_set<unsigned> m_downloadingBodies;		///< Set of block header numbers being downloaded
+    std::map<unsigned, std::vector<Header>> m_headers;	    ///< Downloaded headers
+    std::map<unsigned, std::vector<bytes>> m_bodies;	    ///< Downloaded block bodies
+    std::map<std::weak_ptr<EthereumPeer>, std::vector<unsigned>, std::owner_less<std::weak_ptr<EthereumPeer>>> m_headerSyncPeers; ///< Peers to m_downloadingSubchain number map
+    std::map<std::weak_ptr<EthereumPeer>, std::vector<unsigned>, std::owner_less<std::weak_ptr<EthereumPeer>>> m_bodySyncPeers; ///< Peers to m_downloadingSubchain number map
+    std::unordered_map<HeaderId, unsigned, HeaderIdHash> m_headerIdToNumber;
+    bool m_haveCommonHeader = false;			///< True if common block for our and remote chain has been found
+    unsigned m_lastImportedBlock = 0; 			///< Last imported block number
+    h256 m_lastImportedBlockHash;				///< Last imported block hash
+    u256 m_syncingTotalDifficulty;				///< Highest peer difficulty
+
+    Logger m_logger{createLogger(4, "sync")};
+    Logger m_loggerDetail{createLogger(5, "sync")};
+    Logger m_loggerVerbose{createLogger(13, "sync")};
+
+private:
+    static char const* const s_stateNames[static_cast<int>(SyncState::Size)];
+    bool invariants() const override;
+    void logNewBlock(h256 const& _h);
 };
 
 std::ostream& operator<<(std::ostream& _out, SyncStatus const& _sync);

--- a/libethereum/BlockQueue.cpp
+++ b/libethereum/BlockQueue.cpp
@@ -1,18 +1,18 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file BlockQueue.cpp
  * @author Gav Wood <i@gavwood.com>
@@ -32,13 +32,6 @@ using namespace std;
 using namespace dev;
 using namespace dev::eth;
 
-#if defined(_WIN32)
-const char* BlockQueueChannel::name() { return EthOrange "[]>"; }
-#else
-const char* BlockQueueChannel::name() { return EthOrange "▣┅▶"; }
-#endif
-const char* BlockQueueTraceChannel::name() { return EthOrange "▣ ▶"; }
-
 size_t const c_maxKnownCount = 100000;
 size_t const c_maxKnownSize = 128 * 1024 * 1024;
 size_t const c_maxUnknownCount = 100000;
@@ -46,499 +39,500 @@ size_t const c_maxUnknownSize = 512 * 1024 * 1024; // Block size can be ~50kb
 
 BlockQueue::BlockQueue()
 {
-	// Allow some room for other activity
-	unsigned verifierThreads = std::max(thread::hardware_concurrency(), 3U) - 2U;
-	for (unsigned i = 0; i < verifierThreads; ++i)
-		m_verifiers.emplace_back([=](){
-			setThreadName("verifier" + toString(i));
-			this->verifierBody();
-		});
+    // Allow some room for other activity
+    unsigned verifierThreads = std::max(thread::hardware_concurrency(), 3U) - 2U;
+    for (unsigned i = 0; i < verifierThreads; ++i)
+        m_verifiers.emplace_back([=](){
+            setThreadName("verifier" + toString(i));
+            this->verifierBody();
+        });
 }
 
 BlockQueue::~BlockQueue()
 {
-	stop();
+    stop();
 }
 
 void BlockQueue::stop()
 {
-	DEV_GUARDED(m_verification)
-		m_deleting = true;
+    DEV_GUARDED(m_verification)
+        m_deleting = true;
 
-	m_moreToVerify.notify_all();
-	for (auto& i: m_verifiers)
-		i.join();
-	m_verifiers.clear();
+    m_moreToVerify.notify_all();
+    for (auto& i: m_verifiers)
+        i.join();
+    m_verifiers.clear();
 }
 
 void BlockQueue::clear()
 {
-	WriteGuard l(m_lock);
-	DEV_INVARIANT_CHECK;
-	Guard l2(m_verification);
-	m_readySet.clear();
-	m_drainingSet.clear();
-	m_verified.clear();
-	m_unverified.clear();
-	m_verifying.clear();
-	m_unknownSet.clear();
-	m_unknown.clear();
-	m_future.clear();
-	m_difficulty = 0;
-	m_drainingDifficulty = 0;
+    WriteGuard l(m_lock);
+    DEV_INVARIANT_CHECK;
+    Guard l2(m_verification);
+    m_readySet.clear();
+    m_drainingSet.clear();
+    m_verified.clear();
+    m_unverified.clear();
+    m_verifying.clear();
+    m_unknownSet.clear();
+    m_unknown.clear();
+    m_future.clear();
+    m_difficulty = 0;
+    m_drainingDifficulty = 0;
 }
 
 void BlockQueue::verifierBody()
 {
-	while (!m_deleting)
-	{
-		UnverifiedBlock work;
+    while (!m_deleting)
+    {
+        UnverifiedBlock work;
 
-		{
-			unique_lock<Mutex> l(m_verification);
-			m_moreToVerify.wait(l, [&](){ return !m_unverified.isEmpty() || m_deleting; });
-			if (m_deleting)
-				return;
-			work = m_unverified.dequeue();
+        {
+            unique_lock<Mutex> l(m_verification);
+            m_moreToVerify.wait(l, [&](){ return !m_unverified.isEmpty() || m_deleting; });
+            if (m_deleting)
+                return;
+            work = m_unverified.dequeue();
 
-			BlockHeader bi;
-			bi.setSha3Uncles(work.hash);
-			bi.setParentHash(work.parentHash);
-			m_verifying.enqueue(move(bi));
-		}
+            BlockHeader bi;
+            bi.setSha3Uncles(work.hash);
+            bi.setParentHash(work.parentHash);
+            m_verifying.enqueue(move(bi));
+        }
 
-		VerifiedBlock res;
-		swap(work.blockData, res.blockData);
-		try
-		{
-			res.verified = m_bc->verifyBlock(&res.blockData, m_onBad, ImportRequirements::OutOfOrderChecks);
-		}
-		catch (std::exception const& _ex)
-		{
-			// bad block.
-			// has to be this order as that's how invariants() assumes.
-			WriteGuard l2(m_lock);
-			unique_lock<Mutex> l(m_verification);
-			m_readySet.erase(work.hash);
-			m_knownBad.insert(work.hash);
-			if (!m_verifying.remove(work.hash))
-				cwarn << "Unexpected exception when verifying block: " << _ex.what();
-			drainVerified_WITH_BOTH_LOCKS();
-			continue;
-		}
+        VerifiedBlock res;
+        swap(work.blockData, res.blockData);
+        try
+        {
+            res.verified = m_bc->verifyBlock(&res.blockData, m_onBad, ImportRequirements::OutOfOrderChecks);
+        }
+        catch (std::exception const& _ex)
+        {
+            // bad block.
+            // has to be this order as that's how invariants() assumes.
+            WriteGuard l2(m_lock);
+            unique_lock<Mutex> l(m_verification);
+            m_readySet.erase(work.hash);
+            m_knownBad.insert(work.hash);
+            if (!m_verifying.remove(work.hash))
+                cwarn << "Unexpected exception when verifying block: " << _ex.what();
+            drainVerified_WITH_BOTH_LOCKS();
+            continue;
+        }
 
-		bool ready = false;
-		{
-			WriteGuard l2(m_lock);
-			unique_lock<Mutex> l(m_verification);
-			if (!m_verifying.isEmpty() && m_verifying.nextHash() == work.hash)
-			{
-				// we're next!
-				m_verifying.dequeue();
-				if (m_knownBad.count(res.verified.info.parentHash()))
-				{
-					m_readySet.erase(res.verified.info.hash());
-					m_knownBad.insert(res.verified.info.hash());
-				}
-				else
-					m_verified.enqueue(move(res));
+        bool ready = false;
+        {
+            WriteGuard l2(m_lock);
+            unique_lock<Mutex> l(m_verification);
+            if (!m_verifying.isEmpty() && m_verifying.nextHash() == work.hash)
+            {
+                // we're next!
+                m_verifying.dequeue();
+                if (m_knownBad.count(res.verified.info.parentHash()))
+                {
+                    m_readySet.erase(res.verified.info.hash());
+                    m_knownBad.insert(res.verified.info.hash());
+                }
+                else
+                    m_verified.enqueue(move(res));
 
-				drainVerified_WITH_BOTH_LOCKS();
-				ready = true;
-			}
-			else
-			{
-				if (!m_verifying.replace(work.hash, move(res)))
-					cwarn << "BlockQueue missing our job: was there a GM?";
-			}
-		}
-		if (ready)
-			m_onReady();
-	}
+                drainVerified_WITH_BOTH_LOCKS();
+                ready = true;
+            }
+            else
+            {
+                if (!m_verifying.replace(work.hash, move(res)))
+                    cwarn << "BlockQueue missing our job: was there a GM?";
+            }
+        }
+        if (ready)
+            m_onReady();
+    }
 }
 
 void BlockQueue::drainVerified_WITH_BOTH_LOCKS()
 {
-	while (!m_verifying.isEmpty() && !m_verifying.next().blockData.empty())
-	{
-		VerifiedBlock block = m_verifying.dequeue();
-		if (m_knownBad.count(block.verified.info.parentHash()))
-		{
-			m_readySet.erase(block.verified.info.hash());
-			m_knownBad.insert(block.verified.info.hash());
-		}
-		else
-			m_verified.enqueue(move(block));
-	}
+    while (!m_verifying.isEmpty() && !m_verifying.next().blockData.empty())
+    {
+        VerifiedBlock block = m_verifying.dequeue();
+        if (m_knownBad.count(block.verified.info.parentHash()))
+        {
+            m_readySet.erase(block.verified.info.hash());
+            m_knownBad.insert(block.verified.info.hash());
+        }
+        else
+            m_verified.enqueue(move(block));
+    }
 }
 
 ImportResult BlockQueue::import(bytesConstRef _block, bool _isOurs)
 {
-	// Check if we already know this block.
-	h256 h = BlockHeader::headerHashFromBlock(_block);
+    // Check if we already know this block.
+    h256 h = BlockHeader::headerHashFromBlock(_block);
 
-	clog(BlockQueueTraceChannel) << "Queuing block" << h << "for import...";
+    LOG(m_loggerDetail) << "Queuing block " << h << " for import...";
 
-	UpgradableGuard l(m_lock);
+    UpgradableGuard l(m_lock);
 
-	if (m_readySet.count(h) || m_drainingSet.count(h) || m_unknownSet.count(h) || m_knownBad.count(h))
-	{
-		// Already know about this one.
-		clog(BlockQueueTraceChannel) << "Already known.";
-		return ImportResult::AlreadyKnown;
-	}
+    if (m_readySet.count(h) || m_drainingSet.count(h) || m_unknownSet.count(h) || m_knownBad.count(h))
+    {
+        // Already know about this one.
+        LOG(m_loggerDetail) << "Already known.";
+        return ImportResult::AlreadyKnown;
+    }
 
-	BlockHeader bi;
-	try
-	{
-		// TODO: quick verification of seal - will require BlockQueue to be templated on SealEngine
-		// VERIFY: populates from the block and checks the block is internally coherent.
-		bi = m_bc->verifyBlock(_block, m_onBad, ImportRequirements::PostGenesis).info;
-	}
-	catch (Exception const& _e)
-	{
-		cwarn << "Ignoring malformed block: " << diagnostic_information(_e);
-		return ImportResult::Malformed;
-	}
+    BlockHeader bi;
+    try
+    {
+        // TODO: quick verification of seal - will require BlockQueue to be templated on SealEngine
+        // VERIFY: populates from the block and checks the block is internally coherent.
+        bi = m_bc->verifyBlock(_block, m_onBad, ImportRequirements::PostGenesis).info;
+    }
+    catch (Exception const& _e)
+    {
+        cwarn << "Ignoring malformed block: " << diagnostic_information(_e);
+        return ImportResult::Malformed;
+    }
 
-	clog(BlockQueueTraceChannel) << "Block" << h << "is" << bi.number() << "parent is" << bi.parentHash();
+    LOG(m_loggerDetail) << "Block " << h << " is " << bi.number() << " parent is " << bi.parentHash();
 
-	// Check block doesn't already exist first!
-	if (m_bc->isKnown(h))
-	{
-		cblockq << "Already known in chain.";
-		return ImportResult::AlreadyInChain;
-	}
+    // Check block doesn't already exist first!
+    if (m_bc->isKnown(h))
+    {
+        LOG(m_logger) << "Already known in chain.";
+        return ImportResult::AlreadyInChain;
+    }
 
-	UpgradeGuard ul(l);
-	DEV_INVARIANT_CHECK;
+    UpgradeGuard ul(l);
+    DEV_INVARIANT_CHECK;
 
-	// Check it's not in the future
-	if (bi.timestamp() > utcTime() && !_isOurs)
-	{
-		m_future.insert(static_cast<time_t>(bi.timestamp()), h, _block.toBytes());
-		char buf[24];
-		time_t bit = static_cast<time_t>(bi.timestamp());
-		if (strftime(buf, 24, "%X", localtime(&bit)) == 0)
-			buf[0] = '\0'; // empty if case strftime fails
-		clog(BlockQueueTraceChannel) << "OK - queued for future [" << bi.timestamp() << "vs" << utcTime() << "] - will wait until" << buf;
-		m_difficulty += bi.difficulty();
-		bool unknown =  !m_readySet.count(bi.parentHash()) && !m_drainingSet.count(bi.parentHash()) && !m_bc->isKnown(bi.parentHash());
-		return unknown ? ImportResult::FutureTimeUnknown : ImportResult::FutureTimeKnown;
-	}
-	else
-	{
-		// We now know it.
-		if (m_knownBad.count(bi.parentHash()))
-		{
-			m_knownBad.insert(bi.hash());
-			updateBad_WITH_LOCK(bi.hash());
-			// bad parent; this is bad too, note it as such
-			return ImportResult::BadChain;
-		}
-		else if (!m_readySet.count(bi.parentHash()) && !m_drainingSet.count(bi.parentHash()) && !m_bc->isKnown(bi.parentHash()))
-		{
-			// We don't know the parent (yet) - queue it up for later. It'll get resent to us if we find out about its ancestry later on.
-			clog(BlockQueueTraceChannel) << "OK - queued as unknown parent:" << bi.parentHash();
-			m_unknown.insert(bi.parentHash(), h, _block.toBytes());
-			m_unknownSet.insert(h);
-			m_difficulty += bi.difficulty();
+    // Check it's not in the future
+    if (bi.timestamp() > utcTime() && !_isOurs)
+    {
+        m_future.insert(static_cast<time_t>(bi.timestamp()), h, _block.toBytes());
+        char buf[24];
+        time_t bit = static_cast<time_t>(bi.timestamp());
+        if (strftime(buf, 24, "%X", localtime(&bit)) == 0)
+            buf[0] = '\0'; // empty if case strftime fails
+        LOG(m_loggerDetail) << "OK - queued for future [" << bi.timestamp() << " vs " << utcTime()
+                         << "] - will wait until " << buf;
+        m_difficulty += bi.difficulty();
+        bool unknown =  !m_readySet.count(bi.parentHash()) && !m_drainingSet.count(bi.parentHash()) && !m_bc->isKnown(bi.parentHash());
+        return unknown ? ImportResult::FutureTimeUnknown : ImportResult::FutureTimeKnown;
+    }
+    else
+    {
+        // We now know it.
+        if (m_knownBad.count(bi.parentHash()))
+        {
+            m_knownBad.insert(bi.hash());
+            updateBad_WITH_LOCK(bi.hash());
+            // bad parent; this is bad too, note it as such
+            return ImportResult::BadChain;
+        }
+        else if (!m_readySet.count(bi.parentHash()) && !m_drainingSet.count(bi.parentHash()) && !m_bc->isKnown(bi.parentHash()))
+        {
+            // We don't know the parent (yet) - queue it up for later. It'll get resent to us if we find out about its ancestry later on.
+            LOG(m_loggerDetail) << "OK - queued as unknown parent: " << bi.parentHash();
+            m_unknown.insert(bi.parentHash(), h, _block.toBytes());
+            m_unknownSet.insert(h);
+            m_difficulty += bi.difficulty();
 
-			return ImportResult::UnknownParent;
-		}
-		else
-		{
-			// If valid, append to blocks.
-			clog(BlockQueueTraceChannel) << "OK - ready for chain insertion.";
-			DEV_GUARDED(m_verification)
-				m_unverified.enqueue(UnverifiedBlock { h, bi.parentHash(), _block.toBytes() });
-			m_moreToVerify.notify_one();
-			m_readySet.insert(h);
-			m_difficulty += bi.difficulty();
+            return ImportResult::UnknownParent;
+        }
+        else
+        {
+            // If valid, append to blocks.
+            LOG(m_loggerDetail) << "OK - ready for chain insertion.";
+            DEV_GUARDED(m_verification)
+                m_unverified.enqueue(UnverifiedBlock { h, bi.parentHash(), _block.toBytes() });
+            m_moreToVerify.notify_one();
+            m_readySet.insert(h);
+            m_difficulty += bi.difficulty();
 
-			noteReady_WITH_LOCK(h);
+            noteReady_WITH_LOCK(h);
 
-			return ImportResult::Success;
-		}
-	}
+            return ImportResult::Success;
+        }
+    }
 }
 
 void BlockQueue::updateBad_WITH_LOCK(h256 const& _bad)
 {
-	DEV_INVARIANT_CHECK;
-	DEV_GUARDED(m_verification)
-	{
-		collectUnknownBad_WITH_BOTH_LOCKS(_bad);
-		bool moreBad = true;
-		while (moreBad)
-		{
-			moreBad = false;
-			std::vector<VerifiedBlock> badVerified = m_verified.removeIf([this](VerifiedBlock const& _b)
-			{
-				return m_knownBad.count(_b.verified.info.parentHash()) || m_knownBad.count(_b.verified.info.hash());
-			});
-			for (auto& b: badVerified)
-			{
-				m_knownBad.insert(b.verified.info.hash());
-				m_readySet.erase(b.verified.info.hash());
-				collectUnknownBad_WITH_BOTH_LOCKS(b.verified.info.hash());
-				moreBad = true;
-			}
+    DEV_INVARIANT_CHECK;
+    DEV_GUARDED(m_verification)
+    {
+        collectUnknownBad_WITH_BOTH_LOCKS(_bad);
+        bool moreBad = true;
+        while (moreBad)
+        {
+            moreBad = false;
+            std::vector<VerifiedBlock> badVerified = m_verified.removeIf([this](VerifiedBlock const& _b)
+            {
+                return m_knownBad.count(_b.verified.info.parentHash()) || m_knownBad.count(_b.verified.info.hash());
+            });
+            for (auto& b: badVerified)
+            {
+                m_knownBad.insert(b.verified.info.hash());
+                m_readySet.erase(b.verified.info.hash());
+                collectUnknownBad_WITH_BOTH_LOCKS(b.verified.info.hash());
+                moreBad = true;
+            }
 
-			std::vector<UnverifiedBlock> badUnverified = m_unverified.removeIf([this](UnverifiedBlock const& _b)
-			{
-				return m_knownBad.count(_b.parentHash) || m_knownBad.count(_b.hash);
-			});
-			for (auto& b: badUnverified)
-			{
-				m_knownBad.insert(b.hash);
-				m_readySet.erase(b.hash);
-				collectUnknownBad_WITH_BOTH_LOCKS(b.hash);
-				moreBad = true;
-			}
+            std::vector<UnverifiedBlock> badUnverified = m_unverified.removeIf([this](UnverifiedBlock const& _b)
+            {
+                return m_knownBad.count(_b.parentHash) || m_knownBad.count(_b.hash);
+            });
+            for (auto& b: badUnverified)
+            {
+                m_knownBad.insert(b.hash);
+                m_readySet.erase(b.hash);
+                collectUnknownBad_WITH_BOTH_LOCKS(b.hash);
+                moreBad = true;
+            }
 
-			std::vector<VerifiedBlock> badVerifying = m_verifying.removeIf([this](VerifiedBlock const& _b)
-			{
-				return m_knownBad.count(_b.verified.info.parentHash()) || m_knownBad.count(_b.verified.info.sha3Uncles());
-			});
-			for (auto& b: badVerifying)
-			{
-				h256 const& h = b.blockData.size() != 0 ? b.verified.info.hash() : b.verified.info.sha3Uncles();
-				m_knownBad.insert(h);
-				m_readySet.erase(h);
-				collectUnknownBad_WITH_BOTH_LOCKS(h);
-				moreBad = true;
-			}
-		}
-	}
+            std::vector<VerifiedBlock> badVerifying = m_verifying.removeIf([this](VerifiedBlock const& _b)
+            {
+                return m_knownBad.count(_b.verified.info.parentHash()) || m_knownBad.count(_b.verified.info.sha3Uncles());
+            });
+            for (auto& b: badVerifying)
+            {
+                h256 const& h = b.blockData.size() != 0 ? b.verified.info.hash() : b.verified.info.sha3Uncles();
+                m_knownBad.insert(h);
+                m_readySet.erase(h);
+                collectUnknownBad_WITH_BOTH_LOCKS(h);
+                moreBad = true;
+            }
+        }
+    }
 }
 
 void BlockQueue::collectUnknownBad_WITH_BOTH_LOCKS(h256 const& _bad)
 {
-	list<h256> badQueue(1, _bad);
-	while (!badQueue.empty())
-	{
-		vector<pair<h256, bytes>> const removed = m_unknown.removeByKeyEqual(badQueue.front());
-		badQueue.pop_front();
-		for (auto& newBad: removed)
-		{
-			m_unknownSet.erase(newBad.first);
-			m_knownBad.insert(newBad.first);
-			badQueue.push_back(newBad.first);
-		}
-	}
+    list<h256> badQueue(1, _bad);
+    while (!badQueue.empty())
+    {
+        vector<pair<h256, bytes>> const removed = m_unknown.removeByKeyEqual(badQueue.front());
+        badQueue.pop_front();
+        for (auto& newBad: removed)
+        {
+            m_unknownSet.erase(newBad.first);
+            m_knownBad.insert(newBad.first);
+            badQueue.push_back(newBad.first);
+        }
+    }
 }
 
 bool BlockQueue::doneDrain(h256s const& _bad)
 {
-	WriteGuard l(m_lock);
-	DEV_INVARIANT_CHECK;
-	m_drainingSet.clear();
-	m_difficulty -= m_drainingDifficulty;
-	m_drainingDifficulty = 0;
-	if (_bad.size())
-	{
-		// at least one of them was bad.
-		m_knownBad += _bad;
-		for (h256 const& b: _bad)
-			updateBad_WITH_LOCK(b);
-	}
-	return !m_readySet.empty();
+    WriteGuard l(m_lock);
+    DEV_INVARIANT_CHECK;
+    m_drainingSet.clear();
+    m_difficulty -= m_drainingDifficulty;
+    m_drainingDifficulty = 0;
+    if (_bad.size())
+    {
+        // at least one of them was bad.
+        m_knownBad += _bad;
+        for (h256 const& b: _bad)
+            updateBad_WITH_LOCK(b);
+    }
+    return !m_readySet.empty();
 }
 
 void BlockQueue::tick()
 {
-	vector<pair<h256, bytes>> todo;
-	{
-		UpgradableGuard l(m_lock);
-		if (m_future.isEmpty())
-			return;
+    vector<pair<h256, bytes>> todo;
+    {
+        UpgradableGuard l(m_lock);
+        if (m_future.isEmpty())
+            return;
 
-		cblockq << "Checking past-future blocks...";
+        LOG(m_logger) << "Checking past-future blocks...";
 
-		time_t t = utcTime();
-		if (t < m_future.firstKey())
-			return;
+        time_t t = utcTime();
+        if (t < m_future.firstKey())
+            return;
 
-		cblockq << "Past-future blocks ready.";
+        LOG(m_logger) << "Past-future blocks ready.";
 
-		{
-			UpgradeGuard l2(l);
-			DEV_INVARIANT_CHECK;
-			todo = m_future.removeByKeyNotGreater(t);
-		}
-	}
-	cblockq << "Importing" << todo.size() << "past-future blocks.";
+        {
+            UpgradeGuard l2(l);
+            DEV_INVARIANT_CHECK;
+            todo = m_future.removeByKeyNotGreater(t);
+        }
+    }
+    LOG(m_logger) << "Importing " << todo.size() << " past-future blocks.";
 
-	for (auto const& b: todo)
-		import(&b.second);
+    for (auto const& b: todo)
+        import(&b.second);
 }
 
 BlockQueueStatus BlockQueue::status() const
 { 
-	ReadGuard l(m_lock); 
-	Guard l2(m_verification); 
-	return BlockQueueStatus{ m_drainingSet.size(), m_verified.count(), m_verifying.count(), m_unverified.count(), 
-		m_future.count(), m_unknown.count(), m_knownBad.size() };
+    ReadGuard l(m_lock); 
+    Guard l2(m_verification); 
+    return BlockQueueStatus{ m_drainingSet.size(), m_verified.count(), m_verifying.count(), m_unverified.count(), 
+        m_future.count(), m_unknown.count(), m_knownBad.size() };
 }
 
 QueueStatus BlockQueue::blockStatus(h256 const& _h) const
 {
-	ReadGuard l(m_lock);
-	return
-		m_readySet.count(_h) ?
-			QueueStatus::Ready :
-		m_drainingSet.count(_h) ?
-			QueueStatus::Importing :
-		m_unknownSet.count(_h) ?
-			QueueStatus::UnknownParent :
-		m_knownBad.count(_h) ?
-			QueueStatus::Bad :
-			QueueStatus::Unknown;
+    ReadGuard l(m_lock);
+    return
+        m_readySet.count(_h) ?
+            QueueStatus::Ready :
+        m_drainingSet.count(_h) ?
+            QueueStatus::Importing :
+        m_unknownSet.count(_h) ?
+            QueueStatus::UnknownParent :
+        m_knownBad.count(_h) ?
+            QueueStatus::Bad :
+            QueueStatus::Unknown;
 }
 
 bool BlockQueue::knownFull() const
 {
-	Guard l(m_verification);
-	return knownSize() > c_maxKnownSize || knownCount() > c_maxKnownCount;
+    Guard l(m_verification);
+    return knownSize() > c_maxKnownSize || knownCount() > c_maxKnownCount;
 }
 
 std::size_t BlockQueue::knownSize() const
 {
-	return m_verified.size() + m_unverified.size() + m_verifying.size();
+    return m_verified.size() + m_unverified.size() + m_verifying.size();
 }
 
 std::size_t BlockQueue::knownCount() const
 {
-	return m_verified.count() + m_unverified.count() + m_verifying.count();
+    return m_verified.count() + m_unverified.count() + m_verifying.count();
 }
 
 bool BlockQueue::unknownFull() const
 {
-	ReadGuard l(m_lock);
-	return unknownSize() > c_maxUnknownSize || unknownCount() > c_maxUnknownCount;
+    ReadGuard l(m_lock);
+    return unknownSize() > c_maxUnknownSize || unknownCount() > c_maxUnknownCount;
 }
 
 std::size_t BlockQueue::unknownSize() const
 {
-	return m_future.size() + m_unknown.size();
+    return m_future.size() + m_unknown.size();
 }
 
 std::size_t BlockQueue::unknownCount() const
 {
-	return m_future.count() + m_unknown.count();
+    return m_future.count() + m_unknown.count();
 }
 
 void BlockQueue::drain(VerifiedBlocks& o_out, unsigned _max)
 {
-	bool wasFull = false;
-	DEV_WRITE_GUARDED(m_lock)
-	{
-		DEV_INVARIANT_CHECK;
-		wasFull = knownFull();
-		if (m_drainingSet.empty())
-		{
-			m_drainingDifficulty = 0;
-			DEV_GUARDED(m_verification)
-				o_out = m_verified.dequeueMultiple(min<unsigned>(_max, m_verified.count()));
+    bool wasFull = false;
+    DEV_WRITE_GUARDED(m_lock)
+    {
+        DEV_INVARIANT_CHECK;
+        wasFull = knownFull();
+        if (m_drainingSet.empty())
+        {
+            m_drainingDifficulty = 0;
+            DEV_GUARDED(m_verification)
+                o_out = m_verified.dequeueMultiple(min<unsigned>(_max, m_verified.count()));
 
-			for (auto const& bs: o_out)
-			{
-				// TODO: @optimise use map<h256, bytes> rather than vector<bytes> & set<h256>.
-				auto h = bs.verified.info.hash();
-				m_drainingSet.insert(h);
-				m_drainingDifficulty += bs.verified.info.difficulty();
-				m_readySet.erase(h);
-			}
-		}
-	}
-	if (wasFull && !knownFull())
-		m_onRoomAvailable();
+            for (auto const& bs: o_out)
+            {
+                // TODO: @optimise use map<h256, bytes> rather than vector<bytes> & set<h256>.
+                auto h = bs.verified.info.hash();
+                m_drainingSet.insert(h);
+                m_drainingDifficulty += bs.verified.info.difficulty();
+                m_readySet.erase(h);
+            }
+        }
+    }
+    if (wasFull && !knownFull())
+        m_onRoomAvailable();
 }
 
 bool BlockQueue::invariants() const
 {
-	Guard l(m_verification);
-	if (m_readySet.size() != knownCount())
-	{
-		std::stringstream s;
-		s << "Failed BlockQueue invariant: m_readySet: " << m_readySet.size() << " m_verified: " << m_verified.count() << " m_unverified: " << m_unverified.count() << " m_verifying" << m_verifying.count();
-		BOOST_THROW_EXCEPTION(FailedInvariant() << errinfo_comment(s.str()));
-	}
-	return true;
+    Guard l(m_verification);
+    if (m_readySet.size() != knownCount())
+    {
+        std::stringstream s;
+        s << "Failed BlockQueue invariant: m_readySet: " << m_readySet.size() << " m_verified: " << m_verified.count() << " m_unverified: " << m_unverified.count() << " m_verifying" << m_verifying.count();
+        BOOST_THROW_EXCEPTION(FailedInvariant() << errinfo_comment(s.str()));
+    }
+    return true;
 }
 
 void BlockQueue::noteReady_WITH_LOCK(h256 const& _good)
 {
-	DEV_INVARIANT_CHECK;
-	list<h256> goodQueue(1, _good);
-	bool notify = false;
-	while (!goodQueue.empty())
-	{
-		h256 const parent = goodQueue.front();
-		vector<pair<h256, bytes>> const removed = m_unknown.removeByKeyEqual(parent);
-		goodQueue.pop_front();
-		for (auto& newReady: removed)
-		{
-			DEV_GUARDED(m_verification)
-				m_unverified.enqueue(UnverifiedBlock { newReady.first, parent, move(newReady.second) });
-			m_unknownSet.erase(newReady.first);
-			m_readySet.insert(newReady.first);
-			goodQueue.push_back(newReady.first);
-			notify = true;
-		}
-	}
-	if (notify)
-		m_moreToVerify.notify_all();
+    DEV_INVARIANT_CHECK;
+    list<h256> goodQueue(1, _good);
+    bool notify = false;
+    while (!goodQueue.empty())
+    {
+        h256 const parent = goodQueue.front();
+        vector<pair<h256, bytes>> const removed = m_unknown.removeByKeyEqual(parent);
+        goodQueue.pop_front();
+        for (auto& newReady: removed)
+        {
+            DEV_GUARDED(m_verification)
+                m_unverified.enqueue(UnverifiedBlock { newReady.first, parent, move(newReady.second) });
+            m_unknownSet.erase(newReady.first);
+            m_readySet.insert(newReady.first);
+            goodQueue.push_back(newReady.first);
+            notify = true;
+        }
+    }
+    if (notify)
+        m_moreToVerify.notify_all();
 }
 
 void BlockQueue::retryAllUnknown()
 {
-	WriteGuard l(m_lock);
-	DEV_INVARIANT_CHECK;
-	while (!m_unknown.isEmpty())
-	{
-		h256 parent = m_unknown.firstKey();
-		vector<pair<h256, bytes>> removed = m_unknown.removeByKeyEqual(parent);
-		for (auto& newReady: removed)
-		{
-			DEV_GUARDED(m_verification)
-				m_unverified.enqueue(UnverifiedBlock{ newReady.first, parent, move(newReady.second) });
-			m_unknownSet.erase(newReady.first);
-			m_readySet.insert(newReady.first);
-			m_moreToVerify.notify_one();
-		}
-	}
-	m_moreToVerify.notify_all();
+    WriteGuard l(m_lock);
+    DEV_INVARIANT_CHECK;
+    while (!m_unknown.isEmpty())
+    {
+        h256 parent = m_unknown.firstKey();
+        vector<pair<h256, bytes>> removed = m_unknown.removeByKeyEqual(parent);
+        for (auto& newReady: removed)
+        {
+            DEV_GUARDED(m_verification)
+                m_unverified.enqueue(UnverifiedBlock{ newReady.first, parent, move(newReady.second) });
+            m_unknownSet.erase(newReady.first);
+            m_readySet.insert(newReady.first);
+            m_moreToVerify.notify_one();
+        }
+    }
+    m_moreToVerify.notify_all();
 }
 
 std::ostream& dev::eth::operator<<(std::ostream& _out, BlockQueueStatus const& _bqs)
 {
-	_out << "importing: " << _bqs.importing << endl;
-	_out << "verified: " << _bqs.verified << endl;
-	_out << "verifying: " << _bqs.verifying << endl;
-	_out << "unverified: " << _bqs.unverified << endl;
-	_out << "future: " << _bqs.future << endl;
-	_out << "unknown: " << _bqs.unknown << endl;
-	_out << "bad: " << _bqs.bad << endl;
+    _out << "importing: " << _bqs.importing << endl;
+    _out << "verified: " << _bqs.verified << endl;
+    _out << "verifying: " << _bqs.verifying << endl;
+    _out << "unverified: " << _bqs.unverified << endl;
+    _out << "future: " << _bqs.future << endl;
+    _out << "unknown: " << _bqs.unknown << endl;
+    _out << "bad: " << _bqs.bad << endl;
 
-	return _out;
+    return _out;
 }
 
 u256 BlockQueue::difficulty() const
 {
-	UpgradableGuard l(m_lock);
-	return m_difficulty;
+    UpgradableGuard l(m_lock);
+    return m_difficulty;
 }
 
 bool BlockQueue::isActive() const
 {
-	UpgradableGuard l(m_lock);
-	if (m_readySet.empty() && m_drainingSet.empty())
-		DEV_GUARDED(m_verification)
-			if (m_verified.isEmpty() && m_verifying.isEmpty() && m_unverified.isEmpty())
-				return false;
-	return true;
+    UpgradableGuard l(m_lock);
+    if (m_readySet.empty() && m_drainingSet.empty())
+        DEV_GUARDED(m_verification)
+            if (m_verified.isEmpty() && m_verifying.isEmpty() && m_unverified.isEmpty())
+                return false;
+    return true;
 }
 
 std::ostream& dev::eth::operator<< (std::ostream& os, QueueStatus const& obj)

--- a/libethereum/BlockQueue.h
+++ b/libethereum/BlockQueue.h
@@ -1,18 +1,18 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file BlockQueue.h
  * @author Gav Wood <i@gavwood.com>
@@ -40,28 +40,24 @@ namespace eth
 
 class BlockChain;
 
-struct BlockQueueChannel: public LogChannel { static const char* name(); static const int verbosity = 4; };
-struct BlockQueueTraceChannel: public LogChannel { static const char* name(); static const int verbosity = 7; };
-#define cblockq dev::LogOutputStream<dev::eth::BlockQueueChannel, true>()
-
 struct BlockQueueStatus
 {
-	size_t importing;
-	size_t verified;
-	size_t verifying;
-	size_t unverified;
-	size_t future;
-	size_t unknown;
-	size_t bad;
+    size_t importing;
+    size_t verified;
+    size_t verifying;
+    size_t unverified;
+    size_t future;
+    size_t unknown;
+    size_t bad;
 };
 
 enum class QueueStatus
 {
-	Ready,
-	Importing,
-	UnknownParent,
-	Bad,
-	Unknown
+    Ready,
+    Importing,
+    UnknownParent,
+    Bad,
+    Unknown
 };
 
 std::ostream& operator<< (std::ostream& os, QueueStatus const& obj);
@@ -70,150 +66,150 @@ template<class T>
 class SizedBlockQueue
 {
 public:
-	std::size_t count() const { return m_queue.size(); }
+    std::size_t count() const { return m_queue.size(); }
 
-	std::size_t size() const { return m_size; }
-	
-	bool isEmpty() const { return m_queue.empty(); }
+    std::size_t size() const { return m_size; }
+    
+    bool isEmpty() const { return m_queue.empty(); }
 
-	h256 nextHash() const { return m_queue.front().verified.info.sha3Uncles(); }
+    h256 nextHash() const { return m_queue.front().verified.info.sha3Uncles(); }
 
-	T const& next() const { return m_queue.front(); }
+    T const& next() const { return m_queue.front(); }
 
-	void clear()
-	{
-		m_queue.clear();
-		m_size = 0;
-	}
+    void clear()
+    {
+        m_queue.clear();
+        m_size = 0;
+    }
 
-	void enqueue(T&& _t)
-	{
-		m_queue.emplace_back(std::move(_t));
-		m_size += m_queue.back().blockData.size();
-	}
+    void enqueue(T&& _t)
+    {
+        m_queue.emplace_back(std::move(_t));
+        m_size += m_queue.back().blockData.size();
+    }
 
-	T dequeue()
-	{
-		T t;
-		std::swap(t, m_queue.front());
-		m_queue.pop_front();
-		m_size -= t.blockData.size();
+    T dequeue()
+    {
+        T t;
+        std::swap(t, m_queue.front());
+        m_queue.pop_front();
+        m_size -= t.blockData.size();
 
-		return t;
-	}
+        return t;
+    }
 
-	std::vector<T> dequeueMultiple(std::size_t _n)
-	{
-		return removeRange(m_queue.begin(), m_queue.begin() + _n);
-	}
+    std::vector<T> dequeueMultiple(std::size_t _n)
+    {
+        return removeRange(m_queue.begin(), m_queue.begin() + _n);
+    }
 
-	bool remove(h256 const& _hash)
-	{
-		std::vector<T> removed = removeIf(sha3UnclesEquals(_hash));
-		return !removed.empty();
-	}
+    bool remove(h256 const& _hash)
+    {
+        std::vector<T> removed = removeIf(sha3UnclesEquals(_hash));
+        return !removed.empty();
+    }
 
-	template<class Pred>
-	std::vector<T> removeIf(Pred _pred)
-	{
-		auto const removedBegin = std::remove_if(m_queue.begin(), m_queue.end(), _pred);
+    template<class Pred>
+    std::vector<T> removeIf(Pred _pred)
+    {
+        auto const removedBegin = std::remove_if(m_queue.begin(), m_queue.end(), _pred);
 
-		return removeRange(removedBegin, m_queue.end());
-	}
+        return removeRange(removedBegin, m_queue.end());
+    }
 
-	bool replace(h256 const& _hash, T&& _t)
-	{
-		auto const it = std::find_if(m_queue.begin(), m_queue.end(), sha3UnclesEquals(_hash));
+    bool replace(h256 const& _hash, T&& _t)
+    {
+        auto const it = std::find_if(m_queue.begin(), m_queue.end(), sha3UnclesEquals(_hash));
 
-		if (it == m_queue.end())
-			return false;
+        if (it == m_queue.end())
+            return false;
 
-		m_size -= it->blockData.size();
-		m_size += _t.blockData.size();
-		*it = std::move(_t);
+        m_size -= it->blockData.size();
+        m_size += _t.blockData.size();
+        *it = std::move(_t);
 
-		return true;
-	}
+        return true;
+    }
 
 private:
-	static std::function<bool(T const&)> sha3UnclesEquals(h256 const& _hash)
-	{
-		return [&_hash](T const& _t) { return _t.verified.info.sha3Uncles() == _hash; };
-	}
+    static std::function<bool(T const&)> sha3UnclesEquals(h256 const& _hash)
+    {
+        return [&_hash](T const& _t) { return _t.verified.info.sha3Uncles() == _hash; };
+    }
 
-	std::vector<T> removeRange(typename std::deque<T>::iterator _begin, typename std::deque<T>::iterator _end)
-	{
-		std::vector<T> ret(std::make_move_iterator(_begin), std::make_move_iterator(_end));
+    std::vector<T> removeRange(typename std::deque<T>::iterator _begin, typename std::deque<T>::iterator _end)
+    {
+        std::vector<T> ret(std::make_move_iterator(_begin), std::make_move_iterator(_end));
 
-		for (auto it = ret.begin(); it != ret.end(); ++it)
-			m_size -= it->blockData.size();
+        for (auto it = ret.begin(); it != ret.end(); ++it)
+            m_size -= it->blockData.size();
 
-		m_queue.erase(_begin, _end);
-		return ret;
-	}
+        m_queue.erase(_begin, _end);
+        return ret;
+    }
 
-	std::deque<T> m_queue;
-	std::atomic<size_t> m_size = {0};	///< Tracks total size in bytes
+    std::deque<T> m_queue;
+    std::atomic<size_t> m_size = {0};	///< Tracks total size in bytes
 };
 
 template<class KeyType>
 class SizedBlockMap
 {
 public:
-	std::size_t count() const { return m_map.size(); }
+    std::size_t count() const { return m_map.size(); }
 
-	std::size_t size() const { return m_size; }
+    std::size_t size() const { return m_size; }
 
-	bool isEmpty() const { return m_map.empty(); }
+    bool isEmpty() const { return m_map.empty(); }
 
-	KeyType firstKey() const { return m_map.begin()->first; }
+    KeyType firstKey() const { return m_map.begin()->first; }
 
-	void clear()
-	{
-		m_map.clear();
-		m_size = 0;
-	}
+    void clear()
+    {
+        m_map.clear();
+        m_size = 0;
+    }
 
-	void insert(KeyType const& _key, h256 const& _hash, bytes&& _blockData)
-	{
-		auto hashAndBlock = std::make_pair(_hash, std::move(_blockData));
-		auto keyAndValue = std::make_pair(_key, std::move(hashAndBlock));
-		m_map.insert(std::move(keyAndValue));
-		m_size += _blockData.size();
-	}
+    void insert(KeyType const& _key, h256 const& _hash, bytes&& _blockData)
+    {
+        auto hashAndBlock = std::make_pair(_hash, std::move(_blockData));
+        auto keyAndValue = std::make_pair(_key, std::move(hashAndBlock));
+        m_map.insert(std::move(keyAndValue));
+        m_size += _blockData.size();
+    }
 
-	std::vector<std::pair<h256, bytes>> removeByKeyEqual(KeyType const& _key)
-	{
-		auto const equalRange = m_map.equal_range(_key);
-		return removeRange(equalRange.first, equalRange.second);
-	}
+    std::vector<std::pair<h256, bytes>> removeByKeyEqual(KeyType const& _key)
+    {
+        auto const equalRange = m_map.equal_range(_key);
+        return removeRange(equalRange.first, equalRange.second);
+    }
 
-	std::vector<std::pair<h256, bytes>> removeByKeyNotGreater(KeyType const& _key)
-	{
-		return removeRange(m_map.begin(), m_map.upper_bound(_key));
-	}
+    std::vector<std::pair<h256, bytes>> removeByKeyNotGreater(KeyType const& _key)
+    {
+        return removeRange(m_map.begin(), m_map.upper_bound(_key));
+    }
 
 private:
-	using BlockMultimap = std::multimap<KeyType, std::pair<h256, bytes>>;
+    using BlockMultimap = std::multimap<KeyType, std::pair<h256, bytes>>;
 
-	std::vector<std::pair<h256, bytes>> removeRange(typename BlockMultimap::iterator _begin, typename BlockMultimap::iterator _end)
-	{
-		std::vector<std::pair<h256, bytes>> removed;
-		std::size_t removedSize = 0;
-		for (auto it = _begin; it != _end; ++it)
-		{
-			removed.push_back(std::move(it->second));
-			removedSize += removed.back().second.size();
-		}
+    std::vector<std::pair<h256, bytes>> removeRange(typename BlockMultimap::iterator _begin, typename BlockMultimap::iterator _end)
+    {
+        std::vector<std::pair<h256, bytes>> removed;
+        std::size_t removedSize = 0;
+        for (auto it = _begin; it != _end; ++it)
+        {
+            removed.push_back(std::move(it->second));
+            removedSize += removed.back().second.size();
+        }
 
-		m_size -= removedSize;
-		m_map.erase(_begin, _end);
+        m_size -= removedSize;
+        m_map.erase(_begin, _end);
 
-		return removed;
-	}
-		
-	BlockMultimap m_map;
-	std::atomic<size_t> m_size = {0};	///< Tracks total size in bytes
+        return removed;
+    }
+        
+    BlockMultimap m_map;
+    std::atomic<size_t> m_size = {0};	///< Tracks total size in bytes
 };
 
 /**
@@ -224,105 +220,108 @@ private:
 class BlockQueue: HasInvariants
 {
 public:
-	BlockQueue();
-	~BlockQueue();
+    BlockQueue();
+    ~BlockQueue();
 
-	void setChain(BlockChain const& _bc) { m_bc = &_bc; }
+    void setChain(BlockChain const& _bc) { m_bc = &_bc; }
 
-	/// Import a block into the queue.
-	ImportResult import(bytesConstRef _block, bool _isOurs = false);
+    /// Import a block into the queue.
+    ImportResult import(bytesConstRef _block, bool _isOurs = false);
 
-	/// Notes that time has moved on and some blocks that used to be "in the future" may no be valid.
-	void tick();
+    /// Notes that time has moved on and some blocks that used to be "in the future" may no be valid.
+    void tick();
 
-	/// Grabs at most @a _max of the blocks that are ready, giving them in the correct order for insertion into the chain.
-	/// Don't forget to call doneDrain() once you're done importing.
-	void drain(std::vector<VerifiedBlock>& o_out, unsigned _max);
+    /// Grabs at most @a _max of the blocks that are ready, giving them in the correct order for insertion into the chain.
+    /// Don't forget to call doneDrain() once you're done importing.
+    void drain(std::vector<VerifiedBlock>& o_out, unsigned _max);
 
-	/// Must be called after a drain() call. Notes that the drained blocks have been imported into the blockchain, so we can forget about them.
-	/// @returns true iff there are additional blocks ready to be processed.
-	bool doneDrain(h256s const& _knownBad = h256s());
+    /// Must be called after a drain() call. Notes that the drained blocks have been imported into the blockchain, so we can forget about them.
+    /// @returns true iff there are additional blocks ready to be processed.
+    bool doneDrain(h256s const& _knownBad = h256s());
 
-	/// Notify the queue that the chain has changed and a new block has attained 'ready' status (i.e. is in the chain).
-	void noteReady(h256 const& _b) { WriteGuard l(m_lock); noteReady_WITH_LOCK(_b); }
+    /// Notify the queue that the chain has changed and a new block has attained 'ready' status (i.e. is in the chain).
+    void noteReady(h256 const& _b) { WriteGuard l(m_lock); noteReady_WITH_LOCK(_b); }
 
-	/// Force a retry of all the blocks with unknown parents.
-	void retryAllUnknown();
+    /// Force a retry of all the blocks with unknown parents.
+    void retryAllUnknown();
 
-	/// Get information on the items queued.
-	std::pair<unsigned, unsigned> items() const { ReadGuard l(m_lock); return std::make_pair(m_readySet.size(), m_unknownSet.size()); }
+    /// Get information on the items queued.
+    std::pair<unsigned, unsigned> items() const { ReadGuard l(m_lock); return std::make_pair(m_readySet.size(), m_unknownSet.size()); }
 
-	/// Clear everything.
-	void clear();
+    /// Clear everything.
+    void clear();
 
-	/// Stop all activity, leaves the class in limbo, waiting for destruction
-	void stop();
+    /// Stop all activity, leaves the class in limbo, waiting for destruction
+    void stop();
 
-	/// Return first block with an unknown parent.
-	h256 firstUnknown() const { ReadGuard l(m_lock); return m_unknownSet.size() ? *m_unknownSet.begin() : h256(); }
+    /// Return first block with an unknown parent.
+    h256 firstUnknown() const { ReadGuard l(m_lock); return m_unknownSet.size() ? *m_unknownSet.begin() : h256(); }
 
-	/// Get some infomration on the current status.
-	BlockQueueStatus status() const;
+    /// Get some infomration on the current status.
+    BlockQueueStatus status() const;
 
-	/// Get some infomration on the given block's status regarding us.
-	QueueStatus blockStatus(h256 const& _h) const;
+    /// Get some infomration on the given block's status regarding us.
+    QueueStatus blockStatus(h256 const& _h) const;
 
-	Handler<> onReady(std::function<void(void)> _t) { return m_onReady.add(_t); }
-	Handler<> onRoomAvailable(std::function<void(void)> _t) { return m_onRoomAvailable.add(_t); }
+    Handler<> onReady(std::function<void(void)> _t) { return m_onReady.add(_t); }
+    Handler<> onRoomAvailable(std::function<void(void)> _t) { return m_onRoomAvailable.add(_t); }
 
-	template <class T> void setOnBad(T const& _t) { m_onBad = _t; }
+    template <class T> void setOnBad(T const& _t) { m_onBad = _t; }
 
-	bool knownFull() const;
-	bool unknownFull() const;
-	u256 difficulty() const;	// Total difficulty of queueud blocks
-	bool isActive() const;
+    bool knownFull() const;
+    bool unknownFull() const;
+    u256 difficulty() const;	// Total difficulty of queueud blocks
+    bool isActive() const;
 
 private:
-	struct UnverifiedBlock
-	{
-		h256 hash;
-		h256 parentHash;
-		bytes blockData;
-	};
+    struct UnverifiedBlock
+    {
+        h256 hash;
+        h256 parentHash;
+        bytes blockData;
+    };
 
-	void noteReady_WITH_LOCK(h256 const& _b);
+    void noteReady_WITH_LOCK(h256 const& _b);
 
-	bool invariants() const override;
+    bool invariants() const override;
 
-	void verifierBody();
-	void collectUnknownBad_WITH_BOTH_LOCKS(h256 const& _bad);
-	void updateBad_WITH_LOCK(h256 const& _bad);
-	void drainVerified_WITH_BOTH_LOCKS();
+    void verifierBody();
+    void collectUnknownBad_WITH_BOTH_LOCKS(h256 const& _bad);
+    void updateBad_WITH_LOCK(h256 const& _bad);
+    void drainVerified_WITH_BOTH_LOCKS();
 
-	std::size_t knownSize() const;
-	std::size_t knownCount() const;
-	std::size_t unknownSize() const;
-	std::size_t unknownCount() const;
+    std::size_t knownSize() const;
+    std::size_t knownCount() const;
+    std::size_t unknownSize() const;
+    std::size_t unknownCount() const;
 
-	BlockChain const* m_bc;												///< The blockchain into which our imports go.
+    BlockChain const* m_bc;												///< The blockchain into which our imports go.
 
-	mutable boost::shared_mutex m_lock;									///< General lock for the sets, m_future and m_unknown.
-	h256Hash m_drainingSet;												///< All blocks being imported.
-	h256Hash m_readySet;												///< All blocks ready for chain import.
-	h256Hash m_unknownSet;												///< Set of all blocks whose parents are not ready/in-chain.
-	SizedBlockMap<h256> m_unknown;										///< For blocks that have an unknown parent; we map their parent hash to the block stuff, and insert once the block appears.
-	h256Hash m_knownBad;												///< Set of blocks that we know will never be valid.
-	SizedBlockMap<time_t> m_future;										///< Set of blocks that are not yet valid. Ordered by timestamp
-	Signal<> m_onReady;													///< Called when a subsequent call to import blocks will return a non-empty container. Be nice and exit fast.
-	Signal<> m_onRoomAvailable;											///< Called when space for new blocks becomes availabe after a drain. Be nice and exit fast.
+    mutable boost::shared_mutex m_lock;									///< General lock for the sets, m_future and m_unknown.
+    h256Hash m_drainingSet;												///< All blocks being imported.
+    h256Hash m_readySet;												///< All blocks ready for chain import.
+    h256Hash m_unknownSet;												///< Set of all blocks whose parents are not ready/in-chain.
+    SizedBlockMap<h256> m_unknown;										///< For blocks that have an unknown parent; we map their parent hash to the block stuff, and insert once the block appears.
+    h256Hash m_knownBad;												///< Set of blocks that we know will never be valid.
+    SizedBlockMap<time_t> m_future;										///< Set of blocks that are not yet valid. Ordered by timestamp
+    Signal<> m_onReady;													///< Called when a subsequent call to import blocks will return a non-empty container. Be nice and exit fast.
+    Signal<> m_onRoomAvailable;											///< Called when space for new blocks becomes availabe after a drain. Be nice and exit fast.
 
-	mutable Mutex m_verification;										///< Mutex that allows writing to m_verified, m_verifying and m_unverified.
-	std::condition_variable m_moreToVerify;								///< Signaled when m_unverified has a new entry.
-	SizedBlockQueue<VerifiedBlock> m_verified;								///< List of blocks, in correct order, verified and ready for chain-import.
-	SizedBlockQueue<VerifiedBlock> m_verifying;								///< List of blocks being verified; as long as the block component (bytes) is empty, it's not finished.
-	SizedBlockQueue<UnverifiedBlock> m_unverified;							///< List of <block hash, parent hash, block data> in correct order, ready for verification.
+    mutable Mutex m_verification;										///< Mutex that allows writing to m_verified, m_verifying and m_unverified.
+    std::condition_variable m_moreToVerify;								///< Signaled when m_unverified has a new entry.
+    SizedBlockQueue<VerifiedBlock> m_verified;								///< List of blocks, in correct order, verified and ready for chain-import.
+    SizedBlockQueue<VerifiedBlock> m_verifying;								///< List of blocks being verified; as long as the block component (bytes) is empty, it's not finished.
+    SizedBlockQueue<UnverifiedBlock> m_unverified;							///< List of <block hash, parent hash, block data> in correct order, ready for verification.
 
-	std::vector<std::thread> m_verifiers;								///< Threads who only verify.
-	std::atomic<bool> m_deleting = {false};								///< Exit condition for verifiers.
+    std::vector<std::thread> m_verifiers;								///< Threads who only verify.
+    std::atomic<bool> m_deleting = {false};								///< Exit condition for verifiers.
 
-	std::function<void(Exception&)> m_onBad;							///< Called if we have a block that doesn't verify.
-	u256 m_difficulty;													///< Total difficulty of blocks in the queue
-	u256 m_drainingDifficulty;											///< Total difficulty of blocks in draining
+    std::function<void(Exception&)> m_onBad;							///< Called if we have a block that doesn't verify.
+    u256 m_difficulty;													///< Total difficulty of blocks in the queue
+    u256 m_drainingDifficulty;											///< Total difficulty of blocks in draining
+
+    Logger m_logger{createLogger(4, "bq")};
+    Logger m_loggerDetail{createLogger(7, "bq")};
 };
 
 std::ostream& operator<<(std::ostream& _out, BlockQueueStatus const& _s);

--- a/libethereum/Client.h
+++ b/libethereum/Client.h
@@ -61,11 +61,6 @@ enum ClientWorkState
     Deleted
 };
 
-struct ClientNote: public LogChannel { static const char* name(); static const int verbosity = 2; };
-struct ClientChat: public LogChannel { static const char* name(); static const int verbosity = 4; };
-struct ClientTrace: public LogChannel { static const char* name(); static const int verbosity = 7; };
-struct ClientDetail: public LogChannel { static const char* name(); static const int verbosity = 14; };
-
 struct ActivityReport
 {
     unsigned ticks = 0;
@@ -351,6 +346,9 @@ protected:
     std::atomic<bool> m_syncBlockQueue = {false};
 
     bytes m_extraData;
+
+    Logger m_logger{createLogger(2, "client")};
+    Logger m_loggerDetail{createLogger(7, "client")};
 };
 
 }

--- a/libethereum/ClientBase.cpp
+++ b/libethereum/ClientBase.cpp
@@ -1,18 +1,18 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
  */
 /** @file ClientBase.cpp
  * @author Gav Wood <i@gavwood.com>
@@ -30,503 +30,500 @@ using namespace std;
 using namespace dev;
 using namespace dev::eth;
 
-const char* WatchChannel::name() { return EthBlue "ℹ" EthWhite "  "; }
-const char* WorkInChannel::name() { return EthOrange "⚒" EthGreen "▬▶"; }
-const char* WorkOutChannel::name() { return EthOrange "⚒" EthNavy "◀▬"; }
-const char* WorkChannel::name() { return EthOrange "⚒" EthWhite "  "; }
-
 static const int64_t c_maxGasEstimate = 50000000;
 
 std::pair<u256, ExecutionResult> ClientBase::estimateGas(Address const& _from, u256 _value, Address _dest, bytes const& _data, int64_t _maxGas, u256 _gasPrice, BlockNumber _blockNumber, GasEstimationCallback const& _callback)
 {
-	try
-	{
-		int64_t upperBound = _maxGas;
-		if (upperBound == Invalid256 || upperBound > c_maxGasEstimate)
-			upperBound = c_maxGasEstimate;
-		int64_t lowerBound = Transaction::baseGasRequired(!_dest, &_data, EVMSchedule());
-		Block bk = block(_blockNumber);
-		u256 gasPrice = _gasPrice == Invalid256 ? gasBidPrice() : _gasPrice;
-		ExecutionResult er;
-		ExecutionResult lastGood;
-		bool good = false;
-		while (upperBound != lowerBound)
-		{
-			int64_t mid = (lowerBound + upperBound) / 2;
-			u256 n = bk.transactionsFrom(_from);
-			Transaction t;
-			if (_dest)
-				t = Transaction(_value, gasPrice, mid, _dest, _data, n);
-			else
-				t = Transaction(_value, gasPrice, mid, _data, n);
-			t.forceSender(_from);
-			EnvInfo const env(bk.info(), bc().lastBlockHashes(), 0, mid);
-			State tempState(bk.state());
-			tempState.addBalance(_from, (u256)(t.gas() * t.gasPrice() + t.value()));
-			er = tempState.execute(env, *bc().sealEngine(), t, Permanence::Reverted).first;
-			if (er.excepted == TransactionException::OutOfGas ||
-				er.excepted == TransactionException::OutOfGasBase ||
-				er.excepted == TransactionException::OutOfGasIntrinsic ||
-				er.codeDeposit == CodeDeposit::Failed ||
-				er.excepted == TransactionException::BadJumpDestination)
-					lowerBound = lowerBound == mid ? upperBound : mid;
-			else
-			{
-				lastGood = er;
-				upperBound = upperBound == mid ? lowerBound : mid;
-				good = true;
-			}
+    try
+    {
+        int64_t upperBound = _maxGas;
+        if (upperBound == Invalid256 || upperBound > c_maxGasEstimate)
+            upperBound = c_maxGasEstimate;
+        int64_t lowerBound = Transaction::baseGasRequired(!_dest, &_data, EVMSchedule());
+        Block bk = block(_blockNumber);
+        u256 gasPrice = _gasPrice == Invalid256 ? gasBidPrice() : _gasPrice;
+        ExecutionResult er;
+        ExecutionResult lastGood;
+        bool good = false;
+        while (upperBound != lowerBound)
+        {
+            int64_t mid = (lowerBound + upperBound) / 2;
+            u256 n = bk.transactionsFrom(_from);
+            Transaction t;
+            if (_dest)
+                t = Transaction(_value, gasPrice, mid, _dest, _data, n);
+            else
+                t = Transaction(_value, gasPrice, mid, _data, n);
+            t.forceSender(_from);
+            EnvInfo const env(bk.info(), bc().lastBlockHashes(), 0, mid);
+            State tempState(bk.state());
+            tempState.addBalance(_from, (u256)(t.gas() * t.gasPrice() + t.value()));
+            er = tempState.execute(env, *bc().sealEngine(), t, Permanence::Reverted).first;
+            if (er.excepted == TransactionException::OutOfGas ||
+                er.excepted == TransactionException::OutOfGasBase ||
+                er.excepted == TransactionException::OutOfGasIntrinsic ||
+                er.codeDeposit == CodeDeposit::Failed ||
+                er.excepted == TransactionException::BadJumpDestination)
+                    lowerBound = lowerBound == mid ? upperBound : mid;
+            else
+            {
+                lastGood = er;
+                upperBound = upperBound == mid ? lowerBound : mid;
+                good = true;
+            }
 
-			if (_callback)
-				_callback(GasEstimationProgress { lowerBound, upperBound });
-		}
-		if (_callback)
-			_callback(GasEstimationProgress { lowerBound, upperBound });
-		return make_pair(upperBound, good ? lastGood : er);
-	}
-	catch (...)
-	{
-		// TODO: Some sort of notification of failure.
-		return make_pair(u256(), ExecutionResult());
-	}
+            if (_callback)
+                _callback(GasEstimationProgress { lowerBound, upperBound });
+        }
+        if (_callback)
+            _callback(GasEstimationProgress { lowerBound, upperBound });
+        return make_pair(upperBound, good ? lastGood : er);
+    }
+    catch (...)
+    {
+        // TODO: Some sort of notification of failure.
+        return make_pair(u256(), ExecutionResult());
+    }
 }
 
 ImportResult ClientBase::injectBlock(bytes const& _block)
 {
-	return bc().attemptImport(_block, preSeal().db()).first;
+    return bc().attemptImport(_block, preSeal().db()).first;
 }
 
 u256 ClientBase::balanceAt(Address _a, BlockNumber _block) const
 {
-	return block(_block).balance(_a);
+    return block(_block).balance(_a);
 }
 
 u256 ClientBase::countAt(Address _a, BlockNumber _block) const
 {
-	return block(_block).transactionsFrom(_a);
+    return block(_block).transactionsFrom(_a);
 }
 
 u256 ClientBase::stateAt(Address _a, u256 _l, BlockNumber _block) const
 {
-	return block(_block).storage(_a, _l);
+    return block(_block).storage(_a, _l);
 }
 
 h256 ClientBase::stateRootAt(Address _a, BlockNumber _block) const
 {
-	return block(_block).storageRoot(_a);
+    return block(_block).storageRoot(_a);
 }
 
 bytes ClientBase::codeAt(Address _a, BlockNumber _block) const
 {
-	return block(_block).code(_a);
+    return block(_block).code(_a);
 }
 
 h256 ClientBase::codeHashAt(Address _a, BlockNumber _block) const
 {
-	return block(_block).codeHash(_a);
+    return block(_block).codeHash(_a);
 }
 
 map<h256, pair<u256, u256>> ClientBase::storageAt(Address _a, BlockNumber _block) const
 {
-	return block(_block).storage(_a);
+    return block(_block).storage(_a);
 }
 
 // TODO: remove try/catch, allow exceptions
 LocalisedLogEntries ClientBase::logs(unsigned _watchId) const
 {
-	LogFilter f;
-	try
-	{
-		Guard l(x_filtersWatches);
-		f = m_filters.at(m_watches.at(_watchId).id).filter;
-	}
-	catch (...)
-	{
-		return LocalisedLogEntries();
-	}
-	return logs(f);
+    LogFilter f;
+    try
+    {
+        Guard l(x_filtersWatches);
+        f = m_filters.at(m_watches.at(_watchId).id).filter;
+    }
+    catch (...)
+    {
+        return LocalisedLogEntries();
+    }
+    return logs(f);
 }
 
 LocalisedLogEntries ClientBase::logs(LogFilter const& _f) const
 {
-	LocalisedLogEntries ret;
-	unsigned begin = min(bc().number() + 1, (unsigned)numberFromHash(_f.latest()));
-	unsigned end = min(bc().number(), min(begin, (unsigned)numberFromHash(_f.earliest())));
-	
-	// Handle pending transactions differently as they're not on the block chain.
-	if (begin > bc().number())
-	{
-		Block temp = postSeal();
-		for (unsigned i = 0; i < temp.pending().size(); ++i)
-		{
-			// Might have a transaction that contains a matching log.
-			TransactionReceipt const& tr = temp.receipt(i);
-			LogEntries le = _f.matches(tr);
-			for (unsigned j = 0; j < le.size(); ++j)
-				ret.insert(ret.begin(), LocalisedLogEntry(le[j]));
-		}
-		begin = bc().number();
-	}
+    LocalisedLogEntries ret;
+    unsigned begin = min(bc().number() + 1, (unsigned)numberFromHash(_f.latest()));
+    unsigned end = min(bc().number(), min(begin, (unsigned)numberFromHash(_f.earliest())));
+    
+    // Handle pending transactions differently as they're not on the block chain.
+    if (begin > bc().number())
+    {
+        Block temp = postSeal();
+        for (unsigned i = 0; i < temp.pending().size(); ++i)
+        {
+            // Might have a transaction that contains a matching log.
+            TransactionReceipt const& tr = temp.receipt(i);
+            LogEntries le = _f.matches(tr);
+            for (unsigned j = 0; j < le.size(); ++j)
+                ret.insert(ret.begin(), LocalisedLogEntry(le[j]));
+        }
+        begin = bc().number();
+    }
 
-	// Handle reverted blocks
-	// There are not so many, so let's iterate over them
-	h256s blocks;
-	h256 ancestor;
-	unsigned ancestorIndex;
-	tie(blocks, ancestor, ancestorIndex) = bc().treeRoute(_f.earliest(), _f.latest(), false);
+    // Handle reverted blocks
+    // There are not so many, so let's iterate over them
+    h256s blocks;
+    h256 ancestor;
+    unsigned ancestorIndex;
+    tie(blocks, ancestor, ancestorIndex) = bc().treeRoute(_f.earliest(), _f.latest(), false);
 
-	for (size_t i = 0; i < ancestorIndex; i++)
-		prependLogsFromBlock(_f, blocks[i], BlockPolarity::Dead, ret);
+    for (size_t i = 0; i < ancestorIndex; i++)
+        prependLogsFromBlock(_f, blocks[i], BlockPolarity::Dead, ret);
 
-	// cause end is our earliest block, let's compare it with our ancestor
-	// if ancestor is smaller let's move our end to it
-	// example:
-	//
-	// 3b -> 2b -> 1b
-	//                -> g
-	// 3a -> 2a -> 1a
-	//
-	// if earliest is at 2a and latest is a 3b, coverting them to numbers
-	// will give us pair (2, 3)
-	// and we want to get all logs from 1 (ancestor + 1) to 3
-	// so we have to move 2a to g + 1
-	end = min(end, (unsigned)numberFromHash(ancestor) + 1);
+    // cause end is our earliest block, let's compare it with our ancestor
+    // if ancestor is smaller let's move our end to it
+    // example:
+    //
+    // 3b -> 2b -> 1b
+    //                -> g
+    // 3a -> 2a -> 1a
+    //
+    // if earliest is at 2a and latest is a 3b, coverting them to numbers
+    // will give us pair (2, 3)
+    // and we want to get all logs from 1 (ancestor + 1) to 3
+    // so we have to move 2a to g + 1
+    end = min(end, (unsigned)numberFromHash(ancestor) + 1);
 
-	// Handle blocks from main chain
-	set<unsigned> matchingBlocks;
-	if (!_f.isRangeFilter())
-		for (auto const& i: _f.bloomPossibilities())
-			for (auto u: bc().withBlockBloom(i, end, begin))
-				matchingBlocks.insert(u);
-	else
-		// if it is a range filter, we want to get all logs from all blocks in given range
-		for (unsigned i = end; i <= begin; i++)
-			matchingBlocks.insert(i);
+    // Handle blocks from main chain
+    set<unsigned> matchingBlocks;
+    if (!_f.isRangeFilter())
+        for (auto const& i: _f.bloomPossibilities())
+            for (auto u: bc().withBlockBloom(i, end, begin))
+                matchingBlocks.insert(u);
+    else
+        // if it is a range filter, we want to get all logs from all blocks in given range
+        for (unsigned i = end; i <= begin; i++)
+            matchingBlocks.insert(i);
 
-	for (auto n: matchingBlocks)
-		prependLogsFromBlock(_f, bc().numberHash(n), BlockPolarity::Live, ret);
+    for (auto n: matchingBlocks)
+        prependLogsFromBlock(_f, bc().numberHash(n), BlockPolarity::Live, ret);
 
-	reverse(ret.begin(), ret.end());
-	return ret;
+    reverse(ret.begin(), ret.end());
+    return ret;
 }
 
 void ClientBase::prependLogsFromBlock(LogFilter const& _f, h256 const& _blockHash, BlockPolarity _polarity, LocalisedLogEntries& io_logs) const
 {
-	auto receipts = bc().receipts(_blockHash).receipts;
-	for (size_t i = 0; i < receipts.size(); i++)
-	{
-		TransactionReceipt receipt = receipts[i];
-		auto th = transaction(_blockHash, i).sha3();
-		LogEntries le = _f.matches(receipt);
-		for (unsigned j = 0; j < le.size(); ++j)
-			io_logs.insert(io_logs.begin(), LocalisedLogEntry(le[j], _blockHash, (BlockNumber)bc().number(_blockHash), th, i, 0, _polarity));
-	}
+    auto receipts = bc().receipts(_blockHash).receipts;
+    for (size_t i = 0; i < receipts.size(); i++)
+    {
+        TransactionReceipt receipt = receipts[i];
+        auto th = transaction(_blockHash, i).sha3();
+        LogEntries le = _f.matches(receipt);
+        for (unsigned j = 0; j < le.size(); ++j)
+            io_logs.insert(io_logs.begin(), LocalisedLogEntry(le[j], _blockHash, (BlockNumber)bc().number(_blockHash), th, i, 0, _polarity));
+    }
 }
 
 unsigned ClientBase::installWatch(LogFilter const& _f, Reaping _r)
 {
-	h256 h = _f.sha3();
-	{
-		Guard l(x_filtersWatches);
-		if (!m_filters.count(h))
-		{
-			cwatch << "FFF" << _f << h;
-			m_filters.insert(make_pair(h, _f));
-		}
-	}
-	return installWatch(h, _r);
+    h256 h = _f.sha3();
+    {
+        Guard l(x_filtersWatches);
+        if (!m_filters.count(h))
+        {
+            LOG(m_loggerWatch) << "FFF" << _f << h;
+            m_filters.insert(make_pair(h, _f));
+        }
+    }
+    return installWatch(h, _r);
 }
 
 unsigned ClientBase::installWatch(h256 _h, Reaping _r)
 {
-	unsigned ret;
-	{
-		Guard l(x_filtersWatches);
-		ret = m_watches.size() ? m_watches.rbegin()->first + 1 : 0;
-		m_watches[ret] = ClientWatch(_h, _r);
-		cwatch << "+++" << ret << _h;
-	}
+    unsigned ret;
+    {
+        Guard l(x_filtersWatches);
+        ret = m_watches.size() ? m_watches.rbegin()->first + 1 : 0;
+        m_watches[ret] = ClientWatch(_h, _r);
+        LOG(m_loggerWatch) << "+++" << ret << _h;
+    }
 #if INITIAL_STATE_AS_CHANGES
-	auto ch = logs(ret);
-	if (ch.empty())
-		ch.push_back(InitialChange);
-	{
-		Guard l(x_filtersWatches);
-		swap(m_watches[ret].changes, ch);
-	}
+    auto ch = logs(ret);
+    if (ch.empty())
+        ch.push_back(InitialChange);
+    {
+        Guard l(x_filtersWatches);
+        swap(m_watches[ret].changes, ch);
+    }
 #endif
-	return ret;
+    return ret;
 }
 
 bool ClientBase::uninstallWatch(unsigned _i)
 {
-	cwatch << "XXX" << _i;
-	
-	Guard l(x_filtersWatches);
-	
-	auto it = m_watches.find(_i);
-	if (it == m_watches.end())
-		return false;
-	auto id = it->second.id;
-	m_watches.erase(it);
-	
-	auto fit = m_filters.find(id);
-	if (fit != m_filters.end())
-		if (!--fit->second.refCount)
-		{
-			cwatch << "*X*" << fit->first << ":" << fit->second.filter;
-			m_filters.erase(fit);
-		}
-	return true;
+    LOG(m_loggerWatch) << "XXX" << _i;
+
+    Guard l(x_filtersWatches);
+    
+    auto it = m_watches.find(_i);
+    if (it == m_watches.end())
+        return false;
+    auto id = it->second.id;
+    m_watches.erase(it);
+    
+    auto fit = m_filters.find(id);
+    if (fit != m_filters.end())
+        if (!--fit->second.refCount)
+        {
+            LOG(m_loggerWatch) << "*X*" << fit->first << ":" << fit->second.filter;
+            m_filters.erase(fit);
+        }
+    return true;
 }
 
 LocalisedLogEntries ClientBase::peekWatch(unsigned _watchId) const
 {
-	Guard l(x_filtersWatches);
-	
-//	cwatch << "peekWatch" << _watchId;
-	auto& w = m_watches.at(_watchId);
-//	cwatch << "lastPoll updated to " << chrono::duration_cast<chrono::seconds>(chrono::system_clock::now().time_since_epoch()).count();
-	if (w.lastPoll != chrono::system_clock::time_point::max())
-		w.lastPoll = chrono::system_clock::now();
-	return w.changes;
+    Guard l(x_filtersWatches);
+
+    //	LOG(m_loggerWatch) << "peekWatch" << _watchId;
+    auto& w = m_watches.at(_watchId);
+    //	LOG(m_loggerWatch) << "lastPoll updated to " <<
+    //chrono::duration_cast<chrono::seconds>(chrono::system_clock::now().time_since_epoch()).count();
+    if (w.lastPoll != chrono::system_clock::time_point::max())
+        w.lastPoll = chrono::system_clock::now();
+    return w.changes;
 }
 
 LocalisedLogEntries ClientBase::checkWatch(unsigned _watchId)
 {
-	Guard l(x_filtersWatches);
-	LocalisedLogEntries ret;
-	
-//	cwatch << "checkWatch" << _watchId;
-	auto& w = m_watches.at(_watchId);
-//	cwatch << "lastPoll updated to " << chrono::duration_cast<chrono::seconds>(chrono::system_clock::now().time_since_epoch()).count();
-	std::swap(ret, w.changes);
-	if (w.lastPoll != chrono::system_clock::time_point::max())
-		w.lastPoll = chrono::system_clock::now();
+    Guard l(x_filtersWatches);
+    LocalisedLogEntries ret;
 
-	return ret;
+    //	LOG(m_loggerWatch) << "checkWatch" << _watchId;
+    auto& w = m_watches.at(_watchId);
+    //	LOG(m_loggerWatch) << "lastPoll updated to " <<
+    //chrono::duration_cast<chrono::seconds>(chrono::system_clock::now().time_since_epoch()).count();
+    std::swap(ret, w.changes);
+    if (w.lastPoll != chrono::system_clock::time_point::max())
+        w.lastPoll = chrono::system_clock::now();
+
+    return ret;
 }
 
 BlockHeader ClientBase::blockInfo(h256 _hash) const
 {
-	if (_hash == PendingBlockHash)
-		return preSeal().info();
-	return BlockHeader(bc().block(_hash));
+    if (_hash == PendingBlockHash)
+        return preSeal().info();
+    return BlockHeader(bc().block(_hash));
 }
 
 BlockDetails ClientBase::blockDetails(h256 _hash) const
 {
-	return bc().details(_hash);
+    return bc().details(_hash);
 }
 
 Transaction ClientBase::transaction(h256 _transactionHash) const
 {
-	return Transaction(bc().transaction(_transactionHash), CheckTransaction::Cheap);
+    return Transaction(bc().transaction(_transactionHash), CheckTransaction::Cheap);
 }
 
 LocalisedTransaction ClientBase::localisedTransaction(h256 const& _transactionHash) const
 {
-	std::pair<h256, unsigned> tl = bc().transactionLocation(_transactionHash);
-	return localisedTransaction(tl.first, tl.second);
+    std::pair<h256, unsigned> tl = bc().transactionLocation(_transactionHash);
+    return localisedTransaction(tl.first, tl.second);
 }
 
 Transaction ClientBase::transaction(h256 _blockHash, unsigned _i) const
 {
-	auto bl = bc().block(_blockHash);
-	RLP b(bl);
-	if (_i < b[1].itemCount())
-		return Transaction(b[1][_i].data(), CheckTransaction::Cheap);
-	else
-		return Transaction();
+    auto bl = bc().block(_blockHash);
+    RLP b(bl);
+    if (_i < b[1].itemCount())
+        return Transaction(b[1][_i].data(), CheckTransaction::Cheap);
+    else
+        return Transaction();
 }
 
 LocalisedTransaction ClientBase::localisedTransaction(h256 const& _blockHash, unsigned _i) const
 {
-	Transaction t = Transaction(bc().transaction(_blockHash, _i), CheckTransaction::Cheap);
-	return LocalisedTransaction(t, _blockHash, _i, numberFromHash(_blockHash));
+    Transaction t = Transaction(bc().transaction(_blockHash, _i), CheckTransaction::Cheap);
+    return LocalisedTransaction(t, _blockHash, _i, numberFromHash(_blockHash));
 }
 
 TransactionReceipt ClientBase::transactionReceipt(h256 const& _transactionHash) const
 {
-	return bc().transactionReceipt(_transactionHash);
+    return bc().transactionReceipt(_transactionHash);
 }
 
 LocalisedTransactionReceipt ClientBase::localisedTransactionReceipt(h256 const& _transactionHash) const
 {
-	std::pair<h256, unsigned> tl = bc().transactionLocation(_transactionHash);
-	Transaction t = Transaction(bc().transaction(tl.first, tl.second), CheckTransaction::Cheap);
-	TransactionReceipt tr = bc().transactionReceipt(tl.first, tl.second);
-	u256 gasUsed = tr.cumulativeGasUsed();
-	if (tl.second > 0)
-		gasUsed -= bc().transactionReceipt(tl.first, tl.second - 1).cumulativeGasUsed();
-	return LocalisedTransactionReceipt(
-		tr,
-		t.sha3(),
-		tl.first,
-		numberFromHash(tl.first),
-		tl.second,
-		gasUsed,
-		toAddress(t.from(), t.nonce()));
+    std::pair<h256, unsigned> tl = bc().transactionLocation(_transactionHash);
+    Transaction t = Transaction(bc().transaction(tl.first, tl.second), CheckTransaction::Cheap);
+    TransactionReceipt tr = bc().transactionReceipt(tl.first, tl.second);
+    u256 gasUsed = tr.cumulativeGasUsed();
+    if (tl.second > 0)
+        gasUsed -= bc().transactionReceipt(tl.first, tl.second - 1).cumulativeGasUsed();
+    return LocalisedTransactionReceipt(
+        tr,
+        t.sha3(),
+        tl.first,
+        numberFromHash(tl.first),
+        tl.second,
+        gasUsed,
+        toAddress(t.from(), t.nonce()));
 }
 
 pair<h256, unsigned> ClientBase::transactionLocation(h256 const& _transactionHash) const
 {
-	return bc().transactionLocation(_transactionHash);
+    return bc().transactionLocation(_transactionHash);
 }
 
 Transactions ClientBase::transactions(h256 _blockHash) const
 {
-	auto bl = bc().block(_blockHash);
-	RLP b(bl);
-	Transactions res;
-	for (unsigned i = 0; i < b[1].itemCount(); i++)
-		res.emplace_back(b[1][i].data(), CheckTransaction::Cheap);
-	return res;
+    auto bl = bc().block(_blockHash);
+    RLP b(bl);
+    Transactions res;
+    for (unsigned i = 0; i < b[1].itemCount(); i++)
+        res.emplace_back(b[1][i].data(), CheckTransaction::Cheap);
+    return res;
 }
 
 TransactionHashes ClientBase::transactionHashes(h256 _blockHash) const
 {
-	return bc().transactionHashes(_blockHash);
+    return bc().transactionHashes(_blockHash);
 }
 
 BlockHeader ClientBase::uncle(h256 _blockHash, unsigned _i) const
 {
-	auto bl = bc().block(_blockHash);
-	RLP b(bl);
-	if (_i < b[2].itemCount())
-		return BlockHeader(b[2][_i].data(), HeaderData);
-	else
-		return BlockHeader();
+    auto bl = bc().block(_blockHash);
+    RLP b(bl);
+    if (_i < b[2].itemCount())
+        return BlockHeader(b[2][_i].data(), HeaderData);
+    else
+        return BlockHeader();
 }
 
 UncleHashes ClientBase::uncleHashes(h256 _blockHash) const
 {
-	return bc().uncleHashes(_blockHash);
+    return bc().uncleHashes(_blockHash);
 }
 
 unsigned ClientBase::transactionCount(h256 _blockHash) const
 {
-	auto bl = bc().block(_blockHash);
-	RLP b(bl);
-	return b[1].itemCount();
+    auto bl = bc().block(_blockHash);
+    RLP b(bl);
+    return b[1].itemCount();
 }
 
 unsigned ClientBase::uncleCount(h256 _blockHash) const
 {
-	auto bl = bc().block(_blockHash);
-	RLP b(bl);
-	return b[2].itemCount();
+    auto bl = bc().block(_blockHash);
+    RLP b(bl);
+    return b[2].itemCount();
 }
 
 unsigned ClientBase::number() const
 {
-	return bc().number();
+    return bc().number();
 }
 
 Transactions ClientBase::pending() const
 {
-	return postSeal().pending();
+    return postSeal().pending();
 }
 
 h256s ClientBase::pendingHashes() const
 {
-	return h256s() + postSeal().pendingHashes();
+    return h256s() + postSeal().pendingHashes();
 }
 
 BlockHeader ClientBase::pendingInfo() const
 {
-	return postSeal().info();
+    return postSeal().info();
 }
 
 BlockDetails ClientBase::pendingDetails() const
 {
-	auto pm = postSeal().info();
-	auto li = Interface::blockDetails(LatestBlock);
-	return BlockDetails((unsigned)pm.number(), li.totalDifficulty + pm.difficulty(), pm.parentHash(), h256s{});
+    auto pm = postSeal().info();
+    auto li = Interface::blockDetails(LatestBlock);
+    return BlockDetails((unsigned)pm.number(), li.totalDifficulty + pm.difficulty(), pm.parentHash(), h256s{});
 }
 
 Addresses ClientBase::addresses(BlockNumber _block) const
 {
-	Addresses ret;
-	for (auto const& i: block(_block).addresses())
-		ret.push_back(i.first);
-	return ret;
+    Addresses ret;
+    for (auto const& i: block(_block).addresses())
+        ret.push_back(i.first);
+    return ret;
 }
 
 u256 ClientBase::gasLimitRemaining() const
 {
-	return postSeal().gasLimitRemaining();
+    return postSeal().gasLimitRemaining();
 }
 
 Address ClientBase::author() const
 {
-	return preSeal().author();
+    return preSeal().author();
 }
 
 h256 ClientBase::hashFromNumber(BlockNumber _number) const
 {
-	if (_number == PendingBlock)
-		return h256();
-	if (_number == LatestBlock)
-		return bc().currentHash();
-	return bc().numberHash(_number);
+    if (_number == PendingBlock)
+        return h256();
+    if (_number == LatestBlock)
+        return bc().currentHash();
+    return bc().numberHash(_number);
 }
 
 BlockNumber ClientBase::numberFromHash(h256 _blockHash) const
 {
-	if (_blockHash == PendingBlockHash)
-		return bc().number() + 1;
-	else if (_blockHash == LatestBlockHash)
-		return bc().number();
-	else if (_blockHash == EarliestBlockHash)
-		return 0;
-	return bc().number(_blockHash);
+    if (_blockHash == PendingBlockHash)
+        return bc().number() + 1;
+    else if (_blockHash == LatestBlockHash)
+        return bc().number();
+    else if (_blockHash == EarliestBlockHash)
+        return 0;
+    return bc().number(_blockHash);
 }
 
 int ClientBase::compareBlockHashes(h256 _h1, h256 _h2) const
 {
-	BlockNumber n1 = numberFromHash(_h1);
-	BlockNumber n2 = numberFromHash(_h2);
+    BlockNumber n1 = numberFromHash(_h1);
+    BlockNumber n2 = numberFromHash(_h2);
 
-	if (n1 > n2)
-		return 1;
-	else if (n1 == n2)
-		return 0;
-	return -1;
+    if (n1 > n2)
+        return 1;
+    else if (n1 == n2)
+        return 0;
+    return -1;
 }
 
 bool ClientBase::isKnown(h256 const& _hash) const
 {
-	return _hash == PendingBlockHash ||
-		_hash == LatestBlockHash ||
-		_hash == EarliestBlockHash ||
-		bc().isKnown(_hash);
+    return _hash == PendingBlockHash ||
+        _hash == LatestBlockHash ||
+        _hash == EarliestBlockHash ||
+        bc().isKnown(_hash);
 }
 
 bool ClientBase::isKnown(BlockNumber _block) const
 {
-	return _block == PendingBlock ||
-		_block == LatestBlock ||
-		bc().numberHash(_block) != h256();
+    return _block == PendingBlock ||
+        _block == LatestBlock ||
+        bc().numberHash(_block) != h256();
 }
 
 bool ClientBase::isKnownTransaction(h256 const& _transactionHash) const
 {
-	return bc().isKnownTransaction(_transactionHash);
+    return bc().isKnownTransaction(_transactionHash);
 }
 
 bool ClientBase::isKnownTransaction(h256 const& _blockHash, unsigned _i) const
 {
-	return isKnown(_blockHash) && block(_blockHash).pending().size() > _i;
+    return isKnown(_blockHash) && block(_blockHash).pending().size() > _i;
 }
 
 Block ClientBase::block(BlockNumber _h) const
 {
-	if (_h == PendingBlock)
-		return postSeal();
-	else if (_h == LatestBlock)
-		return preSeal();
-	return block(bc().numberHash(_h));
+    if (_h == PendingBlock)
+        return postSeal();
+    else if (_h == LatestBlock)
+        return preSeal();
+    return block(bc().numberHash(_h));
 }
 
 int ClientBase::chainId() const

--- a/libethereum/ClientBase.h
+++ b/libethereum/ClientBase.h
@@ -64,15 +64,6 @@ struct ClientWatch
     mutable std::chrono::system_clock::time_point lastPoll = std::chrono::system_clock::now();
 };
 
-struct WatchChannel: public LogChannel { static const char* name(); static const int verbosity = 7; };
-#define cwatch LogOutputStream<WatchChannel, true>()
-struct WorkInChannel: public LogChannel { static const char* name(); static const int verbosity = 16; };
-struct WorkOutChannel: public LogChannel { static const char* name(); static const int verbosity = 16; };
-struct WorkChannel: public LogChannel { static const char* name(); static const int verbosity = 21; };
-#define cwork LogOutputStream<WorkChannel, true>()
-#define cworkin LogOutputStream<WorkInChannel, true>()
-#define cworkout LogOutputStream<WorkOutChannel, true>()
-
 class ClientBase: public Interface
 {
 public:
@@ -194,6 +185,8 @@ protected:
     std::unordered_map<h256, h256s> m_specialFilters = std::unordered_map<h256, std::vector<h256>>{{PendingChangedFilter, {}}, {ChainChangedFilter, {}}};
                                                             ///< The dictionary of special filters and their additional data
     std::map<unsigned, ClientWatch> m_watches;				///< Each and every watch - these reference a filter.
+
+    Logger m_loggerWatch{createLogger(7, "watch")};
 };
 
 }}

--- a/libethereum/EthereumHost.cpp
+++ b/libethereum/EthereumHost.cpp
@@ -178,9 +178,9 @@ public:
         if (_blockId.size() == 32) // block id is a hash
         {
             blockHash = _blockId.toHash<h256>();
-            cnetmessage << "GetBlockHeaders (block (hash): " << blockHash
-                << ", maxHeaders: " << _maxHeaders
-                << ", skip: " << _skip << ", reverse: " << _reverse << ")";
+            cnetlog << "GetBlockHeaders (block (hash): " << blockHash
+                    << ", maxHeaders: " << _maxHeaders << ", skip: " << _skip
+                    << ", reverse: " << _reverse << ")";
 
             if (!m_chain.isKnown(blockHash))
                 blockHash = {};
@@ -208,9 +208,8 @@ public:
         else // block id is a number
         {
             auto n = _blockId.toInt<bigint>();
-            cnetmessage << "GetBlockHeaders (" << n
-            << " max: " << _maxHeaders
-            << " skip: " << _skip << (_reverse ? " reverse" : "") << ")";
+            cnetlog << "GetBlockHeaders (" << n << " max: " << _maxHeaders << " skip: " << _skip
+                    << (_reverse ? " reverse" : "") << ")";
 
             if (!_reverse)
             {
@@ -310,9 +309,9 @@ public:
         if (count > 20 && n == 0)
             cnetwarn << "all " << count << " unknown blocks requested; peer on different chain?";
         else
-            cnetmessage
-                << n << " blocks known and returned; " << (numBodiesToSend - n) << " blocks unknown; "
-                << (count > c_maxBlocks ? count - c_maxBlocks : 0) << " blocks ignored";
+            cnetlog << n << " blocks known and returned; " << (numBodiesToSend - n)
+                    << " blocks unknown; " << (count > c_maxBlocks ? count - c_maxBlocks : 0)
+                    << " blocks ignored";
 
         return make_pair(rlp, n);
     }
@@ -334,7 +333,8 @@ public:
                 data.push_back(move(node));
             }
         }
-        cnetmessage << data.size() << " nodes known and returned; " << (numItemsToSend - data.size()) << " unknown; " << (count > c_maxNodes ? count - c_maxNodes : 0) << " ignored";
+        cnetlog << data.size() << " nodes known and returned; " << (numItemsToSend - data.size())
+                << " unknown; " << (count > c_maxNodes ? count - c_maxNodes : 0) << " ignored";
 
         return data;
     }
@@ -357,7 +357,9 @@ public:
                 ++n;
             }
         }
-        cnetmessage << n << " receipt lists known and returned; " << (numItemsToSend - n) << " unknown; " << (count > c_maxReceipts ? count - c_maxReceipts : 0) << " ignored";
+        cnetlog << n << " receipt lists known and returned; " << (numItemsToSend - n)
+                << " unknown; " << (count > c_maxReceipts ? count - c_maxReceipts : 0)
+                << " ignored";
 
         return make_pair(rlp, n);
     }

--- a/libethereum/EthereumHost.cpp
+++ b/libethereum/EthereumHost.cpp
@@ -1,18 +1,18 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file EthereumHost.cpp
  * @author Gav Wood <i@gavwood.com>
@@ -54,599 +54,601 @@ namespace
 class EthereumPeerObserver: public EthereumPeerObserverFace
 {
 public:
-	EthereumPeerObserver(shared_ptr<BlockChainSync> _sync, TransactionQueue& _tq): m_sync(_sync), m_tq(_tq) {}
+    EthereumPeerObserver(shared_ptr<BlockChainSync> _sync, TransactionQueue& _tq): m_sync(_sync), m_tq(_tq) {}
 
-	void onPeerStatus(std::shared_ptr<EthereumPeer> _peer) override
-	{
-		try
-		{
-			m_sync->onPeerStatus(_peer);
-		}
-		catch (FailedInvariant const&)
-		{
-			// "fix" for https://github.com/ethereum/webthree-umbrella/issues/300
-			clog(NetWarn) << "Failed invariant during sync, restarting sync";
-			m_sync->restartSync();
-		}
-	}
+    void onPeerStatus(std::shared_ptr<EthereumPeer> _peer) override
+    {
+        try
+        {
+            m_sync->onPeerStatus(_peer);
+        }
+        catch (FailedInvariant const&)
+        {
+            // "fix" for https://github.com/ethereum/webthree-umbrella/issues/300
+            cnetwarn << "Failed invariant during sync, restarting sync";
+            m_sync->restartSync();
+        }
+    }
 
-	void onPeerTransactions(std::shared_ptr<EthereumPeer> _peer, RLP const& _r) override
-	{
-		unsigned itemCount = _r.itemCount();
-		clog(EthereumHostTrace) << "Transactions (" << dec << itemCount << "entries)";
-		m_tq.enqueue(_r, _peer->id());
-	}
+    void onPeerTransactions(std::shared_ptr<EthereumPeer> _peer, RLP const& _r) override
+    {
+        unsigned itemCount = _r.itemCount();
+        clog(EthereumHostTrace) << "Transactions (" << dec << itemCount << "entries)";
+        m_tq.enqueue(_r, _peer->id());
+    }
 
-	void onPeerAborting() override
-	{
-		try
-		{
-			m_sync->onPeerAborting();
-		}
-		catch (Exception&)
-		{
-			cwarn << "Exception on peer destruciton: " << boost::current_exception_diagnostic_information();
-		}
-	}
+    void onPeerAborting() override
+    {
+        try
+        {
+            m_sync->onPeerAborting();
+        }
+        catch (Exception&)
+        {
+            cwarn << "Exception on peer destruciton: " << boost::current_exception_diagnostic_information();
+        }
+    }
 
-	void onPeerBlockHeaders(std::shared_ptr<EthereumPeer> _peer, RLP const& _headers) override
-	{
-		try
-		{
-			m_sync->onPeerBlockHeaders(_peer, _headers);
-		}
-		catch (FailedInvariant const&)
-		{
-			// "fix" for https://github.com/ethereum/webthree-umbrella/issues/300
-			clog(NetWarn) << "Failed invariant during sync, restarting sync";
-			m_sync->restartSync();
-		}
-	}
+    void onPeerBlockHeaders(std::shared_ptr<EthereumPeer> _peer, RLP const& _headers) override
+    {
+        try
+        {
+            m_sync->onPeerBlockHeaders(_peer, _headers);
+        }
+        catch (FailedInvariant const&)
+        {
+            // "fix" for https://github.com/ethereum/webthree-umbrella/issues/300
+            cnetwarn << "Failed invariant during sync, restarting sync";
+            m_sync->restartSync();
+        }
+    }
 
-	void onPeerBlockBodies(std::shared_ptr<EthereumPeer> _peer, RLP const& _r) override
-	{
-		try
-		{
-			m_sync->onPeerBlockBodies(_peer, _r);
-		}
-		catch (FailedInvariant const&)
-		{
-			// "fix" for https://github.com/ethereum/webthree-umbrella/issues/300
-			clog(NetWarn) << "Failed invariant during sync, restarting sync";
-			m_sync->restartSync();
-		}
-	}
+    void onPeerBlockBodies(std::shared_ptr<EthereumPeer> _peer, RLP const& _r) override
+    {
+        try
+        {
+            m_sync->onPeerBlockBodies(_peer, _r);
+        }
+        catch (FailedInvariant const&)
+        {
+            // "fix" for https://github.com/ethereum/webthree-umbrella/issues/300
+            cnetwarn << "Failed invariant during sync, restarting sync";
+            m_sync->restartSync();
+        }
+    }
 
-	void onPeerNewHashes(std::shared_ptr<EthereumPeer> _peer, std::vector<std::pair<h256, u256>> const& _hashes) override
-	{
-		try
-		{
-			m_sync->onPeerNewHashes(_peer, _hashes);
-		}
-		catch (FailedInvariant const&)
-		{
-			// "fix" for https://github.com/ethereum/webthree-umbrella/issues/300
-			clog(NetWarn) << "Failed invariant during sync, restarting sync";
-			m_sync->restartSync();
-		}
-	}
+    void onPeerNewHashes(std::shared_ptr<EthereumPeer> _peer, std::vector<std::pair<h256, u256>> const& _hashes) override
+    {
+        try
+        {
+            m_sync->onPeerNewHashes(_peer, _hashes);
+        }
+        catch (FailedInvariant const&)
+        {
+            // "fix" for https://github.com/ethereum/webthree-umbrella/issues/300
+            cnetwarn << "Failed invariant during sync, restarting sync";
+            m_sync->restartSync();
+        }
+    }
 
-	void onPeerNewBlock(std::shared_ptr<EthereumPeer> _peer, RLP const& _r) override
-	{
-		try
-		{
-			m_sync->onPeerNewBlock(_peer, _r);
-		}
-		catch (FailedInvariant const&)
-		{
-			// "fix" for https://github.com/ethereum/webthree-umbrella/issues/300
-			clog(NetWarn) << "Failed invariant during sync, restarting sync";
-			m_sync->restartSync();
-		}
-	}
+    void onPeerNewBlock(std::shared_ptr<EthereumPeer> _peer, RLP const& _r) override
+    {
+        try
+        {
+            m_sync->onPeerNewBlock(_peer, _r);
+        }
+        catch (FailedInvariant const&)
+        {
+            // "fix" for https://github.com/ethereum/webthree-umbrella/issues/300
+            cnetwarn << "Failed invariant during sync, restarting sync";
+            m_sync->restartSync();
+        }
+    }
 
-	void onPeerNodeData(std::shared_ptr<EthereumPeer> /* _peer */, RLP const& _r) override
-	{
-		unsigned itemCount = _r.itemCount();
-		clog(EthereumHostTrace) << "Node Data (" << dec << itemCount << "entries)";
-	}
+    void onPeerNodeData(std::shared_ptr<EthereumPeer> /* _peer */, RLP const& _r) override
+    {
+        unsigned itemCount = _r.itemCount();
+        clog(EthereumHostTrace) << "Node Data (" << dec << itemCount << "entries)";
+    }
 
-	void onPeerReceipts(std::shared_ptr<EthereumPeer> /* _peer */, RLP const& _r) override
-	{
-		unsigned itemCount = _r.itemCount();
-		clog(EthereumHostTrace) << "Receipts (" << dec << itemCount << "entries)";
-	}
+    void onPeerReceipts(std::shared_ptr<EthereumPeer> /* _peer */, RLP const& _r) override
+    {
+        unsigned itemCount = _r.itemCount();
+        clog(EthereumHostTrace) << "Receipts (" << dec << itemCount << "entries)";
+    }
 
 private:
-	shared_ptr<BlockChainSync> m_sync;
-	TransactionQueue& m_tq;
+    shared_ptr<BlockChainSync> m_sync;
+    TransactionQueue& m_tq;
 };
 
 class EthereumHostData: public EthereumHostDataFace
 {
 public:
-	EthereumHostData(BlockChain const& _chain, OverlayDB const& _db): m_chain(_chain), m_db(_db) {}
+    EthereumHostData(BlockChain const& _chain, OverlayDB const& _db): m_chain(_chain), m_db(_db) {}
 
-	pair<bytes, unsigned> blockHeaders(RLP const& _blockId, unsigned _maxHeaders, u256 _skip, bool _reverse) const override
-	{
-		auto numHeadersToSend = _maxHeaders;
+    pair<bytes, unsigned> blockHeaders(RLP const& _blockId, unsigned _maxHeaders, u256 _skip, bool _reverse) const override
+    {
+        auto numHeadersToSend = _maxHeaders;
 
-		auto step = static_cast<unsigned>(_skip) + 1;
-		assert(step > 0 && "step must not be 0");
+        auto step = static_cast<unsigned>(_skip) + 1;
+        assert(step > 0 && "step must not be 0");
 
-		h256 blockHash;
-		if (_blockId.size() == 32) // block id is a hash
-		{
-			blockHash = _blockId.toHash<h256>();
-			clog(NetMessageSummary) << "GetBlockHeaders (block (hash): " << blockHash
-				<< ", maxHeaders: " << _maxHeaders
-				<< ", skip: " << _skip << ", reverse: " << _reverse << ")";
+        h256 blockHash;
+        if (_blockId.size() == 32) // block id is a hash
+        {
+            blockHash = _blockId.toHash<h256>();
+            clog(NetMessageSummary) << "GetBlockHeaders (block (hash): " << blockHash
+                << ", maxHeaders: " << _maxHeaders
+                << ", skip: " << _skip << ", reverse: " << _reverse << ")";
 
-			if (!m_chain.isKnown(blockHash))
-				blockHash = {};
-			else if (!_reverse)
-			{
-				auto n = m_chain.number(blockHash);
-				if (numHeadersToSend == 0)
-					blockHash = {};
-				else if (n != 0 || blockHash == m_chain.genesisHash())
-				{
-					auto top = n + uint64_t(step) * numHeadersToSend - 1;
-					auto lastBlock = m_chain.number();
-					if (top > lastBlock)
-					{
-						numHeadersToSend = (lastBlock - n) / step + 1;
-						top = n + step * (numHeadersToSend - 1);
-					}
-					assert(top <= lastBlock && "invalid top block calculated");
-					blockHash = m_chain.numberHash(static_cast<unsigned>(top)); // override start block hash with the hash of the top block we have
-				}
-				else
-					blockHash = {};
-			}
-		}
-		else // block id is a number
-		{
-			auto n = _blockId.toInt<bigint>();
-			clog(NetMessageSummary) << "GetBlockHeaders (" << n
-			<< "max: " << _maxHeaders
-			<< "skip: " << _skip << (_reverse ? "reverse" : "") << ")";
+            if (!m_chain.isKnown(blockHash))
+                blockHash = {};
+            else if (!_reverse)
+            {
+                auto n = m_chain.number(blockHash);
+                if (numHeadersToSend == 0)
+                    blockHash = {};
+                else if (n != 0 || blockHash == m_chain.genesisHash())
+                {
+                    auto top = n + uint64_t(step) * numHeadersToSend - 1;
+                    auto lastBlock = m_chain.number();
+                    if (top > lastBlock)
+                    {
+                        numHeadersToSend = (lastBlock - n) / step + 1;
+                        top = n + step * (numHeadersToSend - 1);
+                    }
+                    assert(top <= lastBlock && "invalid top block calculated");
+                    blockHash = m_chain.numberHash(static_cast<unsigned>(top)); // override start block hash with the hash of the top block we have
+                }
+                else
+                    blockHash = {};
+            }
+        }
+        else // block id is a number
+        {
+            auto n = _blockId.toInt<bigint>();
+            clog(NetMessageSummary) << "GetBlockHeaders (" << n
+            << "max: " << _maxHeaders
+            << "skip: " << _skip << (_reverse ? "reverse" : "") << ")";
 
-			if (!_reverse)
-			{
-				auto lastBlock = m_chain.number();
-				if (n > lastBlock || numHeadersToSend == 0)
-					blockHash = {};
-				else
-				{
-					bigint top = n + uint64_t(step) * (numHeadersToSend - 1);
-					if (top > lastBlock)
-					{
-						numHeadersToSend = (lastBlock - static_cast<unsigned>(n)) / step + 1;
-						top = n + step * (numHeadersToSend - 1);
-					}
-					assert(top <= lastBlock && "invalid top block calculated");
-					blockHash = m_chain.numberHash(static_cast<unsigned>(top)); // override start block hash with the hash of the top block we have
-				}
-			}
-			else if (n <= std::numeric_limits<unsigned>::max())
-				blockHash = m_chain.numberHash(static_cast<unsigned>(n));
-			else
-				blockHash = {};
-		}
+            if (!_reverse)
+            {
+                auto lastBlock = m_chain.number();
+                if (n > lastBlock || numHeadersToSend == 0)
+                    blockHash = {};
+                else
+                {
+                    bigint top = n + uint64_t(step) * (numHeadersToSend - 1);
+                    if (top > lastBlock)
+                    {
+                        numHeadersToSend = (lastBlock - static_cast<unsigned>(n)) / step + 1;
+                        top = n + step * (numHeadersToSend - 1);
+                    }
+                    assert(top <= lastBlock && "invalid top block calculated");
+                    blockHash = m_chain.numberHash(static_cast<unsigned>(top)); // override start block hash with the hash of the top block we have
+                }
+            }
+            else if (n <= std::numeric_limits<unsigned>::max())
+                blockHash = m_chain.numberHash(static_cast<unsigned>(n));
+            else
+                blockHash = {};
+        }
 
-		auto nextHash = [this](h256 _h, unsigned _step)
-		{
-			static const unsigned c_blockNumberUsageLimit = 1000;
+        auto nextHash = [this](h256 _h, unsigned _step)
+        {
+            static const unsigned c_blockNumberUsageLimit = 1000;
 
-			const auto lastBlock = m_chain.number();
-			const auto limitBlock = lastBlock > c_blockNumberUsageLimit ? lastBlock - c_blockNumberUsageLimit : 0; // find the number of the block below which we don't expect BC changes.
+            const auto lastBlock = m_chain.number();
+            const auto limitBlock = lastBlock > c_blockNumberUsageLimit ? lastBlock - c_blockNumberUsageLimit : 0; // find the number of the block below which we don't expect BC changes.
 
-			while (_step) // parent hash traversal
-			{
-				auto details = m_chain.details(_h);
-				if (details.number < limitBlock)
-					break; // stop using parent hash traversal, fallback to using block numbers
-				_h = details.parent;
-				--_step;
-			}
+            while (_step) // parent hash traversal
+            {
+                auto details = m_chain.details(_h);
+                if (details.number < limitBlock)
+                    break; // stop using parent hash traversal, fallback to using block numbers
+                _h = details.parent;
+                --_step;
+            }
 
-			if (_step) // still need lower block
-			{
-				auto n = m_chain.number(_h);
-				if (n >= _step)
-					_h = m_chain.numberHash(n - _step);
-				else
-					_h = {};
-			}
+            if (_step) // still need lower block
+            {
+                auto n = m_chain.number(_h);
+                if (n >= _step)
+                    _h = m_chain.numberHash(n - _step);
+                else
+                    _h = {};
+            }
 
 
-			return _h;
-		};
+            return _h;
+        };
 
-		bytes rlp;
-		unsigned itemCount = 0;
-		vector<h256> hashes;
-		for (unsigned i = 0; i != numHeadersToSend; ++i)
-		{
-			if (!blockHash || !m_chain.isKnown(blockHash))
-				break;
+        bytes rlp;
+        unsigned itemCount = 0;
+        vector<h256> hashes;
+        for (unsigned i = 0; i != numHeadersToSend; ++i)
+        {
+            if (!blockHash || !m_chain.isKnown(blockHash))
+                break;
 
-			hashes.push_back(blockHash);
-			++itemCount;
+            hashes.push_back(blockHash);
+            ++itemCount;
 
-			blockHash = nextHash(blockHash, step);
-		}
+            blockHash = nextHash(blockHash, step);
+        }
 
-		for (unsigned i = 0; i < hashes.size() && rlp.size() < c_maxPayload; ++i)
-			rlp += m_chain.headerData(hashes[_reverse ? i : hashes.size() - 1 - i]);
+        for (unsigned i = 0; i < hashes.size() && rlp.size() < c_maxPayload; ++i)
+            rlp += m_chain.headerData(hashes[_reverse ? i : hashes.size() - 1 - i]);
 
-		return make_pair(rlp, itemCount);
-	}
+        return make_pair(rlp, itemCount);
+    }
 
-	pair<bytes, unsigned> blockBodies(RLP const& _blockHashes) const override
-	{
-		unsigned const count = static_cast<unsigned>(_blockHashes.itemCount());
+    pair<bytes, unsigned> blockBodies(RLP const& _blockHashes) const override
+    {
+        unsigned const count = static_cast<unsigned>(_blockHashes.itemCount());
 
-		bytes rlp;
-		unsigned n = 0;
-		auto numBodiesToSend = std::min(count, c_maxBlocks);
-		for (unsigned i = 0; i < numBodiesToSend && rlp.size() < c_maxPayload; ++i)
-		{
-			auto h = _blockHashes[i].toHash<h256>();
-			if (m_chain.isKnown(h))
-			{
-				bytes blockBytes = m_chain.block(h);
-				RLP block{blockBytes};
-				RLPStream body;
-				body.appendList(2);
-				body.appendRaw(block[1].data()); // transactions
-				body.appendRaw(block[2].data()); // uncles
-				auto bodyBytes = body.out();
-				rlp.insert(rlp.end(), bodyBytes.begin(), bodyBytes.end());
-				++n;
-			}
-		}
-		if (count > 20 && n == 0)
-			clog(NetWarn) << "all" << count << "unknown blocks requested; peer on different chain?";
-		else
-			clog(NetMessageSummary) << n << "blocks known and returned;" << (numBodiesToSend - n) << "blocks unknown;" << (count > c_maxBlocks ? count - c_maxBlocks : 0) << "blocks ignored";
+        bytes rlp;
+        unsigned n = 0;
+        auto numBodiesToSend = std::min(count, c_maxBlocks);
+        for (unsigned i = 0; i < numBodiesToSend && rlp.size() < c_maxPayload; ++i)
+        {
+            auto h = _blockHashes[i].toHash<h256>();
+            if (m_chain.isKnown(h))
+            {
+                bytes blockBytes = m_chain.block(h);
+                RLP block{blockBytes};
+                RLPStream body;
+                body.appendList(2);
+                body.appendRaw(block[1].data()); // transactions
+                body.appendRaw(block[2].data()); // uncles
+                auto bodyBytes = body.out();
+                rlp.insert(rlp.end(), bodyBytes.begin(), bodyBytes.end());
+                ++n;
+            }
+        }
+        if (count > 20 && n == 0)
+            cnetwarn << "all " << count << " unknown blocks requested; peer on different chain?";
+        else
+            clog(NetMessageSummary)
+                << n << "blocks known and returned;" << (numBodiesToSend - n) << "blocks unknown;"
+                << (count > c_maxBlocks ? count - c_maxBlocks : 0) << "blocks ignored";
 
-		return make_pair(rlp, n);
-	}
+        return make_pair(rlp, n);
+    }
 
-	strings nodeData(RLP const& _dataHashes) const override
-	{
-		unsigned const count = static_cast<unsigned>(_dataHashes.itemCount());
+    strings nodeData(RLP const& _dataHashes) const override
+    {
+        unsigned const count = static_cast<unsigned>(_dataHashes.itemCount());
 
-		strings data;
-		size_t payloadSize = 0;
-		auto numItemsToSend = std::min(count, c_maxNodes);
-		for (unsigned i = 0; i < numItemsToSend && payloadSize < c_maxPayload; ++i)
-		{
-			auto h = _dataHashes[i].toHash<h256>();
-			auto node = m_db.lookup(h);
-			if (!node.empty())
-			{
-				payloadSize += node.length();
-				data.push_back(move(node));
-			}
-		}
-		clog(NetMessageSummary) << data.size() << " nodes known and returned;" << (numItemsToSend - data.size()) << " unknown;" << (count > c_maxNodes ? count - c_maxNodes : 0) << " ignored";
+        strings data;
+        size_t payloadSize = 0;
+        auto numItemsToSend = std::min(count, c_maxNodes);
+        for (unsigned i = 0; i < numItemsToSend && payloadSize < c_maxPayload; ++i)
+        {
+            auto h = _dataHashes[i].toHash<h256>();
+            auto node = m_db.lookup(h);
+            if (!node.empty())
+            {
+                payloadSize += node.length();
+                data.push_back(move(node));
+            }
+        }
+        clog(NetMessageSummary) << data.size() << " nodes known and returned;" << (numItemsToSend - data.size()) << " unknown;" << (count > c_maxNodes ? count - c_maxNodes : 0) << " ignored";
 
-		return data;
-	}
+        return data;
+    }
 
-	pair<bytes, unsigned> receipts(RLP const& _blockHashes) const override
-	{
-		unsigned const count = static_cast<unsigned>(_blockHashes.itemCount());
+    pair<bytes, unsigned> receipts(RLP const& _blockHashes) const override
+    {
+        unsigned const count = static_cast<unsigned>(_blockHashes.itemCount());
 
-		bytes rlp;
-		unsigned n = 0;
-		auto numItemsToSend = std::min(count, c_maxReceipts);
-		for (unsigned i = 0; i < numItemsToSend && rlp.size() < c_maxPayload; ++i)
-		{
-			auto h = _blockHashes[i].toHash<h256>();
-			if (m_chain.isKnown(h))
-			{
-				auto const receipts = m_chain.receipts(h);
-				auto receiptsRlpList = receipts.rlp();
-				rlp.insert(rlp.end(), receiptsRlpList.begin(), receiptsRlpList.end());
-				++n;
-			}
-		}
-		clog(NetMessageSummary) << n << " receipt lists known and returned;" << (numItemsToSend - n) << " unknown;" << (count > c_maxReceipts ? count - c_maxReceipts : 0) << " ignored";
+        bytes rlp;
+        unsigned n = 0;
+        auto numItemsToSend = std::min(count, c_maxReceipts);
+        for (unsigned i = 0; i < numItemsToSend && rlp.size() < c_maxPayload; ++i)
+        {
+            auto h = _blockHashes[i].toHash<h256>();
+            if (m_chain.isKnown(h))
+            {
+                auto const receipts = m_chain.receipts(h);
+                auto receiptsRlpList = receipts.rlp();
+                rlp.insert(rlp.end(), receiptsRlpList.begin(), receiptsRlpList.end());
+                ++n;
+            }
+        }
+        clog(NetMessageSummary) << n << " receipt lists known and returned;" << (numItemsToSend - n) << " unknown;" << (count > c_maxReceipts ? count - c_maxReceipts : 0) << " ignored";
 
-		return make_pair(rlp, n);
-	}
+        return make_pair(rlp, n);
+    }
 
 private:
-	BlockChain const& m_chain;
-	OverlayDB const& m_db;
+    BlockChain const& m_chain;
+    OverlayDB const& m_db;
 };
 
 }
 
 EthereumHost::EthereumHost(BlockChain const& _ch, OverlayDB const& _db, TransactionQueue& _tq, BlockQueue& _bq, u256 _networkId):
-	HostCapability<EthereumPeer>(),
-	Worker		("ethsync"),
-	m_chain		(_ch),
-	m_db(_db),
-	m_tq		(_tq),
-	m_bq		(_bq),
-	m_networkId	(_networkId),
-	m_hostData(make_shared<EthereumHostData>(m_chain, m_db))
+    HostCapability<EthereumPeer>(),
+    Worker		("ethsync"),
+    m_chain		(_ch),
+    m_db(_db),
+    m_tq		(_tq),
+    m_bq		(_bq),
+    m_networkId	(_networkId),
+    m_hostData(make_shared<EthereumHostData>(m_chain, m_db))
 {
-	// TODO: Composition would be better. Left like that to avoid initialization
-	//       issues as BlockChainSync accesses other EthereumHost members.
-	m_sync.reset(new BlockChainSync(*this));
-	m_peerObserver = make_shared<EthereumPeerObserver>(m_sync, m_tq);
-	m_latestBlockSent = _ch.currentHash();
-	m_tq.onImport([this](ImportResult _ir, h256 const& _h, h512 const& _nodeId) { onTransactionImported(_ir, _h, _nodeId); });
+    // TODO: Composition would be better. Left like that to avoid initialization
+    //       issues as BlockChainSync accesses other EthereumHost members.
+    m_sync.reset(new BlockChainSync(*this));
+    m_peerObserver = make_shared<EthereumPeerObserver>(m_sync, m_tq);
+    m_latestBlockSent = _ch.currentHash();
+    m_tq.onImport([this](ImportResult _ir, h256 const& _h, h512 const& _nodeId) { onTransactionImported(_ir, _h, _nodeId); });
 }
 
 EthereumHost::~EthereumHost()
 {
-	terminate();
+    terminate();
 }
 
 bool EthereumHost::ensureInitialised()
 {
-	if (!m_latestBlockSent)
-	{
-		// First time - just initialise.
-		m_latestBlockSent = m_chain.currentHash();
-		clog(EthereumHostTrace) << "Initialising: latest=" << m_latestBlockSent;
+    if (!m_latestBlockSent)
+    {
+        // First time - just initialise.
+        m_latestBlockSent = m_chain.currentHash();
+        clog(EthereumHostTrace) << "Initialising: latest=" << m_latestBlockSent;
 
-		Guard l(x_transactions);
-		m_transactionsSent = m_tq.knownTransactions();
-		return true;
-	}
-	return false;
+        Guard l(x_transactions);
+        m_transactionsSent = m_tq.knownTransactions();
+        return true;
+    }
+    return false;
 }
 
 void EthereumHost::reset()
 {
-	m_sync->abortSync();
+    m_sync->abortSync();
 
-	m_latestBlockSent = h256();
-	Guard tl(x_transactions);
-	m_transactionsSent.clear();
+    m_latestBlockSent = h256();
+    Guard tl(x_transactions);
+    m_transactionsSent.clear();
 }
 
 void EthereumHost::completeSync()
 {
-	m_sync->completeSync();
+    m_sync->completeSync();
 }
 
 void EthereumHost::doWork()
 {
-	bool netChange = ensureInitialised();
-	auto h = m_chain.currentHash();
-	// If we've finished our initial sync (including getting all the blocks into the chain so as to reduce invalid transactions), start trading transactions & blocks
-	if (!isSyncing() && m_chain.isKnown(m_latestBlockSent))
-	{
-		if (m_newTransactions)
-		{
-			m_newTransactions = false;
-			maintainTransactions();
-		}
-		if (m_newBlocks)
-		{
-			m_newBlocks = false;
-			maintainBlocks(h);
-		}
-	}
+    bool netChange = ensureInitialised();
+    auto h = m_chain.currentHash();
+    // If we've finished our initial sync (including getting all the blocks into the chain so as to reduce invalid transactions), start trading transactions & blocks
+    if (!isSyncing() && m_chain.isKnown(m_latestBlockSent))
+    {
+        if (m_newTransactions)
+        {
+            m_newTransactions = false;
+            maintainTransactions();
+        }
+        if (m_newBlocks)
+        {
+            m_newBlocks = false;
+            maintainBlocks(h);
+        }
+    }
 
-	time_t  now = std::chrono::system_clock::to_time_t(chrono::system_clock::now());
-	if (now - m_lastTick >= 1)
-	{
-		m_lastTick = now;
-		foreachPeer([](std::shared_ptr<EthereumPeer> _p) { _p->tick(); return true; });
-	}
+    time_t  now = std::chrono::system_clock::to_time_t(chrono::system_clock::now());
+    if (now - m_lastTick >= 1)
+    {
+        m_lastTick = now;
+        foreachPeer([](std::shared_ptr<EthereumPeer> _p) { _p->tick(); return true; });
+    }
 
 //	return netChange;
-	// TODO: Figure out what to do with netChange.
-	(void)netChange;
+    // TODO: Figure out what to do with netChange.
+    (void)netChange;
 }
 
 void EthereumHost::maintainTransactions()
 {
-	// Send any new transactions.
-	unordered_map<std::shared_ptr<EthereumPeer>, std::vector<size_t>> peerTransactions;
-	auto ts = m_tq.topTransactions(c_maxSendTransactions);
-	{
-		Guard l(x_transactions);
-		for (size_t i = 0; i < ts.size(); ++i)
-		{
-			auto const& t = ts[i];
-			bool unsent = !m_transactionsSent.count(t.sha3());
-			auto peers = get<1>(randomSelection(0, [&](EthereumPeer* p) { return p->m_requireTransactions || (unsent && !p->m_knownTransactions.count(t.sha3())); }));
-			for (auto const& p: peers)
-				peerTransactions[p].push_back(i);
-		}
-		for (auto const& t: ts)
-			m_transactionsSent.insert(t.sha3());
-	}
-	foreachPeer([&](shared_ptr<EthereumPeer> _p)
-	{
-		bytes b;
-		unsigned n = 0;
-		for (auto const& i: peerTransactions[_p])
-		{
-			_p->m_knownTransactions.insert(ts[i].sha3());
-			b += ts[i].rlp();
-			++n;
-		}
+    // Send any new transactions.
+    unordered_map<std::shared_ptr<EthereumPeer>, std::vector<size_t>> peerTransactions;
+    auto ts = m_tq.topTransactions(c_maxSendTransactions);
+    {
+        Guard l(x_transactions);
+        for (size_t i = 0; i < ts.size(); ++i)
+        {
+            auto const& t = ts[i];
+            bool unsent = !m_transactionsSent.count(t.sha3());
+            auto peers = get<1>(randomSelection(0, [&](EthereumPeer* p) { return p->m_requireTransactions || (unsent && !p->m_knownTransactions.count(t.sha3())); }));
+            for (auto const& p: peers)
+                peerTransactions[p].push_back(i);
+        }
+        for (auto const& t: ts)
+            m_transactionsSent.insert(t.sha3());
+    }
+    foreachPeer([&](shared_ptr<EthereumPeer> _p)
+    {
+        bytes b;
+        unsigned n = 0;
+        for (auto const& i: peerTransactions[_p])
+        {
+            _p->m_knownTransactions.insert(ts[i].sha3());
+            b += ts[i].rlp();
+            ++n;
+        }
 
-		_p->clearKnownTransactions();
+        _p->clearKnownTransactions();
 
-		if (n || _p->m_requireTransactions)
-		{
-			RLPStream ts;
-			_p->prep(ts, TransactionsPacket, n).appendRaw(b, n);
-			_p->sealAndSend(ts);
-			clog(EthereumHostTrace) << "Sent" << n << "transactions to " << _p->session()->info().clientVersion;
-		}
-		_p->m_requireTransactions = false;
-		return true;
-	});
+        if (n || _p->m_requireTransactions)
+        {
+            RLPStream ts;
+            _p->prep(ts, TransactionsPacket, n).appendRaw(b, n);
+            _p->sealAndSend(ts);
+            clog(EthereumHostTrace) << "Sent" << n << "transactions to " << _p->session()->info().clientVersion;
+        }
+        _p->m_requireTransactions = false;
+        return true;
+    });
 }
 
 void EthereumHost::foreachPeer(std::function<bool(std::shared_ptr<EthereumPeer>)> const& _f) const
 {
-	//order peers by protocol, rating, connection age
-	auto sessions = peerSessions();
-	auto sessionLess = [](std::pair<std::shared_ptr<SessionFace>, std::shared_ptr<Peer>> const& _left, std::pair<std::shared_ptr<SessionFace>, std::shared_ptr<Peer>> const& _right)
-		{ return _left.first->rating() == _right.first->rating() ? _left.first->connectionTime() < _right.first->connectionTime() : _left.first->rating() > _right.first->rating(); };
+    //order peers by protocol, rating, connection age
+    auto sessions = peerSessions();
+    auto sessionLess = [](std::pair<std::shared_ptr<SessionFace>, std::shared_ptr<Peer>> const& _left, std::pair<std::shared_ptr<SessionFace>, std::shared_ptr<Peer>> const& _right)
+        { return _left.first->rating() == _right.first->rating() ? _left.first->connectionTime() < _right.first->connectionTime() : _left.first->rating() > _right.first->rating(); };
 
-	std::sort(sessions.begin(), sessions.end(), sessionLess);
-	for (auto s: sessions)
-		if (!_f(capabilityFromSession<EthereumPeer>(*s.first)))
-			return;
+    std::sort(sessions.begin(), sessions.end(), sessionLess);
+    for (auto s: sessions)
+        if (!_f(capabilityFromSession<EthereumPeer>(*s.first)))
+            return;
 
-	sessions = peerSessions(c_oldProtocolVersion); //TODO: remove once v61+ is common
-	std::sort(sessions.begin(), sessions.end(), sessionLess);
-	for (auto s: sessions)
-		if (!_f(capabilityFromSession<EthereumPeer>(*s.first, c_oldProtocolVersion)))
-			return;
+    sessions = peerSessions(c_oldProtocolVersion); //TODO: remove once v61+ is common
+    std::sort(sessions.begin(), sessions.end(), sessionLess);
+    for (auto s: sessions)
+        if (!_f(capabilityFromSession<EthereumPeer>(*s.first, c_oldProtocolVersion)))
+            return;
 }
 
 tuple<vector<shared_ptr<EthereumPeer>>, vector<shared_ptr<EthereumPeer>>, vector<shared_ptr<SessionFace>>> EthereumHost::randomSelection(unsigned _percent, std::function<bool(EthereumPeer*)> const& _allow)
 {
-	vector<shared_ptr<EthereumPeer>> chosen;
-	vector<shared_ptr<EthereumPeer>> allowed;
-	vector<shared_ptr<SessionFace>> sessions;
+    vector<shared_ptr<EthereumPeer>> chosen;
+    vector<shared_ptr<EthereumPeer>> allowed;
+    vector<shared_ptr<SessionFace>> sessions;
 
-	size_t peerCount = 0;
-	foreachPeer([&](std::shared_ptr<EthereumPeer> _p)
-	{
-		if (_allow(_p.get()))
-		{
-			allowed.push_back(_p);
-			sessions.push_back(_p->session());
-		}
-		++peerCount;
-		return true;
-	});
+    size_t peerCount = 0;
+    foreachPeer([&](std::shared_ptr<EthereumPeer> _p)
+    {
+        if (_allow(_p.get()))
+        {
+            allowed.push_back(_p);
+            sessions.push_back(_p->session());
+        }
+        ++peerCount;
+        return true;
+    });
 
-	size_t chosenSize = (peerCount * _percent + 99) / 100;
-	chosen.reserve(chosenSize);
-	for (unsigned i = chosenSize; i && allowed.size(); i--)
-	{
-		unsigned n = rand() % allowed.size();
-		chosen.push_back(std::move(allowed[n]));
-		allowed.erase(allowed.begin() + n);
-	}
-	return make_tuple(move(chosen), move(allowed), move(sessions));
+    size_t chosenSize = (peerCount * _percent + 99) / 100;
+    chosen.reserve(chosenSize);
+    for (unsigned i = chosenSize; i && allowed.size(); i--)
+    {
+        unsigned n = rand() % allowed.size();
+        chosen.push_back(std::move(allowed[n]));
+        allowed.erase(allowed.begin() + n);
+    }
+    return make_tuple(move(chosen), move(allowed), move(sessions));
 }
 
 void EthereumHost::maintainBlocks(h256 const& _currentHash)
 {
-	// Send any new blocks.
-	auto detailsFrom = m_chain.details(m_latestBlockSent);
-	auto detailsTo = m_chain.details(_currentHash);
-	if (detailsFrom.totalDifficulty < detailsTo.totalDifficulty)
-	{
-		if (diff(detailsFrom.number, detailsTo.number) < 20)
-		{
-			// don't be sending more than 20 "new" blocks. if there are any more we were probably waaaay behind.
-			clog(EthereumHostTrace) << "Sending a new block (current is" << _currentHash << ", was" << m_latestBlockSent << ")";
+    // Send any new blocks.
+    auto detailsFrom = m_chain.details(m_latestBlockSent);
+    auto detailsTo = m_chain.details(_currentHash);
+    if (detailsFrom.totalDifficulty < detailsTo.totalDifficulty)
+    {
+        if (diff(detailsFrom.number, detailsTo.number) < 20)
+        {
+            // don't be sending more than 20 "new" blocks. if there are any more we were probably waaaay behind.
+            clog(EthereumHostTrace) << "Sending a new block (current is" << _currentHash << ", was" << m_latestBlockSent << ")";
 
-			h256s blocks = get<0>(m_chain.treeRoute(m_latestBlockSent, _currentHash, false, false, true));
+            h256s blocks = get<0>(m_chain.treeRoute(m_latestBlockSent, _currentHash, false, false, true));
 
-			auto s = randomSelection(25, [&](EthereumPeer* p){
-				DEV_GUARDED(p->x_knownBlocks)
-					return !p->m_knownBlocks.count(_currentHash);
-				return false;
-			});
-			for (shared_ptr<EthereumPeer> const& p: get<0>(s))
-				for (auto const& b: blocks)
-				{
-					RLPStream ts;
-					p->prep(ts, NewBlockPacket, 2).appendRaw(m_chain.block(b), 1).append(m_chain.details(b).totalDifficulty);
+            auto s = randomSelection(25, [&](EthereumPeer* p){
+                DEV_GUARDED(p->x_knownBlocks)
+                    return !p->m_knownBlocks.count(_currentHash);
+                return false;
+            });
+            for (shared_ptr<EthereumPeer> const& p: get<0>(s))
+                for (auto const& b: blocks)
+                {
+                    RLPStream ts;
+                    p->prep(ts, NewBlockPacket, 2).appendRaw(m_chain.block(b), 1).append(m_chain.details(b).totalDifficulty);
 
-					Guard l(p->x_knownBlocks);
-					p->sealAndSend(ts);
-					p->m_knownBlocks.clear();
-				}
-			for (shared_ptr<EthereumPeer> const& p: get<1>(s))
-			{
-				RLPStream ts;
-				p->prep(ts, NewBlockHashesPacket, blocks.size());
-				for (auto const& b: blocks)
-				{
-					ts.appendList(2);
-					ts.append(b);
-					ts.append(m_chain.number(b));
-				}
+                    Guard l(p->x_knownBlocks);
+                    p->sealAndSend(ts);
+                    p->m_knownBlocks.clear();
+                }
+            for (shared_ptr<EthereumPeer> const& p: get<1>(s))
+            {
+                RLPStream ts;
+                p->prep(ts, NewBlockHashesPacket, blocks.size());
+                for (auto const& b: blocks)
+                {
+                    ts.appendList(2);
+                    ts.append(b);
+                    ts.append(m_chain.number(b));
+                }
 
-				Guard l(p->x_knownBlocks);
-				p->sealAndSend(ts);
-				p->m_knownBlocks.clear();
-			}
-		}
-		m_latestBlockSent = _currentHash;
-	}
+                Guard l(p->x_knownBlocks);
+                p->sealAndSend(ts);
+                p->m_knownBlocks.clear();
+            }
+        }
+        m_latestBlockSent = _currentHash;
+    }
 }
 
 bool EthereumHost::isSyncing() const
 {
-	return m_sync->isSyncing();
+    return m_sync->isSyncing();
 }
 
 SyncStatus EthereumHost::status() const
 {
-	return m_sync->status();
+    return m_sync->status();
 }
 
 void EthereumHost::onTransactionImported(ImportResult _ir, h256 const& _h, h512 const& _nodeId)
 {
-	auto session = host()->peerSession(_nodeId);
-	if (!session)
-		return;
+    auto session = host()->peerSession(_nodeId);
+    if (!session)
+        return;
 
-	std::shared_ptr<EthereumPeer> peer = capabilityFromSession<EthereumPeer>(*session);
-	if (!peer)
-		peer = capabilityFromSession<EthereumPeer>(*session, c_oldProtocolVersion);
-	if (!peer)
-		return;
+    std::shared_ptr<EthereumPeer> peer = capabilityFromSession<EthereumPeer>(*session);
+    if (!peer)
+        peer = capabilityFromSession<EthereumPeer>(*session, c_oldProtocolVersion);
+    if (!peer)
+        return;
 
-	Guard l(peer->x_knownTransactions);
-	peer->m_knownTransactions.insert(_h);
-	switch (_ir)
-	{
-	case ImportResult::Malformed:
-		peer->addRating(-100);
-		break;
-	case ImportResult::AlreadyKnown:
-		// if we already had the transaction, then don't bother sending it on.
-		DEV_GUARDED(x_transactions)
-			m_transactionsSent.insert(_h);
-		peer->addRating(0);
-		break;
-	case ImportResult::Success:
-		peer->addRating(100);
-		break;
-	default:;
-	}
+    Guard l(peer->x_knownTransactions);
+    peer->m_knownTransactions.insert(_h);
+    switch (_ir)
+    {
+    case ImportResult::Malformed:
+        peer->addRating(-100);
+        break;
+    case ImportResult::AlreadyKnown:
+        // if we already had the transaction, then don't bother sending it on.
+        DEV_GUARDED(x_transactions)
+            m_transactionsSent.insert(_h);
+        peer->addRating(0);
+        break;
+    case ImportResult::Success:
+        peer->addRating(100);
+        break;
+    default:;
+    }
 }
 
 shared_ptr<Capability> EthereumHost::newPeerCapability(shared_ptr<SessionFace> const& _s, unsigned _idOffset, p2p::CapDesc const& _cap)
 {
-	auto ret = HostCapability<EthereumPeer>::newPeerCapability(_s, _idOffset, _cap);
+    auto ret = HostCapability<EthereumPeer>::newPeerCapability(_s, _idOffset, _cap);
 
-	auto cap = capabilityFromSession<EthereumPeer>(*_s, _cap.second);
-	assert(cap);
-	cap->init(
-		protocolVersion(),
-		m_networkId,
-		m_chain.details().totalDifficulty,
-		m_chain.currentHash(),
-		m_chain.genesisHash(),
-		m_hostData,
-		m_peerObserver
-	);
+    auto cap = capabilityFromSession<EthereumPeer>(*_s, _cap.second);
+    assert(cap);
+    cap->init(
+        protocolVersion(),
+        m_networkId,
+        m_chain.details().totalDifficulty,
+        m_chain.currentHash(),
+        m_chain.genesisHash(),
+        m_hostData,
+        m_peerObserver
+    );
 
-	return ret;
+    return ret;
 }

--- a/libethereum/EthereumHost.cpp
+++ b/libethereum/EthereumHost.cpp
@@ -178,7 +178,7 @@ public:
         if (_blockId.size() == 32) // block id is a hash
         {
             blockHash = _blockId.toHash<h256>();
-            clog(NetMessageSummary) << "GetBlockHeaders (block (hash): " << blockHash
+            cnetmessage << "GetBlockHeaders (block (hash): " << blockHash
                 << ", maxHeaders: " << _maxHeaders
                 << ", skip: " << _skip << ", reverse: " << _reverse << ")";
 
@@ -208,9 +208,9 @@ public:
         else // block id is a number
         {
             auto n = _blockId.toInt<bigint>();
-            clog(NetMessageSummary) << "GetBlockHeaders (" << n
-            << "max: " << _maxHeaders
-            << "skip: " << _skip << (_reverse ? "reverse" : "") << ")";
+            cnetmessage << "GetBlockHeaders (" << n
+            << " max: " << _maxHeaders
+            << " skip: " << _skip << (_reverse ? " reverse" : "") << ")";
 
             if (!_reverse)
             {
@@ -310,9 +310,9 @@ public:
         if (count > 20 && n == 0)
             cnetwarn << "all " << count << " unknown blocks requested; peer on different chain?";
         else
-            clog(NetMessageSummary)
-                << n << "blocks known and returned;" << (numBodiesToSend - n) << "blocks unknown;"
-                << (count > c_maxBlocks ? count - c_maxBlocks : 0) << "blocks ignored";
+            cnetmessage
+                << n << " blocks known and returned; " << (numBodiesToSend - n) << " blocks unknown; "
+                << (count > c_maxBlocks ? count - c_maxBlocks : 0) << " blocks ignored";
 
         return make_pair(rlp, n);
     }
@@ -334,7 +334,7 @@ public:
                 data.push_back(move(node));
             }
         }
-        clog(NetMessageSummary) << data.size() << " nodes known and returned;" << (numItemsToSend - data.size()) << " unknown;" << (count > c_maxNodes ? count - c_maxNodes : 0) << " ignored";
+        cnetmessage << data.size() << " nodes known and returned; " << (numItemsToSend - data.size()) << " unknown; " << (count > c_maxNodes ? count - c_maxNodes : 0) << " ignored";
 
         return data;
     }
@@ -357,7 +357,7 @@ public:
                 ++n;
             }
         }
-        clog(NetMessageSummary) << n << " receipt lists known and returned;" << (numItemsToSend - n) << " unknown;" << (count > c_maxReceipts ? count - c_maxReceipts : 0) << " ignored";
+        cnetmessage << n << " receipt lists known and returned; " << (numItemsToSend - n) << " unknown; " << (count > c_maxReceipts ? count - c_maxReceipts : 0) << " ignored";
 
         return make_pair(rlp, n);
     }

--- a/libethereum/EthereumHost.h
+++ b/libethereum/EthereumHost.h
@@ -51,8 +51,6 @@ class TransactionQueue;
 class BlockQueue;
 class BlockChainSync;
 
-struct EthereumHostTrace: public LogChannel { static const char* name(); static const int verbosity = 6; };
-
 /**
  * @brief The EthereumHost class
  * @warning None of this is thread-safe. You have been warned.
@@ -138,6 +136,8 @@ private:
 
     std::shared_ptr<EthereumHostDataFace> m_hostData;
     std::shared_ptr<EthereumPeerObserverFace> m_peerObserver;
+
+    Logger m_logger{createLogger(6, "host")};
 };
 
 }

--- a/libethereum/EthereumHost.h
+++ b/libethereum/EthereumHost.h
@@ -1,18 +1,18 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file EthereumHost.h
  * @author Gav Wood <i@gavwood.com>
@@ -61,83 +61,83 @@ struct EthereumHostTrace: public LogChannel { static const char* name(); static 
 class EthereumHost: public p2p::HostCapability<EthereumPeer>, Worker
 {
 public:
-	/// Start server, but don't listen.
-	EthereumHost(BlockChain const& _ch, OverlayDB const& _db, TransactionQueue& _tq, BlockQueue& _bq, u256 _networkId);
+    /// Start server, but don't listen.
+    EthereumHost(BlockChain const& _ch, OverlayDB const& _db, TransactionQueue& _tq, BlockQueue& _bq, u256 _networkId);
 
-	/// Will block on network process events.
-	virtual ~EthereumHost();
+    /// Will block on network process events.
+    virtual ~EthereumHost();
 
-	unsigned protocolVersion() const { return c_protocolVersion; }
-	u256 networkId() const { return m_networkId; }
-	void setNetworkId(u256 _n) { m_networkId = _n; }
+    unsigned protocolVersion() const { return c_protocolVersion; }
+    u256 networkId() const { return m_networkId; }
+    void setNetworkId(u256 _n) { m_networkId = _n; }
 
-	void reset();
-	/// Don't sync further - used only in test mode
-	void completeSync();
+    void reset();
+    /// Don't sync further - used only in test mode
+    void completeSync();
 
-	bool isSyncing() const;
-	bool isBanned(p2p::NodeID const& _id) const { return !!m_banned.count(_id); }
+    bool isSyncing() const;
+    bool isBanned(p2p::NodeID const& _id) const { return !!m_banned.count(_id); }
 
-	void noteNewTransactions() { m_newTransactions = true; }
-	void noteNewBlocks() { m_newBlocks = true; }
-	void onBlockImported(BlockHeader const& _info) { m_sync->onBlockImported(_info); }
+    void noteNewTransactions() { m_newTransactions = true; }
+    void noteNewBlocks() { m_newBlocks = true; }
+    void onBlockImported(BlockHeader const& _info) { m_sync->onBlockImported(_info); }
 
-	BlockChain const& chain() const { return m_chain; }
-	OverlayDB const& db() const { return m_db; }
-	BlockQueue& bq() { return m_bq; }
-	BlockQueue const& bq() const { return m_bq; }
-	SyncStatus status() const;
-	h256 latestBlockSent() { return m_latestBlockSent; }
-	static char const* stateName(SyncState _s) { return s_stateNames[static_cast<int>(_s)]; }
+    BlockChain const& chain() const { return m_chain; }
+    OverlayDB const& db() const { return m_db; }
+    BlockQueue& bq() { return m_bq; }
+    BlockQueue const& bq() const { return m_bq; }
+    SyncStatus status() const;
+    h256 latestBlockSent() { return m_latestBlockSent; }
+    static char const* stateName(SyncState _s) { return s_stateNames[static_cast<int>(_s)]; }
 
-	static unsigned const c_oldProtocolVersion;
-	void foreachPeer(std::function<bool(std::shared_ptr<EthereumPeer>)> const& _f) const;
+    static unsigned const c_oldProtocolVersion;
+    void foreachPeer(std::function<bool(std::shared_ptr<EthereumPeer>)> const& _f) const;
 
 protected:
-	std::shared_ptr<p2p::Capability> newPeerCapability(std::shared_ptr<p2p::SessionFace> const& _s, unsigned _idOffset, p2p::CapDesc const& _cap) override;
+    std::shared_ptr<p2p::Capability> newPeerCapability(std::shared_ptr<p2p::SessionFace> const& _s, unsigned _idOffset, p2p::CapDesc const& _cap) override;
 
 private:
-	static char const* const s_stateNames[static_cast<int>(SyncState::Size)];
+    static char const* const s_stateNames[static_cast<int>(SyncState::Size)];
 
-	std::tuple<std::vector<std::shared_ptr<EthereumPeer>>, std::vector<std::shared_ptr<EthereumPeer>>, std::vector<std::shared_ptr<p2p::SessionFace>>> randomSelection(unsigned _percent = 25, std::function<bool(EthereumPeer*)> const& _allow = [](EthereumPeer const*){ return true; });
+    std::tuple<std::vector<std::shared_ptr<EthereumPeer>>, std::vector<std::shared_ptr<EthereumPeer>>, std::vector<std::shared_ptr<p2p::SessionFace>>> randomSelection(unsigned _percent = 25, std::function<bool(EthereumPeer*)> const& _allow = [](EthereumPeer const*){ return true; });
 
-	/// Sync with the BlockChain. It might contain one of our mined blocks, we might have new candidates from the network.
-	virtual void doWork() override;
+    /// Sync with the BlockChain. It might contain one of our mined blocks, we might have new candidates from the network.
+    virtual void doWork() override;
 
-	void maintainTransactions();
-	void maintainBlocks(h256 const& _currentBlock);
-	void onTransactionImported(ImportResult _ir, h256 const& _h, h512 const& _nodeId);
+    void maintainTransactions();
+    void maintainBlocks(h256 const& _currentBlock);
+    void onTransactionImported(ImportResult _ir, h256 const& _h, h512 const& _nodeId);
 
-	///	Check to see if the network peer-state initialisation has happened.
-	bool isInitialised() const { return (bool)m_latestBlockSent; }
+    ///	Check to see if the network peer-state initialisation has happened.
+    bool isInitialised() const { return (bool)m_latestBlockSent; }
 
-	/// Initialises the network peer-state, doing the stuff that needs to be once-only. @returns true if it really was first.
-	bool ensureInitialised();
+    /// Initialises the network peer-state, doing the stuff that needs to be once-only. @returns true if it really was first.
+    bool ensureInitialised();
 
-	virtual void onStarting() override { startWorking(); }
-	virtual void onStopping() override { stopWorking(); }
+    virtual void onStarting() override { startWorking(); }
+    virtual void onStopping() override { stopWorking(); }
 
-	BlockChain const& m_chain;
-	OverlayDB const& m_db;					///< References to DB, needed for some of the Ethereum Protocol responses.
-	TransactionQueue& m_tq;					///< Maintains a list of incoming transactions not yet in a block on the blockchain.
-	BlockQueue& m_bq;						///< Maintains a list of incoming blocks not yet on the blockchain (to be imported).
+    BlockChain const& m_chain;
+    OverlayDB const& m_db;					///< References to DB, needed for some of the Ethereum Protocol responses.
+    TransactionQueue& m_tq;					///< Maintains a list of incoming transactions not yet in a block on the blockchain.
+    BlockQueue& m_bq;						///< Maintains a list of incoming blocks not yet on the blockchain (to be imported).
 
-	u256 m_networkId;
+    u256 m_networkId;
 
-	h256 m_latestBlockSent;
-	h256Hash m_transactionsSent;
+    h256 m_latestBlockSent;
+    h256Hash m_transactionsSent;
 
-	std::unordered_set<p2p::NodeID> m_banned;
+    std::unordered_set<p2p::NodeID> m_banned;
 
-	bool m_newTransactions = false;
-	bool m_newBlocks = false;
+    bool m_newTransactions = false;
+    bool m_newBlocks = false;
 
-	mutable Mutex x_transactions;
-	std::shared_ptr<BlockChainSync> m_sync;
-	std::atomic<time_t> m_lastTick = { 0 };
+    mutable Mutex x_transactions;
+    std::shared_ptr<BlockChainSync> m_sync;
+    std::atomic<time_t> m_lastTick = { 0 };
 
-	std::shared_ptr<EthereumHostDataFace> m_hostData;
-	std::shared_ptr<EthereumPeerObserverFace> m_peerObserver;
+    std::shared_ptr<EthereumHostDataFace> m_hostData;
+    std::shared_ptr<EthereumPeerObserverFace> m_peerObserver;
 };
 
 }

--- a/libethereum/EthereumPeer.cpp
+++ b/libethereum/EthereumPeer.cpp
@@ -147,7 +147,7 @@ void EthereumPeer::requestBlockHeaders(unsigned _startNumber, unsigned _count, u
 {
     if (m_asking != Asking::Nothing)
     {
-        clog(NetWarn) << "Asking headers while requesting " << ::toString(m_asking);
+        cnetwarn << "Asking headers while requesting " << ::toString(m_asking);
     }
     setAsking(Asking::BlockHeaders);
     RLPStream s;
@@ -161,7 +161,7 @@ void EthereumPeer::requestBlockHeaders(h256 const& _startHash, unsigned _count, 
 {
     if (m_asking != Asking::Nothing)
     {
-        clog(NetWarn) << "Asking headers while requesting " << ::toString(m_asking);
+        cnetwarn << "Asking headers while requesting " << ::toString(m_asking);
     }
     setAsking(Asking::BlockHeaders);
     RLPStream s;
@@ -191,7 +191,8 @@ void EthereumPeer::requestByHashes(h256s const& _hashes, Asking _asking, Subprot
 {
     if (m_asking != Asking::Nothing)
     {
-        clog(NetWarn) << "Asking "<< ::toString(_asking) << " while requesting " << ::toString(m_asking);
+        cnetwarn << "Asking " << ::toString(_asking) << " while requesting "
+                 << ::toString(m_asking);
     }
     setAsking(_asking);
     if (_hashes.size())
@@ -429,11 +430,12 @@ bool EthereumPeer::interpret(unsigned _id, RLP const& _r)
     }
     catch (Exception const&)
     {
-        clog(NetWarn) << "Peer causing an Exception:" << boost::current_exception_diagnostic_information() << _r;
+        cnetwarn << "Peer causing an Exception: "
+                 << boost::current_exception_diagnostic_information() << " " << _r;
     }
     catch (std::exception const& _e)
     {
-        clog(NetWarn) << "Peer causing an exception:" << _e.what() << _r;
+        cnetwarn << "Peer causing an exception: " << _e.what() << " " << _r;
     }
 
     return true;

--- a/libethereum/EthereumPeer.cpp
+++ b/libethereum/EthereumPeer.cpp
@@ -261,7 +261,7 @@ bool EthereumPeer::interpret(unsigned _id, RLP const& _r)
         if (m_peerCapabilityVersion == m_hostProtocolVersion)
             m_protocolVersion = m_hostProtocolVersion;
 
-        clog(NetMessageSummary) << "Status:" << m_protocolVersion << "/" << m_networkId << "/" << m_genesisHash << ", TD:" << m_totalDifficulty << "=" << m_latestHash;
+        cnetmessage << "Status: " << m_protocolVersion << " / " << m_networkId << " / " << m_genesisHash << ", TD: " << m_totalDifficulty << " = " << m_latestHash;
         setIdle();
         observer->onPeerStatus(dynamic_pointer_cast<EthereumPeer>(dynamic_pointer_cast<EthereumPeer>(shared_from_this())));
         break;
@@ -310,7 +310,7 @@ bool EthereumPeer::interpret(unsigned _id, RLP const& _r)
     case GetBlockBodiesPacket:
     {
         unsigned count = static_cast<unsigned>(_r.itemCount());
-        clog(NetMessageSummary) << "GetBlockBodies (" << dec << count << "entries)";
+        cnetmessage << "GetBlockBodies (" << dec << count << " entries)";
 
         if (!count)
         {
@@ -347,7 +347,7 @@ bool EthereumPeer::interpret(unsigned _id, RLP const& _r)
     {
         unsigned itemCount = _r.itemCount();
 
-        clog(NetMessageSummary) << "BlockHashes (" << dec << itemCount << "entries)" << (itemCount ? "" : ": NoMoreHashes");
+        cnetmessage << "BlockHashes (" << dec << itemCount << " entries) " << (itemCount ? "" : " : NoMoreHashes");
 
         if (itemCount > c_maxIncomingNewHashes)
         {
@@ -371,7 +371,7 @@ bool EthereumPeer::interpret(unsigned _id, RLP const& _r)
             addRating(-10);
             break;
         }
-        clog(NetMessageSummary) << "GetNodeData (" << dec << count << " entries)";
+        cnetmessage << "GetNodeData (" << dec << count << " entries)";
 
         strings const data = hostData->nodeData(_r);
 
@@ -392,7 +392,7 @@ bool EthereumPeer::interpret(unsigned _id, RLP const& _r)
             addRating(-10);
             break;
         }
-        clog(NetMessageSummary) << "GetReceipts (" << dec << count << " entries)";
+        cnetmessage << "GetReceipts (" << dec << count << " entries)";
 
         pair<bytes, unsigned> const rlpAndItemCount = hostData->receipts(_r);
 

--- a/libethereum/EthereumPeer.cpp
+++ b/libethereum/EthereumPeer.cpp
@@ -299,7 +299,7 @@ bool EthereumPeer::interpret(unsigned _id, RLP const& _r)
     case BlockHeadersPacket:
     {
         if (m_asking != Asking::BlockHeaders)
-            clog(NetImpolite) << "Peer giving us block headers when we didn't ask for them.";
+            LOG(m_loggerImpolite) << "Peer giving us block headers when we didn't ask for them.";
         else
         {
             setIdle();
@@ -314,7 +314,7 @@ bool EthereumPeer::interpret(unsigned _id, RLP const& _r)
 
         if (!count)
         {
-            clog(NetImpolite) << "Zero-entry GetBlockBodies: Not replying.";
+            LOG(m_loggerImpolite) << "Zero-entry GetBlockBodies: Not replying.";
             addRating(-10);
             break;
         }
@@ -330,7 +330,7 @@ bool EthereumPeer::interpret(unsigned _id, RLP const& _r)
     case BlockBodiesPacket:
     {
         if (m_asking != Asking::BlockBodies)
-            clog(NetImpolite) << "Peer giving us block bodies when we didn't ask for them.";
+            LOG(m_loggerImpolite) << "Peer giving us block bodies when we didn't ask for them.";
         else
         {
             setIdle();
@@ -367,7 +367,7 @@ bool EthereumPeer::interpret(unsigned _id, RLP const& _r)
         unsigned count = static_cast<unsigned>(_r.itemCount());
         if (!count)
         {
-            clog(NetImpolite) << "Zero-entry GetNodeData: Not replying.";
+            LOG(m_loggerImpolite) << "Zero-entry GetNodeData: Not replying.";
             addRating(-10);
             break;
         }
@@ -388,7 +388,7 @@ bool EthereumPeer::interpret(unsigned _id, RLP const& _r)
         unsigned count = static_cast<unsigned>(_r.itemCount());
         if (!count)
         {
-            clog(NetImpolite) << "Zero-entry GetReceipts: Not replying.";
+            LOG(m_loggerImpolite) << "Zero-entry GetReceipts: Not replying.";
             addRating(-10);
             break;
         }
@@ -405,7 +405,7 @@ bool EthereumPeer::interpret(unsigned _id, RLP const& _r)
     case NodeDataPacket:
     {
         if (m_asking != Asking::NodeData)
-            clog(NetImpolite) << "Peer giving us node data when we didn't ask for them.";
+            LOG(m_loggerImpolite) << "Peer giving us node data when we didn't ask for them.";
         else
         {
             setIdle();
@@ -416,7 +416,7 @@ bool EthereumPeer::interpret(unsigned _id, RLP const& _r)
     case ReceiptsPacket:
     {
         if (m_asking != Asking::Receipts)
-            clog(NetImpolite) << "Peer giving us receipts when we didn't ask for them.";
+            LOG(m_loggerImpolite) << "Peer giving us receipts when we didn't ask for them.";
         else
         {
             setIdle();

--- a/libethereum/EthereumPeer.cpp
+++ b/libethereum/EthereumPeer.cpp
@@ -65,7 +65,7 @@ EthereumPeer::~EthereumPeer()
 {
     if (m_asking != Asking::Nothing)
     {
-        clog(NetAllDetail) << "Peer aborting while being asked for " << ::toString(m_asking);
+        cnetdetails << "Peer aborting while being asked for " << ::toString(m_asking);
         setRude();
     }
     abortSync();
@@ -284,7 +284,7 @@ bool EthereumPeer::interpret(unsigned _id, RLP const& _r)
 
         if (skip > std::numeric_limits<unsigned>::max() - 1)
         {
-            clog(NetAllDetail) << "Requested block skip is too big: " << skip;
+            cnetdetails << "Requested block skip is too big: " << skip;
             break;
         }
 

--- a/libethereum/EthereumPeer.cpp
+++ b/libethereum/EthereumPeer.cpp
@@ -152,7 +152,7 @@ void EthereumPeer::requestBlockHeaders(unsigned _startNumber, unsigned _count, u
     setAsking(Asking::BlockHeaders);
     RLPStream s;
     prep(s, GetBlockHeadersPacket, 4) << _startNumber << _count << _skip << (_reverse ? 1 : 0);
-    clog(NetMessageDetail) << "Requesting " << _count << " block headers starting from " << _startNumber << (_reverse ? " in reverse" : "");
+    cnetmessage << "Requesting " << _count << " block headers starting from " << _startNumber << (_reverse ? " in reverse" : "");
     m_lastAskedHeaders = _count;
     sealAndSend(s);
 }
@@ -166,7 +166,7 @@ void EthereumPeer::requestBlockHeaders(h256 const& _startHash, unsigned _count, 
     setAsking(Asking::BlockHeaders);
     RLPStream s;
     prep(s, GetBlockHeadersPacket, 4) << _startHash << _count << _skip << (_reverse ? 1 : 0);
-    clog(NetMessageDetail) << "Requesting " << _count << " block headers starting from " << _startHash << (_reverse ? " in reverse" : "");
+    cnetmessage << "Requesting " << _count << " block headers starting from " << _startHash << (_reverse ? " in reverse" : "");
     m_lastAskedHeaders = _count;
     sealAndSend(s);
 }

--- a/libethereum/EthereumPeer.cpp
+++ b/libethereum/EthereumPeer.cpp
@@ -152,7 +152,8 @@ void EthereumPeer::requestBlockHeaders(unsigned _startNumber, unsigned _count, u
     setAsking(Asking::BlockHeaders);
     RLPStream s;
     prep(s, GetBlockHeadersPacket, 4) << _startNumber << _count << _skip << (_reverse ? 1 : 0);
-    cnetmessage << "Requesting " << _count << " block headers starting from " << _startNumber << (_reverse ? " in reverse" : "");
+    cnetlog << "Requesting " << _count << " block headers starting from " << _startNumber
+            << (_reverse ? " in reverse" : "");
     m_lastAskedHeaders = _count;
     sealAndSend(s);
 }
@@ -166,7 +167,8 @@ void EthereumPeer::requestBlockHeaders(h256 const& _startHash, unsigned _count, 
     setAsking(Asking::BlockHeaders);
     RLPStream s;
     prep(s, GetBlockHeadersPacket, 4) << _startHash << _count << _skip << (_reverse ? 1 : 0);
-    cnetmessage << "Requesting " << _count << " block headers starting from " << _startHash << (_reverse ? " in reverse" : "");
+    cnetlog << "Requesting " << _count << " block headers starting from " << _startHash
+            << (_reverse ? " in reverse" : "");
     m_lastAskedHeaders = _count;
     sealAndSend(s);
 }
@@ -261,7 +263,8 @@ bool EthereumPeer::interpret(unsigned _id, RLP const& _r)
         if (m_peerCapabilityVersion == m_hostProtocolVersion)
             m_protocolVersion = m_hostProtocolVersion;
 
-        cnetmessage << "Status: " << m_protocolVersion << " / " << m_networkId << " / " << m_genesisHash << ", TD: " << m_totalDifficulty << " = " << m_latestHash;
+        cnetlog << "Status: " << m_protocolVersion << " / " << m_networkId << " / " << m_genesisHash
+                << ", TD: " << m_totalDifficulty << " = " << m_latestHash;
         setIdle();
         observer->onPeerStatus(dynamic_pointer_cast<EthereumPeer>(dynamic_pointer_cast<EthereumPeer>(shared_from_this())));
         break;
@@ -310,7 +313,7 @@ bool EthereumPeer::interpret(unsigned _id, RLP const& _r)
     case GetBlockBodiesPacket:
     {
         unsigned count = static_cast<unsigned>(_r.itemCount());
-        cnetmessage << "GetBlockBodies (" << dec << count << " entries)";
+        cnetlog << "GetBlockBodies (" << dec << count << " entries)";
 
         if (!count)
         {
@@ -347,7 +350,8 @@ bool EthereumPeer::interpret(unsigned _id, RLP const& _r)
     {
         unsigned itemCount = _r.itemCount();
 
-        cnetmessage << "BlockHashes (" << dec << itemCount << " entries) " << (itemCount ? "" : " : NoMoreHashes");
+        cnetlog << "BlockHashes (" << dec << itemCount << " entries) "
+                << (itemCount ? "" : " : NoMoreHashes");
 
         if (itemCount > c_maxIncomingNewHashes)
         {
@@ -371,7 +375,7 @@ bool EthereumPeer::interpret(unsigned _id, RLP const& _r)
             addRating(-10);
             break;
         }
-        cnetmessage << "GetNodeData (" << dec << count << " entries)";
+        cnetlog << "GetNodeData (" << dec << count << " entries)";
 
         strings const data = hostData->nodeData(_r);
 
@@ -392,7 +396,7 @@ bool EthereumPeer::interpret(unsigned _id, RLP const& _r)
             addRating(-10);
             break;
         }
-        cnetmessage << "GetReceipts (" << dec << count << " entries)";
+        cnetlog << "GetReceipts (" << dec << count << " entries)";
 
         pair<bytes, unsigned> const rlpAndItemCount = hostData->receipts(_r);
 

--- a/libethereum/EthereumPeer.h
+++ b/libethereum/EthereumPeer.h
@@ -194,6 +194,9 @@ private:
 
 	std::weak_ptr<EthereumPeerObserverFace> m_observer;
 	std::weak_ptr<EthereumHostDataFace> m_hostData;
+
+    /// Logger for messages about impolite behaivour of peers.
+    Logger m_loggerImpolite{createLogger(3, "impolite")};
 };
 
 }

--- a/libethereum/Executive.cpp
+++ b/libethereum/Executive.cpp
@@ -258,7 +258,8 @@ bool Executive::execute()
     // Entry point for a user-executed transaction.
 
     // Pay...
-    clog(StateDetail) << "Paying " << formatBalance(m_gasCost) << " from sender for gas (" << m_t.gas() << " gas at " << formatBalance(m_t.gasPrice()) << ")";
+    LOG(m_detailsLogger) << "Paying " << formatBalance(m_gasCost) << " from sender for gas ("
+                         << m_t.gas() << " gas at " << formatBalance(m_t.gasPrice()) << ")";
     m_s.subBalance(m_t.sender(), m_gasCost);
 
     assert(m_t.gas() >= (u256)m_baseGasRequired);
@@ -374,7 +375,7 @@ bool Executive::executeCreate(Address const& _sender, u256 const& _endowment, u2
     bool accountAlreadyExist = (m_s.addressHasCode(m_newAddress) || m_s.getNonce(m_newAddress) > 0);
     if (accountAlreadyExist)
     {
-        clog(StateSafeExceptions) << "Address already used: " << m_newAddress;
+        LOG(m_detailsLogger) << "Address already used: " << m_newAddress;
         m_gas = 0;
         m_excepted = TransactionException::AddressAlreadyUsed;
         revert();
@@ -474,7 +475,7 @@ bool Executive::go(OnOpFunc const& _onOp)
         }
         catch (VMException const& _e)
         {
-            clog(StateSafeExceptions) << "Safe VM Exception. " << diagnostic_information(_e);
+            LOG(m_detailsLogger) << "Safe VM Exception. " << diagnostic_information(_e);
             m_gas = 0;
             m_excepted = toTransactionException(_e);
             revert();

--- a/libethereum/Executive.cpp
+++ b/libethereum/Executive.cpp
@@ -233,7 +233,7 @@ void Executive::initialize(Transaction const& _transaction)
         {
             BOOST_LOG(m_execLogger)
                 << "Sender: " << m_t.sender().hex() << " Invalid Nonce: Require " << nonceReq
-                << " Got" << m_t.nonce();
+                << " Got " << m_t.nonce();
             m_excepted = TransactionException::InvalidNonce;
             BOOST_THROW_EXCEPTION(InvalidNonce() << RequirementError((bigint)nonceReq, (bigint)m_t.nonce()));
         }
@@ -243,8 +243,8 @@ void Executive::initialize(Transaction const& _transaction)
         bigint totalCost = m_t.value() + gasCost;
         if (m_s.balance(m_t.sender()) < totalCost)
         {
-            BOOST_LOG(m_execLogger) << "Not enough cash: Require >" << totalCost << "=" << m_t.gas()
-                                    << "*" << m_t.gasPrice() << "+" << m_t.value() << " Got"
+            BOOST_LOG(m_execLogger) << "Not enough cash: Require > " << totalCost << " = " << m_t.gas()
+                                    << " * " << m_t.gasPrice() << " + " << m_t.value() << " Got"
                                     << m_s.balance(m_t.sender()) << " for sender: " << m_t.sender();
             m_excepted = TransactionException::NotEnoughCash;
             m_excepted = TransactionException::NotEnoughCash;
@@ -259,7 +259,7 @@ bool Executive::execute()
     // Entry point for a user-executed transaction.
 
     // Pay...
-    clog(StateDetail) << "Paying" << formatBalance(m_gasCost) << "from sender for gas (" << m_t.gas() << "gas at" << formatBalance(m_t.gasPrice()) << ")";
+    clog(StateDetail) << "Paying " << formatBalance(m_gasCost) << " from sender for gas (" << m_t.gas() << " gas at " << formatBalance(m_t.gasPrice()) << ")";
     m_s.subBalance(m_t.sender(), m_gasCost);
 
     assert(m_t.gas() >= (u256)m_baseGasRequired);

--- a/libethereum/Executive.cpp
+++ b/libethereum/Executive.cpp
@@ -225,15 +225,14 @@ void Executive::initialize(Transaction const& _transaction)
         }
         catch (InvalidSignature const&)
         {
-            BOOST_LOG(m_execLogger) << "Invalid Signature";
+            LOG(m_execLogger) << "Invalid Signature";
             m_excepted = TransactionException::InvalidSignature;
             throw;
         }
         if (m_t.nonce() != nonceReq)
         {
-            BOOST_LOG(m_execLogger)
-                << "Sender: " << m_t.sender().hex() << " Invalid Nonce: Require " << nonceReq
-                << " Got " << m_t.nonce();
+            LOG(m_execLogger) << "Sender: " << m_t.sender().hex() << " Invalid Nonce: Require "
+                              << nonceReq << " Got " << m_t.nonce();
             m_excepted = TransactionException::InvalidNonce;
             BOOST_THROW_EXCEPTION(InvalidNonce() << RequirementError((bigint)nonceReq, (bigint)m_t.nonce()));
         }
@@ -243,9 +242,9 @@ void Executive::initialize(Transaction const& _transaction)
         bigint totalCost = m_t.value() + gasCost;
         if (m_s.balance(m_t.sender()) < totalCost)
         {
-            BOOST_LOG(m_execLogger) << "Not enough cash: Require > " << totalCost << " = " << m_t.gas()
-                                    << " * " << m_t.gasPrice() << " + " << m_t.value() << " Got"
-                                    << m_s.balance(m_t.sender()) << " for sender: " << m_t.sender();
+            LOG(m_execLogger) << "Not enough cash: Require > " << totalCost << " = " << m_t.gas()
+                              << " * " << m_t.gasPrice() << " + " << m_t.value() << " Got"
+                              << m_s.balance(m_t.sender()) << " for sender: " << m_t.sender();
             m_excepted = TransactionException::NotEnoughCash;
             m_excepted = TransactionException::NotEnoughCash;
             BOOST_THROW_EXCEPTION(NotEnoughCash() << RequirementError(totalCost, (bigint)m_s.balance(m_t.sender())) << errinfo_comment(m_t.sender().hex()));
@@ -411,13 +410,13 @@ OnOpFunc Executive::simpleTrace()
 
         ostringstream o;
         if (vm)
-            BOOST_LOG(traceLogger) << dumpStackAndMemory(*vm);
-        BOOST_LOG(traceLogger) << dumpStorage(ext);
-        BOOST_LOG(traceLogger) << " < " << dec << ext.depth << " : " << ext.myAddress << " : #"
-                               << steps << " : " << hex << setw(4) << setfill('0') << PC << " : "
-                               << instructionInfo(inst).name << " : " << dec << gas << " : -" << dec
-                               << gasCost << " : " << newMemSize << "x32"
-                               << " >";
+            LOG(traceLogger) << dumpStackAndMemory(*vm);
+        LOG(traceLogger) << dumpStorage(ext);
+        LOG(traceLogger) << " < " << dec << ext.depth << " : " << ext.myAddress << " : #" << steps
+                         << " : " << hex << setw(4) << setfill('0') << PC << " : "
+                         << instructionInfo(inst).name << " : " << dec << gas << " : -" << dec
+                         << gasCost << " : " << newMemSize << "x32"
+                         << " >";
     };
 }
 

--- a/libethereum/Executive.h
+++ b/libethereum/Executive.h
@@ -43,9 +43,6 @@ class ExtVM;
 class SealEngineFace;
 struct Manifest;
 
-struct VMTraceChannel: public LogChannel { static const char* name(); static const int verbosity = 11; };
-struct ExecutiveWarnChannel: public LogChannel { static const char* name(); static const int verbosity = 1; };
-
 class StandardTrace
 {
 public:
@@ -170,7 +167,7 @@ public:
     bool go(OnOpFunc const& _onOp = OnOpFunc());
 
     /// Operation function for providing a simple trace of the VM execution.
-    static OnOpFunc simpleTrace();
+    OnOpFunc simpleTrace();
 
     /// @returns gas remaining after the transaction/operation. Valid after the transaction has been executed.
     u256 gas() const { return m_gas; }
@@ -213,6 +210,9 @@ private:
     bool m_isCreation = false;
     Address m_newAddress;
     size_t m_savepoint = 0;
+
+    Logger m_execLogger{createLogger(1, "exec")};
+    Logger m_vmTraceLogger{createLogger(11, "vmtrace")};
 };
 
 }

--- a/libethereum/Executive.h
+++ b/libethereum/Executive.h
@@ -212,6 +212,7 @@ private:
     size_t m_savepoint = 0;
 
     Logger m_execLogger{createLogger(1, "exec")};
+    Logger m_detailsLogger{createLogger(14, "exec")};
     Logger m_vmTraceLogger{createLogger(11, "vmtrace")};
 };
 

--- a/libethereum/SnapshotImporter.h
+++ b/libethereum/SnapshotImporter.h
@@ -1,18 +1,18 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file
  *  Class for importing snapshot from directory on disk
@@ -39,16 +39,18 @@ class StateImporterFace;
 class SnapshotImporter
 {
 public:
-	SnapshotImporter(StateImporterFace& _stateImporter, BlockChainImporterFace& _bcImporter): m_stateImporter(_stateImporter), m_blockChainImporter(_bcImporter) {}
+    SnapshotImporter(StateImporterFace& _stateImporter, BlockChainImporterFace& _bcImporter): m_stateImporter(_stateImporter), m_blockChainImporter(_bcImporter) {}
 
     void import(SnapshotStorageFace const& _snapshotStorage, h256 const& _genesisHash);
 
 private:
-	void importStateChunks(SnapshotStorageFace const& _snapshotStorage, h256s const& _stateChunkHashes, h256 const& _stateRoot);
-	void importBlockChunks(SnapshotStorageFace const& _snapshotStorage, h256s const& _blockChunkHashes);
+    void importStateChunks(SnapshotStorageFace const& _snapshotStorage, h256s const& _stateChunkHashes, h256 const& _stateRoot);
+    void importBlockChunks(SnapshotStorageFace const& _snapshotStorage, h256s const& _blockChunkHashes);
 
-	StateImporterFace& m_stateImporter;
-	BlockChainImporterFace& m_blockChainImporter;
+    StateImporterFace& m_stateImporter;
+    BlockChainImporterFace& m_blockChainImporter;
+
+    Logger m_logger{createLogger(1, "snap")};
 };
 
 }

--- a/libethereum/State.cpp
+++ b/libethereum/State.cpp
@@ -40,8 +40,6 @@ namespace fs = boost::filesystem;
 
 const char* StateSafeExceptions::name() { return EthViolet "⚙" EthBlue " ℹ"; }
 const char* StateDetail::name() { return EthViolet "⚙" EthWhite " ◌"; }
-const char* StateTrace::name() { return EthViolet "⚙" EthGray " ◎"; }
-const char* StateChat::name() { return EthViolet "⚙" EthWhite " ◌"; }
 
 namespace
 {

--- a/libethereum/State.cpp
+++ b/libethereum/State.cpp
@@ -555,17 +555,16 @@ void State::rollback(size_t _savepoint)
 
 std::pair<ExecutionResult, TransactionReceipt> State::execute(EnvInfo const& _envInfo, SealEngineFace const& _sealEngine, Transaction const& _t, Permanence _p, OnOpFunc const& _onOp)
 {
-    auto onOp = _onOp;
-#if ETH_VMTRACE
-    if (isChannelVisible<VMTraceChannel>())
-        onOp = Executive::simpleTrace(); // override tracer
-#endif
-
     // Create and initialize the executive. This will throw fairly cheaply and quickly if the
     // transaction is bad in any way.
     Executive e(*this, _envInfo, _sealEngine);
     ExecutionResult res;
     e.setResultRecipient(res);
+
+    auto onOp = _onOp;
+#if ETH_VMTRACE
+    onOp = e.simpleTrace();  // override tracer
+#endif
 
     u256 const startGasUsed = _envInfo.gasUsed();
     bool const statusCode = executeTransaction(e, _t, onOp);

--- a/libethereum/State.cpp
+++ b/libethereum/State.cpp
@@ -38,9 +38,6 @@ using namespace dev;
 using namespace dev::eth;
 namespace fs = boost::filesystem;
 
-const char* StateSafeExceptions::name() { return EthViolet "⚙" EthBlue " ℹ"; }
-const char* StateDetail::name() { return EthViolet "⚙" EthWhite " ◌"; }
-
 namespace
 {
 
@@ -82,7 +79,7 @@ OverlayDB State::openDB(fs::path const& _basePath, h256 const& _genesisHash, Wit
 
     if (_we == WithExisting::Kill)
     {
-        clog(StateDetail) << "Killing state database (WithExisting::Kill).";
+        clogSimple(14, "statedb") << "Killing state database (WithExisting::Kill).";
         fs::remove_all(path / fs::path("state"));
     }
 
@@ -93,7 +90,7 @@ OverlayDB State::openDB(fs::path const& _basePath, h256 const& _genesisHash, Wit
     try
     {
         std::unique_ptr<db::DatabaseFace> db(new db::DBImpl(path / fs::path("state")));
-        clog(StateDetail) << "Opened state DB.";
+        clogSimple(14, "statedb") << "Opened state DB.";
         return OverlayDB(std::move(db));
     }
     catch (boost::exception const& ex)

--- a/libethereum/State.h
+++ b/libethereum/State.h
@@ -63,8 +63,6 @@ class State;
 class TransactionQueue;
 struct VerifiedBlockRef;
 
-struct StateChat: public LogChannel { static const char* name(); static const int verbosity = 4; };
-struct StateTrace: public LogChannel { static const char* name(); static const int verbosity = 5; };
 struct StateDetail: public LogChannel { static const char* name(); static const int verbosity = 14; };
 struct StateSafeExceptions: public LogChannel { static const char* name(); static const int verbosity = 21; };
 

--- a/libethereum/State.h
+++ b/libethereum/State.h
@@ -1,18 +1,18 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 #pragma once
@@ -68,15 +68,15 @@ struct StateSafeExceptions: public LogChannel { static const char* name(); stati
 
 enum class BaseState
 {
-	PreExisting,
-	Empty
+    PreExisting,
+    Empty
 };
 
 enum class Permanence
 {
-	Reverted,
-	Committed,
-	Uncommitted	///< Uncommitted state for change log readings in tests.
+    Reverted,
+    Committed,
+    Uncommitted	///< Uncommitted state for change log readings in tests.
 };
 
 #if ETH_FATDB
@@ -94,60 +94,60 @@ class Executive;
 /// An atomic state changelog entry.
 struct Change
 {
-	enum Kind: int
-	{
-		/// Account balance changed. Change::value contains the amount the
-		/// balance was increased by.
-		Balance,
+    enum Kind: int
+    {
+        /// Account balance changed. Change::value contains the amount the
+        /// balance was increased by.
+        Balance,
 
-		/// Account storage was modified. Change::key contains the storage key,
-		/// Change::value the storage value.
-		Storage,
+        /// Account storage was modified. Change::key contains the storage key,
+        /// Change::value the storage value.
+        Storage,
 
-		/// Account storage root was modified.  Change::value contains the old
-		/// account storage root.
-		StorageRoot,
+        /// Account storage root was modified.  Change::value contains the old
+        /// account storage root.
+        StorageRoot,
 
-		/// Account nonce was changed.
-		Nonce,
+        /// Account nonce was changed.
+        Nonce,
 
-		/// Account was created (it was not existing before).
-		Create,
+        /// Account was created (it was not existing before).
+        Create,
 
-		/// New code was added to an account (by "create" message execution).
-		Code,
+        /// New code was added to an account (by "create" message execution).
+        Code,
 
-		/// Account was touched for the first time.
-		Touch
-	};
+        /// Account was touched for the first time.
+        Touch
+    };
 
-	Kind kind;        ///< The kind of the change.
-	Address address;  ///< Changed account address.
-	u256 value;       ///< Change value, e.g. balance, storage and nonce.
-	u256 key;         ///< Storage key. Last because used only in one case.
-	bytes oldCode;    ///< Code overwritten by CREATE, empty except in case of address collision.
+    Kind kind;        ///< The kind of the change.
+    Address address;  ///< Changed account address.
+    u256 value;       ///< Change value, e.g. balance, storage and nonce.
+    u256 key;         ///< Storage key. Last because used only in one case.
+    bytes oldCode;    ///< Code overwritten by CREATE, empty except in case of address collision.
 
-	/// Helper constructor to make change log update more readable.
-	Change(Kind _kind, Address const& _addr, u256 const& _value = 0):
-			kind(_kind), address(_addr), value(_value)
-	{
-		assert(_kind != Code); // For this the special constructor needs to be used.
-	}
+    /// Helper constructor to make change log update more readable.
+    Change(Kind _kind, Address const& _addr, u256 const& _value = 0):
+            kind(_kind), address(_addr), value(_value)
+    {
+        assert(_kind != Code); // For this the special constructor needs to be used.
+    }
 
-	/// Helper constructor especially for storage change log.
-	Change(Address const& _addr, u256 const& _key, u256 const& _value):
-			kind(Storage), address(_addr), value(_value), key(_key)
-	{}
+    /// Helper constructor especially for storage change log.
+    Change(Address const& _addr, u256 const& _key, u256 const& _value):
+            kind(Storage), address(_addr), value(_value), key(_key)
+    {}
 
-	/// Helper constructor for nonce change log.
-	Change(Address const& _addr, u256 const& _value):
-			kind(Nonce), address(_addr), value(_value)
-	{}
+    /// Helper constructor for nonce change log.
+    Change(Address const& _addr, u256 const& _value):
+            kind(Nonce), address(_addr), value(_value)
+    {}
 
-	/// Helper constructor especially for new code change log.
-	Change(Address const& _addr, bytes const& _oldCode):
-			kind(Code), address(_addr), oldCode(_oldCode)
-	{}
+    /// Helper constructor especially for new code change log.
+    Change(Address const& _addr, bytes const& _oldCode):
+            kind(Code), address(_addr), oldCode(_oldCode)
+    {}
 };
 
 using ChangeLog = std::vector<Change>;
@@ -167,195 +167,195 @@ using ChangeLog = std::vector<Change>;
  */
 class State
 {
-	friend class ExtVM;
-	friend class dev::test::ImportTest;
-	friend class dev::test::StateLoader;
-	friend class BlockChain;
+    friend class ExtVM;
+    friend class dev::test::ImportTest;
+    friend class dev::test::StateLoader;
+    friend class BlockChain;
 
 public:
-	enum class CommitBehaviour
-	{
-		KeepEmptyAccounts,
-		RemoveEmptyAccounts
-	};
+    enum class CommitBehaviour
+    {
+        KeepEmptyAccounts,
+        RemoveEmptyAccounts
+    };
 
-	/// Default constructor; creates with a blank database prepopulated with the genesis block.
-	explicit State(u256 const& _accountStartNonce): State(_accountStartNonce, OverlayDB(), BaseState::Empty) {}
+    /// Default constructor; creates with a blank database prepopulated with the genesis block.
+    explicit State(u256 const& _accountStartNonce): State(_accountStartNonce, OverlayDB(), BaseState::Empty) {}
 
-	/// Basic state object from database.
-	/// Use the default when you already have a database and you just want to make a State object
-	/// which uses it. If you have no preexisting database then set BaseState to something other
-	/// than BaseState::PreExisting in order to prepopulate the Trie.
-	explicit State(u256 const& _accountStartNonce, OverlayDB const& _db, BaseState _bs = BaseState::PreExisting);
+    /// Basic state object from database.
+    /// Use the default when you already have a database and you just want to make a State object
+    /// which uses it. If you have no preexisting database then set BaseState to something other
+    /// than BaseState::PreExisting in order to prepopulate the Trie.
+    explicit State(u256 const& _accountStartNonce, OverlayDB const& _db, BaseState _bs = BaseState::PreExisting);
 
-	enum NullType { Null };
-	State(NullType): State(Invalid256, OverlayDB(), BaseState::Empty) {}
+    enum NullType { Null };
+    State(NullType): State(Invalid256, OverlayDB(), BaseState::Empty) {}
 
-	/// Copy state object.
-	State(State const& _s);
+    /// Copy state object.
+    State(State const& _s);
 
-	/// Copy state object.
-	State& operator=(State const& _s);
+    /// Copy state object.
+    State& operator=(State const& _s);
 
-	/// Open a DB - useful for passing into the constructor & keeping for other states that are necessary.
-	static OverlayDB openDB(boost::filesystem::path const& _path, h256 const& _genesisHash, WithExisting _we = WithExisting::Trust);
-	OverlayDB const& db() const { return m_db; }
-	OverlayDB& db() { return m_db; }
+    /// Open a DB - useful for passing into the constructor & keeping for other states that are necessary.
+    static OverlayDB openDB(boost::filesystem::path const& _path, h256 const& _genesisHash, WithExisting _we = WithExisting::Trust);
+    OverlayDB const& db() const { return m_db; }
+    OverlayDB& db() { return m_db; }
 
-	/// Populate the state from the given AccountMap. Just uses dev::eth::commit().
-	void populateFrom(AccountMap const& _map);
+    /// Populate the state from the given AccountMap. Just uses dev::eth::commit().
+    void populateFrom(AccountMap const& _map);
 
-	/// @returns the set containing all addresses currently in use in Ethereum.
-	/// @warning This is slowslowslow. Don't use it unless you want to lock the object for seconds or minutes at a time.
-	/// @throws InterfaceNotSupported if compiled without ETH_FATDB.
-	std::unordered_map<Address, u256> addresses() const;
+    /// @returns the set containing all addresses currently in use in Ethereum.
+    /// @warning This is slowslowslow. Don't use it unless you want to lock the object for seconds or minutes at a time.
+    /// @throws InterfaceNotSupported if compiled without ETH_FATDB.
+    std::unordered_map<Address, u256> addresses() const;
 
-	/// Execute a given transaction.
-	/// This will change the state accordingly.
-	std::pair<ExecutionResult, TransactionReceipt> execute(EnvInfo const& _envInfo, SealEngineFace const& _sealEngine, Transaction const& _t, Permanence _p = Permanence::Committed, OnOpFunc const& _onOp = OnOpFunc());
+    /// Execute a given transaction.
+    /// This will change the state accordingly.
+    std::pair<ExecutionResult, TransactionReceipt> execute(EnvInfo const& _envInfo, SealEngineFace const& _sealEngine, Transaction const& _t, Permanence _p = Permanence::Committed, OnOpFunc const& _onOp = OnOpFunc());
 
-	/// Execute @a _txCount transactions of a given block.
-	/// This will change the state accordingly.
-	void executeBlockTransactions(Block const& _block, unsigned _txCount, LastBlockHashesFace const& _lastHashes, SealEngineFace const& _sealEngine);
+    /// Execute @a _txCount transactions of a given block.
+    /// This will change the state accordingly.
+    void executeBlockTransactions(Block const& _block, unsigned _txCount, LastBlockHashesFace const& _lastHashes, SealEngineFace const& _sealEngine);
 
-	/// Check if the address is in use.
-	bool addressInUse(Address const& _address) const;
+    /// Check if the address is in use.
+    bool addressInUse(Address const& _address) const;
 
-	/// Check if the account exists in the state and is non empty (nonce > 0 || balance > 0 || code nonempty).
-	/// These two notions are equivalent after EIP158.
-	bool accountNonemptyAndExisting(Address const& _address) const;
+    /// Check if the account exists in the state and is non empty (nonce > 0 || balance > 0 || code nonempty).
+    /// These two notions are equivalent after EIP158.
+    bool accountNonemptyAndExisting(Address const& _address) const;
 
-	/// Check if the address contains executable code.
-	bool addressHasCode(Address const& _address) const;
+    /// Check if the address contains executable code.
+    bool addressHasCode(Address const& _address) const;
 
-	/// Get an account's balance.
-	/// @returns 0 if the address has never been used.
-	u256 balance(Address const& _id) const;
+    /// Get an account's balance.
+    /// @returns 0 if the address has never been used.
+    u256 balance(Address const& _id) const;
 
-	/// Add some amount to balance.
-	/// Will initialise the address if it has never been used.
-	void addBalance(Address const& _id, u256 const& _amount);
+    /// Add some amount to balance.
+    /// Will initialise the address if it has never been used.
+    void addBalance(Address const& _id, u256 const& _amount);
 
-	/// Subtract the @p _value amount from the balance of @p _addr account.
-	/// @throws NotEnoughCash if the balance of the account is less than the
-	/// amount to be subtrackted (also in case the account does not exist).
-	void subBalance(Address const& _addr, u256 const& _value);
+    /// Subtract the @p _value amount from the balance of @p _addr account.
+    /// @throws NotEnoughCash if the balance of the account is less than the
+    /// amount to be subtrackted (also in case the account does not exist).
+    void subBalance(Address const& _addr, u256 const& _value);
 
     /// Set the balance of @p _addr to @p _value.
     /// Will instantiate the address if it has never been used.
     void setBalance(Address const& _addr, u256 const& _value);
 
     /**
-	 * @brief Transfers "the balance @a _value between two accounts.
-	 * @param _from Account from which @a _value will be deducted.
-	 * @param _to Account to which @a _value will be added.
-	 * @param _value Amount to be transferred.
-	 */
-	void transferBalance(Address const& _from, Address const& _to, u256 const& _value) { subBalance(_from, _value); addBalance(_to, _value); }
+     * @brief Transfers "the balance @a _value between two accounts.
+     * @param _from Account from which @a _value will be deducted.
+     * @param _to Account to which @a _value will be added.
+     * @param _value Amount to be transferred.
+     */
+    void transferBalance(Address const& _from, Address const& _to, u256 const& _value) { subBalance(_from, _value); addBalance(_to, _value); }
 
-	/// Get the root of the storage of an account.
-	h256 storageRoot(Address const& _contract) const;
+    /// Get the root of the storage of an account.
+    h256 storageRoot(Address const& _contract) const;
 
-	/// Get the value of a storage position of an account.
-	/// @returns 0 if no account exists at that address.
-	u256 storage(Address const& _contract, u256 const& _memory) const;
+    /// Get the value of a storage position of an account.
+    /// @returns 0 if no account exists at that address.
+    u256 storage(Address const& _contract, u256 const& _memory) const;
 
-	/// Set the value of a storage position of an account.
-	void setStorage(Address const& _contract, u256 const& _location, u256 const& _value);
+    /// Set the value of a storage position of an account.
+    void setStorage(Address const& _contract, u256 const& _location, u256 const& _value);
 
-	/// Clear the storage root hash of an account to the hash of the empty trie.
-	void clearStorage(Address const& _contract);
+    /// Clear the storage root hash of an account to the hash of the empty trie.
+    void clearStorage(Address const& _contract);
 
-	/// Create a contract at the given address (with unset code and unchanged balance).
-	void createContract(Address const& _address);
+    /// Create a contract at the given address (with unset code and unchanged balance).
+    void createContract(Address const& _address);
 
-	/// Sets the code of the account. Must only be called during / after contract creation.
-	void setCode(Address const& _address, bytes&& _code);
+    /// Sets the code of the account. Must only be called during / after contract creation.
+    void setCode(Address const& _address, bytes&& _code);
 
-	/// Delete an account (used for processing suicides).
-	void kill(Address _a);
+    /// Delete an account (used for processing suicides).
+    void kill(Address _a);
 
-	/// Get the storage of an account.
-	/// @note This is expensive. Don't use it unless you need to.
-	/// @returns map of hashed keys to key-value pairs or empty map if no account exists at that address.
-	std::map<h256, std::pair<u256, u256>> storage(Address const& _contract) const;
+    /// Get the storage of an account.
+    /// @note This is expensive. Don't use it unless you need to.
+    /// @returns map of hashed keys to key-value pairs or empty map if no account exists at that address.
+    std::map<h256, std::pair<u256, u256>> storage(Address const& _contract) const;
 
-	/// Get the code of an account.
-	/// @returns bytes() if no account exists at that address.
-	/// @warning The reference to the code is only valid until the access to
-	///          other account. Do not keep it.
-	bytes const& code(Address const& _addr) const;
+    /// Get the code of an account.
+    /// @returns bytes() if no account exists at that address.
+    /// @warning The reference to the code is only valid until the access to
+    ///          other account. Do not keep it.
+    bytes const& code(Address const& _addr) const;
 
-	/// Get the code hash of an account.
-	/// @returns EmptySHA3 if no account exists at that address or if there is no code associated with the address.
-	h256 codeHash(Address const& _contract) const;
+    /// Get the code hash of an account.
+    /// @returns EmptySHA3 if no account exists at that address or if there is no code associated with the address.
+    h256 codeHash(Address const& _contract) const;
 
-	/// Get the byte-size of the code of an account.
-	/// @returns code(_contract).size(), but utilizes CodeSizeHash.
-	size_t codeSize(Address const& _contract) const;
+    /// Get the byte-size of the code of an account.
+    /// @returns code(_contract).size(), but utilizes CodeSizeHash.
+    size_t codeSize(Address const& _contract) const;
 
-	/// Increament the account nonce.
-	void incNonce(Address const& _id);
+    /// Increament the account nonce.
+    void incNonce(Address const& _id);
 
-	/// Set the account nonce.
-	void setNonce(Address const& _addr, u256 const& _newNonce);
+    /// Set the account nonce.
+    void setNonce(Address const& _addr, u256 const& _newNonce);
 
-	/// Get the account nonce -- the number of transactions it has sent.
-	/// @returns 0 if the address has never been used.
-	u256 getNonce(Address const& _addr) const;
+    /// Get the account nonce -- the number of transactions it has sent.
+    /// @returns 0 if the address has never been used.
+    u256 getNonce(Address const& _addr) const;
 
-	/// The hash of the root of our state tree.
-	h256 rootHash() const { return m_state.root(); }
+    /// The hash of the root of our state tree.
+    h256 rootHash() const { return m_state.root(); }
 
-	/// Commit all changes waiting in the address cache to the DB.
-	/// @param _commitBehaviour whether or not to remove empty accounts during commit.
-	void commit(CommitBehaviour _commitBehaviour);
+    /// Commit all changes waiting in the address cache to the DB.
+    /// @param _commitBehaviour whether or not to remove empty accounts during commit.
+    void commit(CommitBehaviour _commitBehaviour);
 
-	/// Resets any uncommitted changes to the cache.
-	void setRoot(h256 const& _root);
+    /// Resets any uncommitted changes to the cache.
+    void setRoot(h256 const& _root);
 
-	/// Get the account start nonce. May be required.
-	u256 const& accountStartNonce() const { return m_accountStartNonce; }
-	u256 const& requireAccountStartNonce() const;
-	void noteAccountStartNonce(u256 const& _actual);
+    /// Get the account start nonce. May be required.
+    u256 const& accountStartNonce() const { return m_accountStartNonce; }
+    u256 const& requireAccountStartNonce() const;
+    void noteAccountStartNonce(u256 const& _actual);
 
-	/// Create a savepoint in the state changelog.	///
-	/// @return The savepoint index that can be used in rollback() function.
-	size_t savepoint() const;
+    /// Create a savepoint in the state changelog.	///
+    /// @return The savepoint index that can be used in rollback() function.
+    size_t savepoint() const;
 
-	/// Revert all recent changes up to the given @p _savepoint savepoint.
-	void rollback(size_t _savepoint);
+    /// Revert all recent changes up to the given @p _savepoint savepoint.
+    void rollback(size_t _savepoint);
 
-	ChangeLog const& changeLog() const { return m_changeLog; }
+    ChangeLog const& changeLog() const { return m_changeLog; }
 
 private:
-	/// Turns all "touched" empty accounts into non-alive accounts.
-	void removeEmptyAccounts();
+    /// Turns all "touched" empty accounts into non-alive accounts.
+    void removeEmptyAccounts();
 
-	/// @returns the account at the given address or a null pointer if it does not exist.
-	/// The pointer is valid until the next access to the state or account.
-	Account const* account(Address const& _addr) const;
+    /// @returns the account at the given address or a null pointer if it does not exist.
+    /// The pointer is valid until the next access to the state or account.
+    Account const* account(Address const& _addr) const;
 
-	/// @returns the account at the given address or a null pointer if it does not exist.
-	/// The pointer is valid until the next access to the state or account.
-	Account* account(Address const& _addr);
+    /// @returns the account at the given address or a null pointer if it does not exist.
+    /// The pointer is valid until the next access to the state or account.
+    Account* account(Address const& _addr);
 
-	/// Purges non-modified entries in m_cache if it grows too large.
-	void clearCacheIfTooLarge() const;
+    /// Purges non-modified entries in m_cache if it grows too large.
+    void clearCacheIfTooLarge() const;
 
-	void createAccount(Address const& _address, Account const&& _account);
+    void createAccount(Address const& _address, Account const&& _account);
 
-	OverlayDB m_db;								///< Our overlay for the state tree.
-	SecureTrieDB<Address, OverlayDB> m_state;	///< Our state tree, as an OverlayDB DB.
-	mutable std::unordered_map<Address, Account> m_cache;	///< Our address cache. This stores the states of each address that has (or at least might have) been changed.
-	mutable std::vector<Address> m_unchangedCacheEntries;	///< Tracks entries in m_cache that can potentially be purged if it grows too large.
-	mutable std::set<Address> m_nonExistingAccountsCache;	///< Tracks addresses that are known to not exist.
-	AddressHash m_touched;						///< Tracks all addresses touched so far.
+    OverlayDB m_db;								///< Our overlay for the state tree.
+    SecureTrieDB<Address, OverlayDB> m_state;	///< Our state tree, as an OverlayDB DB.
+    mutable std::unordered_map<Address, Account> m_cache;	///< Our address cache. This stores the states of each address that has (or at least might have) been changed.
+    mutable std::vector<Address> m_unchangedCacheEntries;	///< Tracks entries in m_cache that can potentially be purged if it grows too large.
+    mutable std::set<Address> m_nonExistingAccountsCache;	///< Tracks addresses that are known to not exist.
+    AddressHash m_touched;						///< Tracks all addresses touched so far.
 
-	u256 m_accountStartNonce;
+    u256 m_accountStartNonce;
 
-	friend std::ostream& operator<<(std::ostream& _out, State const& _s);
-	ChangeLog m_changeLog;
+    friend std::ostream& operator<<(std::ostream& _out, State const& _s);
+    ChangeLog m_changeLog;
 };
 
 std::ostream& operator<<(std::ostream& _out, State const& _s);

--- a/libethereum/State.h
+++ b/libethereum/State.h
@@ -63,9 +63,6 @@ class State;
 class TransactionQueue;
 struct VerifiedBlockRef;
 
-struct StateDetail: public LogChannel { static const char* name(); static const int verbosity = 14; };
-struct StateSafeExceptions: public LogChannel { static const char* name(); static const int verbosity = 21; };
-
 enum class BaseState
 {
     PreExisting,

--- a/libethereum/TransactionQueue.cpp
+++ b/libethereum/TransactionQueue.cpp
@@ -1,18 +1,18 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file TransactionQueue.cpp
  * @author Gav Wood <i@gavwood.com>
@@ -28,379 +28,378 @@ using namespace std;
 using namespace dev;
 using namespace dev::eth;
 
-const char* TransactionQueueChannel::name() { return EthCyan "┉┅▶"; }
-const char* TransactionQueueTraceChannel::name() { return EthCyan " ┅▶"; }
-
 const size_t c_maxVerificationQueueSize = 8192;
 
 TransactionQueue::TransactionQueue(unsigned _limit, unsigned _futureLimit):
-	m_current(PriorityCompare { *this }),
-	m_limit(_limit),
-	m_futureLimit(_futureLimit)
+    m_current(PriorityCompare { *this }),
+    m_limit(_limit),
+    m_futureLimit(_futureLimit)
 {
-	unsigned verifierThreads = std::max(thread::hardware_concurrency(), 3U) - 2U;
-	for (unsigned i = 0; i < verifierThreads; ++i)
-		m_verifiers.emplace_back([=](){
-			setThreadName("txcheck" + toString(i));
-			this->verifierBody();
-		});
+    unsigned verifierThreads = std::max(thread::hardware_concurrency(), 3U) - 2U;
+    for (unsigned i = 0; i < verifierThreads; ++i)
+        m_verifiers.emplace_back([=](){
+            setThreadName("txcheck" + toString(i));
+            this->verifierBody();
+        });
 }
 
 TransactionQueue::~TransactionQueue()
 {
-	DEV_GUARDED(x_queue)
-		m_aborting = true;
-	m_queueReady.notify_all();
-	for (auto& i: m_verifiers)
-		i.join();
+    DEV_GUARDED(x_queue)
+        m_aborting = true;
+    m_queueReady.notify_all();
+    for (auto& i: m_verifiers)
+        i.join();
 }
 
 ImportResult TransactionQueue::import(bytesConstRef _transactionRLP, IfDropped _ik)
 {
-	try
-	{
-		Transaction t = Transaction(_transactionRLP, CheckTransaction::Everything);
-		return import(t, _ik);
-	}
-	catch (Exception const&)
-	{
-		return ImportResult::Malformed;
-	}
+    try
+    {
+        Transaction t = Transaction(_transactionRLP, CheckTransaction::Everything);
+        return import(t, _ik);
+    }
+    catch (Exception const&)
+    {
+        return ImportResult::Malformed;
+    }
 }
 
 ImportResult TransactionQueue::check_WITH_LOCK(h256 const& _h, IfDropped _ik)
 {
-	if (m_known.count(_h))
-		return ImportResult::AlreadyKnown;
+    if (m_known.count(_h))
+        return ImportResult::AlreadyKnown;
 
-	if (m_dropped.count(_h) && _ik == IfDropped::Ignore)
-		return ImportResult::AlreadyInChain;
+    if (m_dropped.count(_h) && _ik == IfDropped::Ignore)
+        return ImportResult::AlreadyInChain;
 
-	return ImportResult::Success;
+    return ImportResult::Success;
 }
 
 ImportResult TransactionQueue::import(Transaction const& _transaction, IfDropped _ik)
 {
-	if (_transaction.hasZeroSignature())
-		return ImportResult::ZeroSignature;
-	// Check if we already know this transaction.
-	h256 h = _transaction.sha3(WithSignature);
+    if (_transaction.hasZeroSignature())
+        return ImportResult::ZeroSignature;
+    // Check if we already know this transaction.
+    h256 h = _transaction.sha3(WithSignature);
 
-	ImportResult ret;
-	{
-		UpgradableGuard l(m_lock);
-		auto ir = check_WITH_LOCK(h, _ik);
-		if (ir != ImportResult::Success)
-			return ir;
+    ImportResult ret;
+    {
+        UpgradableGuard l(m_lock);
+        auto ir = check_WITH_LOCK(h, _ik);
+        if (ir != ImportResult::Success)
+            return ir;
 
-		{
-			_transaction.safeSender(); // Perform EC recovery outside of the write lock
-			UpgradeGuard ul(l);
-			ret = manageImport_WITH_LOCK(h, _transaction);
-		}
-	}
-	return ret;
+        {
+            _transaction.safeSender();  // Perform EC recovery outside of the write lock
+            UpgradeGuard ul(l);
+            ret = manageImport_WITH_LOCK(h, _transaction);
+        }
+    }
+    return ret;
 }
 
 Transactions TransactionQueue::topTransactions(unsigned _limit, h256Hash const& _avoid) const
 {
-	ReadGuard l(m_lock);
-	Transactions ret;
-	for (auto t = m_current.begin(); ret.size() < _limit && t != m_current.end(); ++t)
-		if (!_avoid.count(t->transaction.sha3()))
-			ret.push_back(t->transaction);
-	return ret;
+    ReadGuard l(m_lock);
+    Transactions ret;
+    for (auto t = m_current.begin(); ret.size() < _limit && t != m_current.end(); ++t)
+        if (!_avoid.count(t->transaction.sha3()))
+            ret.push_back(t->transaction);
+    return ret;
 }
 
 h256Hash TransactionQueue::knownTransactions() const
 {
-	ReadGuard l(m_lock);
-	return m_known;
+    ReadGuard l(m_lock);
+    return m_known;
 }
 
 ImportResult TransactionQueue::manageImport_WITH_LOCK(h256 const& _h, Transaction const& _transaction)
 {
-	try
-	{
-		assert(_h == _transaction.sha3());
-		// Remove any prior transaction with the same nonce but a lower gas price.
-		// Bomb out if there's a prior transaction with higher gas price.
-		auto cs = m_currentByAddressAndNonce.find(_transaction.from());
-		if (cs != m_currentByAddressAndNonce.end())
-		{
-			auto t = cs->second.find(_transaction.nonce());
-			if (t != cs->second.end())
-			{
-				if (_transaction.gasPrice() < (*t->second).transaction.gasPrice())
-					return ImportResult::OverbidGasPrice;
-				else
-				{
-					h256 dropped = (*t->second).transaction.sha3();
-					remove_WITH_LOCK(dropped);
-					m_onReplaced(dropped);
-				}
-			}
-		}
-		auto fs = m_future.find(_transaction.from());
-		if (fs != m_future.end())
-		{
-			auto t = fs->second.find(_transaction.nonce());
-			if (t != fs->second.end())
-			{
-				if (_transaction.gasPrice() < t->second.transaction.gasPrice())
-					return ImportResult::OverbidGasPrice;
-				else
-				{
-					fs->second.erase(t);
-					--m_futureSize;
-					if (fs->second.empty())
-						m_future.erase(fs);
-				}
-			}
-		}
-		// If valid, append to transactions.
-		insertCurrent_WITH_LOCK(make_pair(_h, _transaction));
-		clog(TransactionQueueTraceChannel) << "Queued vaguely legit-looking transaction" << _h;
+    try
+    {
+        assert(_h == _transaction.sha3());
+        // Remove any prior transaction with the same nonce but a lower gas price.
+        // Bomb out if there's a prior transaction with higher gas price.
+        auto cs = m_currentByAddressAndNonce.find(_transaction.from());
+        if (cs != m_currentByAddressAndNonce.end())
+        {
+            auto t = cs->second.find(_transaction.nonce());
+            if (t != cs->second.end())
+            {
+                if (_transaction.gasPrice() < (*t->second).transaction.gasPrice())
+                    return ImportResult::OverbidGasPrice;
+                else
+                {
+                    h256 dropped = (*t->second).transaction.sha3();
+                    remove_WITH_LOCK(dropped);
+                    m_onReplaced(dropped);
+                }
+            }
+        }
+        auto fs = m_future.find(_transaction.from());
+        if (fs != m_future.end())
+        {
+            auto t = fs->second.find(_transaction.nonce());
+            if (t != fs->second.end())
+            {
+                if (_transaction.gasPrice() < t->second.transaction.gasPrice())
+                    return ImportResult::OverbidGasPrice;
+                else
+                {
+                    fs->second.erase(t);
+                    --m_futureSize;
+                    if (fs->second.empty())
+                        m_future.erase(fs);
+                }
+            }
+        }
+        // If valid, append to transactions.
+        insertCurrent_WITH_LOCK(make_pair(_h, _transaction));
+        LOG(m_loggerDetail) << "Queued vaguely legit-looking transaction " << _h;
 
-		while (m_current.size() > m_limit)
-		{
-			clog(TransactionQueueTraceChannel) << "Dropping out of bounds transaction" << _h;
-			remove_WITH_LOCK(m_current.rbegin()->transaction.sha3());
-		}
+        while (m_current.size() > m_limit)
+        {
+            LOG(m_loggerDetail) << "Dropping out of bounds transaction " << _h;
+            remove_WITH_LOCK(m_current.rbegin()->transaction.sha3());
+        }
 
-		m_onReady();
-	}
-	catch (Exception const& _e)
-	{
-		ctxq << "Ignoring invalid transaction: " <<  diagnostic_information(_e);
-		return ImportResult::Malformed;
-	}
-	catch (std::exception const& _e)
-	{
-		ctxq << "Ignoring invalid transaction: " << _e.what();
-		return ImportResult::Malformed;
-	}
+        m_onReady();
+    }
+    catch (Exception const& _e)
+    {
+        LOG(m_loggerDetail) << "Ignoring invalid transaction: " << diagnostic_information(_e);
+        return ImportResult::Malformed;
+    }
+    catch (std::exception const& _e)
+    {
+        LOG(m_loggerDetail) << "Ignoring invalid transaction: " << _e.what();
+        return ImportResult::Malformed;
+    }
 
-	return ImportResult::Success;
+    return ImportResult::Success;
 }
 
 u256 TransactionQueue::maxNonce(Address const& _a) const
 {
-	ReadGuard l(m_lock);
-	return maxNonce_WITH_LOCK(_a);
+    ReadGuard l(m_lock);
+    return maxNonce_WITH_LOCK(_a);
 }
 
 u256 TransactionQueue::maxNonce_WITH_LOCK(Address const& _a) const
 {
-	u256 ret = 0;
-	auto cs = m_currentByAddressAndNonce.find(_a);
-	if (cs != m_currentByAddressAndNonce.end() && !cs->second.empty())
-		ret = cs->second.rbegin()->first + 1;
-	auto fs = m_future.find(_a);
-	if (fs != m_future.end() && !fs->second.empty())
-		ret = std::max(ret, fs->second.rbegin()->first + 1);
-	return ret;
+    u256 ret = 0;
+    auto cs = m_currentByAddressAndNonce.find(_a);
+    if (cs != m_currentByAddressAndNonce.end() && !cs->second.empty())
+        ret = cs->second.rbegin()->first + 1;
+    auto fs = m_future.find(_a);
+    if (fs != m_future.end() && !fs->second.empty())
+        ret = std::max(ret, fs->second.rbegin()->first + 1);
+    return ret;
 }
 
 void TransactionQueue::insertCurrent_WITH_LOCK(std::pair<h256, Transaction> const& _p)
 {
-	if (m_currentByHash.count(_p.first))
-	{
-		cwarn << "Transaction hash" << _p.first << "already in current?!";
-		return;
-	}
+    if (m_currentByHash.count(_p.first))
+    {
+        cwarn << "Transaction hash" << _p.first << "already in current?!";
+        return;
+    }
 
-	Transaction const& t = _p.second;
-	// Insert into current
-	auto inserted = m_currentByAddressAndNonce[t.from()].insert(std::make_pair(t.nonce(), PriorityQueue::iterator()));
-	PriorityQueue::iterator handle = m_current.emplace(VerifiedTransaction(t));
-	inserted.first->second = handle;
-	m_currentByHash[_p.first] = handle;
+    Transaction const& t = _p.second;
+    // Insert into current
+    auto inserted = m_currentByAddressAndNonce[t.from()].insert(std::make_pair(t.nonce(), PriorityQueue::iterator()));
+    PriorityQueue::iterator handle = m_current.emplace(VerifiedTransaction(t));
+    inserted.first->second = handle;
+    m_currentByHash[_p.first] = handle;
 
-	// Move following transactions from future to current
-	makeCurrent_WITH_LOCK(t);
-	m_known.insert(_p.first);
+    // Move following transactions from future to current
+    makeCurrent_WITH_LOCK(t);
+    m_known.insert(_p.first);
 }
 
 bool TransactionQueue::remove_WITH_LOCK(h256 const& _txHash)
 {
-	auto t = m_currentByHash.find(_txHash);
-	if (t == m_currentByHash.end())
-		return false;
+    auto t = m_currentByHash.find(_txHash);
+    if (t == m_currentByHash.end())
+        return false;
 
-	Address from = (*t->second).transaction.from();
-	auto it = m_currentByAddressAndNonce.find(from);
-	assert (it != m_currentByAddressAndNonce.end());
-	it->second.erase((*t->second).transaction.nonce());
-	m_current.erase(t->second);
-	m_currentByHash.erase(t);
-	if (it->second.empty())
-		m_currentByAddressAndNonce.erase(it);
-	m_known.erase(_txHash);
-	return true;
+    Address from = (*t->second).transaction.from();
+    auto it = m_currentByAddressAndNonce.find(from);
+    assert (it != m_currentByAddressAndNonce.end());
+    it->second.erase((*t->second).transaction.nonce());
+    m_current.erase(t->second);
+    m_currentByHash.erase(t);
+    if (it->second.empty())
+        m_currentByAddressAndNonce.erase(it);
+    m_known.erase(_txHash);
+    return true;
 }
 
 unsigned TransactionQueue::waiting(Address const& _a) const
 {
-	ReadGuard l(m_lock);
-	unsigned ret = 0;
-	auto cs = m_currentByAddressAndNonce.find(_a);
-	if (cs != m_currentByAddressAndNonce.end())
-		ret = cs->second.size();
-	auto fs = m_future.find(_a);
-	if (fs != m_future.end())
-		ret += fs->second.size();
-	return ret;
+    ReadGuard l(m_lock);
+    unsigned ret = 0;
+    auto cs = m_currentByAddressAndNonce.find(_a);
+    if (cs != m_currentByAddressAndNonce.end())
+        ret = cs->second.size();
+    auto fs = m_future.find(_a);
+    if (fs != m_future.end())
+        ret += fs->second.size();
+    return ret;
 }
 
 void TransactionQueue::setFuture(h256 const& _txHash)
 {
-	WriteGuard l(m_lock);
-	auto it = m_currentByHash.find(_txHash);
-	if (it == m_currentByHash.end())
-		return;
+    WriteGuard l(m_lock);
+    auto it = m_currentByHash.find(_txHash);
+    if (it == m_currentByHash.end())
+        return;
 
-	VerifiedTransaction const& st = *(it->second);
+    VerifiedTransaction const& st = *(it->second);
 
-	Address from = st.transaction.from();
-	auto& queue = m_currentByAddressAndNonce[from];
-	auto& target = m_future[from];
-	auto cutoff = queue.lower_bound(st.transaction.nonce());
-	for (auto m = cutoff; m != queue.end(); ++m)
-	{
-		VerifiedTransaction& t = const_cast<VerifiedTransaction&>(*(m->second)); // set has only const iterators. Since we are moving out of container that's fine
-		m_currentByHash.erase(t.transaction.sha3());
-		target.emplace(t.transaction.nonce(), move(t));
-		m_current.erase(m->second);
-		++m_futureSize;
-	}
-	queue.erase(cutoff, queue.end());
-	if (queue.empty())
-		m_currentByAddressAndNonce.erase(from);
+    Address from = st.transaction.from();
+    auto& queue = m_currentByAddressAndNonce[from];
+    auto& target = m_future[from];
+    auto cutoff = queue.lower_bound(st.transaction.nonce());
+    for (auto m = cutoff; m != queue.end(); ++m)
+    {
+        VerifiedTransaction& t = const_cast<VerifiedTransaction&>(*(m->second)); // set has only const iterators. Since we are moving out of container that's fine
+        m_currentByHash.erase(t.transaction.sha3());
+        target.emplace(t.transaction.nonce(), move(t));
+        m_current.erase(m->second);
+        ++m_futureSize;
+    }
+    queue.erase(cutoff, queue.end());
+    if (queue.empty())
+        m_currentByAddressAndNonce.erase(from);
 }
 
 void TransactionQueue::makeCurrent_WITH_LOCK(Transaction const& _t)
 {
-	bool newCurrent = false;
-	auto fs = m_future.find(_t.from());
-	if (fs != m_future.end())
-	{
-		u256 nonce = _t.nonce() + 1;
-		auto fb = fs->second.find(nonce);
-		if (fb != fs->second.end())
-		{
-			auto ft = fb;
-			while (ft != fs->second.end() && ft->second.transaction.nonce() == nonce)
-			{
-				auto inserted = m_currentByAddressAndNonce[_t.from()].insert(std::make_pair(ft->second.transaction.nonce(), PriorityQueue::iterator()));
-				PriorityQueue::iterator handle = m_current.emplace(move(ft->second));
-				inserted.first->second = handle;
-				m_currentByHash[(*handle).transaction.sha3()] = handle;
-				--m_futureSize;
-				++ft;
-				++nonce;
-				newCurrent = true;
-			}
-			fs->second.erase(fb, ft);
-			if (fs->second.empty())
-				m_future.erase(_t.from());
-		}
-	}
+    bool newCurrent = false;
+    auto fs = m_future.find(_t.from());
+    if (fs != m_future.end())
+    {
+        u256 nonce = _t.nonce() + 1;
+        auto fb = fs->second.find(nonce);
+        if (fb != fs->second.end())
+        {
+            auto ft = fb;
+            while (ft != fs->second.end() && ft->second.transaction.nonce() == nonce)
+            {
+                auto inserted = m_currentByAddressAndNonce[_t.from()].insert(std::make_pair(ft->second.transaction.nonce(), PriorityQueue::iterator()));
+                PriorityQueue::iterator handle = m_current.emplace(move(ft->second));
+                inserted.first->second = handle;
+                m_currentByHash[(*handle).transaction.sha3()] = handle;
+                --m_futureSize;
+                ++ft;
+                ++nonce;
+                newCurrent = true;
+            }
+            fs->second.erase(fb, ft);
+            if (fs->second.empty())
+                m_future.erase(_t.from());
+        }
+    }
 
-	while (m_futureSize > m_futureLimit)
-	{
-		// TODO: priority queue for future transactions
-		// For now just drop random chain end
-		--m_futureSize;
-		clog(TransactionQueueTraceChannel) << "Dropping out of bounds future transaction" << m_future.begin()->second.rbegin()->second.transaction.sha3();
-		m_future.begin()->second.erase(--m_future.begin()->second.end());
-		if (m_future.begin()->second.empty())
-			m_future.erase(m_future.begin());
-	}
+    while (m_futureSize > m_futureLimit)
+    {
+        // TODO: priority queue for future transactions
+        // For now just drop random chain end
+        --m_futureSize;
+        LOG(m_loggerDetail) << "Dropping out of bounds future transaction "
+                            << m_future.begin()->second.rbegin()->second.transaction.sha3();
+        m_future.begin()->second.erase(--m_future.begin()->second.end());
+        if (m_future.begin()->second.empty())
+            m_future.erase(m_future.begin());
+    }
 
-	if (newCurrent)
-		m_onReady();
+    if (newCurrent)
+        m_onReady();
 }
 
 void TransactionQueue::drop(h256 const& _txHash)
 {
-	UpgradableGuard l(m_lock);
+    UpgradableGuard l(m_lock);
 
-	if (!m_known.count(_txHash))
-		return;
+    if (!m_known.count(_txHash))
+        return;
 
-	UpgradeGuard ul(l);
-	m_dropped.insert(_txHash);
-	remove_WITH_LOCK(_txHash);
+    UpgradeGuard ul(l);
+    m_dropped.insert(_txHash);
+    remove_WITH_LOCK(_txHash);
 }
 
 void TransactionQueue::dropGood(Transaction const& _t)
 {
-	WriteGuard l(m_lock);
-	makeCurrent_WITH_LOCK(_t);
-	if (!m_known.count(_t.sha3()))
-		return;
-	remove_WITH_LOCK(_t.sha3());
+    WriteGuard l(m_lock);
+    makeCurrent_WITH_LOCK(_t);
+    if (!m_known.count(_t.sha3()))
+        return;
+    remove_WITH_LOCK(_t.sha3());
 }
 
 void TransactionQueue::clear()
 {
-	WriteGuard l(m_lock);
-	m_known.clear();
-	m_current.clear();
-	m_dropped.clear();
-	m_currentByAddressAndNonce.clear();
-	m_currentByHash.clear();
-	m_future.clear();
-	m_futureSize = 0;
+    WriteGuard l(m_lock);
+    m_known.clear();
+    m_current.clear();
+    m_dropped.clear();
+    m_currentByAddressAndNonce.clear();
+    m_currentByHash.clear();
+    m_future.clear();
+    m_futureSize = 0;
 }
 
 void TransactionQueue::enqueue(RLP const& _data, h512 const& _nodeId)
 {
-	bool queued = false;
-	{
-		Guard l(x_queue);
-		unsigned itemCount = _data.itemCount();
-		for (unsigned i = 0; i < itemCount; ++i)
-		{
-			if (m_unverified.size() >= c_maxVerificationQueueSize)
-			{
-				clog(TransactionQueueChannel) << "Transaction verification queue is full. Dropping" << itemCount - i << "transactions";
-				break;
-			}
-			m_unverified.emplace_back(UnverifiedTransaction(_data[i].data(), _nodeId));
-			queued = true;
-		}
-	}
-	if (queued)
-		m_queueReady.notify_all();
+    bool queued = false;
+    {
+        Guard l(x_queue);
+        unsigned itemCount = _data.itemCount();
+        for (unsigned i = 0; i < itemCount; ++i)
+        {
+            if (m_unverified.size() >= c_maxVerificationQueueSize)
+            {
+                LOG(m_logger) << "Transaction verification queue is full. Dropping "
+                              << itemCount - i << " transactions";
+                break;
+            }
+            m_unverified.emplace_back(UnverifiedTransaction(_data[i].data(), _nodeId));
+            queued = true;
+        }
+    }
+    if (queued)
+        m_queueReady.notify_all();
 }
 
 void TransactionQueue::verifierBody()
 {
-	while (!m_aborting)
-	{
-		UnverifiedTransaction work;
+    while (!m_aborting)
+    {
+        UnverifiedTransaction work;
 
-		{
-			unique_lock<Mutex> l(x_queue);
-			m_queueReady.wait(l, [&](){ return !m_unverified.empty() || m_aborting; });
-			if (m_aborting)
-				return;
-			work = move(m_unverified.front());
-			m_unverified.pop_front();
-		}
+        {
+            unique_lock<Mutex> l(x_queue);
+            m_queueReady.wait(l, [&](){ return !m_unverified.empty() || m_aborting; });
+            if (m_aborting)
+                return;
+            work = move(m_unverified.front());
+            m_unverified.pop_front();
+        }
 
-		try
-		{
-			Transaction t(work.transaction, CheckTransaction::Cheap); //Signature will be checked later
-			ImportResult ir = import(t);
-			m_onImport(ir, t.sha3(), work.nodeId);
-		}
-		catch (...)
-		{
-			// should not happen as exceptions are handled in import.
-			cwarn << "Bad transaction:" << boost::current_exception_diagnostic_information();
-		}
-	}
+        try
+        {
+            Transaction t(work.transaction, CheckTransaction::Cheap); //Signature will be checked later
+            ImportResult ir = import(t);
+            m_onImport(ir, t.sha3(), work.nodeId);
+        }
+        catch (...)
+        {
+            // should not happen as exceptions are handled in import.
+            cwarn << "Bad transaction:" << boost::current_exception_diagnostic_information();
+        }
+    }
 }

--- a/libethereum/TransactionQueue.h
+++ b/libethereum/TransactionQueue.h
@@ -1,18 +1,18 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file TransactionQueue.h
  * @author Gav Wood <i@gavwood.com>
@@ -36,10 +36,6 @@ namespace dev
 namespace eth
 {
 
-struct TransactionQueueChannel: public LogChannel { static const char* name(); static const int verbosity = 4; };
-struct TransactionQueueTraceChannel: public LogChannel { static const char* name(); static const int verbosity = 7; };
-#define ctxq dev::LogOutputStream<dev::eth::TransactionQueueTraceChannel, true>()
-
 /**
  * @brief A queue of Transactions, each stored as RLP.
  * Maintains a transaction queue sorted by nonce diff and gas price.
@@ -48,170 +44,173 @@ struct TransactionQueueTraceChannel: public LogChannel { static const char* name
 class TransactionQueue
 {
 public:
-	struct Limits { size_t current; size_t future; };
+    struct Limits { size_t current; size_t future; };
 
-	/// @brief TransactionQueue
-	/// @param _limit Maximum number of pending transactions in the queue.
-	/// @param _futureLimit Maximum number of future nonce transactions.
-	TransactionQueue(unsigned _limit = 1024, unsigned _futureLimit = 1024);
-	TransactionQueue(Limits const& _l): TransactionQueue(_l.current, _l.future) {}
-	~TransactionQueue();
-	/// Add transaction to the queue to be verified and imported.
-	/// @param _data RLP encoded transaction data.
-	/// @param _nodeId Optional network identified of a node transaction comes from.
-	void enqueue(RLP const& _data, h512 const& _nodeId);
+    /// @brief TransactionQueue
+    /// @param _limit Maximum number of pending transactions in the queue.
+    /// @param _futureLimit Maximum number of future nonce transactions.
+    TransactionQueue(unsigned _limit = 1024, unsigned _futureLimit = 1024);
+    TransactionQueue(Limits const& _l): TransactionQueue(_l.current, _l.future) {}
+    ~TransactionQueue();
+    /// Add transaction to the queue to be verified and imported.
+    /// @param _data RLP encoded transaction data.
+    /// @param _nodeId Optional network identified of a node transaction comes from.
+    void enqueue(RLP const& _data, h512 const& _nodeId);
 
-	/// Verify and add transaction to the queue synchronously.
-	/// @param _tx RLP encoded transaction data.
-	/// @param _ik Set to Retry to force re-addinga transaction that was previously dropped.
-	/// @returns Import result code.
-	ImportResult import(bytes const& _tx, IfDropped _ik = IfDropped::Ignore) { return import(&_tx, _ik); }
+    /// Verify and add transaction to the queue synchronously.
+    /// @param _tx RLP encoded transaction data.
+    /// @param _ik Set to Retry to force re-addinga transaction that was previously dropped.
+    /// @returns Import result code.
+    ImportResult import(bytes const& _tx, IfDropped _ik = IfDropped::Ignore) { return import(&_tx, _ik); }
 
-	/// Verify and add transaction to the queue synchronously.
-	/// @param _tx Trasnaction data.
-	/// @param _ik Set to Retry to force re-addinga transaction that was previously dropped.
-	/// @returns Import result code.
-	ImportResult import(Transaction const& _tx, IfDropped _ik = IfDropped::Ignore);
+    /// Verify and add transaction to the queue synchronously.
+    /// @param _tx Trasnaction data.
+    /// @param _ik Set to Retry to force re-addinga transaction that was previously dropped.
+    /// @returns Import result code.
+    ImportResult import(Transaction const& _tx, IfDropped _ik = IfDropped::Ignore);
 
-	/// Remove transaction from the queue
-	/// @param _txHash Trasnaction hash
-	void drop(h256 const& _txHash);
+    /// Remove transaction from the queue
+    /// @param _txHash Trasnaction hash
+    void drop(h256 const& _txHash);
 
-	/// Get number of pending transactions for account.
-	/// @returns Pending transaction count.
-	unsigned waiting(Address const& _a) const;
+    /// Get number of pending transactions for account.
+    /// @returns Pending transaction count.
+    unsigned waiting(Address const& _a) const;
 
-	/// Get top transactions from the queue. Returned transactions are not removed from the queue automatically.
-	/// @param _limit Max number of transactions to return.
-	/// @param _avoid Transactions to avoid returning.
-	/// @returns up to _limit transactions ordered by nonce and gas price.
-	Transactions topTransactions(unsigned _limit, h256Hash const& _avoid = h256Hash()) const;
+    /// Get top transactions from the queue. Returned transactions are not removed from the queue automatically.
+    /// @param _limit Max number of transactions to return.
+    /// @param _avoid Transactions to avoid returning.
+    /// @returns up to _limit transactions ordered by nonce and gas price.
+    Transactions topTransactions(unsigned _limit, h256Hash const& _avoid = h256Hash()) const;
 
-	/// Get a hash set of transactions in the queue
-	/// @returns A hash set of all transactions in the queue
-	h256Hash knownTransactions() const;
+    /// Get a hash set of transactions in the queue
+    /// @returns A hash set of all transactions in the queue
+    h256Hash knownTransactions() const;
 
-	/// Get max nonce for an account
-	/// @returns Max transaction nonce for account in the queue
-	u256 maxNonce(Address const& _a) const;
+    /// Get max nonce for an account
+    /// @returns Max transaction nonce for account in the queue
+    u256 maxNonce(Address const& _a) const;
 
-	/// Mark transaction as future. It wont be retured in topTransactions list until a transaction with a preceeding nonce is imported or marked with dropGood
-	/// @param _t Transaction hash
-	void setFuture(h256 const& _t);
+    /// Mark transaction as future. It wont be retured in topTransactions list until a transaction with a preceeding nonce is imported or marked with dropGood
+    /// @param _t Transaction hash
+    void setFuture(h256 const& _t);
 
-	/// Drop a trasnaction from the list if exists and move following future trasnactions to current (if any)
-	/// @param _t Transaction hash
-	void dropGood(Transaction const& _t);
+    /// Drop a trasnaction from the list if exists and move following future trasnactions to current (if any)
+    /// @param _t Transaction hash
+    void dropGood(Transaction const& _t);
 
-	struct Status
-	{
-		size_t current;
-		size_t future;
-		size_t unverified;
-		size_t dropped;
-	};
-	/// @returns the status of the transaction queue.
-	Status status() const { Status ret; DEV_GUARDED(x_queue) { ret.unverified = m_unverified.size(); } ReadGuard l(m_lock); ret.dropped = m_dropped.size(); ret.current = m_currentByHash.size(); ret.future = m_future.size(); return ret; }
+    struct Status
+    {
+        size_t current;
+        size_t future;
+        size_t unverified;
+        size_t dropped;
+    };
+    /// @returns the status of the transaction queue.
+    Status status() const { Status ret; DEV_GUARDED(x_queue) { ret.unverified = m_unverified.size(); } ReadGuard l(m_lock); ret.dropped = m_dropped.size(); ret.current = m_currentByHash.size(); ret.future = m_future.size(); return ret; }
 
-	/// @returns the transacrtion limits on current/future.
-	Limits limits() const { return Limits{m_limit, m_futureLimit}; }
+    /// @returns the transacrtion limits on current/future.
+    Limits limits() const { return Limits{m_limit, m_futureLimit}; }
 
-	/// Clear the queue
-	void clear();
+    /// Clear the queue
+    void clear();
 
-	/// Register a handler that will be called once there is a new transaction imported
-	template <class T> Handler<> onReady(T const& _t) { return m_onReady.add(_t); }
+    /// Register a handler that will be called once there is a new transaction imported
+    template <class T> Handler<> onReady(T const& _t) { return m_onReady.add(_t); }
 
-	/// Register a handler that will be called once asynchronous verification is comeplte an transaction has been imported
-	template <class T> Handler<ImportResult, h256 const&, h512 const&> onImport(T const& _t) { return m_onImport.add(_t); }
+    /// Register a handler that will be called once asynchronous verification is comeplte an transaction has been imported
+    template <class T> Handler<ImportResult, h256 const&, h512 const&> onImport(T const& _t) { return m_onImport.add(_t); }
 
-	/// Register a handler that will be called once asynchronous verification is comeplte an transaction has been imported
-	template <class T> Handler<h256 const&> onReplaced(T const& _t) { return m_onReplaced.add(_t); }
+    /// Register a handler that will be called once asynchronous verification is comeplte an transaction has been imported
+    template <class T> Handler<h256 const&> onReplaced(T const& _t) { return m_onReplaced.add(_t); }
 
 private:
 
-	/// Verified and imported transaction
-	struct VerifiedTransaction
-	{
-		VerifiedTransaction(Transaction const& _t): transaction(_t) {}
-		VerifiedTransaction(VerifiedTransaction&& _t): transaction(std::move(_t.transaction)) {}
+    /// Verified and imported transaction
+    struct VerifiedTransaction
+    {
+        VerifiedTransaction(Transaction const& _t): transaction(_t) {}
+        VerifiedTransaction(VerifiedTransaction&& _t): transaction(std::move(_t.transaction)) {}
 
-		VerifiedTransaction(VerifiedTransaction const&) = delete;
-		VerifiedTransaction& operator=(VerifiedTransaction const&) = delete;
+        VerifiedTransaction(VerifiedTransaction const&) = delete;
+        VerifiedTransaction& operator=(VerifiedTransaction const&) = delete;
 
-		Transaction transaction; ///< Transaction data
-	};
+        Transaction transaction;  ///< Transaction data
+    };
 
-	/// Transaction pending verification
-	struct UnverifiedTransaction
-	{
-		UnverifiedTransaction() {}
-		UnverifiedTransaction(bytesConstRef const& _t, h512 const& _nodeId): transaction(_t.toBytes()), nodeId(_nodeId) {}
-		UnverifiedTransaction(UnverifiedTransaction&& _t): transaction(std::move(_t.transaction)), nodeId(std::move(_t.nodeId)) {}
-		UnverifiedTransaction& operator=(UnverifiedTransaction&& _other)
-		{
-			assert(&_other != this);
+    /// Transaction pending verification
+    struct UnverifiedTransaction
+    {
+        UnverifiedTransaction() {}
+        UnverifiedTransaction(bytesConstRef const& _t, h512 const& _nodeId): transaction(_t.toBytes()), nodeId(_nodeId) {}
+        UnverifiedTransaction(UnverifiedTransaction&& _t): transaction(std::move(_t.transaction)), nodeId(std::move(_t.nodeId)) {}
+        UnverifiedTransaction& operator=(UnverifiedTransaction&& _other)
+        {
+            assert(&_other != this);
 
-			transaction = std::move(_other.transaction);
-			nodeId = std::move(_other.nodeId);
-			return *this;
-		}
+            transaction = std::move(_other.transaction);
+            nodeId = std::move(_other.nodeId);
+            return *this;
+        }
 
-		UnverifiedTransaction(UnverifiedTransaction const&) = delete;
-		UnverifiedTransaction& operator=(UnverifiedTransaction const&) = delete;
+        UnverifiedTransaction(UnverifiedTransaction const&) = delete;
+        UnverifiedTransaction& operator=(UnverifiedTransaction const&) = delete;
 
-		bytes transaction;	///< RLP encoded transaction data
-		h512 nodeId;		///< Network Id of the peer transaction comes from
-	};
+        bytes transaction;  ///< RLP encoded transaction data
+        h512 nodeId;        ///< Network Id of the peer transaction comes from
+    };
 
-	struct PriorityCompare
-	{
-		TransactionQueue& queue;
-		/// Compare transaction by nonce height and gas price.
-		bool operator()(VerifiedTransaction const& _first, VerifiedTransaction const& _second) const
-		{
-			u256 const& height1 = _first.transaction.nonce() - queue.m_currentByAddressAndNonce[_first.transaction.sender()].begin()->first;
-			u256 const& height2 = _second.transaction.nonce() - queue.m_currentByAddressAndNonce[_second.transaction.sender()].begin()->first;
-			return height1 < height2 || (height1 == height2 && _first.transaction.gasPrice() > _second.transaction.gasPrice());
-		}
-	};
+    struct PriorityCompare
+    {
+        TransactionQueue& queue;
+        /// Compare transaction by nonce height and gas price.
+        bool operator()(VerifiedTransaction const& _first, VerifiedTransaction const& _second) const
+        {
+            u256 const& height1 = _first.transaction.nonce() - queue.m_currentByAddressAndNonce[_first.transaction.sender()].begin()->first;
+            u256 const& height2 = _second.transaction.nonce() - queue.m_currentByAddressAndNonce[_second.transaction.sender()].begin()->first;
+            return height1 < height2 || (height1 == height2 && _first.transaction.gasPrice() > _second.transaction.gasPrice());
+        }
+    };
 
-	// Use a set with dynamic comparator for minmax priority queue. The comparator takes into account min account nonce. Updating it does not affect the order.
-	using PriorityQueue = std::multiset<VerifiedTransaction, PriorityCompare>;
+    // Use a set with dynamic comparator for minmax priority queue. The comparator takes into account min account nonce. Updating it does not affect the order.
+    using PriorityQueue = std::multiset<VerifiedTransaction, PriorityCompare>;
 
-	ImportResult import(bytesConstRef _tx, IfDropped _ik = IfDropped::Ignore);
-	ImportResult check_WITH_LOCK(h256 const& _h, IfDropped _ik);
-	ImportResult manageImport_WITH_LOCK(h256 const& _h, Transaction const& _transaction);
+    ImportResult import(bytesConstRef _tx, IfDropped _ik = IfDropped::Ignore);
+    ImportResult check_WITH_LOCK(h256 const& _h, IfDropped _ik);
+    ImportResult manageImport_WITH_LOCK(h256 const& _h, Transaction const& _transaction);
 
-	void insertCurrent_WITH_LOCK(std::pair<h256, Transaction> const& _p);
-	void makeCurrent_WITH_LOCK(Transaction const& _t);
-	bool remove_WITH_LOCK(h256 const& _txHash);
-	u256 maxNonce_WITH_LOCK(Address const& _a) const;
-	void verifierBody();
+    void insertCurrent_WITH_LOCK(std::pair<h256, Transaction> const& _p);
+    void makeCurrent_WITH_LOCK(Transaction const& _t);
+    bool remove_WITH_LOCK(h256 const& _txHash);
+    u256 maxNonce_WITH_LOCK(Address const& _a) const;
+    void verifierBody();
 
-	mutable SharedMutex m_lock;													///< General lock.
-	h256Hash m_known;															///< Headers of transactions in both sets.
+    mutable SharedMutex m_lock;  ///< General lock.
+    h256Hash m_known;            ///< Headers of transactions in both sets.
 
-	std::unordered_map<h256, std::function<void(ImportResult)>> m_callbacks;	///< Called once.
-	h256Hash m_dropped;															///< Transactions that have previously been dropped
+    std::unordered_map<h256, std::function<void(ImportResult)>> m_callbacks;	///< Called once.
+    h256Hash m_dropped;															///< Transactions that have previously been dropped
 
-	PriorityQueue m_current;
-	std::unordered_map<h256, PriorityQueue::iterator> m_currentByHash;			///< Transaction hash to set ref
-	std::unordered_map<Address, std::map<u256, PriorityQueue::iterator>> m_currentByAddressAndNonce; ///< Transactions grouped by account and nonce
-	std::unordered_map<Address, std::map<u256, VerifiedTransaction>> m_future;	/// Future transactions
+    PriorityQueue m_current;
+    std::unordered_map<h256, PriorityQueue::iterator> m_currentByHash;			///< Transaction hash to set ref
+    std::unordered_map<Address, std::map<u256, PriorityQueue::iterator>> m_currentByAddressAndNonce; ///< Transactions grouped by account and nonce
+    std::unordered_map<Address, std::map<u256, VerifiedTransaction>> m_future;	/// Future transactions
 
-	Signal<> m_onReady;															///< Called when a subsequent call to import transactions will return a non-empty container. Be nice and exit fast.
-	Signal<ImportResult, h256 const&, h512 const&> m_onImport;					///< Called for each import attempt. Arguments are result, transaction id an node id. Be nice and exit fast.
-	Signal<h256 const&> m_onReplaced;											///< Called whan transction is dropped during a call to import() to make room for another transaction.
-	unsigned m_limit;															///< Max number of pending transactions
-	unsigned m_futureLimit;														///< Max number of future transactions
-	unsigned m_futureSize = 0;													///< Current number of future transactions
+    Signal<> m_onReady;															///< Called when a subsequent call to import transactions will return a non-empty container. Be nice and exit fast.
+    Signal<ImportResult, h256 const&, h512 const&> m_onImport;					///< Called for each import attempt. Arguments are result, transaction id an node id. Be nice and exit fast.
+    Signal<h256 const&> m_onReplaced;											///< Called whan transction is dropped during a call to import() to make room for another transaction.
+    unsigned m_limit;															///< Max number of pending transactions
+    unsigned m_futureLimit;														///< Max number of future transactions
+    unsigned m_futureSize = 0;													///< Current number of future transactions
 
-	std::condition_variable m_queueReady;										///< Signaled when m_unverified has a new entry.
-	std::vector<std::thread> m_verifiers;
-	std::deque<UnverifiedTransaction> m_unverified;								///< Pending verification queue
-	mutable Mutex x_queue;														///< Verification queue mutex
-	std::atomic<bool> m_aborting = {false};										///< Exit condition for verifier.
+    std::condition_variable m_queueReady;										///< Signaled when m_unverified has a new entry.
+    std::vector<std::thread> m_verifiers;
+    std::deque<UnverifiedTransaction> m_unverified;  ///< Pending verification queue
+    mutable Mutex x_queue;                           ///< Verification queue mutex
+    std::atomic<bool> m_aborting = {false};          ///< Exit condition for verifier.
+
+    Logger m_logger{createLogger(4, "tq")};
+    Logger m_loggerDetail{createLogger(7, "tq")};
 };
 
 }

--- a/libethereum/WarpPeerCapability.cpp
+++ b/libethereum/WarpPeerCapability.cpp
@@ -153,12 +153,12 @@ bool WarpPeerCapability::interpret(unsigned _id, RLP const& _r)
     }
     catch (Exception const&)
     {
-        clog(p2p::NetWarn) << "Warp Peer causing an Exception:"
-                           << boost::current_exception_diagnostic_information() << _r;
+        cnetwarn << "Warp Peer causing an Exception: "
+                 << boost::current_exception_diagnostic_information() << " " << _r;
     }
     catch (std::exception const& _e)
     {
-        clog(p2p::NetWarn) << "Warp Peer causing an exception:" << _e.what() << _r;
+        cnetwarn << "Warp Peer causing an exception: " << _e.what() << " " << _r;
     }
 
     return true;

--- a/libethereum/WarpPeerCapability.cpp
+++ b/libethereum/WarpPeerCapability.cpp
@@ -85,12 +85,12 @@ bool WarpPeerCapability::interpret(unsigned _id, RLP const& _r)
             m_snapshotHash = _r[5].toHash<h256>();
             m_snapshotNumber = _r[6].toInt<u256>();
 
-            clog(p2p::NetMessageSummary)
+            cnetmessage
                 << "Status: "
-                << "protocol version " << m_protocolVersion << "networkId " << m_networkId
-                << "genesis hash " << m_genesisHash << "total difficulty " << m_totalDifficulty
-                << "latest hash" << m_latestHash << "snapshot hash" << m_snapshotHash
-                << "snapshot number" << m_snapshotNumber;
+                << " protocol version " << m_protocolVersion << " networkId " << m_networkId
+                << " genesis hash " << m_genesisHash << " total difficulty " << m_totalDifficulty
+                << " latest hash " << m_latestHash << " snapshot hash " << m_snapshotHash
+                << " snapshot number " << m_snapshotNumber;
             setIdle();
             observer->onPeerStatus(
                 std::dynamic_pointer_cast<WarpPeerCapability>(shared_from_this()));

--- a/libethereum/WarpPeerCapability.cpp
+++ b/libethereum/WarpPeerCapability.cpp
@@ -85,12 +85,11 @@ bool WarpPeerCapability::interpret(unsigned _id, RLP const& _r)
             m_snapshotHash = _r[5].toHash<h256>();
             m_snapshotNumber = _r[6].toInt<u256>();
 
-            cnetmessage
-                << "Status: "
-                << " protocol version " << m_protocolVersion << " networkId " << m_networkId
-                << " genesis hash " << m_genesisHash << " total difficulty " << m_totalDifficulty
-                << " latest hash " << m_latestHash << " snapshot hash " << m_snapshotHash
-                << " snapshot number " << m_snapshotNumber;
+            cnetlog << "Status: "
+                    << " protocol version " << m_protocolVersion << " networkId " << m_networkId
+                    << " genesis hash " << m_genesisHash << " total difficulty "
+                    << m_totalDifficulty << " latest hash " << m_latestHash << " snapshot hash "
+                    << m_snapshotHash << " snapshot number " << m_snapshotNumber;
             setIdle();
             observer->onPeerStatus(
                 std::dynamic_pointer_cast<WarpPeerCapability>(shared_from_this()));

--- a/libp2p/Capability.cpp
+++ b/libp2p/Capability.cpp
@@ -1,18 +1,18 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file Capability.cpp
  * @author Gav Wood <i@gavwood.com>
@@ -29,32 +29,34 @@ using namespace dev;
 using namespace dev::p2p;
 
 Capability::Capability(std::shared_ptr<SessionFace> _s, HostCapabilityFace* _h, unsigned _idOffset):
-	m_session(_s), m_hostCap(_h), m_idOffset(_idOffset)
+    m_session(_s), m_hostCap(_h), m_idOffset(_idOffset)
 {
-	clog(NetConnect) << "New session for capability" << m_hostCap->name() << "; idOffset:" << m_idOffset;
+    cnetdetails << "New session for capability " << m_hostCap->name()
+                << "; idOffset: " << m_idOffset;
 }
 
 void Capability::disable(std::string const& _problem)
 {
-	clog(NetTriviaSummary) << "DISABLE: Disabling capability '" << m_hostCap->name() << "'. Reason:" << _problem;
-	m_enabled = false;
+    cnetdetails << "DISABLE: Disabling capability '" << m_hostCap->name()
+                << "'. Reason: " << _problem;
+    m_enabled = false;
 }
 
 RLPStream& Capability::prep(RLPStream& _s, unsigned _id, unsigned _args)
 {
-	return _s.appendRaw(bytes(1, _id + m_idOffset)).appendList(_args);
+    return _s.appendRaw(bytes(1, _id + m_idOffset)).appendList(_args);
 }
 
 void Capability::sealAndSend(RLPStream& _s)
 {
-	shared_ptr<SessionFace> session = m_session.lock();
-	if (session)
-		session->sealAndSend(_s);
+    shared_ptr<SessionFace> session = m_session.lock();
+    if (session)
+        session->sealAndSend(_s);
 }
 
 void Capability::addRating(int _r)
 {
-	shared_ptr<SessionFace> session = m_session.lock();
-	if (session)
-		session->addRating(_r);
+    shared_ptr<SessionFace> session = m_session.lock();
+    if (session)
+        session->addRating(_r);
 }

--- a/libp2p/Common.cpp
+++ b/libp2p/Common.cpp
@@ -37,7 +37,6 @@ bool dev::p2p::NodeIPEndpoint::test_allowLocal = false;
 //⊳⊲◀▶■▣▢□▷◁▧▨▩▲◆◉◈◇◎●◍◌○◼☑☒☎☢☣☰☀♽♥♠✩✭❓✔✓✖✕✘✓✔✅⚒⚡⦸⬌∅⁕«««»»»⚙━┅┉▬
 
 #if defined(_WIN32)
-const char* NetWarn::name() { return EthYellow "N" EthRed " X"; }
 const char* NetImpolite::name() { return EthYellow "N" EthRed " !"; }
 const char* NetNote::name() { return EthYellow "N" EthBlue " i"; }
 const char* NetConnect::name() { return EthYellow "N" EthYellow " C"; }
@@ -50,7 +49,6 @@ const char* NetLeft::name() { return EthYellow "N" EthNavy "<-"; }
 const char* NetP2PWarn::name() { return EthYellow "N" EthRed " X"; }
 const char* NetP2PNote::name() { return EthYellow "N" EthBlue " i"; }
 #else
-const char* NetWarn::name() { return EthYellow "⧎" EthRed " ✘"; }
 const char* NetImpolite::name() { return EthYellow "⧎" EthRed " !"; }
 const char* NetNote::name() { return EthYellow "⧎" EthBlue " ℹ"; }
 const char* NetConnect::name() { return EthYellow "⧎" EthYellow " ▢"; }

--- a/libp2p/Common.cpp
+++ b/libp2p/Common.cpp
@@ -37,7 +37,6 @@ bool dev::p2p::NodeIPEndpoint::test_allowLocal = false;
 //⊳⊲◀▶■▣▢□▷◁▧▨▩▲◆◉◈◇◎●◍◌○◼☑☒☎☢☣☰☀♽♥♠✩✭❓✔✓✖✕✘✓✔✅⚒⚡⦸⬌∅⁕«««»»»⚙━┅┉▬
 
 #if defined(_WIN32)
-const char* NetImpolite::name() { return EthYellow "N" EthRed " !"; }
 const char* NetConnect::name() { return EthYellow "N" EthYellow " C"; }
 const char* NetMessageSummary::name() { return EthYellow "N" EthWhite " ."; }
 const char* NetMessageDetail::name() { return EthYellow "N" EthGray " o"; }
@@ -48,7 +47,6 @@ const char* NetLeft::name() { return EthYellow "N" EthNavy "<-"; }
 const char* NetP2PWarn::name() { return EthYellow "N" EthRed " X"; }
 const char* NetP2PNote::name() { return EthYellow "N" EthBlue " i"; }
 #else
-const char* NetImpolite::name() { return EthYellow "⧎" EthRed " !"; }
 const char* NetConnect::name() { return EthYellow "⧎" EthYellow " ▢"; }
 const char* NetMessageSummary::name() { return EthYellow "⧎" EthWhite " ◌"; }
 const char* NetMessageDetail::name() { return EthYellow "⧎" EthGray " ○"; }

--- a/libp2p/Common.cpp
+++ b/libp2p/Common.cpp
@@ -37,12 +37,8 @@ bool dev::p2p::NodeIPEndpoint::test_allowLocal = false;
 //⊳⊲◀▶■▣▢□▷◁▧▨▩▲◆◉◈◇◎●◍◌○◼☑☒☎☢☣☰☀♽♥♠✩✭❓✔✓✖✕✘✓✔✅⚒⚡⦸⬌∅⁕«««»»»⚙━┅┉▬
 
 #if defined(_WIN32)
-const char* NetConnect::name() { return EthYellow "N" EthYellow " C"; }
-const char* NetTriviaSummary::name() { return EthYellow "N" EthGray " O"; }
 const char* NetAllDetail::name() { return EthYellow "N" EthCoal " A"; }
 #else
-const char* NetConnect::name() { return EthYellow "⧎" EthYellow " ▢"; }
-const char* NetTriviaSummary::name() { return EthYellow "⧎" EthGray " ◎"; }
 const char* NetAllDetail::name() { return EthYellow "⧎" EthCoal " ●"; }
 #endif
 

--- a/libp2p/Common.cpp
+++ b/libp2p/Common.cpp
@@ -38,7 +38,6 @@ bool dev::p2p::NodeIPEndpoint::test_allowLocal = false;
 
 #if defined(_WIN32)
 const char* NetImpolite::name() { return EthYellow "N" EthRed " !"; }
-const char* NetNote::name() { return EthYellow "N" EthBlue " i"; }
 const char* NetConnect::name() { return EthYellow "N" EthYellow " C"; }
 const char* NetMessageSummary::name() { return EthYellow "N" EthWhite " ."; }
 const char* NetMessageDetail::name() { return EthYellow "N" EthGray " o"; }
@@ -50,7 +49,6 @@ const char* NetP2PWarn::name() { return EthYellow "N" EthRed " X"; }
 const char* NetP2PNote::name() { return EthYellow "N" EthBlue " i"; }
 #else
 const char* NetImpolite::name() { return EthYellow "⧎" EthRed " !"; }
-const char* NetNote::name() { return EthYellow "⧎" EthBlue " ℹ"; }
 const char* NetConnect::name() { return EthYellow "⧎" EthYellow " ▢"; }
 const char* NetMessageSummary::name() { return EthYellow "⧎" EthWhite " ◌"; }
 const char* NetMessageDetail::name() { return EthYellow "⧎" EthGray " ○"; }

--- a/libp2p/Common.cpp
+++ b/libp2p/Common.cpp
@@ -43,8 +43,6 @@ const char* NetTriviaSummary::name() { return EthYellow "N" EthGray " O"; }
 const char* NetAllDetail::name() { return EthYellow "N" EthCoal " A"; }
 const char* NetRight::name() { return EthYellow "N" EthGreen "->"; }
 const char* NetLeft::name() { return EthYellow "N" EthNavy "<-"; }
-const char* NetP2PWarn::name() { return EthYellow "N" EthRed " X"; }
-const char* NetP2PNote::name() { return EthYellow "N" EthBlue " i"; }
 #else
 const char* NetConnect::name() { return EthYellow "⧎" EthYellow " ▢"; }
 const char* NetMessageDetail::name() { return EthYellow "⧎" EthGray " ○"; }
@@ -52,8 +50,6 @@ const char* NetTriviaSummary::name() { return EthYellow "⧎" EthGray " ◎"; }
 const char* NetAllDetail::name() { return EthYellow "⧎" EthCoal " ●"; }
 const char* NetRight::name() { return EthYellow "⧎" EthGreen "▬▶"; }
 const char* NetLeft::name() { return EthYellow "⧎" EthNavy "◀▬"; }
-const char* NetP2PWarn::name() { return EthYellow "⧎" EthRed " ✘"; }
-const char* NetP2PNote::name() { return EthYellow "⧎" EthBlue " ℹ"; }
 #endif
 
 bool p2p::isPublicAddress(std::string const& _addressToCheck)

--- a/libp2p/Common.cpp
+++ b/libp2p/Common.cpp
@@ -38,18 +38,12 @@ bool dev::p2p::NodeIPEndpoint::test_allowLocal = false;
 
 #if defined(_WIN32)
 const char* NetConnect::name() { return EthYellow "N" EthYellow " C"; }
-const char* NetMessageDetail::name() { return EthYellow "N" EthGray " o"; }
 const char* NetTriviaSummary::name() { return EthYellow "N" EthGray " O"; }
 const char* NetAllDetail::name() { return EthYellow "N" EthCoal " A"; }
-const char* NetRight::name() { return EthYellow "N" EthGreen "->"; }
-const char* NetLeft::name() { return EthYellow "N" EthNavy "<-"; }
 #else
 const char* NetConnect::name() { return EthYellow "⧎" EthYellow " ▢"; }
-const char* NetMessageDetail::name() { return EthYellow "⧎" EthGray " ○"; }
 const char* NetTriviaSummary::name() { return EthYellow "⧎" EthGray " ◎"; }
 const char* NetAllDetail::name() { return EthYellow "⧎" EthCoal " ●"; }
-const char* NetRight::name() { return EthYellow "⧎" EthGreen "▬▶"; }
-const char* NetLeft::name() { return EthYellow "⧎" EthNavy "◀▬"; }
 #endif
 
 bool p2p::isPublicAddress(std::string const& _addressToCheck)

--- a/libp2p/Common.cpp
+++ b/libp2p/Common.cpp
@@ -49,7 +49,6 @@ const char* NetRight::name() { return EthYellow "N" EthGreen "->"; }
 const char* NetLeft::name() { return EthYellow "N" EthNavy "<-"; }
 const char* NetP2PWarn::name() { return EthYellow "N" EthRed " X"; }
 const char* NetP2PNote::name() { return EthYellow "N" EthBlue " i"; }
-const char* NetP2PConnect::name() { return EthYellow "N" EthYellow " C"; }
 #else
 const char* NetWarn::name() { return EthYellow "⧎" EthRed " ✘"; }
 const char* NetImpolite::name() { return EthYellow "⧎" EthRed " !"; }
@@ -63,7 +62,6 @@ const char* NetRight::name() { return EthYellow "⧎" EthGreen "▬▶"; }
 const char* NetLeft::name() { return EthYellow "⧎" EthNavy "◀▬"; }
 const char* NetP2PWarn::name() { return EthYellow "⧎" EthRed " ✘"; }
 const char* NetP2PNote::name() { return EthYellow "⧎" EthBlue " ℹ"; }
-const char* NetP2PConnect::name() { return EthYellow "⧎" EthYellow " ▢"; }
 #endif
 
 bool p2p::isPublicAddress(std::string const& _addressToCheck)

--- a/libp2p/Common.cpp
+++ b/libp2p/Common.cpp
@@ -38,7 +38,6 @@ bool dev::p2p::NodeIPEndpoint::test_allowLocal = false;
 
 #if defined(_WIN32)
 const char* NetConnect::name() { return EthYellow "N" EthYellow " C"; }
-const char* NetMessageSummary::name() { return EthYellow "N" EthWhite " ."; }
 const char* NetMessageDetail::name() { return EthYellow "N" EthGray " o"; }
 const char* NetTriviaSummary::name() { return EthYellow "N" EthGray " O"; }
 const char* NetAllDetail::name() { return EthYellow "N" EthCoal " A"; }
@@ -48,7 +47,6 @@ const char* NetP2PWarn::name() { return EthYellow "N" EthRed " X"; }
 const char* NetP2PNote::name() { return EthYellow "N" EthBlue " i"; }
 #else
 const char* NetConnect::name() { return EthYellow "⧎" EthYellow " ▢"; }
-const char* NetMessageSummary::name() { return EthYellow "⧎" EthWhite " ◌"; }
 const char* NetMessageDetail::name() { return EthYellow "⧎" EthGray " ○"; }
 const char* NetTriviaSummary::name() { return EthYellow "⧎" EthGray " ◎"; }
 const char* NetAllDetail::name() { return EthYellow "⧎" EthCoal " ●"; }

--- a/libp2p/Common.cpp
+++ b/libp2p/Common.cpp
@@ -34,14 +34,6 @@ const dev::p2p::Node dev::p2p::UnspecifiedNode = dev::p2p::Node(NodeID(), Unspec
 
 bool dev::p2p::NodeIPEndpoint::test_allowLocal = false;
 
-//⊳⊲◀▶■▣▢□▷◁▧▨▩▲◆◉◈◇◎●◍◌○◼☑☒☎☢☣☰☀♽♥♠✩✭❓✔✓✖✕✘✓✔✅⚒⚡⦸⬌∅⁕«««»»»⚙━┅┉▬
-
-#if defined(_WIN32)
-const char* NetAllDetail::name() { return EthYellow "N" EthCoal " A"; }
-#else
-const char* NetAllDetail::name() { return EthYellow "⧎" EthCoal " ●"; }
-#endif
-
 bool p2p::isPublicAddress(std::string const& _addressToCheck)
 {
     return _addressToCheck.empty() ? false : isPublicAddress(bi::address::from_string(_addressToCheck));

--- a/libp2p/Common.cpp
+++ b/libp2p/Common.cpp
@@ -1,18 +1,18 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file Common.cpp
  * @author Gav Wood <i@gavwood.com>
@@ -44,7 +44,6 @@ const char* NetConnect::name() { return EthYellow "N" EthYellow " C"; }
 const char* NetMessageSummary::name() { return EthYellow "N" EthWhite " ."; }
 const char* NetMessageDetail::name() { return EthYellow "N" EthGray " o"; }
 const char* NetTriviaSummary::name() { return EthYellow "N" EthGray " O"; }
-const char* NetTriviaDetail::name() { return EthYellow "N" EthCoal " 0"; }
 const char* NetAllDetail::name() { return EthYellow "N" EthCoal " A"; }
 const char* NetRight::name() { return EthYellow "N" EthGreen "->"; }
 const char* NetLeft::name() { return EthYellow "N" EthNavy "<-"; }
@@ -59,7 +58,6 @@ const char* NetConnect::name() { return EthYellow "⧎" EthYellow " ▢"; }
 const char* NetMessageSummary::name() { return EthYellow "⧎" EthWhite " ◌"; }
 const char* NetMessageDetail::name() { return EthYellow "⧎" EthGray " ○"; }
 const char* NetTriviaSummary::name() { return EthYellow "⧎" EthGray " ◎"; }
-const char* NetTriviaDetail::name() { return EthYellow "⧎" EthCoal " ◍"; }
 const char* NetAllDetail::name() { return EthYellow "⧎" EthCoal " ●"; }
 const char* NetRight::name() { return EthYellow "⧎" EthGreen "▬▶"; }
 const char* NetLeft::name() { return EthYellow "⧎" EthNavy "◀▬"; }
@@ -70,12 +68,12 @@ const char* NetP2PConnect::name() { return EthYellow "⧎" EthYellow " ▢"; }
 
 bool p2p::isPublicAddress(std::string const& _addressToCheck)
 {
-	return _addressToCheck.empty() ? false : isPublicAddress(bi::address::from_string(_addressToCheck));
+    return _addressToCheck.empty() ? false : isPublicAddress(bi::address::from_string(_addressToCheck));
 }
 
 bool p2p::isPublicAddress(bi::address const& _addressToCheck)
 {
-	return !(isPrivateAddress(_addressToCheck) || isLocalHostAddress(_addressToCheck));
+    return !(isPrivateAddress(_addressToCheck) || isLocalHostAddress(_addressToCheck));
 }
 
 // Helper function to determine if an address falls within one of the reserved ranges
@@ -83,188 +81,188 @@ bool p2p::isPublicAddress(bi::address const& _addressToCheck)
 // Class A "10.*", Class B "172.[16->31].*", Class C "192.168.*"
 bool p2p::isPrivateAddress(bi::address const& _addressToCheck)
 {
-	if (_addressToCheck.is_v4())
-	{
-		bi::address_v4 v4Address = _addressToCheck.to_v4();
-		bi::address_v4::bytes_type bytesToCheck = v4Address.to_bytes();
-		if (bytesToCheck[0] == 10 || bytesToCheck[0] == 127)
-			return true;
-		if (bytesToCheck[0] == 172 && (bytesToCheck[1] >= 16 && bytesToCheck[1] <= 31))
-			return true;
-		if (bytesToCheck[0] == 192 && bytesToCheck[1] == 168)
-			return true;
-	}
-	else if (_addressToCheck.is_v6())
-	{
-		bi::address_v6 v6Address = _addressToCheck.to_v6();
-		bi::address_v6::bytes_type bytesToCheck = v6Address.to_bytes();
-		if (bytesToCheck[0] == 0xfd && bytesToCheck[1] == 0)
-			return true;
-		if (!bytesToCheck[0] && !bytesToCheck[1] && !bytesToCheck[2] && !bytesToCheck[3] && !bytesToCheck[4] && !bytesToCheck[5] && !bytesToCheck[6] && !bytesToCheck[7]
-				 && !bytesToCheck[8] && !bytesToCheck[9] && !bytesToCheck[10] && !bytesToCheck[11] && !bytesToCheck[12] && !bytesToCheck[13] && !bytesToCheck[14] && (bytesToCheck[15] == 0 || bytesToCheck[15] == 1))
-			return true;
-	}
-	return false;
+    if (_addressToCheck.is_v4())
+    {
+        bi::address_v4 v4Address = _addressToCheck.to_v4();
+        bi::address_v4::bytes_type bytesToCheck = v4Address.to_bytes();
+        if (bytesToCheck[0] == 10 || bytesToCheck[0] == 127)
+            return true;
+        if (bytesToCheck[0] == 172 && (bytesToCheck[1] >= 16 && bytesToCheck[1] <= 31))
+            return true;
+        if (bytesToCheck[0] == 192 && bytesToCheck[1] == 168)
+            return true;
+    }
+    else if (_addressToCheck.is_v6())
+    {
+        bi::address_v6 v6Address = _addressToCheck.to_v6();
+        bi::address_v6::bytes_type bytesToCheck = v6Address.to_bytes();
+        if (bytesToCheck[0] == 0xfd && bytesToCheck[1] == 0)
+            return true;
+        if (!bytesToCheck[0] && !bytesToCheck[1] && !bytesToCheck[2] && !bytesToCheck[3] && !bytesToCheck[4] && !bytesToCheck[5] && !bytesToCheck[6] && !bytesToCheck[7]
+                 && !bytesToCheck[8] && !bytesToCheck[9] && !bytesToCheck[10] && !bytesToCheck[11] && !bytesToCheck[12] && !bytesToCheck[13] && !bytesToCheck[14] && (bytesToCheck[15] == 0 || bytesToCheck[15] == 1))
+            return true;
+    }
+    return false;
 }
 
 bool p2p::isPrivateAddress(std::string const& _addressToCheck)
 {
-	return _addressToCheck.empty() ? false : isPrivateAddress(bi::address::from_string(_addressToCheck));
+    return _addressToCheck.empty() ? false : isPrivateAddress(bi::address::from_string(_addressToCheck));
 }
 
 // Helper function to determine if an address is localhost
 bool p2p::isLocalHostAddress(bi::address const& _addressToCheck)
 {
-	// @todo: ivp6 link-local adresses (macos), ex: fe80::1%lo0
-	static const set<bi::address> c_rejectAddresses = {
-		{bi::address_v4::from_string("127.0.0.1")},
-		{bi::address_v4::from_string("0.0.0.0")},
-		{bi::address_v6::from_string("::1")},
-		{bi::address_v6::from_string("::")}
-	};
-	
-	return find(c_rejectAddresses.begin(), c_rejectAddresses.end(), _addressToCheck) != c_rejectAddresses.end();
+    // @todo: ivp6 link-local adresses (macos), ex: fe80::1%lo0
+    static const set<bi::address> c_rejectAddresses = {
+        {bi::address_v4::from_string("127.0.0.1")},
+        {bi::address_v4::from_string("0.0.0.0")},
+        {bi::address_v6::from_string("::1")},
+        {bi::address_v6::from_string("::")}
+    };
+    
+    return find(c_rejectAddresses.begin(), c_rejectAddresses.end(), _addressToCheck) != c_rejectAddresses.end();
 }
 
 bool p2p::isLocalHostAddress(std::string const& _addressToCheck)
 {
-	return _addressToCheck.empty() ? false : isLocalHostAddress(bi::address::from_string(_addressToCheck));
+    return _addressToCheck.empty() ? false : isLocalHostAddress(bi::address::from_string(_addressToCheck));
 }
 
 std::string p2p::reasonOf(DisconnectReason _r)
 {
-	switch (_r)
-	{
-	case DisconnectRequested: return "Disconnect was requested.";
-	case TCPError: return "Low-level TCP communication error.";
-	case BadProtocol: return "Data format error.";
-	case UselessPeer: return "Peer had no use for this node.";
-	case TooManyPeers: return "Peer had too many connections.";
-	case DuplicatePeer: return "Peer was already connected.";
-	case IncompatibleProtocol: return "Peer protocol versions are incompatible.";
-	case NullIdentity: return "Null identity given.";
-	case ClientQuit: return "Peer is exiting.";
-	case UnexpectedIdentity: return "Unexpected identity given.";
-	case LocalIdentity: return "Connected to ourselves.";
-	case UserReason: return "Subprotocol reason.";
-	case NoDisconnect: return "(No disconnect has happened.)";
-	default: return "Unknown reason.";
-	}
+    switch (_r)
+    {
+    case DisconnectRequested: return "Disconnect was requested.";
+    case TCPError: return "Low-level TCP communication error.";
+    case BadProtocol: return "Data format error.";
+    case UselessPeer: return "Peer had no use for this node.";
+    case TooManyPeers: return "Peer had too many connections.";
+    case DuplicatePeer: return "Peer was already connected.";
+    case IncompatibleProtocol: return "Peer protocol versions are incompatible.";
+    case NullIdentity: return "Null identity given.";
+    case ClientQuit: return "Peer is exiting.";
+    case UnexpectedIdentity: return "Unexpected identity given.";
+    case LocalIdentity: return "Connected to ourselves.";
+    case UserReason: return "Subprotocol reason.";
+    case NoDisconnect: return "(No disconnect has happened.)";
+    default: return "Unknown reason.";
+    }
 }
 
 void NodeIPEndpoint::streamRLP(RLPStream& _s, RLPAppend _append) const
 {
-	if (_append == StreamList)
-		_s.appendList(3);
-	if (address.is_v4())
-		_s << bytesConstRef(&address.to_v4().to_bytes()[0], 4);
-	else if (address.is_v6())
-		_s << bytesConstRef(&address.to_v6().to_bytes()[0], 16);
-	else
-		_s << bytes();
-	_s << udpPort << tcpPort;
+    if (_append == StreamList)
+        _s.appendList(3);
+    if (address.is_v4())
+        _s << bytesConstRef(&address.to_v4().to_bytes()[0], 4);
+    else if (address.is_v6())
+        _s << bytesConstRef(&address.to_v6().to_bytes()[0], 16);
+    else
+        _s << bytes();
+    _s << udpPort << tcpPort;
 }
 
 void NodeIPEndpoint::interpretRLP(RLP const& _r)
 {
-	if (_r[0].size() == 4)
-		address = bi::address_v4(*(bi::address_v4::bytes_type*)_r[0].toBytes().data());
-	else if (_r[0].size() == 16)
-		address = bi::address_v6(*(bi::address_v6::bytes_type*)_r[0].toBytes().data());
-	else
-		address = bi::address();
-	udpPort = _r[1].toInt<uint16_t>();
-	tcpPort = _r[2].toInt<uint16_t>();
+    if (_r[0].size() == 4)
+        address = bi::address_v4(*(bi::address_v4::bytes_type*)_r[0].toBytes().data());
+    else if (_r[0].size() == 16)
+        address = bi::address_v6(*(bi::address_v6::bytes_type*)_r[0].toBytes().data());
+    else
+        address = bi::address();
+    udpPort = _r[1].toInt<uint16_t>();
+    tcpPort = _r[2].toInt<uint16_t>();
 }
 
 void DeadlineOps::reap()
 {
-	if (m_stopped)
-		return;
+    if (m_stopped)
+        return;
 
-	Guard l(x_timers);
-	std::vector<DeadlineOp>::iterator t = m_timers.begin();
-	while (t != m_timers.end())
-		if (t->expired())
-		{
-			t->wait();
-			t = m_timers.erase(t);
-		}
-		else
-			t++;
+    Guard l(x_timers);
+    std::vector<DeadlineOp>::iterator t = m_timers.begin();
+    while (t != m_timers.end())
+        if (t->expired())
+        {
+            t->wait();
+            t = m_timers.erase(t);
+        }
+        else
+            t++;
 
-	m_timers.emplace_back(m_io, m_reapIntervalMs, [this](boost::system::error_code const& ec)
-	{
-		if (!ec && !m_stopped)
-			reap();
-	});
+    m_timers.emplace_back(m_io, m_reapIntervalMs, [this](boost::system::error_code const& ec)
+    {
+        if (!ec && !m_stopped)
+            reap();
+    });
 }
 
 Node::Node(Node const& _original):
-	id(_original.id),
-	endpoint(_original.endpoint),
-	peerType(_original.peerType.load())
+    id(_original.id),
+    endpoint(_original.endpoint),
+    peerType(_original.peerType.load())
 {}
 
 Node::Node(NodeSpec const& _s, PeerType _p):
-	id(_s.id()),
-	endpoint(_s.nodeIPEndpoint()),
-	peerType(_p)
+    id(_s.id()),
+    endpoint(_s.nodeIPEndpoint()),
+    peerType(_p)
 {}
 
 NodeSpec::NodeSpec(string const& _user)
 {
-	m_address = _user;
-	if (m_address.substr(0, 8) == "enode://" && m_address.find('@') == 136)
-	{
-		m_id = p2p::NodeID(m_address.substr(8, 128));
-		m_address = m_address.substr(137);
-	}
-	size_t colon = m_address.find_first_of(":");
-	if (colon != string::npos)
-	{
-		string ports = m_address.substr(colon + 1);
-		m_address = m_address.substr(0, colon);
-		size_t p2 = ports.find_first_of(".");
-		if (p2 != string::npos)
-		{
-			m_udpPort = stoi(ports.substr(p2 + 1));
-			m_tcpPort = stoi(ports.substr(0, p2));
-		}
-		else
-			m_tcpPort = m_udpPort = stoi(ports);
-	}
+    m_address = _user;
+    if (m_address.substr(0, 8) == "enode://" && m_address.find('@') == 136)
+    {
+        m_id = p2p::NodeID(m_address.substr(8, 128));
+        m_address = m_address.substr(137);
+    }
+    size_t colon = m_address.find_first_of(":");
+    if (colon != string::npos)
+    {
+        string ports = m_address.substr(colon + 1);
+        m_address = m_address.substr(0, colon);
+        size_t p2 = ports.find_first_of(".");
+        if (p2 != string::npos)
+        {
+            m_udpPort = stoi(ports.substr(p2 + 1));
+            m_tcpPort = stoi(ports.substr(0, p2));
+        }
+        else
+            m_tcpPort = m_udpPort = stoi(ports);
+    }
 }
 
 NodeIPEndpoint NodeSpec::nodeIPEndpoint() const
 {
-	return NodeIPEndpoint(p2p::Network::resolveHost(m_address).address(), m_udpPort, m_tcpPort);
+    return NodeIPEndpoint(p2p::Network::resolveHost(m_address).address(), m_udpPort, m_tcpPort);
 }
 
 std::string NodeSpec::enode() const
 {
-	string ret = m_address;
+    string ret = m_address;
 
-	if (m_tcpPort)
-		if (m_udpPort && m_tcpPort != m_udpPort)
-			ret += ":" + toString(m_tcpPort) + "." + toString(m_udpPort);
-		else
-			ret += ":" + toString(m_tcpPort);
-	else if (m_udpPort)
-		ret += ":" + toString(m_udpPort);
+    if (m_tcpPort)
+        if (m_udpPort && m_tcpPort != m_udpPort)
+            ret += ":" + toString(m_tcpPort) + "." + toString(m_udpPort);
+        else
+            ret += ":" + toString(m_tcpPort);
+    else if (m_udpPort)
+        ret += ":" + toString(m_udpPort);
 
-	if (m_id)
-		return "enode://" + m_id.hex() + "@" + ret;
-	return ret;
+    if (m_id)
+        return "enode://" + m_id.hex() + "@" + ret;
+    return ret;
 }
 
 namespace dev
 {
-	
+    
 std::ostream& operator<<(std::ostream& _out, dev::p2p::NodeIPEndpoint const& _ep)
 {
-	_out << _ep.address << _ep.udpPort << _ep.tcpPort;
-	return _out;
+    _out << _ep.address << _ep.udpPort << _ep.tcpPort;
+    return _out;
 }
 
 }

--- a/libp2p/Common.h
+++ b/libp2p/Common.h
@@ -90,7 +90,6 @@ NET_GLOBAL_LOGGER(netwarn, 0)
 NET_GLOBAL_LOGGER(netnote, 2)
 #define cnetnote LOG(dev::p2p::g_netnoteLogger::get())
 
-struct NetImpolite: public LogChannel { static const char* name(); static const int verbosity = 3; };
 struct NetMessageSummary: public LogChannel { static const char* name(); static const int verbosity = 4; };
 struct NetConnect: public LogChannel { static const char* name(); static const int verbosity = 10; };
 struct NetMessageDetail: public LogChannel { static const char* name(); static const int verbosity = 5; };

--- a/libp2p/Common.h
+++ b/libp2p/Common.h
@@ -80,7 +80,14 @@ struct InvalidPublicIPAddress: virtual dev::Exception {};
 /// The ECDHE agreement failed during RLPx handshake.
 struct ECDHEError: virtual Exception {};
 
-struct NetWarn: public LogChannel { static const char* name(); static const int verbosity = 0; };
+#define NET_GLOBAL_LOGGER(NAME, SEVERITY)                      \
+    BOOST_LOG_INLINE_GLOBAL_LOGGER_CTOR_ARGS(g_##NAME##Logger, \
+        boost::log::sources::severity_channel_logger_mt<>,     \
+        (boost::log::keywords::severity = SEVERITY)(boost::log::keywords::channel = "net"))
+
+NET_GLOBAL_LOGGER(netwarn, 0)
+#define cnetwarn LOG(dev::p2p::g_netwarnLogger::get())
+
 struct NetNote: public LogChannel { static const char* name(); static const int verbosity = 2; };
 struct NetImpolite: public LogChannel { static const char* name(); static const int verbosity = 3; };
 struct NetMessageSummary: public LogChannel { static const char* name(); static const int verbosity = 4; };

--- a/libp2p/Common.h
+++ b/libp2p/Common.h
@@ -87,8 +87,9 @@ struct ECDHEError: virtual Exception {};
 
 NET_GLOBAL_LOGGER(netwarn, 0)
 #define cnetwarn LOG(dev::p2p::g_netwarnLogger::get())
+NET_GLOBAL_LOGGER(netnote, 2)
+#define cnetnote LOG(dev::p2p::g_netnoteLogger::get())
 
-struct NetNote: public LogChannel { static const char* name(); static const int verbosity = 2; };
 struct NetImpolite: public LogChannel { static const char* name(); static const int verbosity = 3; };
 struct NetMessageSummary: public LogChannel { static const char* name(); static const int verbosity = 4; };
 struct NetConnect: public LogChannel { static const char* name(); static const int verbosity = 10; };

--- a/libp2p/Common.h
+++ b/libp2p/Common.h
@@ -90,10 +90,11 @@ NET_GLOBAL_LOGGER(netwarn, 0)
 NET_GLOBAL_LOGGER(netnote, 2)
 #define cnetnote LOG(dev::p2p::g_netnoteLogger::get())
 NET_GLOBAL_LOGGER(netmessage, 4)
+// TODO rename to cnetlog
 #define cnetmessage LOG(dev::p2p::g_netmessageLogger::get())
+NET_GLOBAL_LOGGER(netdetails, 10)
+#define cnetdetails LOG(dev::p2p::g_netdetailsLogger::get())
 
-struct NetConnect: public LogChannel { static const char* name(); static const int verbosity = 10; };
-struct NetTriviaSummary: public LogChannel { static const char* name(); static const int verbosity = 10; };
 struct NetAllDetail: public LogChannel { static const char* name(); static const int verbosity = 13; };
 
 enum PacketType

--- a/libp2p/Common.h
+++ b/libp2p/Common.h
@@ -98,8 +98,6 @@ struct NetTriviaSummary: public LogChannel { static const char* name(); static c
 struct NetAllDetail: public LogChannel { static const char* name(); static const int verbosity = 13; };
 struct NetRight: public LogChannel { static const char* name(); static const int verbosity = 14; };
 struct NetLeft: public LogChannel { static const char* name(); static const int verbosity = 15; };
-struct NetP2PWarn: public LogChannel { static const char* name(); static const int verbosity = 2; };
-struct NetP2PNote: public LogChannel { static const char* name(); static const int verbosity = 6; };
 
 enum PacketType
 {

--- a/libp2p/Common.h
+++ b/libp2p/Common.h
@@ -89,8 +89,9 @@ NET_GLOBAL_LOGGER(netwarn, 0)
 #define cnetwarn LOG(dev::p2p::g_netwarnLogger::get())
 NET_GLOBAL_LOGGER(netnote, 2)
 #define cnetnote LOG(dev::p2p::g_netnoteLogger::get())
+NET_GLOBAL_LOGGER(netmessage, 4)
+#define cnetmessage LOG(dev::p2p::g_netmessageLogger::get())
 
-struct NetMessageSummary: public LogChannel { static const char* name(); static const int verbosity = 4; };
 struct NetConnect: public LogChannel { static const char* name(); static const int verbosity = 10; };
 struct NetMessageDetail: public LogChannel { static const char* name(); static const int verbosity = 5; };
 struct NetTriviaSummary: public LogChannel { static const char* name(); static const int verbosity = 10; };

--- a/libp2p/Common.h
+++ b/libp2p/Common.h
@@ -92,7 +92,6 @@ struct NetRight: public LogChannel { static const char* name(); static const int
 struct NetLeft: public LogChannel { static const char* name(); static const int verbosity = 15; };
 struct NetP2PWarn: public LogChannel { static const char* name(); static const int verbosity = 2; };
 struct NetP2PNote: public LogChannel { static const char* name(); static const int verbosity = 6; };
-struct NetP2PConnect: public LogChannel { static const char* name(); static const int verbosity = 10; };
 
 enum PacketType
 {

--- a/libp2p/Common.h
+++ b/libp2p/Common.h
@@ -89,9 +89,8 @@ NET_GLOBAL_LOGGER(netwarn, 0)
 #define cnetwarn LOG(dev::p2p::g_netwarnLogger::get())
 NET_GLOBAL_LOGGER(netnote, 2)
 #define cnetnote LOG(dev::p2p::g_netnoteLogger::get())
-NET_GLOBAL_LOGGER(netmessage, 4)
-// TODO rename to cnetlog
-#define cnetmessage LOG(dev::p2p::g_netmessageLogger::get())
+NET_GLOBAL_LOGGER(netlog, 4)
+#define cnetlog LOG(dev::p2p::g_netlogLogger::get())
 NET_GLOBAL_LOGGER(netdetails, 10)
 #define cnetdetails LOG(dev::p2p::g_netdetailsLogger::get())
 

--- a/libp2p/Common.h
+++ b/libp2p/Common.h
@@ -95,8 +95,6 @@ NET_GLOBAL_LOGGER(netmessage, 4)
 NET_GLOBAL_LOGGER(netdetails, 10)
 #define cnetdetails LOG(dev::p2p::g_netdetailsLogger::get())
 
-struct NetAllDetail: public LogChannel { static const char* name(); static const int verbosity = 13; };
-
 enum PacketType
 {
     HelloPacket = 0,

--- a/libp2p/Common.h
+++ b/libp2p/Common.h
@@ -93,11 +93,8 @@ NET_GLOBAL_LOGGER(netmessage, 4)
 #define cnetmessage LOG(dev::p2p::g_netmessageLogger::get())
 
 struct NetConnect: public LogChannel { static const char* name(); static const int verbosity = 10; };
-struct NetMessageDetail: public LogChannel { static const char* name(); static const int verbosity = 5; };
 struct NetTriviaSummary: public LogChannel { static const char* name(); static const int verbosity = 10; };
 struct NetAllDetail: public LogChannel { static const char* name(); static const int verbosity = 13; };
-struct NetRight: public LogChannel { static const char* name(); static const int verbosity = 14; };
-struct NetLeft: public LogChannel { static const char* name(); static const int verbosity = 15; };
 
 enum PacketType
 {

--- a/libp2p/Common.h
+++ b/libp2p/Common.h
@@ -1,18 +1,18 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file Common.h
  * @author Gav Wood <i@gavwood.com>
@@ -87,7 +87,6 @@ struct NetMessageSummary: public LogChannel { static const char* name(); static 
 struct NetConnect: public LogChannel { static const char* name(); static const int verbosity = 10; };
 struct NetMessageDetail: public LogChannel { static const char* name(); static const int verbosity = 5; };
 struct NetTriviaSummary: public LogChannel { static const char* name(); static const int verbosity = 10; };
-struct NetTriviaDetail: public LogChannel { static const char* name(); static const int verbosity = 11; };
 struct NetAllDetail: public LogChannel { static const char* name(); static const int verbosity = 13; };
 struct NetRight: public LogChannel { static const char* name(); static const int verbosity = 14; };
 struct NetLeft: public LogChannel { static const char* name(); static const int verbosity = 15; };
@@ -97,46 +96,46 @@ struct NetP2PConnect: public LogChannel { static const char* name(); static cons
 
 enum PacketType
 {
-	HelloPacket = 0,
-	DisconnectPacket,
-	PingPacket,
-	PongPacket,
-	GetPeersPacket,
-	PeersPacket,
-	UserPacket = 0x10
+    HelloPacket = 0,
+    DisconnectPacket,
+    PingPacket,
+    PongPacket,
+    GetPeersPacket,
+    PeersPacket,
+    UserPacket = 0x10
 };
 
 enum DisconnectReason
 {
-	DisconnectRequested = 0,
-	TCPError,
-	BadProtocol,
-	UselessPeer,
-	TooManyPeers,
-	DuplicatePeer,
-	IncompatibleProtocol,
-	NullIdentity,
-	ClientQuit,
-	UnexpectedIdentity,
-	LocalIdentity,
-	PingTimeout,
-	UserReason = 0x10,
-	NoDisconnect = 0xffff
+    DisconnectRequested = 0,
+    TCPError,
+    BadProtocol,
+    UselessPeer,
+    TooManyPeers,
+    DuplicatePeer,
+    IncompatibleProtocol,
+    NullIdentity,
+    ClientQuit,
+    UnexpectedIdentity,
+    LocalIdentity,
+    PingTimeout,
+    UserReason = 0x10,
+    NoDisconnect = 0xffff
 };
 
 inline bool isPermanentProblem(DisconnectReason _r)
 {
-	switch (_r)
-	{
-	case DuplicatePeer:
-	case IncompatibleProtocol:
-	case NullIdentity:
-	case UnexpectedIdentity:
-	case LocalIdentity:
-		return true;
-	default:
-		return false;
-	}
+    switch (_r)
+    {
+    case DuplicatePeer:
+    case IncompatibleProtocol:
+    case NullIdentity:
+    case UnexpectedIdentity:
+    case LocalIdentity:
+        return true;
+    default:
+        return false;
+    }
 }
 
 /// @returns the string form of the given disconnection reason.
@@ -153,23 +152,23 @@ using CapDescs = std::vector<CapDesc>;
  */
 struct PeerSessionInfo
 {
-	NodeID const id;
-	std::string const clientVersion;
-	std::string const host;
-	unsigned short const port;
-	std::chrono::steady_clock::duration lastPing;
-	std::set<CapDesc> const caps;
-	unsigned socketId;
-	std::map<std::string, std::string> notes;
-	unsigned const protocolVersion;
+    NodeID const id;
+    std::string const clientVersion;
+    std::string const host;
+    unsigned short const port;
+    std::chrono::steady_clock::duration lastPing;
+    std::set<CapDesc> const caps;
+    unsigned socketId;
+    std::map<std::string, std::string> notes;
+    unsigned const protocolVersion;
 };
 
 using PeerSessionInfos = std::vector<PeerSessionInfo>;
 
 enum class PeerType
 {
-	Optional,
-	Required
+    Optional,
+    Required
 };
 
 /**
@@ -178,143 +177,143 @@ enum class PeerType
 class NodeIPEndpoint
 {
 public:
-	enum RLPAppend
-	{
-		StreamList,
-		StreamInline
-	};
-	
-	/// Setting true causes isAllowed to return true for all addresses. (Used by test fixtures)
-	static bool test_allowLocal;
+    enum RLPAppend
+    {
+        StreamList,
+        StreamInline
+    };
+    
+    /// Setting true causes isAllowed to return true for all addresses. (Used by test fixtures)
+    static bool test_allowLocal;
 
-	NodeIPEndpoint() = default;
-	NodeIPEndpoint(bi::address _addr, uint16_t _udp, uint16_t _tcp): address(_addr), udpPort(_udp), tcpPort(_tcp) {}
-	NodeIPEndpoint(RLP const& _r) { interpretRLP(_r); }
+    NodeIPEndpoint() = default;
+    NodeIPEndpoint(bi::address _addr, uint16_t _udp, uint16_t _tcp): address(_addr), udpPort(_udp), tcpPort(_tcp) {}
+    NodeIPEndpoint(RLP const& _r) { interpretRLP(_r); }
 
-	operator bi::udp::endpoint() const { return bi::udp::endpoint(address, udpPort); }
-	operator bi::tcp::endpoint() const { return bi::tcp::endpoint(address, tcpPort); }
-	
-	operator bool() const { return !address.is_unspecified() && udpPort > 0 && tcpPort > 0; }
-	
-	bool isAllowed() const { return NodeIPEndpoint::test_allowLocal ? !address.is_unspecified() : isPublicAddress(address); }
+    operator bi::udp::endpoint() const { return bi::udp::endpoint(address, udpPort); }
+    operator bi::tcp::endpoint() const { return bi::tcp::endpoint(address, tcpPort); }
+    
+    operator bool() const { return !address.is_unspecified() && udpPort > 0 && tcpPort > 0; }
+    
+    bool isAllowed() const { return NodeIPEndpoint::test_allowLocal ? !address.is_unspecified() : isPublicAddress(address); }
 
-	bool operator==(NodeIPEndpoint const& _cmp) const {
-		return address == _cmp.address && udpPort == _cmp.udpPort && tcpPort == _cmp.tcpPort;
- 	}
-	bool operator!=(NodeIPEndpoint const& _cmp) const {
-		return !operator==(_cmp);
- 	}
-	
-	void streamRLP(RLPStream& _s, RLPAppend _append = StreamList) const;
-	void interpretRLP(RLP const& _r);
+    bool operator==(NodeIPEndpoint const& _cmp) const {
+        return address == _cmp.address && udpPort == _cmp.udpPort && tcpPort == _cmp.tcpPort;
+    }
+    bool operator!=(NodeIPEndpoint const& _cmp) const {
+        return !operator==(_cmp);
+    }
+    
+    void streamRLP(RLPStream& _s, RLPAppend _append = StreamList) const;
+    void interpretRLP(RLP const& _r);
 
-	// TODO: make private, give accessors and rename m_...
-	bi::address address;
-	uint16_t udpPort = 0;
-	uint16_t tcpPort = 0;
+    // TODO: make private, give accessors and rename m_...
+    bi::address address;
+    uint16_t udpPort = 0;
+    uint16_t tcpPort = 0;
 };
 
 struct NodeSpec
 {
-	NodeSpec() {}
+    NodeSpec() {}
 
-	/// Accepts user-readable strings of the form (enode://pubkey@)host({:port,:tcpport.udpport})
-	NodeSpec(std::string const& _user);
+    /// Accepts user-readable strings of the form (enode://pubkey@)host({:port,:tcpport.udpport})
+    NodeSpec(std::string const& _user);
 
-	NodeSpec(std::string const& _addr, uint16_t _port, int _udpPort = -1):
-		m_address(_addr),
-		m_tcpPort(_port),
-		m_udpPort(_udpPort == -1 ? _port : (uint16_t)_udpPort)
-	{}
+    NodeSpec(std::string const& _addr, uint16_t _port, int _udpPort = -1):
+        m_address(_addr),
+        m_tcpPort(_port),
+        m_udpPort(_udpPort == -1 ? _port : (uint16_t)_udpPort)
+    {}
 
-	NodeID id() const { return m_id; }
+    NodeID id() const { return m_id; }
 
-	NodeIPEndpoint nodeIPEndpoint() const;
+    NodeIPEndpoint nodeIPEndpoint() const;
 
-	std::string enode() const;
+    std::string enode() const;
 
 private:
-	std::string m_address;
-	uint16_t m_tcpPort = 0;
-	uint16_t m_udpPort = 0;
-	NodeID m_id;
+    std::string m_address;
+    uint16_t m_tcpPort = 0;
+    uint16_t m_udpPort = 0;
+    NodeID m_id;
 };
 
 class Node
 {
 public:
-	Node() = default;
-	virtual ~Node() = default;
-	Node(Node const&);
-	Node(Public _publicKey, NodeIPEndpoint const& _ip, PeerType _peerType = PeerType::Optional): id(_publicKey), endpoint(_ip), peerType(_peerType) {}
-	Node(NodeSpec const& _s, PeerType _peerType = PeerType::Optional);
+    Node() = default;
+    virtual ~Node() = default;
+    Node(Node const&);
+    Node(Public _publicKey, NodeIPEndpoint const& _ip, PeerType _peerType = PeerType::Optional): id(_publicKey), endpoint(_ip), peerType(_peerType) {}
+    Node(NodeSpec const& _s, PeerType _peerType = PeerType::Optional);
 
-	virtual NodeID const& address() const { return id; }
-	virtual Public const& publicKey() const { return id; }
-	
-	virtual operator bool() const { return (bool)id; }
+    virtual NodeID const& address() const { return id; }
+    virtual Public const& publicKey() const { return id; }
+    
+    virtual operator bool() const { return (bool)id; }
 
-	// TODO: make private, give accessors and rename m_...
-	NodeID id;
+    // TODO: make private, give accessors and rename m_...
+    NodeID id;
 
-	/// Endpoints by which we expect to reach node.
-	// TODO: make private, give accessors and rename m_...
-	NodeIPEndpoint endpoint;
+    /// Endpoints by which we expect to reach node.
+    // TODO: make private, give accessors and rename m_...
+    NodeIPEndpoint endpoint;
 
-	// TODO: p2p implement
-	std::atomic<PeerType> peerType{PeerType::Optional};
+    // TODO: p2p implement
+    std::atomic<PeerType> peerType{PeerType::Optional};
 };
 
 class DeadlineOps
 {
-	class DeadlineOp
-	{
-	public:
-		DeadlineOp(ba::io_service& _io, unsigned _msInFuture, std::function<void(boost::system::error_code const&)> const& _f): m_timer(new ba::deadline_timer(_io)) { m_timer->expires_from_now(boost::posix_time::milliseconds(_msInFuture)); m_timer->async_wait(_f); }
-		~DeadlineOp() { if (m_timer) m_timer->cancel(); }
-		
-		DeadlineOp(DeadlineOp&& _s): m_timer(_s.m_timer.release()) {}
-		DeadlineOp& operator=(DeadlineOp&& _s)
-		{
-			assert(&_s != this);
+    class DeadlineOp
+    {
+    public:
+        DeadlineOp(ba::io_service& _io, unsigned _msInFuture, std::function<void(boost::system::error_code const&)> const& _f): m_timer(new ba::deadline_timer(_io)) { m_timer->expires_from_now(boost::posix_time::milliseconds(_msInFuture)); m_timer->async_wait(_f); }
+        ~DeadlineOp() { if (m_timer) m_timer->cancel(); }
+        
+        DeadlineOp(DeadlineOp&& _s): m_timer(_s.m_timer.release()) {}
+        DeadlineOp& operator=(DeadlineOp&& _s)
+        {
+            assert(&_s != this);
 
-			m_timer.reset(_s.m_timer.release());
-			return *this;
-		}
-		
-		bool expired() { Guard l(x_timer); return m_timer->expires_from_now().total_nanoseconds() <= 0; }
-		void wait() { Guard l(x_timer); m_timer->wait(); }
-		
-	private:
-		std::unique_ptr<ba::deadline_timer> m_timer;
-		Mutex x_timer;
-	};
-	
+            m_timer.reset(_s.m_timer.release());
+            return *this;
+        }
+        
+        bool expired() { Guard l(x_timer); return m_timer->expires_from_now().total_nanoseconds() <= 0; }
+        void wait() { Guard l(x_timer); m_timer->wait(); }
+        
+    private:
+        std::unique_ptr<ba::deadline_timer> m_timer;
+        Mutex x_timer;
+    };
+    
 public:
-	DeadlineOps(ba::io_service& _io, unsigned _reapIntervalMs = 100): m_io(_io), m_reapIntervalMs(_reapIntervalMs), m_stopped(false) { reap(); }
-	~DeadlineOps() { stop(); }
+    DeadlineOps(ba::io_service& _io, unsigned _reapIntervalMs = 100): m_io(_io), m_reapIntervalMs(_reapIntervalMs), m_stopped(false) { reap(); }
+    ~DeadlineOps() { stop(); }
 
-	void schedule(unsigned _msInFuture, std::function<void(boost::system::error_code const&)> const& _f) { if (m_stopped) return; DEV_GUARDED(x_timers) m_timers.emplace_back(m_io, _msInFuture, _f); }	
+    void schedule(unsigned _msInFuture, std::function<void(boost::system::error_code const&)> const& _f) { if (m_stopped) return; DEV_GUARDED(x_timers) m_timers.emplace_back(m_io, _msInFuture, _f); }	
 
-	void stop() { m_stopped = true; DEV_GUARDED(x_timers) m_timers.clear(); }
+    void stop() { m_stopped = true; DEV_GUARDED(x_timers) m_timers.clear(); }
 
-	bool isStopped() const { return m_stopped; }
-	
+    bool isStopped() const { return m_stopped; }
+    
 protected:
-	void reap();
-	
+    void reap();
+    
 private:
-	ba::io_service& m_io;
-	unsigned m_reapIntervalMs;
-	
-	std::vector<DeadlineOp> m_timers;
-	Mutex x_timers;
-	
-	std::atomic<bool> m_stopped;
+    ba::io_service& m_io;
+    unsigned m_reapIntervalMs;
+    
+    std::vector<DeadlineOp> m_timers;
+    Mutex x_timers;
+    
+    std::atomic<bool> m_stopped;
 };
 
 }
-	
+    
 /// Simple stream output for a NodeIPEndpoint.
 std::ostream& operator<<(std::ostream& _out, dev::p2p::NodeIPEndpoint const& _ep);
 }
@@ -325,19 +324,19 @@ namespace std
 
 template <> struct hash<bi::address>
 {
-	size_t operator()(bi::address const& _a) const
-	{
-		if (_a.is_v4())
-			return std::hash<unsigned long>()(_a.to_v4().to_ulong());
-		if (_a.is_v6())
-		{
-			auto const& range = _a.to_v6().to_bytes();
-			return boost::hash_range(range.begin(), range.end());
-		}
-		if (_a.is_unspecified())
-			return static_cast<size_t>(0x3487194039229152ull);  // Chosen by fair dice roll, guaranteed to be random
-		return std::hash<std::string>()(_a.to_string());
-	}
+    size_t operator()(bi::address const& _a) const
+    {
+        if (_a.is_v4())
+            return std::hash<unsigned long>()(_a.to_v4().to_ulong());
+        if (_a.is_v6())
+        {
+            auto const& range = _a.to_v6().to_bytes();
+            return boost::hash_range(range.begin(), range.end());
+        }
+        if (_a.is_unspecified())
+            return static_cast<size_t>(0x3487194039229152ull);  // Chosen by fair dice roll, guaranteed to be random
+        return std::hash<std::string>()(_a.to_string());
+    }
 };
 
 }

--- a/libp2p/Host.cpp
+++ b/libp2p/Host.cpp
@@ -316,8 +316,8 @@ void Host::startPeerSession(Public const& _id, RLP const& _rlp, unique_ptr<RLPXF
         
         if (!peerSlotsAvailable())
         {
-            clog(NetAllDetail) << "Too many peers, can't connect. peer count: " << peerCount()
-                                << " pending peers: " << m_pendingPeerConns.size();
+            cnetdetails << "Too many peers, can't connect. peer count: " << peerCount()
+                        << " pending peers: " << m_pendingPeerConns.size();
             ps->disconnect(TooManyPeers);
             return;
         }

--- a/libp2p/Host.cpp
+++ b/libp2p/Host.cpp
@@ -339,14 +339,14 @@ void Host::startPeerSession(Public const& _id, RLP const& _rlp, unique_ptr<RLPXF
         m_sessions[_id] = ps;
     }
     
-    clog(NetP2PNote) << "p2p.host.peer.register" << _id;
+    LOG(m_logger) << "p2p.host.peer.register " << _id;
 }
 
 void Host::onNodeTableEvent(NodeID const& _n, NodeTableEventType const& _e)
 {
     if (_e == NodeEntryAdded)
     {
-        clog(NetP2PNote) << "p2p.host.nodeTable.events.nodeEntryAdded " << _n;
+        LOG(m_logger) << "p2p.host.nodeTable.events.nodeEntryAdded " << _n;
         if (Node n = nodeFromNodeTable(_n))
         {
             shared_ptr<Peer> p;
@@ -361,7 +361,7 @@ void Host::onNodeTableEvent(NodeID const& _n, NodeTableEventType const& _e)
                 {
                     p = make_shared<Peer>(n);
                     m_peers[_n] = p;
-                    clog(NetP2PNote) << "p2p.host.peers.events.peerAdded " << _n << p->endpoint;
+                    LOG(m_logger) << "p2p.host.peers.events.peerAdded " << _n << " " << p->endpoint;
                 }
             }
             if (peerSlotsAvailable(Egress))
@@ -370,7 +370,7 @@ void Host::onNodeTableEvent(NodeID const& _n, NodeTableEventType const& _e)
     }
     else if (_e == NodeEntryDropped)
     {
-        clog(NetP2PNote) << "p2p.host.nodeTable.events.NodeEntryDropped " << _n;
+        LOG(m_logger) << "p2p.host.nodeTable.events.NodeEntryDropped " << _n;
         RecursiveGuard l(x_sessions);
         if (m_peers.count(_n) && m_peers[_n]->peerType == PeerType::Optional)
             m_peers.erase(_n);
@@ -753,7 +753,7 @@ void Host::startedWorking()
         runAcceptor();
     }
     else
-        clog(NetP2PNote) << "p2p.start.notice id:" << id() << "TCP Listen port is invalid or unavailable.";
+        LOG(m_logger) << "p2p.start.notice id: " << id() << " TCP Listen port is invalid or unavailable.";
 
     auto nodeTable = make_shared<NodeTable>(
         m_ioService,
@@ -766,7 +766,7 @@ void Host::startedWorking()
         m_nodeTable = nodeTable;
     restoreNetwork(&m_restoreNetwork);
 
-    clog(NetP2PNote) << "p2p.started id:" << id();
+    LOG(m_logger) << "p2p.started id: " << id();
 
     run(boost::system::error_code());
 }
@@ -780,8 +780,8 @@ void Host::doWork()
     }
     catch (std::exception const& _e)
     {
-        clog(NetP2PWarn) << "Exception in Network Thread:" << _e.what();
-        clog(NetP2PWarn) << "Network Restart is Recommended.";
+        cwarn << "Exception in Network Thread: " << _e.what();
+        cwarn << "Network Restart is Recommended.";
     }
 }
 

--- a/libp2p/Host.cpp
+++ b/libp2p/Host.cpp
@@ -107,7 +107,7 @@ Host::Host(string const& _clientVersion, KeyPair const& _alias, NetworkPreferenc
     m_alias(_alias),
     m_lastPing(chrono::steady_clock::time_point::min())
 {
-    clog(NetNote) << "Id:" << id();
+    cnetnote << "Id: " << id();
 }
 
 Host::Host(string const& _clientVersion, NetworkPreferences const& _n, bytesConstRef _restoreNetwork):
@@ -393,12 +393,12 @@ void Host::determinePublic()
     bi::tcp::endpoint ep(bi::address(), m_listenPort);
     if (m_netPrefs.traverseNAT && listenIsPublic)
     {
-        clog(NetNote) << "Listen address set to Public address:" << laddr << ". UPnP disabled.";
+        cnetnote << "Listen address set to Public address: " << laddr << ". UPnP disabled.";
         ep.address(laddr);
     }
     else if (m_netPrefs.traverseNAT && publicIsHost)
     {
-        clog(NetNote) << "Public address set to Host configured address:" << paddr << ". UPnP disabled.";
+        cnetnote << "Public address set to Host configured address: " << paddr << ". UPnP disabled.";
         ep.address(paddr);
     }
     else if (m_netPrefs.traverseNAT)

--- a/libp2p/Host.cpp
+++ b/libp2p/Host.cpp
@@ -280,7 +280,7 @@ void Host::startPeerSession(Public const& _id, RLP const& _rlp, unique_ptr<RLPXF
     for (auto cap: caps)
         capslog << "(" << cap.first << "," << dec << cap.second << ")";
 
-    clog(NetMessageSummary) << "Hello: " << clientVersion << "V[" << protocolVersion << "]" << _id << showbase << capslog.str() << dec << listenPort;
+    cnetmessage << "Hello: " << clientVersion << " V[" << protocolVersion << "]" << " " << _id << " " << showbase << capslog.str() << " " << dec << listenPort;
     
     // create session so disconnects are managed
     shared_ptr<SessionFace> ps = make_shared<Session>(this, move(_io), _s, p, PeerSessionInfo({_id, clientVersion, p->endpoint.address.to_string(), listenPort, chrono::steady_clock::duration(), _rlp[2].toSet<CapDesc>(), 0, map<string, string>(), protocolVersion}));

--- a/libp2p/Host.cpp
+++ b/libp2p/Host.cpp
@@ -133,7 +133,7 @@ void Host::start()
     if (isWorking())
         return;
 
-    clog(NetWarn) << "Network start failed!";
+    cnetwarn << "Network start failed!";
     doneWorking();
 }
 
@@ -309,7 +309,7 @@ void Host::startPeerSession(Public const& _id, RLP const& _rlp, unique_ptr<RLPXF
                 if(s->isConnected())
                 {
                     // Already connected.
-                    clog(NetWarn) << "Session already exists for peer with id" << _id;
+                    cnetwarn << "Session already exists for peer with id " << _id;
                     ps->disconnect(DuplicatePeer);
                     return;
                 }
@@ -408,12 +408,14 @@ void Host::determinePublic()
         
         if (lset && natIFAddr != laddr)
             // if listen address is set, Host will use it, even if upnp returns different
-            clog(NetWarn) << "Listen address" << laddr << "differs from local address" << natIFAddr << "returned by UPnP!";
-        
+            cnetwarn << "Listen address " << laddr << " differs from local address " << natIFAddr
+                     << " returned by UPnP!";
+
         if (pset && ep.address() != paddr)
         {
             // if public address is set, Host will advertise it, even if upnp returns different
-            clog(NetWarn) << "Specified public address" << paddr << "differs from external address" << ep.address() << "returned by UPnP!";
+            cnetwarn << "Specified public address " << paddr << " differs from external address "
+                     << ep.address() << " returned by UPnP!";
             ep.address(paddr);
         }
     }
@@ -461,11 +463,11 @@ void Host::runAcceptor()
             }
             catch (Exception const& _e)
             {
-                clog(NetWarn) << "ERROR: " << diagnostic_information(_e);
+                cnetwarn << "ERROR: " << diagnostic_information(_e);
             }
             catch (std::exception const& _e)
             {
-                clog(NetWarn) << "ERROR: " << _e.what();
+                cnetwarn << "ERROR: " << _e.what();
             }
 
             if (!success)

--- a/libp2p/Host.cpp
+++ b/libp2p/Host.cpp
@@ -280,8 +280,9 @@ void Host::startPeerSession(Public const& _id, RLP const& _rlp, unique_ptr<RLPXF
     for (auto cap: caps)
         capslog << "(" << cap.first << "," << dec << cap.second << ")";
 
-    cnetmessage << "Hello: " << clientVersion << " V[" << protocolVersion << "]" << " " << _id << " " << showbase << capslog.str() << " " << dec << listenPort;
-    
+    cnetlog << "Hello: " << clientVersion << " V[" << protocolVersion << "]"
+            << " " << _id << " " << showbase << capslog.str() << " " << dec << listenPort;
+
     // create session so disconnects are managed
     shared_ptr<SessionFace> ps = make_shared<Session>(this, move(_io), _s, p, PeerSessionInfo({_id, clientVersion, p->endpoint.address.to_string(), listenPort, chrono::steady_clock::duration(), _rlp[2].toSet<CapDesc>(), 0, map<string, string>(), protocolVersion}));
     if (protocolVersion < dev::p2p::c_protocolVersion - 1)

--- a/libp2p/Host.h
+++ b/libp2p/Host.h
@@ -349,6 +349,8 @@ private:
 	bool m_dropPeers = false;
 
 	ReputationManager m_repMan;
+
+    Logger m_logger{createLogger(6, "net")};
 };
 
 }

--- a/libp2p/Network.cpp
+++ b/libp2p/Network.cpp
@@ -201,8 +201,8 @@ bi::tcp::endpoint Network::traverseNAT(std::set<bi::address> const& _ifAddresses
         bi::address eIPAddr(bi::address::from_string(eIP));
         if (extPort && eIP != string("0.0.0.0") && !isPrivateAddress(eIPAddr))
         {
-            clog(NetNote) << "Punched through NAT and mapped local port" << _listenPort << "onto external port" << extPort << ".";
-            clog(NetNote) << "External addr:" << eIP;
+            cnetnote << "Punched through NAT and mapped local port " << _listenPort << " onto external port " << extPort << ".";
+            cnetnote << "External addr: " << eIP;
             o_upnpInterfaceAddr = pAddr;
             upnpEP = bi::tcp::endpoint(eIPAddr, (unsigned short)extPort);
         }

--- a/libp2p/Network.cpp
+++ b/libp2p/Network.cpp
@@ -1,18 +1,18 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file Network.cpp
  * @author Alex Leverington <nessence@gmail.com>
@@ -45,208 +45,208 @@ static_assert(BOOST_VERSION >= 106400, "Wrong boost headers version");
 
 std::set<bi::address> Network::getInterfaceAddresses()
 {
-	std::set<bi::address> addresses;
+    std::set<bi::address> addresses;
 
 #if defined(_WIN32)
-	WSAData wsaData;
-	if (WSAStartup(MAKEWORD(1, 1), &wsaData) != 0)
-		BOOST_THROW_EXCEPTION(NoNetworking());
+    WSAData wsaData;
+    if (WSAStartup(MAKEWORD(1, 1), &wsaData) != 0)
+        BOOST_THROW_EXCEPTION(NoNetworking());
 
-	char ac[80];
-	if (gethostname(ac, sizeof(ac)) == SOCKET_ERROR)
-	{
-		clog(NetWarn) << "Error " << WSAGetLastError() << " when getting local host name.";
-		WSACleanup();
-		BOOST_THROW_EXCEPTION(NoNetworking());
-	}
+    char ac[80];
+    if (gethostname(ac, sizeof(ac)) == SOCKET_ERROR)
+    {
+        cnetwarn << "Error " << WSAGetLastError() << " when getting local host name.";
+        WSACleanup();
+        BOOST_THROW_EXCEPTION(NoNetworking());
+    }
 
-	struct hostent* phe = gethostbyname(ac);
-	if (phe == 0)
-	{
-		clog(NetWarn) << "Bad host lookup.";
-		WSACleanup();
-		BOOST_THROW_EXCEPTION(NoNetworking());
-	}
+    struct hostent* phe = gethostbyname(ac);
+    if (phe == 0)
+    {
+        cnetwarn << "Bad host lookup.";
+        WSACleanup();
+        BOOST_THROW_EXCEPTION(NoNetworking());
+    }
 
-	for (int i = 0; phe->h_addr_list[i] != 0; ++i)
-	{
-		struct in_addr addr;
-		memcpy(&addr, phe->h_addr_list[i], sizeof(struct in_addr));
-		char *addrStr = inet_ntoa(addr);
-		bi::address address(bi::address::from_string(addrStr));
-		if (!isLocalHostAddress(address))
-			addresses.insert(address.to_v4());
-	}
+    for (int i = 0; phe->h_addr_list[i] != 0; ++i)
+    {
+        struct in_addr addr;
+        memcpy(&addr, phe->h_addr_list[i], sizeof(struct in_addr));
+        char *addrStr = inet_ntoa(addr);
+        bi::address address(bi::address::from_string(addrStr));
+        if (!isLocalHostAddress(address))
+            addresses.insert(address.to_v4());
+    }
 
-	WSACleanup();
+    WSACleanup();
 #else
-	ifaddrs* ifaddr;
-	if (getifaddrs(&ifaddr) == -1)
-		BOOST_THROW_EXCEPTION(NoNetworking());
+    ifaddrs* ifaddr;
+    if (getifaddrs(&ifaddr) == -1)
+        BOOST_THROW_EXCEPTION(NoNetworking());
 
-	for (auto ifa = ifaddr; ifa != NULL; ifa = ifa->ifa_next)
-	{
-		if (!ifa->ifa_addr || string(ifa->ifa_name) == "lo0" || !(ifa->ifa_flags & IFF_UP))
-			continue;
+    for (auto ifa = ifaddr; ifa != NULL; ifa = ifa->ifa_next)
+    {
+        if (!ifa->ifa_addr || string(ifa->ifa_name) == "lo0" || !(ifa->ifa_flags & IFF_UP))
+            continue;
 
-		if (ifa->ifa_addr->sa_family == AF_INET)
-		{
-			in_addr addr = ((struct sockaddr_in *)ifa->ifa_addr)->sin_addr;
-			boost::asio::ip::address_v4 address(boost::asio::detail::socket_ops::network_to_host_long(addr.s_addr));
-			if (!isLocalHostAddress(address))
-				addresses.insert(address);
-		}
-		else if (ifa->ifa_addr->sa_family == AF_INET6)
-		{
-			sockaddr_in6* sockaddr = ((struct sockaddr_in6 *)ifa->ifa_addr);
-			in6_addr addr = sockaddr->sin6_addr;
-			boost::asio::ip::address_v6::bytes_type bytes;
-			memcpy(&bytes[0], addr.s6_addr, 16);
-			boost::asio::ip::address_v6 address(bytes, sockaddr->sin6_scope_id);
-			if (!isLocalHostAddress(address))
-				addresses.insert(address);
-		}
-	}
+        if (ifa->ifa_addr->sa_family == AF_INET)
+        {
+            in_addr addr = ((struct sockaddr_in *)ifa->ifa_addr)->sin_addr;
+            boost::asio::ip::address_v4 address(boost::asio::detail::socket_ops::network_to_host_long(addr.s_addr));
+            if (!isLocalHostAddress(address))
+                addresses.insert(address);
+        }
+        else if (ifa->ifa_addr->sa_family == AF_INET6)
+        {
+            sockaddr_in6* sockaddr = ((struct sockaddr_in6 *)ifa->ifa_addr);
+            in6_addr addr = sockaddr->sin6_addr;
+            boost::asio::ip::address_v6::bytes_type bytes;
+            memcpy(&bytes[0], addr.s6_addr, 16);
+            boost::asio::ip::address_v6 address(bytes, sockaddr->sin6_scope_id);
+            if (!isLocalHostAddress(address))
+                addresses.insert(address);
+        }
+    }
 
-	if (ifaddr!=NULL)
-		freeifaddrs(ifaddr);
+    if (ifaddr!=NULL)
+        freeifaddrs(ifaddr);
 
 #endif
 
-	return addresses;
+    return addresses;
 }
 
 int Network::tcp4Listen(bi::tcp::acceptor& _acceptor, NetworkPreferences const& _netPrefs)
 {
-	// Due to the complexities of NAT and network environments (multiple NICs, tunnels, etc)
-	// and security concerns automation is the enemy of network configuration.
-	// If a preference cannot be accommodate the network must fail to start.
-	//
-	// Preferred IP: Attempt if set, else, try 0.0.0.0 (all interfaces)
-	// Preferred Port: Attempt if set, else, try c_defaultListenPort or 0 (random)
-	// TODO: throw instead of returning -1 and rename NetworkPreferences to NetworkConfig
-	
-	bi::address listenIP;
-	try
-	{
-		listenIP = _netPrefs.listenIPAddress.empty() ? bi::address_v4() : bi::address::from_string(_netPrefs.listenIPAddress);
-	}
-	catch (...)
-	{
-		cwarn << "Couldn't start accepting connections on host. Failed to accept socket on " << listenIP << ":" << _netPrefs.listenPort << ".\n" << boost::current_exception_diagnostic_information();
-		return -1;
-	}
-	bool requirePort = (bool)_netPrefs.listenPort;
+    // Due to the complexities of NAT and network environments (multiple NICs, tunnels, etc)
+    // and security concerns automation is the enemy of network configuration.
+    // If a preference cannot be accommodate the network must fail to start.
+    //
+    // Preferred IP: Attempt if set, else, try 0.0.0.0 (all interfaces)
+    // Preferred Port: Attempt if set, else, try c_defaultListenPort or 0 (random)
+    // TODO: throw instead of returning -1 and rename NetworkPreferences to NetworkConfig
+    
+    bi::address listenIP;
+    try
+    {
+        listenIP = _netPrefs.listenIPAddress.empty() ? bi::address_v4() : bi::address::from_string(_netPrefs.listenIPAddress);
+    }
+    catch (...)
+    {
+        cwarn << "Couldn't start accepting connections on host. Failed to accept socket on " << listenIP << ":" << _netPrefs.listenPort << ".\n" << boost::current_exception_diagnostic_information();
+        return -1;
+    }
+    bool requirePort = (bool)_netPrefs.listenPort;
 
-	for (unsigned i = 0; i < 2; ++i)
-	{
-		bi::tcp::endpoint endpoint(listenIP, requirePort ? _netPrefs.listenPort : (i ? 0 : c_defaultListenPort));
-		try
-		{
+    for (unsigned i = 0; i < 2; ++i)
+    {
+        bi::tcp::endpoint endpoint(listenIP, requirePort ? _netPrefs.listenPort : (i ? 0 : c_defaultListenPort));
+        try
+        {
 #if defined(_WIN32)
-			bool reuse = false;
+            bool reuse = false;
 #else
-			bool reuse = true;
+            bool reuse = true;
 #endif
-			_acceptor.open(endpoint.protocol());
-			_acceptor.set_option(ba::socket_base::reuse_address(reuse));
-			_acceptor.bind(endpoint);
-			_acceptor.listen();
-			return _acceptor.local_endpoint().port();
-		}
-		catch (...)
-		{
-			// bail if this is first attempt && port was specificed, or second attempt failed (random port)
-			if (i || requirePort)
-			{
-				// both attempts failed
-				cwarn << "Couldn't start accepting connections on host. Failed to accept socket on " << listenIP << ":" << _netPrefs.listenPort << ".\n" << boost::current_exception_diagnostic_information();
-				_acceptor.close();
-				return -1;
-			}
-			
-			_acceptor.close();
-			continue;
-		}
-	}
+            _acceptor.open(endpoint.protocol());
+            _acceptor.set_option(ba::socket_base::reuse_address(reuse));
+            _acceptor.bind(endpoint);
+            _acceptor.listen();
+            return _acceptor.local_endpoint().port();
+        }
+        catch (...)
+        {
+            // bail if this is first attempt && port was specificed, or second attempt failed (random port)
+            if (i || requirePort)
+            {
+                // both attempts failed
+                cwarn << "Couldn't start accepting connections on host. Failed to accept socket on " << listenIP << ":" << _netPrefs.listenPort << ".\n" << boost::current_exception_diagnostic_information();
+                _acceptor.close();
+                return -1;
+            }
+            
+            _acceptor.close();
+            continue;
+        }
+    }
 
-	return -1;
+    return -1;
 }
 
 bi::tcp::endpoint Network::traverseNAT(std::set<bi::address> const& _ifAddresses, unsigned short _listenPort, bi::address& o_upnpInterfaceAddr)
 {
-	asserts(_listenPort != 0);
+    asserts(_listenPort != 0);
 
-	unique_ptr<UPnP> upnp;
-	try
-	{
-		upnp.reset(new UPnP);
-	}
-	// let m_upnp continue as null - we handle it properly.
-	catch (...) {}
+    unique_ptr<UPnP> upnp;
+    try
+    {
+        upnp.reset(new UPnP);
+    }
+    // let m_upnp continue as null - we handle it properly.
+    catch (...) {}
 
-	bi::tcp::endpoint upnpEP;
-	if (upnp && upnp->isValid())
-	{
-		bi::address pAddr;
-		int extPort = 0;
-		for (auto const& addr: _ifAddresses)
-			if (addr.is_v4() && isPrivateAddress(addr) && (extPort = upnp->addRedirect(addr.to_string().c_str(), _listenPort)))
-			{
-				pAddr = addr;
-				break;
-			}
+    bi::tcp::endpoint upnpEP;
+    if (upnp && upnp->isValid())
+    {
+        bi::address pAddr;
+        int extPort = 0;
+        for (auto const& addr: _ifAddresses)
+            if (addr.is_v4() && isPrivateAddress(addr) && (extPort = upnp->addRedirect(addr.to_string().c_str(), _listenPort)))
+            {
+                pAddr = addr;
+                break;
+            }
 
-		auto eIP = upnp->externalIP();
-		bi::address eIPAddr(bi::address::from_string(eIP));
-		if (extPort && eIP != string("0.0.0.0") && !isPrivateAddress(eIPAddr))
-		{
-			clog(NetNote) << "Punched through NAT and mapped local port" << _listenPort << "onto external port" << extPort << ".";
-			clog(NetNote) << "External addr:" << eIP;
-			o_upnpInterfaceAddr = pAddr;
-			upnpEP = bi::tcp::endpoint(eIPAddr, (unsigned short)extPort);
-		}
-		else
-			clog(NetWarn) << "Couldn't punch through NAT (or no NAT in place).";
-	}
+        auto eIP = upnp->externalIP();
+        bi::address eIPAddr(bi::address::from_string(eIP));
+        if (extPort && eIP != string("0.0.0.0") && !isPrivateAddress(eIPAddr))
+        {
+            clog(NetNote) << "Punched through NAT and mapped local port" << _listenPort << "onto external port" << extPort << ".";
+            clog(NetNote) << "External addr:" << eIP;
+            o_upnpInterfaceAddr = pAddr;
+            upnpEP = bi::tcp::endpoint(eIPAddr, (unsigned short)extPort);
+        }
+        else
+            cnetwarn << "Couldn't punch through NAT (or no NAT in place).";
+    }
 
-	return upnpEP;
+    return upnpEP;
 }
 
 bi::tcp::endpoint Network::resolveHost(string const& _addr)
 {
-	static boost::asio::io_service s_resolverIoService;
+    static boost::asio::io_service s_resolverIoService;
 
-	vector<string> split;
-	boost::split(split, _addr, boost::is_any_of(":"));
-	unsigned port = dev::p2p::c_defaultIPPort;
+    vector<string> split;
+    boost::split(split, _addr, boost::is_any_of(":"));
+    unsigned port = dev::p2p::c_defaultIPPort;
 
-	try
-	{
-		if (split.size() > 1)
-			port = static_cast<unsigned>(stoi(split.at(1)));
-	}
-	catch(...) {}
+    try
+    {
+        if (split.size() > 1)
+            port = static_cast<unsigned>(stoi(split.at(1)));
+    }
+    catch(...) {}
 
-	boost::system::error_code ec;
-	bi::address address = bi::address::from_string(split[0], ec);
-	bi::tcp::endpoint ep(bi::address(), port);
-	if (!ec)
-		ep.address(address);
-	else
-	{
-		boost::system::error_code ec;
-		// resolve returns an iterator (host can resolve to multiple addresses)
-		bi::tcp::resolver r(s_resolverIoService);
-		auto it = r.resolve({bi::tcp::v4(), split[0], toString(port)}, ec);
-		if (ec)
-		{
-			clog(NetWarn) << "Error resolving host address..." << LogTag::Url << _addr << ":" << LogTag::Error << ec.message();
-			return bi::tcp::endpoint();
-		}
-		else
-			ep = *it;
-	}
-	return ep;
+    boost::system::error_code ec;
+    bi::address address = bi::address::from_string(split[0], ec);
+    bi::tcp::endpoint ep(bi::address(), port);
+    if (!ec)
+        ep.address(address);
+    else
+    {
+        boost::system::error_code ec;
+        // resolve returns an iterator (host can resolve to multiple addresses)
+        bi::tcp::resolver r(s_resolverIoService);
+        auto it = r.resolve({bi::tcp::v4(), split[0], toString(port)}, ec);
+        if (ec)
+        {
+            cnetwarn << "Error resolving host address... " << _addr << " : " << ec.message();
+            return bi::tcp::endpoint();
+        }
+        else
+            ep = *it;
+    }
+    return ep;
 }
 

--- a/libp2p/NodeTable.cpp
+++ b/libp2p/NodeTable.cpp
@@ -203,8 +203,9 @@ void NodeTable::doDiscover(NodeID _node, unsigned _round, shared_ptr<set<shared_
     m_timers.schedule(c_reqTimeout.count() * 2, [this, _node, _round, _tried](boost::system::error_code const& _ec)
     {
         if (_ec)
-            LOG(m_logger) << "Discovery timer was probably cancelled: " << _ec.value() << " "
-                          << _ec.message();
+            // we can't use m_logger here, because captured this might be already destroyed
+            clogSimple(10, "discov") << "Discovery timer was probably cancelled: " << _ec.value()
+                                     << " " << _ec.message();
 
         if (_ec.value() == boost::asio::error::operation_aborted || m_timers.isStopped())
             return;
@@ -537,8 +538,10 @@ void NodeTable::doCheckEvictions()
     m_timers.schedule(c_evictionCheckInterval.count(), [this](boost::system::error_code const& _ec)
     {
         if (_ec)
-            LOG(m_logger) << "Check Evictions timer was probably cancelled: " << _ec.value() << " "
-                          << _ec.message();
+            // we can't use m_logger here, because captured this might be already destroyed
+            clogSimple(10, "discov")
+                << "Check Evictions timer was probably cancelled: " << _ec.value() << " "
+                << _ec.message();
 
         if (_ec.value() == boost::asio::error::operation_aborted || m_timers.isStopped())
             return;
@@ -569,6 +572,7 @@ void NodeTable::doDiscovery()
     m_timers.schedule(c_bucketRefresh.count(), [this](boost::system::error_code const& _ec)
     {
         if (_ec)
+            // we can't use m_logger here, because captured this might be already destroyed
             clogSimple(10, "discov") << "Discovery timer was probably cancelled: " << _ec.value()
                                      << " " << _ec.message();
 

--- a/libp2p/NodeTable.cpp
+++ b/libp2p/NodeTable.cpp
@@ -68,8 +68,8 @@ NodeTable::NodeTable(ba::io_service& _io, KeyPair const& _alias, NodeIPEndpoint 
     }
     catch (std::exception const& _e)
     {
-        clog(NetWarn) << "Exception connecting NodeTable socket: " << _e.what();
-        clog(NetWarn) << "Discovery disabled.";
+        cnetwarn << "Exception connecting NodeTable socket: " << _e.what();
+        cnetwarn << "Discovery disabled.";
     }
 }
     
@@ -497,7 +497,7 @@ void NodeTable::onReceived(UDPSocketFace*, bi::udp::endpoint const& _from, bytes
                     Neighbours out(_from, nearest, offset, nlimit);
                     out.sign(m_secret);
                     if (out.data.size() > 1280)
-                        clog(NetWarn) << "Sending truncated datagram, size: " << out.data.size();
+                        cnetwarn << "Sending truncated datagram, size: " << out.data.size();
                     m_socketPointer->send(out);
                 }
                 break;

--- a/libp2p/NodeTable.cpp
+++ b/libp2p/NodeTable.cpp
@@ -478,7 +478,8 @@ void NodeTable::onReceived(UDPSocketFace*, bi::udp::endpoint const& _from, bytes
                     });
                 if (!expected)
                 {
-                    clog(NetConnect) << "Dropping unsolicited neighbours packet from " << _from.address();
+                    cnetdetails << "Dropping unsolicited neighbours packet from "
+                                << _from.address();
                     break;
                 }
 

--- a/libp2p/NodeTable.cpp
+++ b/libp2p/NodeTable.cpp
@@ -569,8 +569,8 @@ void NodeTable::doDiscovery()
     m_timers.schedule(c_bucketRefresh.count(), [this](boost::system::error_code const& _ec)
     {
         if (_ec)
-            LOG(m_logger) << "Discovery timer was probably cancelled: " << _ec.value() << " "
-                          << _ec.message();
+            clogSimple(10, "discov") << "Discovery timer was probably cancelled: " << _ec.value()
+                                     << " " << _ec.message();
 
         if (_ec.value() == boost::asio::error::operation_aborted || m_timers.isStopped())
             return;

--- a/libp2p/NodeTable.h
+++ b/libp2p/NodeTable.h
@@ -275,10 +275,10 @@ private:
     std::shared_ptr<NodeSocket> m_socket;							///< Shared pointer for our UDPSocket; ASIO requires shared_ptr.
     NodeSocket* m_socketPointer;									///< Set to m_socket.get(). Socket is created in constructor and disconnected in destructor to ensure access to pointer is safe.
 
-    DeadlineOps m_timers; ///< this should be the last member - it must be destroyed first
-
     Logger m_logger{createLogger(10, "discov")};
     Logger m_loggerWarn{createLogger(0, "discov")};
+
+    DeadlineOps m_timers; ///< this should be the last member - it must be destroyed first
 };
 
 inline std::ostream& operator<<(std::ostream& _out, NodeTable const& _nodeTable)

--- a/libp2p/NodeTable.h
+++ b/libp2p/NodeTable.h
@@ -276,6 +276,9 @@ private:
     NodeSocket* m_socketPointer;									///< Set to m_socket.get(). Socket is created in constructor and disconnected in destructor to ensure access to pointer is safe.
 
     DeadlineOps m_timers; ///< this should be the last member - it must be destroyed first
+
+    Logger m_logger{createLogger(10, "discov")};
+    Logger m_loggerWarn{createLogger(0, "discov")};
 };
 
 inline std::ostream& operator<<(std::ostream& _out, NodeTable const& _nodeTable)
@@ -455,20 +458,6 @@ struct Neighbours: DiscoveryDatagram
         ts = r[1].toInt<uint32_t>();
     }
 };
-
-struct NodeTableWarn: public LogChannel { static const char* name(); static const int verbosity = 0; };
-struct NodeTableNote: public LogChannel { static const char* name(); static const int verbosity = 1; };
-struct NodeTableMessageSummary: public LogChannel { static const char* name(); static const int verbosity = 2; };
-struct NodeTableMessageDetail: public LogChannel { static const char* name(); static const int verbosity = 5; };
-struct NodeTableConnect: public LogChannel { static const char* name(); static const int verbosity = 10; };
-struct NodeTableEvent: public LogChannel { static const char* name(); static const int verbosity = 10; };
-struct NodeTableTimer: public LogChannel { static const char* name(); static const int verbosity = 10; };
-struct NodeTableUpdate: public LogChannel { static const char* name(); static const int verbosity = 10; };
-struct NodeTableTriviaSummary: public LogChannel { static const char* name(); static const int verbosity = 10; };
-struct NodeTableTriviaDetail: public LogChannel { static const char* name(); static const int verbosity = 11; };
-struct NodeTableAllDetail: public LogChannel { static const char* name(); static const int verbosity = 13; };
-struct NodeTableEgress: public LogChannel { static const char* name(); static const int verbosity = 14; };
-struct NodeTableIngress: public LogChannel { static const char* name(); static const int verbosity = 15; };
 
 }
 }

--- a/libp2p/RLPxHandshake.cpp
+++ b/libp2p/RLPxHandshake.cpp
@@ -30,383 +30,389 @@ using namespace dev::crypto;
 
 void RLPXHandshake::writeAuth()
 {
-	clog(NetP2PConnect) << "p2p.connect.egress sending auth to " << m_socket->remoteEndpoint();
-	m_auth.resize(Signature::size + h256::size + Public::size + h256::size + 1);
-	bytesRef sig(&m_auth[0], Signature::size);
-	bytesRef hepubk(&m_auth[Signature::size], h256::size);
-	bytesRef pubk(&m_auth[Signature::size + h256::size], Public::size);
-	bytesRef nonce(&m_auth[Signature::size + h256::size + Public::size], h256::size);
-	
-	// E(remote-pubk, S(ecdhe-random, ecdh-shared-secret^nonce) || H(ecdhe-random-pubk) || pubk || nonce || 0x0)
-	Secret staticShared;
-	crypto::ecdh::agree(m_host->m_alias.secret(), m_remote, staticShared);
-	sign(m_ecdheLocal.secret(), staticShared.makeInsecure() ^ m_nonce).ref().copyTo(sig);
-	sha3(m_ecdheLocal.pub().ref(), hepubk);
-	m_host->m_alias.pub().ref().copyTo(pubk);
-	m_nonce.ref().copyTo(nonce);
-	m_auth[m_auth.size() - 1] = 0x0;
-	encryptECIES(m_remote, &m_auth, m_authCipher);
+    LOG(m_logger) << "p2p.connect.egress sending auth to " << m_socket->remoteEndpoint();
+    m_auth.resize(Signature::size + h256::size + Public::size + h256::size + 1);
+    bytesRef sig(&m_auth[0], Signature::size);
+    bytesRef hepubk(&m_auth[Signature::size], h256::size);
+    bytesRef pubk(&m_auth[Signature::size + h256::size], Public::size);
+    bytesRef nonce(&m_auth[Signature::size + h256::size + Public::size], h256::size);
+    
+    // E(remote-pubk, S(ecdhe-random, ecdh-shared-secret^nonce) || H(ecdhe-random-pubk) || pubk || nonce || 0x0)
+    Secret staticShared;
+    crypto::ecdh::agree(m_host->m_alias.secret(), m_remote, staticShared);
+    sign(m_ecdheLocal.secret(), staticShared.makeInsecure() ^ m_nonce).ref().copyTo(sig);
+    sha3(m_ecdheLocal.pub().ref(), hepubk);
+    m_host->m_alias.pub().ref().copyTo(pubk);
+    m_nonce.ref().copyTo(nonce);
+    m_auth[m_auth.size() - 1] = 0x0;
+    encryptECIES(m_remote, &m_auth, m_authCipher);
 
-	auto self(shared_from_this());
-	ba::async_write(m_socket->ref(), ba::buffer(m_authCipher), [this, self](boost::system::error_code ec, std::size_t)
-	{
-		transition(ec);
-	});
+    auto self(shared_from_this());
+    ba::async_write(m_socket->ref(), ba::buffer(m_authCipher), [this, self](boost::system::error_code ec, std::size_t)
+    {
+        transition(ec);
+    });
 }
 
 void RLPXHandshake::writeAck()
 {
-	clog(NetP2PConnect) << "p2p.connect.ingress sending ack to " << m_socket->remoteEndpoint();
-	m_ack.resize(Public::size + h256::size + 1);
-	bytesRef epubk(&m_ack[0], Public::size);
-	bytesRef nonce(&m_ack[Public::size], h256::size);
-	m_ecdheLocal.pub().ref().copyTo(epubk);
-	m_nonce.ref().copyTo(nonce);
-	m_ack[m_ack.size() - 1] = 0x0;
-	encryptECIES(m_remote, &m_ack, m_ackCipher);
+    LOG(m_logger) << "p2p.connect.ingress sending ack to " << m_socket->remoteEndpoint();
+    m_ack.resize(Public::size + h256::size + 1);
+    bytesRef epubk(&m_ack[0], Public::size);
+    bytesRef nonce(&m_ack[Public::size], h256::size);
+    m_ecdheLocal.pub().ref().copyTo(epubk);
+    m_nonce.ref().copyTo(nonce);
+    m_ack[m_ack.size() - 1] = 0x0;
+    encryptECIES(m_remote, &m_ack, m_ackCipher);
 
-	auto self(shared_from_this());
-	ba::async_write(m_socket->ref(), ba::buffer(m_ackCipher), [this, self](boost::system::error_code ec, std::size_t)
-	{
-		transition(ec);
-	});
+    auto self(shared_from_this());
+    ba::async_write(m_socket->ref(), ba::buffer(m_ackCipher), [this, self](boost::system::error_code ec, std::size_t)
+    {
+        transition(ec);
+    });
 }
 
 void RLPXHandshake::writeAckEIP8()
 {
-	clog(NetP2PConnect) << "p2p.connect.ingress sending EIP-8 ack to " << m_socket->remoteEndpoint();
+    LOG(m_logger) << "p2p.connect.ingress sending EIP-8 ack to " << m_socket->remoteEndpoint();
 
-	RLPStream rlp;
-	rlp.appendList(3)
-		<< m_ecdheLocal.pub()
-		<< m_nonce
-		<< c_rlpxVersion;
-	m_ack = rlp.out();
-	int padAmount(rand()%100 + 100);
-	m_ack.resize(m_ack.size() + padAmount, 0);
+    RLPStream rlp;
+    rlp.appendList(3)
+        << m_ecdheLocal.pub()
+        << m_nonce
+        << c_rlpxVersion;
+    m_ack = rlp.out();
+    int padAmount(rand()%100 + 100);
+    m_ack.resize(m_ack.size() + padAmount, 0);
 
-	bytes prefix(2);
-	toBigEndian<uint16_t>(m_ack.size() + c_eciesOverhead, prefix);
-	encryptECIES(m_remote, bytesConstRef(&prefix), &m_ack, m_ackCipher);
-	m_ackCipher.insert(m_ackCipher.begin(), prefix.begin(), prefix.end());
-	
-	auto self(shared_from_this());
-	ba::async_write(m_socket->ref(), ba::buffer(m_ackCipher), [this, self](boost::system::error_code ec, std::size_t)
-	{
-		transition(ec);
-	});
+    bytes prefix(2);
+    toBigEndian<uint16_t>(m_ack.size() + c_eciesOverhead, prefix);
+    encryptECIES(m_remote, bytesConstRef(&prefix), &m_ack, m_ackCipher);
+    m_ackCipher.insert(m_ackCipher.begin(), prefix.begin(), prefix.end());
+    
+    auto self(shared_from_this());
+    ba::async_write(m_socket->ref(), ba::buffer(m_ackCipher), [this, self](boost::system::error_code ec, std::size_t)
+    {
+        transition(ec);
+    });
 }
 
 void RLPXHandshake::setAuthValues(Signature const& _sig, Public const& _remotePubk, h256 const& _remoteNonce, uint64_t _remoteVersion)
 {
-	_remotePubk.ref().copyTo(m_remote.ref());
-	_remoteNonce.ref().copyTo(m_remoteNonce.ref());
-	m_remoteVersion = _remoteVersion;
-	Secret sharedSecret;
-	crypto::ecdh::agree(m_host->m_alias.secret(), _remotePubk, sharedSecret);
-	m_ecdheRemote = recover(_sig, sharedSecret.makeInsecure() ^ _remoteNonce);
+    _remotePubk.ref().copyTo(m_remote.ref());
+    _remoteNonce.ref().copyTo(m_remoteNonce.ref());
+    m_remoteVersion = _remoteVersion;
+    Secret sharedSecret;
+    crypto::ecdh::agree(m_host->m_alias.secret(), _remotePubk, sharedSecret);
+    m_ecdheRemote = recover(_sig, sharedSecret.makeInsecure() ^ _remoteNonce);
 }
 
 void RLPXHandshake::readAuth()
 {
-	clog(NetP2PConnect) << "p2p.connect.ingress receiving auth from " << m_socket->remoteEndpoint();
-	m_authCipher.resize(307);
-	auto self(shared_from_this());
-	ba::async_read(m_socket->ref(), ba::buffer(m_authCipher, 307), [this, self](boost::system::error_code ec, std::size_t)
-	{
-		if (ec)
-			transition(ec);
-		else if (decryptECIES(m_host->m_alias.secret(), bytesConstRef(&m_authCipher), m_auth))
-		{
-			bytesConstRef data(&m_auth);
-			Signature sig(data.cropped(0, Signature::size));
-			Public pubk(data.cropped(Signature::size + h256::size, Public::size));
-			h256 nonce(data.cropped(Signature::size + h256::size + Public::size, h256::size));
-			setAuthValues(sig, pubk, nonce, 4);
-			transition();
-		}
-		else
-			readAuthEIP8();
-	});
+    LOG(m_logger) << "p2p.connect.ingress receiving auth from " << m_socket->remoteEndpoint();
+    m_authCipher.resize(307);
+    auto self(shared_from_this());
+    ba::async_read(m_socket->ref(), ba::buffer(m_authCipher, 307), [this, self](boost::system::error_code ec, std::size_t)
+    {
+        if (ec)
+            transition(ec);
+        else if (decryptECIES(m_host->m_alias.secret(), bytesConstRef(&m_authCipher), m_auth))
+        {
+            bytesConstRef data(&m_auth);
+            Signature sig(data.cropped(0, Signature::size));
+            Public pubk(data.cropped(Signature::size + h256::size, Public::size));
+            h256 nonce(data.cropped(Signature::size + h256::size + Public::size, h256::size));
+            setAuthValues(sig, pubk, nonce, 4);
+            transition();
+        }
+        else
+            readAuthEIP8();
+    });
 }
 
 void RLPXHandshake::readAuthEIP8()
 {
-	assert(m_authCipher.size() == 307);
-	uint16_t size(m_authCipher[0]<<8 | m_authCipher[1]);
-	clog(NetP2PConnect) << "p2p.connect.ingress receiving " << size << "bytes EIP-8 auth from " << m_socket->remoteEndpoint();
-	m_authCipher.resize((size_t)size + 2);
-	auto rest = ba::buffer(ba::buffer(m_authCipher) + 307);
-	auto self(shared_from_this());
-	ba::async_read(m_socket->ref(), rest, [this, self](boost::system::error_code ec, std::size_t)
-	{
-		bytesConstRef ct(&m_authCipher);
-		if (ec)
-			transition(ec);
-		else if (decryptECIES(m_host->m_alias.secret(), ct.cropped(0, 2), ct.cropped(2), m_auth))
-		{
-			RLP rlp(m_auth, RLP::ThrowOnFail | RLP::FailIfTooSmall);
-			setAuthValues(
-				rlp[0].toHash<Signature>(),
-				rlp[1].toHash<Public>(),
-				rlp[2].toHash<h256>(),
-				rlp[3].toInt<uint64_t>()
-			);
-			m_nextState = AckAuthEIP8;
-			transition();
-		}
-		else
-		{
-			clog(NetP2PConnect) << "p2p.connect.ingress auth decrypt failed for" << m_socket->remoteEndpoint();
-			m_nextState = Error;
-			transition();
-		}
-	});
+    assert(m_authCipher.size() == 307);
+    uint16_t size(m_authCipher[0]<<8 | m_authCipher[1]);
+    LOG(m_logger) << "p2p.connect.ingress receiving " << size << " bytes EIP-8 auth from "
+                  << m_socket->remoteEndpoint();
+    m_authCipher.resize((size_t)size + 2);
+    auto rest = ba::buffer(ba::buffer(m_authCipher) + 307);
+    auto self(shared_from_this());
+    ba::async_read(m_socket->ref(), rest, [this, self](boost::system::error_code ec, std::size_t)
+    {
+        bytesConstRef ct(&m_authCipher);
+        if (ec)
+            transition(ec);
+        else if (decryptECIES(m_host->m_alias.secret(), ct.cropped(0, 2), ct.cropped(2), m_auth))
+        {
+            RLP rlp(m_auth, RLP::ThrowOnFail | RLP::FailIfTooSmall);
+            setAuthValues(
+                rlp[0].toHash<Signature>(),
+                rlp[1].toHash<Public>(),
+                rlp[2].toHash<h256>(),
+                rlp[3].toInt<uint64_t>()
+            );
+            m_nextState = AckAuthEIP8;
+            transition();
+        }
+        else
+        {
+            LOG(m_logger) << "p2p.connect.ingress auth decrypt failed for "
+                          << m_socket->remoteEndpoint();
+            m_nextState = Error;
+            transition();
+        }
+    });
 }
 
 void RLPXHandshake::readAck()
 {
-	clog(NetP2PConnect) << "p2p.connect.egress receiving ack from " << m_socket->remoteEndpoint();
-	m_ackCipher.resize(210);
-	auto self(shared_from_this());
-	ba::async_read(m_socket->ref(), ba::buffer(m_ackCipher, 210), [this, self](boost::system::error_code ec, std::size_t)
-	{
-		if (ec)
-			transition(ec);
-		else if (decryptECIES(m_host->m_alias.secret(), bytesConstRef(&m_ackCipher), m_ack))
-		{
-			bytesConstRef(&m_ack).cropped(0, Public::size).copyTo(m_ecdheRemote.ref());
-			bytesConstRef(&m_ack).cropped(Public::size, h256::size).copyTo(m_remoteNonce.ref());
-			m_remoteVersion = 4;
-			transition();
-		}
-		else
-			readAckEIP8();
-	});
+    LOG(m_logger) << "p2p.connect.egress receiving ack from " << m_socket->remoteEndpoint();
+    m_ackCipher.resize(210);
+    auto self(shared_from_this());
+    ba::async_read(m_socket->ref(), ba::buffer(m_ackCipher, 210), [this, self](boost::system::error_code ec, std::size_t)
+    {
+        if (ec)
+            transition(ec);
+        else if (decryptECIES(m_host->m_alias.secret(), bytesConstRef(&m_ackCipher), m_ack))
+        {
+            bytesConstRef(&m_ack).cropped(0, Public::size).copyTo(m_ecdheRemote.ref());
+            bytesConstRef(&m_ack).cropped(Public::size, h256::size).copyTo(m_remoteNonce.ref());
+            m_remoteVersion = 4;
+            transition();
+        }
+        else
+            readAckEIP8();
+    });
 }
 
 void RLPXHandshake::readAckEIP8()
 {
-	assert(m_ackCipher.size() == 210);
-	uint16_t size(m_ackCipher[0]<<8 | m_ackCipher[1]);
-	clog(NetP2PConnect) << "p2p.connect.egress receiving " << size << "bytes EIP-8 ack from " << m_socket->remoteEndpoint();
-	m_ackCipher.resize((size_t)size + 2);
-	auto rest = ba::buffer(ba::buffer(m_ackCipher) + 210);
-	auto self(shared_from_this());
-	ba::async_read(m_socket->ref(), rest, [this, self](boost::system::error_code ec, std::size_t)
-	{
-		bytesConstRef ct(&m_ackCipher);
-		if (ec)
-			transition(ec);
-		else if (decryptECIES(m_host->m_alias.secret(), ct.cropped(0, 2), ct.cropped(2), m_ack))
-		{
-			RLP rlp(m_ack, RLP::ThrowOnFail | RLP::FailIfTooSmall);
-			m_ecdheRemote = rlp[0].toHash<Public>();
-			m_remoteNonce = rlp[1].toHash<h256>();
-			m_remoteVersion = rlp[2].toInt<uint64_t>();
-			transition();
-		}
-		else
-		{
-			clog(NetP2PConnect) << "p2p.connect.egress ack decrypt failed for " << m_socket->remoteEndpoint();
-			m_nextState = Error;
-			transition();
-		}
-	});
+    assert(m_ackCipher.size() == 210);
+    uint16_t size(m_ackCipher[0]<<8 | m_ackCipher[1]);
+    LOG(m_logger) << "p2p.connect.egress receiving " << size << " bytes EIP-8 ack from "
+                  << m_socket->remoteEndpoint();
+    m_ackCipher.resize((size_t)size + 2);
+    auto rest = ba::buffer(ba::buffer(m_ackCipher) + 210);
+    auto self(shared_from_this());
+    ba::async_read(m_socket->ref(), rest, [this, self](boost::system::error_code ec, std::size_t)
+    {
+        bytesConstRef ct(&m_ackCipher);
+        if (ec)
+            transition(ec);
+        else if (decryptECIES(m_host->m_alias.secret(), ct.cropped(0, 2), ct.cropped(2), m_ack))
+        {
+            RLP rlp(m_ack, RLP::ThrowOnFail | RLP::FailIfTooSmall);
+            m_ecdheRemote = rlp[0].toHash<Public>();
+            m_remoteNonce = rlp[1].toHash<h256>();
+            m_remoteVersion = rlp[2].toInt<uint64_t>();
+            transition();
+        }
+        else
+        {
+            LOG(m_logger) << "p2p.connect.egress ack decrypt failed for "
+                          << m_socket->remoteEndpoint();
+            m_nextState = Error;
+            transition();
+        }
+    });
 }
 
 void RLPXHandshake::cancel()
 {
-	m_cancel = true;
-	m_idleTimer.cancel();
-	m_socket->close();
-	m_io.reset();
+    m_cancel = true;
+    m_idleTimer.cancel();
+    m_socket->close();
+    m_io.reset();
 }
 
 void RLPXHandshake::error()
 {
-	auto connected = m_socket->isConnected();
-	if (connected && !m_socket->remoteEndpoint().address().is_unspecified())
-		clog(NetP2PConnect) << "Disconnecting " << m_socket->remoteEndpoint() << " (Handshake Failed)";
-	else
-		clog(NetP2PConnect) << "Handshake Failed (Connection reset by peer)";
+    auto connected = m_socket->isConnected();
+    if (connected && !m_socket->remoteEndpoint().address().is_unspecified())
+        LOG(m_logger) << "Disconnecting " << m_socket->remoteEndpoint() << " (Handshake Failed)";
+    else
+        LOG(m_logger) << "Handshake Failed (Connection reset by peer)";
 
-	cancel();
+    cancel();
 }
 
 void RLPXHandshake::transition(boost::system::error_code _ech)
 {
-	// reset timeout
-	m_idleTimer.cancel();
-	
-	if (_ech || m_nextState == Error || m_cancel)
-	{
-		clog(NetP2PConnect) << "Handshake Failed (I/O Error:" << _ech.message() << ")";
-		return error();
-	}
-	
-	auto self(shared_from_this());
-	assert(m_nextState != StartSession);
-	m_idleTimer.expires_from_now(c_timeout);
-	m_idleTimer.async_wait([this, self](boost::system::error_code const& _ec)
-	{
-		if (!_ec)
-		{
-			if (!m_socket->remoteEndpoint().address().is_unspecified())
-				clog(NetP2PConnect) << "Disconnecting " << m_socket->remoteEndpoint() << " (Handshake Timeout)";
-			cancel();
-		}
-	});
-	
-	if (m_nextState == New)
-	{
-		m_nextState = AckAuth;
-		if (m_originated)
-			writeAuth();
-		else
-			readAuth();
-	}
-	else if (m_nextState == AckAuth)
-	{
-		m_nextState = WriteHello;
-		if (m_originated)
-			readAck();
-		else
-			writeAck();
-	}
-	else if (m_nextState == AckAuthEIP8)
-	{
-		m_nextState = WriteHello;
-		if (m_originated)
-			readAck();
-		else
-			writeAckEIP8();
-	}
-	else if (m_nextState == WriteHello)
-	{
-		m_nextState = ReadHello;
-		clog(NetP2PConnect) << (m_originated ? "p2p.connect.egress" : "p2p.connect.ingress") << "sending capabilities handshake";
+    // reset timeout
+    m_idleTimer.cancel();
+    
+    if (_ech || m_nextState == Error || m_cancel)
+    {
+        LOG(m_logger) << "Handshake Failed (I/O Error: " << _ech.message() << ")";
+        return error();
+    }
+    
+    auto self(shared_from_this());
+    assert(m_nextState != StartSession);
+    m_idleTimer.expires_from_now(c_timeout);
+    m_idleTimer.async_wait([this, self](boost::system::error_code const& _ec)
+    {
+        if (!_ec)
+        {
+            if (!m_socket->remoteEndpoint().address().is_unspecified())
+                LOG(m_logger) << "Disconnecting " << m_socket->remoteEndpoint()
+                              << " (Handshake Timeout)";
+            cancel();
+        }
+    });
+    
+    if (m_nextState == New)
+    {
+        m_nextState = AckAuth;
+        if (m_originated)
+            writeAuth();
+        else
+            readAuth();
+    }
+    else if (m_nextState == AckAuth)
+    {
+        m_nextState = WriteHello;
+        if (m_originated)
+            readAck();
+        else
+            writeAck();
+    }
+    else if (m_nextState == AckAuthEIP8)
+    {
+        m_nextState = WriteHello;
+        if (m_originated)
+            readAck();
+        else
+            writeAckEIP8();
+    }
+    else if (m_nextState == WriteHello)
+    {
+        m_nextState = ReadHello;
+        LOG(m_logger) << (m_originated ? "p2p.connect.egress" : "p2p.connect.ingress")
+                      << " sending capabilities handshake";
 
-		/// This pointer will be freed if there is an error otherwise
-		/// it will be passed to Host which will take ownership.
-		m_io.reset(new RLPXFrameCoder(*this));
+        /// This pointer will be freed if there is an error otherwise
+        /// it will be passed to Host which will take ownership.
+        m_io.reset(new RLPXFrameCoder(*this));
 
-		RLPStream s;
-		s.append((unsigned)HelloPacket).appendList(5)
-			<< dev::p2p::c_protocolVersion
-			<< m_host->m_clientVersion
-			<< m_host->caps()
-			<< m_host->listenPort()
-			<< m_host->id();
+        RLPStream s;
+        s.append((unsigned)HelloPacket).appendList(5)
+            << dev::p2p::c_protocolVersion
+            << m_host->m_clientVersion
+            << m_host->caps()
+            << m_host->listenPort()
+            << m_host->id();
 
-		bytes packet;
-		s.swapOut(packet);
-		m_io->writeSingleFramePacket(&packet, m_handshakeOutBuffer);
-		ba::async_write(m_socket->ref(), ba::buffer(m_handshakeOutBuffer), [this, self](boost::system::error_code ec, std::size_t)
-		{
-			transition(ec);
-		});
-	}
-	else if (m_nextState == ReadHello)
-	{
-		// Authenticate and decrypt initial hello frame with initial RLPXFrameCoder
-		// and request m_host to start session.
-		m_nextState = StartSession;
-		
-		// read frame header
-		unsigned const handshakeSize = 32;
-		m_handshakeInBuffer.resize(handshakeSize);
-		ba::async_read(m_socket->ref(), boost::asio::buffer(m_handshakeInBuffer, handshakeSize), [this, self](boost::system::error_code ec, std::size_t)
-		{
-			if (ec)
-				transition(ec);
-			else
-			{
-				if (!m_io)
-				{
-					clog(NetP2PWarn) << "Internal error in handshake: RLPXFrameCoder disappeared.";
-					m_nextState = Error;
-					transition();
-					return;
+        bytes packet;
+        s.swapOut(packet);
+        m_io->writeSingleFramePacket(&packet, m_handshakeOutBuffer);
+        ba::async_write(m_socket->ref(), ba::buffer(m_handshakeOutBuffer), [this, self](boost::system::error_code ec, std::size_t)
+        {
+            transition(ec);
+        });
+    }
+    else if (m_nextState == ReadHello)
+    {
+        // Authenticate and decrypt initial hello frame with initial RLPXFrameCoder
+        // and request m_host to start session.
+        m_nextState = StartSession;
+        
+        // read frame header
+        unsigned const handshakeSize = 32;
+        m_handshakeInBuffer.resize(handshakeSize);
+        ba::async_read(m_socket->ref(), boost::asio::buffer(m_handshakeInBuffer, handshakeSize), [this, self](boost::system::error_code ec, std::size_t)
+        {
+            if (ec)
+                transition(ec);
+            else
+            {
+                if (!m_io)
+                {
+                    clog(NetP2PWarn) << "Internal error in handshake: RLPXFrameCoder disappeared.";
+                    m_nextState = Error;
+                    transition();
+                    return;
 
-				}
-				/// authenticate and decrypt header
-				if (!m_io->authAndDecryptHeader(bytesRef(m_handshakeInBuffer.data(), m_handshakeInBuffer.size())))
-				{
-					m_nextState = Error;
-					transition();
-					return;
-				}
-				
-				clog(NetP2PNote) << (m_originated ? "p2p.connect.egress" : "p2p.connect.ingress") << "recvd hello header";
-				
-				/// check frame size
-				bytes& header = m_handshakeInBuffer;
-				uint32_t frameSize = (uint32_t)(header[2]) | (uint32_t)(header[1])<<8 | (uint32_t)(header[0])<<16;
-				if (frameSize > 1024)
-				{
-					// all future frames: 16777216
-					clog(NetP2PWarn) << (m_originated ? "p2p.connect.egress" : "p2p.connect.ingress") << "hello frame is too large" << frameSize;
-					m_nextState = Error;
-					transition();
-					return;
-				}
-				
-				/// rlp of header has protocol-type, sequence-id[, total-packet-size]
-				bytes headerRLP(header.size() - 3 - h128::size);	// this is always 32 - 3 - 16 = 13. wtf?
-				bytesConstRef(&header).cropped(3).copyTo(&headerRLP);
-				
-				/// read padded frame and mac
-				m_handshakeInBuffer.resize(frameSize + ((16 - (frameSize % 16)) % 16) + h128::size);
-				ba::async_read(m_socket->ref(), boost::asio::buffer(m_handshakeInBuffer, m_handshakeInBuffer.size()), [this, self, headerRLP](boost::system::error_code ec, std::size_t)
-				{
-					m_idleTimer.cancel();
-					
-					if (ec)
-						transition(ec);
-					else
-					{
-						if (!m_io)
-						{
-							clog(NetP2PWarn) << "Internal error in handshake: RLPXFrameCoder disappeared.";
-							m_nextState = Error;
-							transition();
-							return;
+                }
+                /// authenticate and decrypt header
+                if (!m_io->authAndDecryptHeader(bytesRef(m_handshakeInBuffer.data(), m_handshakeInBuffer.size())))
+                {
+                    m_nextState = Error;
+                    transition();
+                    return;
+                }
+                
+                clog(NetP2PNote) << (m_originated ? "p2p.connect.egress" : "p2p.connect.ingress") << "recvd hello header";
+                
+                /// check frame size
+                bytes& header = m_handshakeInBuffer;
+                uint32_t frameSize = (uint32_t)(header[2]) | (uint32_t)(header[1])<<8 | (uint32_t)(header[0])<<16;
+                if (frameSize > 1024)
+                {
+                    // all future frames: 16777216
+                    clog(NetP2PWarn) << (m_originated ? "p2p.connect.egress" : "p2p.connect.ingress") << "hello frame is too large" << frameSize;
+                    m_nextState = Error;
+                    transition();
+                    return;
+                }
+                
+                /// rlp of header has protocol-type, sequence-id[, total-packet-size]
+                bytes headerRLP(header.size() - 3 - h128::size);	// this is always 32 - 3 - 16 = 13. wtf?
+                bytesConstRef(&header).cropped(3).copyTo(&headerRLP);
+                
+                /// read padded frame and mac
+                m_handshakeInBuffer.resize(frameSize + ((16 - (frameSize % 16)) % 16) + h128::size);
+                ba::async_read(m_socket->ref(), boost::asio::buffer(m_handshakeInBuffer, m_handshakeInBuffer.size()), [this, self, headerRLP](boost::system::error_code ec, std::size_t)
+                {
+                    m_idleTimer.cancel();
+                    
+                    if (ec)
+                        transition(ec);
+                    else
+                    {
+                        if (!m_io)
+                        {
+                            clog(NetP2PWarn) << "Internal error in handshake: RLPXFrameCoder disappeared.";
+                            m_nextState = Error;
+                            transition();
+                            return;
 
-						}
-						bytesRef frame(&m_handshakeInBuffer);
-						if (!m_io->authAndDecryptFrame(frame))
-						{
-							clog(NetTriviaSummary) << (m_originated ? "p2p.connect.egress" : "p2p.connect.ingress") << "hello frame: decrypt failed";
-							m_nextState = Error;
-							transition();
-							return;
-						}
-						
-						PacketType packetType = frame[0] == 0x80 ? HelloPacket : (PacketType)frame[0];
-						if (packetType != HelloPacket)
-						{
-							clog(NetTriviaSummary) << (m_originated ? "p2p.connect.egress" : "p2p.connect.ingress") << "hello frame: invalid packet type";
-							m_nextState = Error;
-							transition();
-							return;
-						}
+                        }
+                        bytesRef frame(&m_handshakeInBuffer);
+                        if (!m_io->authAndDecryptFrame(frame))
+                        {
+                            clog(NetTriviaSummary) << (m_originated ? "p2p.connect.egress" : "p2p.connect.ingress") << "hello frame: decrypt failed";
+                            m_nextState = Error;
+                            transition();
+                            return;
+                        }
+                        
+                        PacketType packetType = frame[0] == 0x80 ? HelloPacket : (PacketType)frame[0];
+                        if (packetType != HelloPacket)
+                        {
+                            clog(NetTriviaSummary) << (m_originated ? "p2p.connect.egress" : "p2p.connect.ingress") << "hello frame: invalid packet type";
+                            m_nextState = Error;
+                            transition();
+                            return;
+                        }
 
-						clog(NetTriviaSummary) << (m_originated ? "p2p.connect.egress" : "p2p.connect.ingress") << "hello frame: success. starting session.";
-						try
-						{
-							RLP rlp(frame.cropped(1), RLP::ThrowOnFail | RLP::FailIfTooSmall);
-							m_host->startPeerSession(m_remote, rlp, move(m_io), m_socket);
-						}
-						catch (std::exception const& _e)
-						{
-							clog(NetWarn) << "Handshake causing an exception:" << _e.what();
-							m_nextState = Error;
-							transition();
-						}
-					}
-				});
-			}
-		});
-	}
+                        clog(NetTriviaSummary) << (m_originated ? "p2p.connect.egress" : "p2p.connect.ingress") << "hello frame: success. starting session.";
+                        try
+                        {
+                            RLP rlp(frame.cropped(1), RLP::ThrowOnFail | RLP::FailIfTooSmall);
+                            m_host->startPeerSession(m_remote, rlp, move(m_io), m_socket);
+                        }
+                        catch (std::exception const& _e)
+                        {
+                            clog(NetWarn) << "Handshake causing an exception:" << _e.what();
+                            m_nextState = Error;
+                            transition();
+                        }
+                    }
+                });
+            }
+        });
+    }
 }

--- a/libp2p/RLPxHandshake.cpp
+++ b/libp2p/RLPxHandshake.cpp
@@ -343,16 +343,19 @@ void RLPXHandshake::transition(boost::system::error_code _ech)
                     transition();
                     return;
                 }
-                
-                clog(NetP2PNote) << (m_originated ? "p2p.connect.egress" : "p2p.connect.ingress") << "recvd hello header";
-                
+
+                clog(NetP2PNote) << (m_originated ? "p2p.connect.egress" : "p2p.connect.ingress")
+                                 << " recvd hello header";
+
                 /// check frame size
                 bytes& header = m_handshakeInBuffer;
                 uint32_t frameSize = (uint32_t)(header[2]) | (uint32_t)(header[1])<<8 | (uint32_t)(header[0])<<16;
                 if (frameSize > 1024)
                 {
                     // all future frames: 16777216
-                    clog(NetP2PWarn) << (m_originated ? "p2p.connect.egress" : "p2p.connect.ingress") << "hello frame is too large" << frameSize;
+                    clog(NetP2PWarn)
+                        << (m_originated ? "p2p.connect.egress" : "p2p.connect.ingress")
+                        << " hello frame is too large " << frameSize;
                     m_nextState = Error;
                     transition();
                     return;
@@ -383,7 +386,9 @@ void RLPXHandshake::transition(boost::system::error_code _ech)
                         bytesRef frame(&m_handshakeInBuffer);
                         if (!m_io->authAndDecryptFrame(frame))
                         {
-                            clog(NetTriviaSummary) << (m_originated ? "p2p.connect.egress" : "p2p.connect.ingress") << "hello frame: decrypt failed";
+                            clog(NetTriviaSummary)
+                                << (m_originated ? "p2p.connect.egress" : "p2p.connect.ingress")
+                                << " hello frame: decrypt failed";
                             m_nextState = Error;
                             transition();
                             return;
@@ -392,13 +397,17 @@ void RLPXHandshake::transition(boost::system::error_code _ech)
                         PacketType packetType = frame[0] == 0x80 ? HelloPacket : (PacketType)frame[0];
                         if (packetType != HelloPacket)
                         {
-                            clog(NetTriviaSummary) << (m_originated ? "p2p.connect.egress" : "p2p.connect.ingress") << "hello frame: invalid packet type";
+                            clog(NetTriviaSummary)
+                                << (m_originated ? "p2p.connect.egress" : "p2p.connect.ingress")
+                                << " hello frame: invalid packet type";
                             m_nextState = Error;
                             transition();
                             return;
                         }
 
-                        clog(NetTriviaSummary) << (m_originated ? "p2p.connect.egress" : "p2p.connect.ingress") << "hello frame: success. starting session.";
+                        clog(NetTriviaSummary)
+                            << (m_originated ? "p2p.connect.egress" : "p2p.connect.ingress")
+                            << " hello frame: success. starting session.";
                         try
                         {
                             RLP rlp(frame.cropped(1), RLP::ThrowOnFail | RLP::FailIfTooSmall);
@@ -406,7 +415,7 @@ void RLPXHandshake::transition(boost::system::error_code _ech)
                         }
                         catch (std::exception const& _e)
                         {
-                            clog(NetWarn) << "Handshake causing an exception:" << _e.what();
+                            cnetwarn << "Handshake causing an exception: " << _e.what();
                             m_nextState = Error;
                             transition();
                         }

--- a/libp2p/RLPxHandshake.cpp
+++ b/libp2p/RLPxHandshake.cpp
@@ -386,7 +386,7 @@ void RLPXHandshake::transition(boost::system::error_code _ech)
                         bytesRef frame(&m_handshakeInBuffer);
                         if (!m_io->authAndDecryptFrame(frame))
                         {
-                            clog(NetTriviaSummary)
+                            cnetdetails
                                 << (m_originated ? "p2p.connect.egress" : "p2p.connect.ingress")
                                 << " hello frame: decrypt failed";
                             m_nextState = Error;
@@ -397,7 +397,7 @@ void RLPXHandshake::transition(boost::system::error_code _ech)
                         PacketType packetType = frame[0] == 0x80 ? HelloPacket : (PacketType)frame[0];
                         if (packetType != HelloPacket)
                         {
-                            clog(NetTriviaSummary)
+                            cnetdetails
                                 << (m_originated ? "p2p.connect.egress" : "p2p.connect.ingress")
                                 << " hello frame: invalid packet type";
                             m_nextState = Error;
@@ -405,9 +405,8 @@ void RLPXHandshake::transition(boost::system::error_code _ech)
                             return;
                         }
 
-                        clog(NetTriviaSummary)
-                            << (m_originated ? "p2p.connect.egress" : "p2p.connect.ingress")
-                            << " hello frame: success. starting session.";
+                        cnetdetails << (m_originated ? "p2p.connect.egress" : "p2p.connect.ingress")
+                                    << " hello frame: success. starting session.";
                         try
                         {
                             RLP rlp(frame.cropped(1), RLP::ThrowOnFail | RLP::FailIfTooSmall);

--- a/libp2p/RLPxHandshake.cpp
+++ b/libp2p/RLPxHandshake.cpp
@@ -330,7 +330,7 @@ void RLPXHandshake::transition(boost::system::error_code _ech)
             {
                 if (!m_io)
                 {
-                    clog(NetP2PWarn) << "Internal error in handshake: RLPXFrameCoder disappeared.";
+                    LOG(m_logger) << "Internal error in handshake: RLPXFrameCoder disappeared.";
                     m_nextState = Error;
                     transition();
                     return;
@@ -344,7 +344,7 @@ void RLPXHandshake::transition(boost::system::error_code _ech)
                     return;
                 }
 
-                clog(NetP2PNote) << (m_originated ? "p2p.connect.egress" : "p2p.connect.ingress")
+                LOG(m_logger) << (m_originated ? "p2p.connect.egress" : "p2p.connect.ingress")
                                  << " recvd hello header";
 
                 /// check frame size
@@ -353,7 +353,7 @@ void RLPXHandshake::transition(boost::system::error_code _ech)
                 if (frameSize > 1024)
                 {
                     // all future frames: 16777216
-                    clog(NetP2PWarn)
+                    LOG(m_logger)
                         << (m_originated ? "p2p.connect.egress" : "p2p.connect.ingress")
                         << " hello frame is too large " << frameSize;
                     m_nextState = Error;
@@ -377,7 +377,7 @@ void RLPXHandshake::transition(boost::system::error_code _ech)
                     {
                         if (!m_io)
                         {
-                            clog(NetP2PWarn) << "Internal error in handshake: RLPXFrameCoder disappeared.";
+                            LOG(m_logger) << "Internal error in handshake: RLPXFrameCoder disappeared.";
                             m_nextState = Error;
                             transition();
                             return;

--- a/libp2p/RLPxHandshake.h
+++ b/libp2p/RLPxHandshake.h
@@ -49,100 +49,102 @@ static const unsigned c_rlpxVersion = 4;
  */
 class RLPXHandshake: public std::enable_shared_from_this<RLPXHandshake>
 {
-	friend class RLPXFrameCoder;
+    friend class RLPXFrameCoder;
 
 public:
-	/// Setup incoming connection.
-	RLPXHandshake(Host* _host, std::shared_ptr<RLPXSocket> const& _socket): m_host(_host), m_originated(false), m_socket(_socket), m_idleTimer(m_socket->ref().get_io_service()) { crypto::Nonce::get().ref().copyTo(m_nonce.ref()); }
-	
-	/// Setup outbound connection.
-	RLPXHandshake(Host* _host, std::shared_ptr<RLPXSocket> const& _socket, NodeID _remote): m_host(_host), m_remote(_remote), m_originated(true), m_socket(_socket), m_idleTimer(m_socket->ref().get_io_service()) { crypto::Nonce::get().ref().copyTo(m_nonce.ref()); }
+    /// Setup incoming connection.
+    RLPXHandshake(Host* _host, std::shared_ptr<RLPXSocket> const& _socket): m_host(_host), m_originated(false), m_socket(_socket), m_idleTimer(m_socket->ref().get_io_service()) { crypto::Nonce::get().ref().copyTo(m_nonce.ref()); }
+    
+    /// Setup outbound connection.
+    RLPXHandshake(Host* _host, std::shared_ptr<RLPXSocket> const& _socket, NodeID _remote): m_host(_host), m_remote(_remote), m_originated(true), m_socket(_socket), m_idleTimer(m_socket->ref().get_io_service()) { crypto::Nonce::get().ref().copyTo(m_nonce.ref()); }
 
-	virtual ~RLPXHandshake() = default;
+    virtual ~RLPXHandshake() = default;
 
-	/// Start handshake.
-	void start() { transition(); }
+    /// Start handshake.
+    void start() { transition(); }
 
-	/// Aborts the handshake.
-	void cancel();
+    /// Aborts the handshake.
+    void cancel();
 
 protected:
-	/// Sequential states of handshake
-	enum State
-	{
-		Error = -1,
-		New,
-		AckAuth,
-		AckAuthEIP8,
-		WriteHello,
-		ReadHello,
-		StartSession
-	};
+    /// Sequential states of handshake
+    enum State
+    {
+        Error = -1,
+        New,
+        AckAuth,
+        AckAuthEIP8,
+        WriteHello,
+        ReadHello,
+        StartSession
+    };
 
-	/// Write Auth message to socket and transitions to AckAuth.
-	void writeAuth();
+    /// Write Auth message to socket and transitions to AckAuth.
+    void writeAuth();
 
-	/// Reads Auth message from socket and transitions to AckAuth.
-	void readAuth();
+    /// Reads Auth message from socket and transitions to AckAuth.
+    void readAuth();
 
-	/// Continues reading Auth message in EIP-8 format and transitions to AckAuthEIP8.
-	void readAuthEIP8();
+    /// Continues reading Auth message in EIP-8 format and transitions to AckAuthEIP8.
+    void readAuthEIP8();
 
-	/// Derives ephemeral secret from signature and sets members after Auth has been decrypted.
-	void setAuthValues(Signature const& sig, Public const& remotePubk, h256 const& remoteNonce, uint64_t remoteVersion);
-	
-	/// Write Ack message to socket and transitions to WriteHello.
-	void writeAck();
+    /// Derives ephemeral secret from signature and sets members after Auth has been decrypted.
+    void setAuthValues(Signature const& sig, Public const& remotePubk, h256 const& remoteNonce, uint64_t remoteVersion);
+    
+    /// Write Ack message to socket and transitions to WriteHello.
+    void writeAck();
 
-	/// Write Ack message in EIP-8 format to socket and transitions to WriteHello.
-	void writeAckEIP8();
-	
-	/// Reads Auth message from socket and transitions to WriteHello.
-	void readAck();
+    /// Write Ack message in EIP-8 format to socket and transitions to WriteHello.
+    void writeAckEIP8();
+    
+    /// Reads Auth message from socket and transitions to WriteHello.
+    void readAck();
 
-	/// Continues reading Ack message in EIP-8 format and transitions to WriteHello.
-	void readAckEIP8();
-	
-	/// Closes connection and ends transitions.
-	void error();
-	
-	/// Performs transition for m_nextState.
-	virtual void transition(boost::system::error_code _ech = boost::system::error_code());
+    /// Continues reading Ack message in EIP-8 format and transitions to WriteHello.
+    void readAckEIP8();
+    
+    /// Closes connection and ends transitions.
+    void error();
+    
+    /// Performs transition for m_nextState.
+    virtual void transition(boost::system::error_code _ech = boost::system::error_code());
 
-	/// Timeout for remote to respond to transition events. Enforced by m_idleTimer and refreshed by transition().
-	boost::posix_time::milliseconds const c_timeout = boost::posix_time::milliseconds(1800);
+    /// Timeout for remote to respond to transition events. Enforced by m_idleTimer and refreshed by transition().
+    boost::posix_time::milliseconds const c_timeout = boost::posix_time::milliseconds(1800);
 
-	State m_nextState = New;		///< Current or expected state of transition.
-	bool m_cancel = false;			///< Will be set to true if connection was canceled.
-	
-	Host* m_host;					///< Host which provides m_alias, protocolVersion(), m_clientVersion, caps(), and TCP listenPort().
-	
-	/// Node id of remote host for socket.
-	NodeID m_remote;				///< Public address of remote host.
-	bool m_originated = false;		///< True if connection is outbound.
-	
-	/// Buffers for encoded and decoded handshake phases
-	bytes m_auth;					///< Plaintext of egress or ingress Auth message.
-	bytes m_authCipher;				///< Ciphertext of egress or ingress Auth message.
-	bytes m_ack;					///< Plaintext of egress or ingress Ack message.
-	bytes m_ackCipher;				///< Ciphertext of egress or ingress Ack message.
-	bytes m_handshakeOutBuffer;		///< Frame buffer for egress Hello packet.
-	bytes m_handshakeInBuffer;		///< Frame buffer for ingress Hello packet.
-	
-	KeyPair m_ecdheLocal = KeyPair::create();  ///< Ephemeral ECDH secret and agreement.
-	h256 m_nonce;					///< Nonce generated by this host for handshake.
-	
-	Public m_ecdheRemote;			///< Remote ephemeral public key.
-	h256 m_remoteNonce;				///< Nonce generated by remote host for handshake.
-	uint64_t m_remoteVersion;
-	
-	/// Used to read and write RLPx encrypted frames for last step of handshake authentication.
-	/// Passed onto Host which will take ownership.
-	std::unique_ptr<RLPXFrameCoder> m_io;
-	
-	std::shared_ptr<RLPXSocket> m_socket;		///< Socket.
-	boost::asio::deadline_timer m_idleTimer;	///< Timer which enforces c_timeout.
+    State m_nextState = New;		///< Current or expected state of transition.
+    bool m_cancel = false;			///< Will be set to true if connection was canceled.
+    
+    Host* m_host;					///< Host which provides m_alias, protocolVersion(), m_clientVersion, caps(), and TCP listenPort().
+    
+    /// Node id of remote host for socket.
+    NodeID m_remote;				///< Public address of remote host.
+    bool m_originated = false;		///< True if connection is outbound.
+    
+    /// Buffers for encoded and decoded handshake phases
+    bytes m_auth;					///< Plaintext of egress or ingress Auth message.
+    bytes m_authCipher;				///< Ciphertext of egress or ingress Auth message.
+    bytes m_ack;					///< Plaintext of egress or ingress Ack message.
+    bytes m_ackCipher;				///< Ciphertext of egress or ingress Ack message.
+    bytes m_handshakeOutBuffer;		///< Frame buffer for egress Hello packet.
+    bytes m_handshakeInBuffer;		///< Frame buffer for ingress Hello packet.
+    
+    KeyPair m_ecdheLocal = KeyPair::create();  ///< Ephemeral ECDH secret and agreement.
+    h256 m_nonce;					///< Nonce generated by this host for handshake.
+    
+    Public m_ecdheRemote;			///< Remote ephemeral public key.
+    h256 m_remoteNonce;				///< Nonce generated by remote host for handshake.
+    uint64_t m_remoteVersion;
+    
+    /// Used to read and write RLPx encrypted frames for last step of handshake authentication.
+    /// Passed onto Host which will take ownership.
+    std::unique_ptr<RLPXFrameCoder> m_io;
+    
+    std::shared_ptr<RLPXSocket> m_socket;		///< Socket.
+    boost::asio::deadline_timer m_idleTimer;	///< Timer which enforces c_timeout.
+
+    Logger m_logger{createLogger(10, "net")};
 };
-	
+    
 }
 }

--- a/libp2p/Session.cpp
+++ b/libp2p/Session.cpp
@@ -116,7 +116,7 @@ template <class T> vector<T> randomSelection(vector<T> const& _t, unsigned _n)
 bool Session::readPacket(uint16_t _capId, PacketType _t, RLP const& _r)
 {
     m_lastReceived = chrono::steady_clock::now();
-    clog(NetRight) << _t << _r;
+    clogSimple(14, "net") << "-> " << _t << " " << _r;
     try // Generic try-catch block designed to capture RLP format errors - TODO: give decent diagnostics, make a bit more specific over what is caught.
     {
         // v4 frame headers are useless, offset packet type used
@@ -212,7 +212,7 @@ bool Session::checkPacket(bytesConstRef _msg)
 void Session::send(bytes&& _msg)
 {
     bytesConstRef msg(&_msg);
-    clog(NetLeft) << RLP(msg.cropped(1));
+    clogSimple(15, "net") << "<- " << RLP(msg.cropped(1));
     if (!checkPacket(msg))
         cnetwarn << "INVALID PACKET CONSTRUCTED!";
 

--- a/libp2p/Session.cpp
+++ b/libp2p/Session.cpp
@@ -50,7 +50,7 @@ Session::~Session()
 {
     ThreadContext tc(info().id.abridged());
     ThreadContext tc2(info().clientVersion);
-    cnetmessage << "Closing peer session :-(";
+    cnetlog << "Closing peer session :-(";
     m_peer->m_lastConnected = m_peer->m_lastAttempted - chrono::seconds(1);
 
     // Read-chain finished for one reason or another.
@@ -153,7 +153,7 @@ bool Session::interpret(PacketType _t, RLP const& _r)
         else
         {
             reason = reasonOf(r);
-            cnetmessage << "Disconnect (reason: " << reason << ")";
+            cnetlog << "Disconnect (reason: " << reason << ")";
             drop(DisconnectRequested);
         }
         break;

--- a/libp2p/Session.cpp
+++ b/libp2p/Session.cpp
@@ -160,7 +160,7 @@ bool Session::interpret(PacketType _t, RLP const& _r)
     }
     case PingPacket:
     {
-        clog(NetTriviaSummary) << "Ping" << m_info.id;
+        cnetdetails << "Ping " << m_info.id;
         RLPStream s;
         sealAndSend(prep(s, PongPacket));
         break;
@@ -169,7 +169,9 @@ bool Session::interpret(PacketType _t, RLP const& _r)
         DEV_GUARDED(x_info)
         {
             m_info.lastPing = std::chrono::steady_clock::now() - m_ping;
-            clog(NetTriviaSummary) << "Latency: " << chrono::duration_cast<chrono::milliseconds>(m_info.lastPing).count() << " ms";
+            cnetdetails << "Latency: "
+                        << chrono::duration_cast<chrono::milliseconds>(m_info.lastPing).count()
+                        << " ms";
         }
         break;
     case GetPeersPacket:
@@ -287,7 +289,8 @@ void Session::drop(DisconnectReason _reason)
         try
         {
             boost::system::error_code ec;
-            clog(NetConnect) << "Closing " << socket.remote_endpoint(ec) << "(" << reasonOf(_reason) << ")";
+            cnetdetails << "Closing " << socket.remote_endpoint(ec) << " (" << reasonOf(_reason)
+                        << ")";
             socket.shutdown(boost::asio::ip::tcp::socket::shutdown_both, ec);
             socket.close();
         }
@@ -304,7 +307,7 @@ void Session::drop(DisconnectReason _reason)
 
 void Session::disconnect(DisconnectReason _reason)
 {
-    clog(NetConnect) << "Disconnecting (our reason:" << reasonOf(_reason) << ")";
+    cnetdetails << "Disconnecting (our reason: " << reasonOf(_reason) << ")";
 
     if (m_socket->ref().is_open())
     {
@@ -401,7 +404,7 @@ bool Session::checkRead(std::size_t _expected, boost::system::error_code _ec, st
 {
     if (_ec && _ec.category() != boost::asio::error::get_misc_category() && _ec.value() != boost::asio::error::eof)
     {
-        clog(NetConnect) << "Error reading: " << _ec.message();
+        cnetdetails << "Error reading: " << _ec.message();
         drop(TCPError);
         return false;
     }

--- a/libp2p/Session.cpp
+++ b/libp2p/Session.cpp
@@ -50,7 +50,7 @@ Session::~Session()
 {
     ThreadContext tc(info().id.abridged());
     ThreadContext tc2(info().clientVersion);
-    clog(NetMessageSummary) << "Closing peer session :-(";
+    cnetmessage << "Closing peer session :-(";
     m_peer->m_lastConnected = m_peer->m_lastAttempted - chrono::seconds(1);
 
     // Read-chain finished for one reason or another.
@@ -153,7 +153,7 @@ bool Session::interpret(PacketType _t, RLP const& _r)
         else
         {
             reason = reasonOf(r);
-            clog(NetMessageSummary) << "Disconnect (reason: " << reason << ")";
+            cnetmessage << "Disconnect (reason: " << reason << ")";
             drop(DisconnectRequested);
         }
         break;

--- a/libp2p/UDP.cpp
+++ b/libp2p/UDP.cpp
@@ -24,40 +24,37 @@ using namespace std;
 using namespace dev;
 using namespace dev::p2p;
 
-const char* RLPXWarn::name() { return "!X!"; }
-const char* RLPXNote::name() { return "-X-"; }
-
 h256 RLPXDatagramFace::sign(Secret const& _k)
 {
-	assert(packetType());
-	
-	RLPStream rlpxstream;
+    assert(packetType());
+    
+    RLPStream rlpxstream;
 //	rlpxstream.appendRaw(toPublic(_k).asBytes()); // for mdc-based signature
-	rlpxstream.appendRaw(bytes(1, packetType())); // prefix by 1 byte for type
-	streamRLP(rlpxstream);
-	bytes rlpxBytes(rlpxstream.out());
-	
-	bytesConstRef rlpx(&rlpxBytes);
-	h256 sighash(dev::sha3(rlpx)); // H(type||data)
-	Signature sig = dev::sign(_k, sighash); // S(H(type||data))
-	
-	data.resize(h256::size + Signature::size + rlpx.size());
-	bytesRef rlpxHash(&data[0], h256::size);
-	bytesRef rlpxSig(&data[h256::size], Signature::size);
-	bytesRef rlpxPayload(&data[h256::size + Signature::size], rlpx.size());
-	
-	sig.ref().copyTo(rlpxSig);
-	rlpx.copyTo(rlpxPayload);
-	
-	bytesConstRef signedRLPx(&data[h256::size], data.size() - h256::size);
-	dev::sha3(signedRLPx).ref().copyTo(rlpxHash);
+    rlpxstream.appendRaw(bytes(1, packetType())); // prefix by 1 byte for type
+    streamRLP(rlpxstream);
+    bytes rlpxBytes(rlpxstream.out());
+    
+    bytesConstRef rlpx(&rlpxBytes);
+    h256 sighash(dev::sha3(rlpx)); // H(type||data)
+    Signature sig = dev::sign(_k, sighash); // S(H(type||data))
+    
+    data.resize(h256::size + Signature::size + rlpx.size());
+    bytesRef rlpxHash(&data[0], h256::size);
+    bytesRef rlpxSig(&data[h256::size], Signature::size);
+    bytesRef rlpxPayload(&data[h256::size + Signature::size], rlpx.size());
+    
+    sig.ref().copyTo(rlpxSig);
+    rlpx.copyTo(rlpxPayload);
+    
+    bytesConstRef signedRLPx(&data[h256::size], data.size() - h256::size);
+    dev::sha3(signedRLPx).ref().copyTo(rlpxHash);
 
-	return sighash;
+    return sighash;
 }
 
 Public RLPXDatagramFace::authenticate(bytesConstRef _sig, bytesConstRef _rlp)
 {
-	Signature const& sig = *(Signature const*)_sig.data();
-	return dev::recover(sig, sha3(_rlp));
+    Signature const& sig = *(Signature const*)_sig.data();
+    return dev::recover(sig, sha3(_rlp));
 }
 

--- a/libp2p/UDP.h
+++ b/libp2p/UDP.h
@@ -41,9 +41,6 @@ namespace dev
 namespace p2p
 {
 
-struct RLPXWarn: public LogChannel { static const char* name(); static const int verbosity = 0; };
-struct RLPXNote: public LogChannel { static const char* name(); static const int verbosity = 1; };
-
 /**
  * UDP Datagram
  * @todo make data protected/functional

--- a/libp2p/UDP.h
+++ b/libp2p/UDP.h
@@ -51,13 +51,13 @@ struct RLPXNote: public LogChannel { static const char* name(); static const int
 class UDPDatagram
 {
 public:
-	UDPDatagram(bi::udp::endpoint const& _ep): locus(_ep) {}
-	UDPDatagram(bi::udp::endpoint const& _ep, bytes _data): data(_data), locus(_ep) {}
-	bi::udp::endpoint const& endpoint() const { return locus; }
+    UDPDatagram(bi::udp::endpoint const& _ep): locus(_ep) {}
+    UDPDatagram(bi::udp::endpoint const& _ep, bytes _data): data(_data), locus(_ep) {}
+    bi::udp::endpoint const& endpoint() const { return locus; }
 
-	bytes data;
+    bytes data;
 protected:
-	bi::udp::endpoint locus;
+    bi::udp::endpoint locus;
 };
 
 /**
@@ -65,18 +65,18 @@ protected:
  */
 struct RLPXDatagramFace: public UDPDatagram
 {
-	static uint32_t futureFromEpoch(std::chrono::seconds _sec) { return static_cast<uint32_t>(std::chrono::duration_cast<std::chrono::seconds>((std::chrono::system_clock::now() + _sec).time_since_epoch()).count()); }
-	static uint32_t secondsSinceEpoch() { return static_cast<uint32_t>(std::chrono::duration_cast<std::chrono::seconds>((std::chrono::system_clock::now()).time_since_epoch()).count()); }
-	static Public authenticate(bytesConstRef _sig, bytesConstRef _rlp);
+    static uint32_t futureFromEpoch(std::chrono::seconds _sec) { return static_cast<uint32_t>(std::chrono::duration_cast<std::chrono::seconds>((std::chrono::system_clock::now() + _sec).time_since_epoch()).count()); }
+    static uint32_t secondsSinceEpoch() { return static_cast<uint32_t>(std::chrono::duration_cast<std::chrono::seconds>((std::chrono::system_clock::now()).time_since_epoch()).count()); }
+    static Public authenticate(bytesConstRef _sig, bytesConstRef _rlp);
 
-	RLPXDatagramFace(bi::udp::endpoint const& _ep): UDPDatagram(_ep) {}
-	virtual ~RLPXDatagramFace() = default;
+    RLPXDatagramFace(bi::udp::endpoint const& _ep): UDPDatagram(_ep) {}
+    virtual ~RLPXDatagramFace() = default;
 
-	virtual h256 sign(Secret const& _from);
-	virtual uint8_t packetType() const = 0;
+    virtual h256 sign(Secret const& _from);
+    virtual uint8_t packetType() const = 0;
 
-	virtual void streamRLP(RLPStream&) const = 0;
-	virtual void interpretRLP(bytesConstRef _bytes) = 0;
+    virtual void streamRLP(RLPStream&) const = 0;
+    virtual void interpretRLP(bytesConstRef _bytes) = 0;
 };
 
 /**
@@ -84,8 +84,8 @@ struct RLPXDatagramFace: public UDPDatagram
  */
 struct UDPSocketFace
 {
-	virtual bool send(UDPDatagram const& _msg) = 0;
-	virtual void disconnect() = 0;
+    virtual bool send(UDPDatagram const& _msg) = 0;
+    virtual void disconnect() = 0;
 };
 
 /**
@@ -93,9 +93,9 @@ struct UDPSocketFace
  */
 struct UDPSocketEvents
 {
-	virtual ~UDPSocketEvents() = default;
-	virtual void onDisconnected(UDPSocketFace*) {}
-	virtual void onReceived(UDPSocketFace*, bi::udp::endpoint const& _from, bytesConstRef _packetData) = 0;
+    virtual ~UDPSocketEvents() = default;
+    virtual void onDisconnected(UDPSocketFace*) {}
+    virtual void onReceived(UDPSocketFace*, bi::udp::endpoint const& _from, bytesConstRef _packetData) = 0;
 };
 
 /**
@@ -109,172 +109,172 @@ template <typename Handler, unsigned MaxDatagramSize>
 class UDPSocket: UDPSocketFace, public std::enable_shared_from_this<UDPSocket<Handler, MaxDatagramSize>>
 {
 public:
-	enum { maxDatagramSize = MaxDatagramSize };
-	static_assert((unsigned)maxDatagramSize < 65507u, "UDP datagrams cannot be larger than 65507 bytes");
+    enum { maxDatagramSize = MaxDatagramSize };
+    static_assert((unsigned)maxDatagramSize < 65507u, "UDP datagrams cannot be larger than 65507 bytes");
 
-	/// Create socket for specific endpoint.
-	UDPSocket(ba::io_service& _io, UDPSocketEvents& _host, bi::udp::endpoint _endpoint): m_host(_host), m_endpoint(_endpoint), m_socket(_io) { m_started.store(false); m_closed.store(true); };
+    /// Create socket for specific endpoint.
+    UDPSocket(ba::io_service& _io, UDPSocketEvents& _host, bi::udp::endpoint _endpoint): m_host(_host), m_endpoint(_endpoint), m_socket(_io) { m_started.store(false); m_closed.store(true); };
 
-	/// Create socket which listens to all ports.
-	UDPSocket(ba::io_service& _io, UDPSocketEvents& _host, unsigned _port): m_host(_host), m_endpoint(bi::udp::v4(), _port), m_socket(_io) { m_started.store(false); m_closed.store(true); };
-	virtual ~UDPSocket() { disconnect(); }
+    /// Create socket which listens to all ports.
+    UDPSocket(ba::io_service& _io, UDPSocketEvents& _host, unsigned _port): m_host(_host), m_endpoint(bi::udp::v4(), _port), m_socket(_io) { m_started.store(false); m_closed.store(true); };
+    virtual ~UDPSocket() { disconnect(); }
 
-	/// Socket will begin listening for and delivering packets
-	void connect();
+    /// Socket will begin listening for and delivering packets
+    void connect();
 
-	/// Send datagram.
-	bool send(UDPDatagram const& _datagram);
+    /// Send datagram.
+    bool send(UDPDatagram const& _datagram);
 
-	/// Returns if socket is open.
-	bool isOpen() { return !m_closed; }
+    /// Returns if socket is open.
+    bool isOpen() { return !m_closed; }
 
-	/// Disconnect socket.
-	void disconnect() { disconnectWithError(boost::asio::error::connection_reset); }
+    /// Disconnect socket.
+    void disconnect() { disconnectWithError(boost::asio::error::connection_reset); }
 
 protected:
-	void doRead();
+    void doRead();
 
-	void doWrite();
+    void doWrite();
 
-	void disconnectWithError(boost::system::error_code _ec);
+    void disconnectWithError(boost::system::error_code _ec);
 
-	std::atomic<bool> m_started;					///< Atomically ensure connection is started once. Start cannot occur unless m_started is false. Managed by start and disconnectWithError.
-	std::atomic<bool> m_closed;					///< Connection availability.
+    std::atomic<bool> m_started;					///< Atomically ensure connection is started once. Start cannot occur unless m_started is false. Managed by start and disconnectWithError.
+    std::atomic<bool> m_closed;					///< Connection availability.
 
-	UDPSocketEvents& m_host;						///< Interface which owns this socket.
-	bi::udp::endpoint m_endpoint;					///< Endpoint which we listen to.
+    UDPSocketEvents& m_host;						///< Interface which owns this socket.
+    bi::udp::endpoint m_endpoint;					///< Endpoint which we listen to.
 
-	Mutex x_sendQ;
-	std::deque<UDPDatagram> m_sendQ;				///< Queue for egress data.
-	std::array<byte, maxDatagramSize> m_recvData;	///< Buffer for ingress data.
-	bi::udp::endpoint m_recvEndpoint;				///< Endpoint data was received from.
-	bi::udp::socket m_socket;						///< Boost asio udp socket.
+    Mutex x_sendQ;
+    std::deque<UDPDatagram> m_sendQ;				///< Queue for egress data.
+    std::array<byte, maxDatagramSize> m_recvData;	///< Buffer for ingress data.
+    bi::udp::endpoint m_recvEndpoint;				///< Endpoint data was received from.
+    bi::udp::socket m_socket;						///< Boost asio udp socket.
 
-	Mutex x_socketError;							///< Mutex for error which can be set from host or IO thread.
-	boost::system::error_code m_socketError;		///< Set when shut down due to error.
+    Mutex x_socketError;							///< Mutex for error which can be set from host or IO thread.
+    boost::system::error_code m_socketError;		///< Set when shut down due to error.
 };
 
 template <typename Handler, unsigned MaxDatagramSize>
 void UDPSocket<Handler, MaxDatagramSize>::connect()
 {
-	bool expect = false;
-	if (!m_started.compare_exchange_strong(expect, true))
-		return;
+    bool expect = false;
+    if (!m_started.compare_exchange_strong(expect, true))
+        return;
 
-	m_socket.open(bi::udp::v4());
-	try
-	{
-		m_socket.bind(m_endpoint);
-	}
-	catch (...)
-	{
-		m_socket.bind(bi::udp::endpoint(bi::udp::v4(), m_endpoint.port()));
-	}
+    m_socket.open(bi::udp::v4());
+    try
+    {
+        m_socket.bind(m_endpoint);
+    }
+    catch (...)
+    {
+        m_socket.bind(bi::udp::endpoint(bi::udp::v4(), m_endpoint.port()));
+    }
 
-	// clear write queue so reconnect doesn't send stale messages
-	Guard l(x_sendQ);
-	m_sendQ.clear();
+    // clear write queue so reconnect doesn't send stale messages
+    Guard l(x_sendQ);
+    m_sendQ.clear();
 
-	m_closed = false;
-	doRead();
+    m_closed = false;
+    doRead();
 }
 
 template <typename Handler, unsigned MaxDatagramSize>
 bool UDPSocket<Handler, MaxDatagramSize>::send(UDPDatagram const& _datagram)
 {
-	if (m_closed)
-		return false;
+    if (m_closed)
+        return false;
 
-	Guard l(x_sendQ);
-	m_sendQ.push_back(_datagram);
-	if (m_sendQ.size() == 1)
-		doWrite();
+    Guard l(x_sendQ);
+    m_sendQ.push_back(_datagram);
+    if (m_sendQ.size() == 1)
+        doWrite();
 
-	return true;
+    return true;
 }
 
 template <typename Handler, unsigned MaxDatagramSize>
 void UDPSocket<Handler, MaxDatagramSize>::doRead()
 {
-	if (m_closed)
-		return;
+    if (m_closed)
+        return;
 
-	auto self(UDPSocket<Handler, MaxDatagramSize>::shared_from_this());
-	m_socket.async_receive_from(boost::asio::buffer(m_recvData), m_recvEndpoint, [this, self](boost::system::error_code _ec, size_t _len)
-	{
-		if (m_closed)
-			return disconnectWithError(_ec);
-		
-		if (_ec != boost::system::errc::success)
-			clog(NetWarn) << "Receiving UDP message failed. " << _ec.value() << ":" << _ec.message();
+    auto self(UDPSocket<Handler, MaxDatagramSize>::shared_from_this());
+    m_socket.async_receive_from(boost::asio::buffer(m_recvData), m_recvEndpoint, [this, self](boost::system::error_code _ec, size_t _len)
+    {
+        if (m_closed)
+            return disconnectWithError(_ec);
+        
+        if (_ec != boost::system::errc::success)
+            cnetwarn << "Receiving UDP message failed. " << _ec.value() << " : " << _ec.message();
 
-		if (_len)
-			m_host.onReceived(this, m_recvEndpoint, bytesConstRef(m_recvData.data(), _len));
-		doRead();
-	});
+        if (_len)
+            m_host.onReceived(this, m_recvEndpoint, bytesConstRef(m_recvData.data(), _len));
+        doRead();
+    });
 }
 
 template <typename Handler, unsigned MaxDatagramSize>
 void UDPSocket<Handler, MaxDatagramSize>::doWrite()
 {
-	if (m_closed)
-		return;
+    if (m_closed)
+        return;
 
-	const UDPDatagram& datagram = m_sendQ[0];
-	auto self(UDPSocket<Handler, MaxDatagramSize>::shared_from_this());
-	bi::udp::endpoint endpoint(datagram.endpoint());
-	m_socket.async_send_to(boost::asio::buffer(datagram.data), endpoint, [this, self, endpoint](boost::system::error_code _ec, std::size_t)
-	{
-		if (m_closed)
-			return disconnectWithError(_ec);
-		
-		if (_ec != boost::system::errc::success)
-			clog(NetWarn) << "Failed delivering UDP message. " << _ec.value() << ":" << _ec.message();
-		
-		Guard l(x_sendQ);
-		m_sendQ.pop_front();
-		if (m_sendQ.empty())
-			return;
-		doWrite();
-	});
+    const UDPDatagram& datagram = m_sendQ[0];
+    auto self(UDPSocket<Handler, MaxDatagramSize>::shared_from_this());
+    bi::udp::endpoint endpoint(datagram.endpoint());
+    m_socket.async_send_to(boost::asio::buffer(datagram.data), endpoint, [this, self, endpoint](boost::system::error_code _ec, std::size_t)
+    {
+        if (m_closed)
+            return disconnectWithError(_ec);
+        
+        if (_ec != boost::system::errc::success)
+            cnetwarn << "Failed delivering UDP message. " << _ec.value() << " : " << _ec.message();
+
+        Guard l(x_sendQ);
+        m_sendQ.pop_front();
+        if (m_sendQ.empty())
+            return;
+        doWrite();
+    });
 }
 
 template <typename Handler, unsigned MaxDatagramSize>
 void UDPSocket<Handler, MaxDatagramSize>::disconnectWithError(boost::system::error_code _ec)
 {
-	// If !started and already stopped, shutdown has already occured. (EOF or Operation canceled)
-	if (!m_started && m_closed && !m_socket.is_open() /* todo: veirfy this logic*/)
-		return;
+    // If !started and already stopped, shutdown has already occured. (EOF or Operation canceled)
+    if (!m_started && m_closed && !m_socket.is_open() /* todo: veirfy this logic*/)
+        return;
 
-	assert(_ec);
-	{
-		// disconnect-operation following prior non-zero errors are ignored
-		Guard l(x_socketError);
-		if (m_socketError != boost::system::error_code())
-			return;
-		m_socketError = _ec;
-	}
-	// TODO: (if non-zero error) schedule high-priority writes
+    assert(_ec);
+    {
+        // disconnect-operation following prior non-zero errors are ignored
+        Guard l(x_socketError);
+        if (m_socketError != boost::system::error_code())
+            return;
+        m_socketError = _ec;
+    }
+    // TODO: (if non-zero error) schedule high-priority writes
 
-	// prevent concurrent disconnect
-	bool expected = true;
-	if (!m_started.compare_exchange_strong(expected, false))
-		return;
+    // prevent concurrent disconnect
+    bool expected = true;
+    if (!m_started.compare_exchange_strong(expected, false))
+        return;
 
-	// set m_closed to true to prevent undeliverable egress messages
-	bool wasClosed = m_closed;
-	m_closed = true;
+    // set m_closed to true to prevent undeliverable egress messages
+    bool wasClosed = m_closed;
+    m_closed = true;
 
-	// close sockets
-	boost::system::error_code ec;
-	m_socket.shutdown(bi::udp::socket::shutdown_both, ec);
-	m_socket.close();
+    // close sockets
+    boost::system::error_code ec;
+    m_socket.shutdown(bi::udp::socket::shutdown_both, ec);
+    m_socket.close();
 
-	// socket never started if it never left stopped-state (pre-handshake)
-	if (wasClosed)
-		return;
+    // socket never started if it never left stopped-state (pre-handshake)
+    if (wasClosed)
+        return;
 
-	m_host.onDisconnected(this);
+    m_host.onDisconnected(this);
 }
 
 }

--- a/libweb3jsonrpc/IpcServerBase.cpp
+++ b/libweb3jsonrpc/IpcServerBase.cpp
@@ -1,18 +1,18 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file IpcServerBase.cpp
  * @authors:
@@ -33,125 +33,120 @@ using namespace dev;
 
 int const c_bufferSize = 1024;
 
-struct IpcSendChannel: public LogChannel { static const char* name() { return "I>"; } static const int verbosity = 10; };
-struct IpcReceiveChannel: public LogChannel { static const char* name() { return "I<"; } static const int verbosity = 10; };
-#define cipcs dev::LogOutputStream<IpcSendChannel, true>()
-#define cipcr dev::LogOutputStream<IpcReceiveChannel, true>()
-
 template <class S> IpcServerBase<S>::IpcServerBase(string const& _path):
-	m_path(_path)
+    m_path(_path)
 {
 }
 
 template <class S> bool IpcServerBase<S>::StartListening()
 {
-	bool wasRunning = m_running.exchange(true);
-	if (!wasRunning)
-	{
-		m_listeningThread = std::thread([this](){ Listen(); });
-		return true;
-	}
-	return false;
+    bool wasRunning = m_running.exchange(true);
+    if (!wasRunning)
+    {
+        m_listeningThread = std::thread([this](){ Listen(); });
+        return true;
+    }
+    return false;
 }
 
 template <class S> bool IpcServerBase<S>::StopListening()
 {
-	bool wasRunning = m_running.exchange(false);
-	if (wasRunning)
-	{
-		DEV_GUARDED(x_sockets)
-		{
-			for (S s : m_sockets)
-				CloseConnection(s);
-			m_sockets.clear();
-		}
-		m_listeningThread.join();
-		return true;
-	}
-	return false;
+    bool wasRunning = m_running.exchange(false);
+    if (wasRunning)
+    {
+        DEV_GUARDED(x_sockets)
+        {
+            for (S s : m_sockets)
+                CloseConnection(s);
+            m_sockets.clear();
+        }
+        m_listeningThread.join();
+        return true;
+    }
+    return false;
 }
 
 template <class S> bool IpcServerBase<S>::SendResponse(string const& _response, void* _addInfo)
 {
-	bool fullyWritten = false;
-	bool errorOccured = false;
-	S socket = (S)(reinterpret_cast<intptr_t>(_addInfo));
-	string toSend = _response;
-	do
-	{
-		size_t bytesWritten = Write(socket, toSend);
-		if (bytesWritten == 0)
-			errorOccured = true;
-		else if (bytesWritten < toSend.size())
-		{
-			int len = toSend.size() - bytesWritten;
-			toSend = toSend.substr(bytesWritten + sizeof(char), len);
-		}
-		else
-			fullyWritten = true;
-	} while (!fullyWritten && !errorOccured);
-	cipcs << _response;
-	return fullyWritten && !errorOccured;
+    bool fullyWritten = false;
+    bool errorOccured = false;
+    S socket = (S)(reinterpret_cast<intptr_t>(_addInfo));
+    string toSend = _response;
+    do
+    {
+        size_t bytesWritten = Write(socket, toSend);
+        if (bytesWritten == 0)
+            errorOccured = true;
+        else if (bytesWritten < toSend.size())
+        {
+            int len = toSend.size() - bytesWritten;
+            toSend = toSend.substr(bytesWritten + sizeof(char), len);
+        }
+        else
+            fullyWritten = true;
+    } while (!fullyWritten && !errorOccured);
+    clogSimple(10, "rpc") << _response;
+    return fullyWritten && !errorOccured;
 }
 
 template <class S> void IpcServerBase<S>::GenerateResponse(S _connection)
 {
-	char buffer[c_bufferSize];
-	string request;
-	bool escape = false;
-	bool inString = false;
-	size_t i = 0;
-	int depth = 0;
-	size_t nbytes = 0;
-	do
-	{
-		nbytes = Read(_connection, buffer, c_bufferSize);
-		if (nbytes <= 0)
-			break;
-		request.append(buffer, nbytes);
-		while (i < request.size())
-		{
-			char c = request[i];
-			if (c == '\"' && !inString)
-			{
-				inString = true;
-				escape = false;
-			}
-			else if (c == '\"' && inString && !escape)
-			{
-				inString = false;
-				escape = false;
-			}
-			else if (inString && c == '\\' && !escape)
-			{
-				escape = true;
-			}
-			else if (inString)
-			{
-				escape = false;
-			}
-			else if (!inString && (c == '{' || c == '['))
-			{
-				depth++;
-			}
-			else if (!inString && (c == '}' || c == ']'))
-			{
-				depth--;
-				if (depth == 0)
-				{
-					std::string r = request.substr(0, i + 1);
-					request.erase(0, i + 1);
-					cipcr << r;
-					OnRequest(r, reinterpret_cast<void*>((intptr_t)_connection));
-					i = 0;
-					continue;
-				}
-			}
-			i++;
-		}
-	} while (true);
-	DEV_GUARDED(x_sockets)
-		m_sockets.erase(_connection);
+    char buffer[c_bufferSize];
+    string request;
+    bool escape = false;
+    bool inString = false;
+    size_t i = 0;
+    int depth = 0;
+    size_t nbytes = 0;
+    do
+    {
+        nbytes = Read(_connection, buffer, c_bufferSize);
+        if (nbytes <= 0)
+            break;
+        request.append(buffer, nbytes);
+        while (i < request.size())
+        {
+            char c = request[i];
+            if (c == '\"' && !inString)
+            {
+                inString = true;
+                escape = false;
+            }
+            else if (c == '\"' && inString && !escape)
+            {
+                inString = false;
+                escape = false;
+            }
+            else if (inString && c == '\\' && !escape)
+            {
+                escape = true;
+            }
+            else if (inString)
+            {
+                escape = false;
+            }
+            else if (!inString && (c == '{' || c == '['))
+            {
+                depth++;
+            }
+            else if (!inString && (c == '}' || c == ']'))
+            {
+                depth--;
+                if (depth == 0)
+                {
+                    std::string r = request.substr(0, i + 1);
+                    request.erase(0, i + 1);
+                    clogSimple(10, "rpc") << r;
+                    OnRequest(r, reinterpret_cast<void*>((intptr_t)_connection));
+                    i = 0;
+                    continue;
+                }
+            }
+            i++;
+        }
+    } while (true);
+    DEV_GUARDED(x_sockets)
+        m_sockets.erase(_connection);
 }
 
 namespace dev

--- a/test/tools/jsontests/vm.cpp
+++ b/test/tools/jsontests/vm.cpp
@@ -36,6 +36,15 @@ using namespace dev::eth;
 using namespace dev::test;
 namespace fs = boost::filesystem;
 
+namespace
+{
+struct VMTraceChannel : public LogChannel
+{
+    static const char* name() { return "EVM"; }
+    static const int verbosity = 11;
+};
+}  // namespace
+
 FakeExtVM::FakeExtVM(EnvInfo const& _envInfo, unsigned _depth):			/// TODO: XXX: remove the default argument & fix.
     ExtVMFace(_envInfo, Address(), Address(), Address(), 0, 1, bytesConstRef(), bytes(), EmptySHA3, false, false, _depth)
 {}
@@ -247,11 +256,16 @@ eth::OnOpFunc FakeExtVM::simpleTrace() const
         for (auto const& i: std::get<2>(ext.addresses.find(ext.myAddress)->second))
             o << std::showbase << std::hex << i.first << ": " << i.second << "\n";
 
-        dev::LogOutputStream<eth::VMTraceChannel, false>() << o.str();
-        dev::LogOutputStream<eth::VMTraceChannel, false>() << " | " << std::dec << ext.depth << " | " << ext.myAddress << " | #" << steps << " | " << std::hex << std::setw(4) << std::setfill('0') << pc << " : " << instructionInfo(inst).name << " | " << std::dec << gas << " | -" << std::dec << gasCost << " | " << newMemSize << "x32" << " ]";
+        dev::LogOutputStream<VMTraceChannel, false>() << o.str();
+        dev::LogOutputStream<VMTraceChannel, false>()
+            << " | " << std::dec << ext.depth << " | " << ext.myAddress << " | #" << steps << " | "
+            << std::hex << std::setw(4) << std::setfill('0') << pc << " : "
+            << instructionInfo(inst).name << " | " << std::dec << gas << " | -" << std::dec
+            << gasCost << " | " << newMemSize << "x32"
+            << " ]";
 
         /*creates json stack trace*/
-        if (eth::VMTraceChannel::verbosity <= g_logVerbosity)
+        if (VMTraceChannel::verbosity <= g_logVerbosity)
         {
             Object o_step;
 

--- a/test/tools/jsontests/vm.h
+++ b/test/tools/jsontests/vm.h
@@ -50,48 +50,50 @@ namespace test
 class FakeExtVM: public eth::ExtVMFace
 {
 public:
-	FakeExtVM() = delete;
-	FakeExtVM(eth::EnvInfo const& _envInfo, unsigned _depth = 0);
+    FakeExtVM() = delete;
+    FakeExtVM(eth::EnvInfo const& _envInfo, unsigned _depth = 0);
 
-	virtual u256 store(u256 _n) override { return std::get<2>(addresses[myAddress])[_n]; }
-	virtual void setStore(u256 _n, u256 _v) override { std::get<2>(addresses[myAddress])[_n] = _v; }
-	virtual bool exists(Address _a) override { return !!addresses.count(_a); }
-	virtual u256 balance(Address _a) override { return std::get<0>(addresses[_a]); }
-	virtual void suicide(Address _a) override { std::get<0>(addresses[_a]) += std::get<0>(addresses[myAddress]); addresses.erase(myAddress); }
-	virtual bytes const& codeAt(Address _a) override { return std::get<3>(addresses[_a]); }
-	virtual size_t codeSizeAt(Address _a) override { return std::get<3>(addresses[_a]).size(); }
-	eth::CreateResult create(u256 _endowment, u256& io_gas, bytesConstRef _init, eth::Instruction _op, u256 _salt, eth::OnOpFunc const&) override;
-	eth::CallResult call(eth::CallParameters&) override;
-	virtual h256 blockHash(u256 _number) override;
-	void setTransaction(Address _caller, u256 _value, u256 _gasPrice, bytes const& _data);
-	void setContract(Address _myAddress, u256 _myBalance, u256 _myNonce, std::map<u256, u256> const& _storage, bytes const& _code);
-	void set(Address _a, u256 _myBalance, u256 _myNonce, std::map<u256, u256> const& _storage, bytes const& _code);
-	void reset(u256 _myBalance, u256 _myNonce, std::map<u256, u256> const& _storage);
-	u256 doPosts();
-	json_spirit::mObject exportEnv();
-	static dev::eth::EnvInfo importEnv(json_spirit::mObject const& _o, eth::LastBlockHashesFace const& _lastBlockHashes);
-	json_spirit::mObject exportState();
-	void importState(json_spirit::mObject const& _object);
-	json_spirit::mObject exportExec();
-	void importExec(json_spirit::mObject const& _o);
-	json_spirit::mArray exportCallCreates();
-	void importCallCreates(json_spirit::mArray const& _callcreates);
+    virtual u256 store(u256 _n) override { return std::get<2>(addresses[myAddress])[_n]; }
+    virtual void setStore(u256 _n, u256 _v) override { std::get<2>(addresses[myAddress])[_n] = _v; }
+    virtual bool exists(Address _a) override { return !!addresses.count(_a); }
+    virtual u256 balance(Address _a) override { return std::get<0>(addresses[_a]); }
+    virtual void suicide(Address _a) override { std::get<0>(addresses[_a]) += std::get<0>(addresses[myAddress]); addresses.erase(myAddress); }
+    virtual bytes const& codeAt(Address _a) override { return std::get<3>(addresses[_a]); }
+    virtual size_t codeSizeAt(Address _a) override { return std::get<3>(addresses[_a]).size(); }
+    eth::CreateResult create(u256 _endowment, u256& io_gas, bytesConstRef _init, eth::Instruction _op, u256 _salt, eth::OnOpFunc const&) override;
+    eth::CallResult call(eth::CallParameters&) override;
+    virtual h256 blockHash(u256 _number) override;
+    void setTransaction(Address _caller, u256 _value, u256 _gasPrice, bytes const& _data);
+    void setContract(Address _myAddress, u256 _myBalance, u256 _myNonce, std::map<u256, u256> const& _storage, bytes const& _code);
+    void set(Address _a, u256 _myBalance, u256 _myNonce, std::map<u256, u256> const& _storage, bytes const& _code);
+    void reset(u256 _myBalance, u256 _myNonce, std::map<u256, u256> const& _storage);
+    u256 doPosts();
+    json_spirit::mObject exportEnv();
+    static dev::eth::EnvInfo importEnv(json_spirit::mObject const& _o, eth::LastBlockHashesFace const& _lastBlockHashes);
+    json_spirit::mObject exportState();
+    void importState(json_spirit::mObject const& _object);
+    json_spirit::mObject exportExec();
+    void importExec(json_spirit::mObject const& _o);
+    json_spirit::mArray exportCallCreates();
+    void importCallCreates(json_spirit::mArray const& _callcreates);
 
-	eth::OnOpFunc simpleTrace() const;
+    eth::OnOpFunc simpleTrace() const;
 
-	std::map<Address, std::tuple<u256, u256, std::map<u256, u256>, bytes>> addresses;
-	eth::Transactions callcreates;
-	bytes thisTxData;
-	bytes thisTxCode;
-	u256 gas;
-	u256 execGas;
+    std::map<Address, std::tuple<u256, u256, std::map<u256, u256>, bytes>> addresses;
+    eth::Transactions callcreates;
+    bytes thisTxData;
+    bytes thisTxCode;
+    u256 gas;
+    u256 execGas;
+
+    mutable Logger m_logger{createLogger(11, "EVM")};
 };
 
 class VmTestSuite: public TestSuite
 {
-	json_spirit::mValue doTests(json_spirit::mValue const& _input, bool _fillin) const override;
-	boost::filesystem::path suiteFolder() const override;
-	boost::filesystem::path suiteFillerFolder() const override;
+    json_spirit::mValue doTests(json_spirit::mValue const& _input, bool _fillin) const override;
+    boost::filesystem::path suiteFolder() const override;
+    boost::filesystem::path suiteFillerFolder() const override;
 };
 
 } } // Namespace Close

--- a/test/tools/libtesteth/FillJsonFunctions.cpp
+++ b/test/tools/libtesteth/FillJsonFunctions.cpp
@@ -164,7 +164,8 @@ json_spirit::mObject fillJsonWithStateChange(
             log << (*it).second.str();
     }
 
-    dev::LogOutputStream<eth::StateTrace, false>() << log.str();
+    Logger logger{createLogger(5, "state")};
+    BOOST_LOG(logger) << log.str();
     return oState;
 }
 

--- a/test/tools/libtesteth/FillJsonFunctions.cpp
+++ b/test/tools/libtesteth/FillJsonFunctions.cpp
@@ -165,7 +165,7 @@ json_spirit::mObject fillJsonWithStateChange(
     }
 
     Logger logger{createLogger(5, "state")};
-    BOOST_LOG(logger) << log.str();
+    LOG(logger) << log.str();
     return oState;
 }
 

--- a/test/tools/libtesteth/ImportTest.cpp
+++ b/test/tools/libtesteth/ImportTest.cpp
@@ -781,7 +781,7 @@ void ImportTest::traceStateDiff()
 			std::ostringstream log;
 			log << "trNetID: " << netIdToString(tr.netId) << "\n";
 			log << "trDataInd: " << tr.dataInd << " tdGasInd: " << tr.gasInd << " trValInd: " << tr.valInd << "\n";
-			dev::LogOutputStream<eth::StateTrace, false>() << log.str();
+			BOOST_LOG(m_logger) << log.str();
 			fillJsonWithStateChange(m_statePre, tr.postState, tr.changeLog); //output std log
 		}
 	}

--- a/test/tools/libtesteth/ImportTest.cpp
+++ b/test/tools/libtesteth/ImportTest.cpp
@@ -781,7 +781,7 @@ void ImportTest::traceStateDiff()
             std::ostringstream log;
             log << "trNetID: " << netIdToString(tr.netId) << "\n";
             log << "trDataInd: " << tr.dataInd << " tdGasInd: " << tr.gasInd << " trValInd: " << tr.valInd << "\n";
-            BOOST_LOG(m_logger) << log.str();
+            LOG(m_logger) << log.str();
             fillJsonWithStateChange(m_statePre, tr.postState, tr.changeLog); //output std log
         }
     }

--- a/test/tools/libtesteth/ImportTest.cpp
+++ b/test/tools/libtesteth/ImportTest.cpp
@@ -1,18 +1,18 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file
  * Helper class for managing data when running state tests
@@ -38,22 +38,22 @@ namespace
 {
 vector<h256> lastHashes(u256 _currentBlockNumber)
 {
-	vector<h256> ret;
-	for (u256 i = 1; i <= 256 && i <= _currentBlockNumber; ++i)
-		ret.push_back(sha3(toString(_currentBlockNumber - i)));
-	return ret;
+    vector<h256> ret;
+    for (u256 i = 1; i <= 256 && i <= _currentBlockNumber; ++i)
+        ret.push_back(sha3(toString(_currentBlockNumber - i)));
+    return ret;
 }
 }
 
 ImportTest::ImportTest(json_spirit::mObject const& _input, json_spirit::mObject& _output):
-	m_statePre(0, OverlayDB(), eth::BaseState::Empty),
-	m_statePost(0, OverlayDB(), eth::BaseState::Empty),
-	m_testInputObject(_input),
-	m_testOutputObject(_output)
+    m_statePre(0, OverlayDB(), eth::BaseState::Empty),
+    m_statePost(0, OverlayDB(), eth::BaseState::Empty),
+    m_testInputObject(_input),
+    m_testOutputObject(_output)
 {
-	importEnv(_input.at("env").get_obj());
-	importTransaction(_input.at("transaction").get_obj());
-	importState(_input.at("pre").get_obj(), m_statePre);
+    importEnv(_input.at("env").get_obj());
+    importTransaction(_input.at("transaction").get_obj());
+    importState(_input.at("pre").get_obj(), m_statePre);
 }
 
 void ImportTest::makeBlockchainTestFromStateTest(set<eth::Network> const& _networks) const
@@ -216,26 +216,26 @@ bytes ImportTest::executeTest(bool _isFilling)
 
     vector<transactionToExecute> transactionResults;
     for (auto const& net : networks)
-	{
-		if (isDisabledNetwork(net))
-			continue;
+    {
+        if (isDisabledNetwork(net))
+            continue;
 
-		for (auto& tr : m_transactions)
-		{
-			Options const& opt = Options::get();
-			if(opt.trDataIndex != -1 && opt.trDataIndex != tr.dataInd)
-				continue;
-			if(opt.trGasIndex != -1 && opt.trGasIndex != tr.gasInd)
-				continue;
-			if(opt.trValueIndex != -1 && opt.trValueIndex != tr.valInd)
-				continue;
+        for (auto& tr : m_transactions)
+        {
+            Options const& opt = Options::get();
+            if(opt.trDataIndex != -1 && opt.trDataIndex != tr.dataInd)
+                continue;
+            if(opt.trGasIndex != -1 && opt.trGasIndex != tr.gasInd)
+                continue;
+            if(opt.trValueIndex != -1 && opt.trValueIndex != tr.valInd)
+                continue;
 
-			std::tie(tr.postState, tr.output, tr.changeLog) =
-				executeTransaction(net, *m_envInfo, m_statePre, tr.transaction);
-			tr.netId = net;
-			transactionResults.push_back(tr);
-		}
-	}
+            std::tie(tr.postState, tr.output, tr.changeLog) =
+                executeTransaction(net, *m_envInfo, m_statePre, tr.transaction);
+            tr.netId = net;
+            transactionResults.push_back(tr);
+        }
+    }
 
     if (Options::get().fillchain && _isFilling)
         makeBlockchainTestFromStateTest(networks);
@@ -246,70 +246,70 @@ bytes ImportTest::executeTest(bool _isFilling)
 
 void ImportTest::checkBalance(eth::State const& _pre, eth::State const& _post, bigint _miningReward)
 {
-	bigint preBalance = 0;
-	bigint postBalance = 0;
-	for (auto const& addr : _pre.addresses())
-		preBalance += addr.second;
-	for (auto const& addr : _post.addresses())
-		postBalance += addr.second;
+    bigint preBalance = 0;
+    bigint postBalance = 0;
+    for (auto const& addr : _pre.addresses())
+        preBalance += addr.second;
+    for (auto const& addr : _post.addresses())
+        postBalance += addr.second;
 
-	//account could destroy ether if it suicides to itself
-	BOOST_REQUIRE_MESSAGE(preBalance + _miningReward >= postBalance, "Error when comparing states: preBalance + miningReward < postBalance (" + toString(preBalance) + " < " + toString(postBalance) + ") " + TestOutputHelper::get().testName());
+    //account could destroy ether if it suicides to itself
+    BOOST_REQUIRE_MESSAGE(preBalance + _miningReward >= postBalance, "Error when comparing states: preBalance + miningReward < postBalance (" + toString(preBalance) + " < " + toString(postBalance) + ") " + TestOutputHelper::get().testName());
 }
 
 std::tuple<eth::State, ImportTest::ExecOutput, eth::ChangeLog> ImportTest::executeTransaction(eth::Network const _sealEngineNetwork, eth::EnvInfo const& _env, eth::State const& _preState, eth::Transaction const& _tr)
 {
-	assert(m_envInfo);
+    assert(m_envInfo);
 
-	State initialState = _preState;
-	ExecOutput out(std::make_pair(eth::ExecutionResult(), eth::TransactionReceipt(h256(), u256(), eth::LogEntries())));
-	try
-	{
-		unique_ptr<SealEngineFace> se(ChainParams(genesisInfo(_sealEngineNetwork)).createSealEngine());
-		if (Options::get().jsontrace)
-		{
-			StandardTrace st;
-			st.setShowMnemonics();
-			st.setOptions(Options::get().jsontraceOptions);
-			out = initialState.execute(_env, *se.get(), _tr, Permanence::Committed, st.onOp());
-			cout << st.json();
-			cout << "{\"stateRoot\": \"" << initialState.rootHash().hex() << "\"}";
-		}
-		else
-			out = initialState.execute(_env, *se.get(), _tr, Permanence::Uncommitted);
+    State initialState = _preState;
+    ExecOutput out(std::make_pair(eth::ExecutionResult(), eth::TransactionReceipt(h256(), u256(), eth::LogEntries())));
+    try
+    {
+        unique_ptr<SealEngineFace> se(ChainParams(genesisInfo(_sealEngineNetwork)).createSealEngine());
+        if (Options::get().jsontrace)
+        {
+            StandardTrace st;
+            st.setShowMnemonics();
+            st.setOptions(Options::get().jsontraceOptions);
+            out = initialState.execute(_env, *se.get(), _tr, Permanence::Committed, st.onOp());
+            cout << st.json();
+            cout << "{\"stateRoot\": \"" << initialState.rootHash().hex() << "\"}";
+        }
+        else
+            out = initialState.execute(_env, *se.get(), _tr, Permanence::Uncommitted);
 
-		// the changeLog might be broken under --jsontrace, because it uses intialState.execute with Permanence::Committed rather than Permanence::Uncommitted
-		eth::ChangeLog changeLog = initialState.changeLog();
-		ImportTest::checkBalance(_preState, initialState);
+        // the changeLog might be broken under --jsontrace, because it uses intialState.execute with Permanence::Committed rather than Permanence::Uncommitted
+        eth::ChangeLog changeLog = initialState.changeLog();
+        ImportTest::checkBalance(_preState, initialState);
 
-		//Finalize the state manually (clear logs)
-		bool removeEmptyAccounts = m_envInfo->number() >= se->chainParams().EIP158ForkBlock;
-		initialState.commit(removeEmptyAccounts ? State::CommitBehaviour::RemoveEmptyAccounts : State::CommitBehaviour::KeepEmptyAccounts);
-		return std::make_tuple(initialState, out, changeLog);
-	}
-	catch (Exception const& _e)
-	{
-		cnote << "Exception: " << diagnostic_information(_e);
-	}
-	catch (std::exception const& _e)
-	{
-		cnote << "state execution exception: " << _e.what();
-	}
+        //Finalize the state manually (clear logs)
+        bool removeEmptyAccounts = m_envInfo->number() >= se->chainParams().EIP158ForkBlock;
+        initialState.commit(removeEmptyAccounts ? State::CommitBehaviour::RemoveEmptyAccounts : State::CommitBehaviour::KeepEmptyAccounts);
+        return std::make_tuple(initialState, out, changeLog);
+    }
+    catch (Exception const& _e)
+    {
+        cnote << "Exception: " << diagnostic_information(_e);
+    }
+    catch (std::exception const& _e)
+    {
+        cnote << "state execution exception: " << _e.what();
+    }
 
-	initialState.commit(State::CommitBehaviour::KeepEmptyAccounts);
-	return std::make_tuple(initialState, out, initialState.changeLog());
+    initialState.commit(State::CommitBehaviour::KeepEmptyAccounts);
+    return std::make_tuple(initialState, out, initialState.changeLog());
 }
 
 json_spirit::mObject ImportTest::makeAllFieldsHex(json_spirit::mObject const& _input, bool _isHeader)
 {
-	static const set<string> hashes {"bloom" , "coinbase", "hash", "mixHash", "parentHash", "receiptTrie",
-									 "stateRoot", "transactionsTrie", "uncleHash", "currentCoinbase",
-									 "previousHash", "to", "address", "caller", "origin", "secretKey", "data", "extraData"};
+    static const set<string> hashes {"bloom" , "coinbase", "hash", "mixHash", "parentHash", "receiptTrie",
+                                     "stateRoot", "transactionsTrie", "uncleHash", "currentCoinbase",
+                                     "previousHash", "to", "address", "caller", "origin", "secretKey", "data", "extraData"};
 
-	json_spirit::mObject output = _input;
+    json_spirit::mObject output = _input;
 
-	for (auto const& i: output)
-	{
+    for (auto const& i: output)
+    {
         std::string key = i.first;
         if (key == "extraData")
             continue;
@@ -320,33 +320,33 @@ json_spirit::mObject ImportTest::makeAllFieldsHex(json_spirit::mObject const& _i
         if (_isHeader && key == "nonce")
             isHash = true;
 
-		std::string str;
-		json_spirit::mValue value = i.second;
+        std::string str;
+        json_spirit::mValue value = i.second;
 
-		if (value.type() == json_spirit::int_type)
-			str = toString(value.get_int());
-		else if (value.type() == json_spirit::str_type)
+        if (value.type() == json_spirit::int_type)
+            str = toString(value.get_int());
+        else if (value.type() == json_spirit::str_type)
             str = isData ? replaceCode(value.get_str()) : value.get_str();
         else if (value.type() == json_spirit::array_type)
         {
-			json_spirit::mArray arr;
-			for (auto const& j: value.get_array())
-			{
+            json_spirit::mArray arr;
+            for (auto const& j: value.get_array())
+            {
                 str = isData ? replaceCode(j.get_str()) : j.get_str();
                 arr.push_back(
                     (str.substr(0, 2) == "0x") ? str : toCompactHexPrefixed(toInt(str), 1));
             }
-			output[key] = arr;
-			continue;
-		}
-		else continue;
+            output[key] = arr;
+            continue;
+        }
+        else continue;
 
-		if (isHash)
-			output[key] = (str.substr(0, 2) == "0x" || str.empty()) ? str : "0x" + str;
-		else
-			output[key] = (str.substr(0, 2) == "0x") ? str : toCompactHexPrefixed(toInt(str), 1);
-	}
-	return output;
+        if (isHash)
+            output[key] = (str.substr(0, 2) == "0x" || str.empty()) ? str : "0x" + str;
+        else
+            output[key] = (str.substr(0, 2) == "0x") ? str : toCompactHexPrefixed(toInt(str), 1);
+    }
+    return output;
 }
 
 void ImportTest::importEnv(json_spirit::mObject const& _o)
@@ -357,21 +357,21 @@ void ImportTest::importEnv(json_spirit::mObject const& _o)
             {"currentTimestamp", jsonVType::str_type}, {"previousHash", jsonVType::str_type}});
     auto gasLimit = toInt(_o.at("currentGasLimit"));
     BOOST_REQUIRE(gasLimit <= std::numeric_limits<int64_t>::max());
-	BlockHeader header;
-	header.setGasLimit(gasLimit.convert_to<int64_t>());
-	header.setDifficulty(toInt(_o.at("currentDifficulty")));
-	header.setNumber(toPositiveInt64(_o.at("currentNumber")));
-	header.setTimestamp(toPositiveInt64(_o.at("currentTimestamp")));
-	header.setAuthor(Address(_o.at("currentCoinbase").get_str()));
+    BlockHeader header;
+    header.setGasLimit(gasLimit.convert_to<int64_t>());
+    header.setDifficulty(toInt(_o.at("currentDifficulty")));
+    header.setNumber(toPositiveInt64(_o.at("currentNumber")));
+    header.setTimestamp(toPositiveInt64(_o.at("currentTimestamp")));
+    header.setAuthor(Address(_o.at("currentCoinbase").get_str()));
 
-	m_lastBlockHashes.reset(new TestLastBlockHashes(lastHashes(header.number())));
-	m_envInfo.reset(new EnvInfo(header, *m_lastBlockHashes, 0));
+    m_lastBlockHashes.reset(new TestLastBlockHashes(lastHashes(header.number())));
+    m_envInfo.reset(new EnvInfo(header, *m_lastBlockHashes, 0));
 }
 
 // import state from not fully declared json_spirit::mObject, writing to _stateOptionsMap which fields were defined in json
 void ImportTest::importState(json_spirit::mObject const& _o, State& _state, AccountMaskMap& o_mask)
 {
-	json_spirit::mObject o = _o;
+    json_spirit::mObject o = _o;
     replaceCodeInState(
         o);  // Compile LLL and other src code of the test Fillers using external call to lllc
     std::string jsondata = json_spirit::write_string((json_spirit::mValue)o, false);
@@ -395,8 +395,8 @@ void ImportTest::importState(json_spirit::mObject const& _o, State& _state)
 
 void ImportTest::importTransaction (json_spirit::mObject const& _o, eth::Transaction& o_tr)
 {
-	if (_o.count("secretKey") > 0)
-	{
+    if (_o.count("secretKey") > 0)
+    {
         requireJsonFields(_o, "transaction",
             {{"data", jsonVType::str_type}, {"gasLimit", jsonVType::str_type},
                 {"gasPrice", jsonVType::str_type}, {"nonce", jsonVType::str_type},
@@ -405,19 +405,19 @@ void ImportTest::importTransaction (json_spirit::mObject const& _o, eth::Transac
 
         if (bigint(_o.at("nonce").get_str()) >= c_max256plus1)
             BOOST_THROW_EXCEPTION(ValueTooLarge() << errinfo_comment("Transaction 'nonce' is equal or greater than 2**256") );
-		if (bigint(_o.at("gasPrice").get_str()) >= c_max256plus1)
-			BOOST_THROW_EXCEPTION(ValueTooLarge() << errinfo_comment("Transaction 'gasPrice' is equal or greater than 2**256") );
-		if (bigint(_o.at("gasLimit").get_str()) >= c_max256plus1)
-			BOOST_THROW_EXCEPTION(ValueTooLarge() << errinfo_comment("Transaction 'gasLimit' is equal or greater than 2**256") );
-		if (bigint(_o.at("value").get_str()) >= c_max256plus1)
-			BOOST_THROW_EXCEPTION(ValueTooLarge() << errinfo_comment("Transaction 'value' is equal or greater than 2**256") );
+        if (bigint(_o.at("gasPrice").get_str()) >= c_max256plus1)
+            BOOST_THROW_EXCEPTION(ValueTooLarge() << errinfo_comment("Transaction 'gasPrice' is equal or greater than 2**256") );
+        if (bigint(_o.at("gasLimit").get_str()) >= c_max256plus1)
+            BOOST_THROW_EXCEPTION(ValueTooLarge() << errinfo_comment("Transaction 'gasLimit' is equal or greater than 2**256") );
+        if (bigint(_o.at("value").get_str()) >= c_max256plus1)
+            BOOST_THROW_EXCEPTION(ValueTooLarge() << errinfo_comment("Transaction 'value' is equal or greater than 2**256") );
 
-		o_tr = _o.at("to").get_str().empty() ?
-			Transaction(toInt(_o.at("value")), toInt(_o.at("gasPrice")), toInt(_o.at("gasLimit")), importData(_o), toInt(_o.at("nonce")), Secret(_o.at("secretKey").get_str())) :
-			Transaction(toInt(_o.at("value")), toInt(_o.at("gasPrice")), toInt(_o.at("gasLimit")), Address(_o.at("to").get_str()), importData(_o), toInt(_o.at("nonce")), Secret(_o.at("secretKey").get_str()));
-	}
-	else
-	{
+        o_tr = _o.at("to").get_str().empty() ?
+            Transaction(toInt(_o.at("value")), toInt(_o.at("gasPrice")), toInt(_o.at("gasLimit")), importData(_o), toInt(_o.at("nonce")), Secret(_o.at("secretKey").get_str())) :
+            Transaction(toInt(_o.at("value")), toInt(_o.at("gasPrice")), toInt(_o.at("gasLimit")), Address(_o.at("to").get_str()), importData(_o), toInt(_o.at("nonce")), Secret(_o.at("secretKey").get_str()));
+    }
+    else
+    {
         requireJsonFields(_o, "transaction",
             {{"data", jsonVType::str_type}, {"gasLimit", jsonVType::str_type},
                 {"gasPrice", jsonVType::str_type}, {"nonce", jsonVType::str_type},
@@ -426,22 +426,22 @@ void ImportTest::importTransaction (json_spirit::mObject const& _o, eth::Transac
 
         RLPStream transactionRLPStream = createRLPStreamFromTransactionFields(_o);
         RLP transactionRLP(transactionRLPStream.out());
-		try
-		{
-			o_tr = Transaction(transactionRLP.data(), CheckTransaction::Everything);
-		}
-		catch (InvalidSignature)
-		{
-			// create unsigned transaction
-			o_tr = _o.at("to").get_str().empty() ?
-				Transaction(toInt(_o.at("value")), toInt(_o.at("gasPrice")), toInt(_o.at("gasLimit")), importData(_o), toInt(_o.at("nonce"))) :
-				Transaction(toInt(_o.at("value")), toInt(_o.at("gasPrice")), toInt(_o.at("gasLimit")), Address(_o.at("to").get_str()), importData(_o), toInt(_o.at("nonce")));
-		}
-		catch (Exception& _e)
-		{
-			cnote << "invalid transaction" << boost::diagnostic_information(_e);
-		}
-	}
+        try
+        {
+            o_tr = Transaction(transactionRLP.data(), CheckTransaction::Everything);
+        }
+        catch (InvalidSignature)
+        {
+            // create unsigned transaction
+            o_tr = _o.at("to").get_str().empty() ?
+                Transaction(toInt(_o.at("value")), toInt(_o.at("gasPrice")), toInt(_o.at("gasLimit")), importData(_o), toInt(_o.at("nonce"))) :
+                Transaction(toInt(_o.at("value")), toInt(_o.at("gasPrice")), toInt(_o.at("gasLimit")), Address(_o.at("to").get_str()), importData(_o), toInt(_o.at("nonce")));
+        }
+        catch (Exception& _e)
+        {
+            cnote << "invalid transaction" << boost::diagnostic_information(_e);
+        }
+    }
 }
 
 void ImportTest::importTransaction(json_spirit::mObject const& o_tr)
@@ -461,116 +461,116 @@ void ImportTest::importTransaction(json_spirit::mObject const& o_tr)
 
     // Parse extended transaction
     size_t dataVectorSize = o_tr.at("data").get_array().size();
-	size_t gasVectorSize = o_tr.at("gasLimit").get_array().size();
-	size_t valueVectorSize = o_tr.at("value").get_array().size();
+    size_t gasVectorSize = o_tr.at("gasLimit").get_array().size();
+    size_t valueVectorSize = o_tr.at("value").get_array().size();
 
-	BOOST_REQUIRE_MESSAGE(dataVectorSize > 0, "Transaction should has at least 1 data item!");
-	BOOST_REQUIRE_MESSAGE(gasVectorSize > 0, "Transaction should has at least 1 gas item!");
-	BOOST_REQUIRE_MESSAGE(valueVectorSize > 0, "Transaction should has at least 1 value item!");
+    BOOST_REQUIRE_MESSAGE(dataVectorSize > 0, "Transaction should has at least 1 data item!");
+    BOOST_REQUIRE_MESSAGE(gasVectorSize > 0, "Transaction should has at least 1 gas item!");
+    BOOST_REQUIRE_MESSAGE(valueVectorSize > 0, "Transaction should has at least 1 value item!");
 
-	for (size_t d = 0; d < dataVectorSize; d++)
-		for (size_t g = 0; g < gasVectorSize; g++)
-			for (size_t v = 0; v < valueVectorSize; v++)
-			{
-				json_spirit::mValue gas = o_tr.at("gasLimit").get_array().at(g);
-				json_spirit::mValue value = o_tr.at("value").get_array().at(v);
-				json_spirit::mValue data = o_tr.at("data").get_array().at(d);
+    for (size_t d = 0; d < dataVectorSize; d++)
+        for (size_t g = 0; g < gasVectorSize; g++)
+            for (size_t v = 0; v < valueVectorSize; v++)
+            {
+                json_spirit::mValue gas = o_tr.at("gasLimit").get_array().at(g);
+                json_spirit::mValue value = o_tr.at("value").get_array().at(v);
+                json_spirit::mValue data = o_tr.at("data").get_array().at(d);
 
-				json_spirit::mObject o_tr_tmp = o_tr;
-				o_tr_tmp["data"] = data;
-				o_tr_tmp["gasLimit"] = gas;
-				o_tr_tmp["value"] = value;
+                json_spirit::mObject o_tr_tmp = o_tr;
+                o_tr_tmp["data"] = data;
+                o_tr_tmp["gasLimit"] = gas;
+                o_tr_tmp["value"] = value;
 
-				importTransaction(o_tr_tmp, m_transaction);
+                importTransaction(o_tr_tmp, m_transaction);
 
-				transactionToExecute execData(d, g, v, m_transaction);
-				m_transactions.push_back(execData);
-			}
+                transactionToExecute execData(d, g, v, m_transaction);
+                m_transactions.push_back(execData);
+            }
 }
 
 int ImportTest::compareStates(State const& _stateExpect, State const& _statePost, AccountMaskMap const _expectedStateOptions, WhenError _throw)
 {
-	bool wasError = false;
-	#define CHECK(a,b)						\
-		{									\
-			if (_throw == WhenError::Throw) \
-			{								\
-				BOOST_CHECK_MESSAGE(a, b);	\
-				if (!a)						\
-					return 1;				\
-			}								\
-			else							\
-			{								\
-				BOOST_WARN_MESSAGE(a,b);	\
-				if (!a)						\
-					wasError = true;		\
-			}								\
-		}
+    bool wasError = false;
+    #define CHECK(a,b)						\
+        {									\
+            if (_throw == WhenError::Throw) \
+            {								\
+                BOOST_CHECK_MESSAGE(a, b);	\
+                if (!a)						\
+                    return 1;				\
+            }								\
+            else							\
+            {								\
+                BOOST_WARN_MESSAGE(a,b);	\
+                if (!a)						\
+                    wasError = true;		\
+            }								\
+        }
 
-	for (auto const& a: _stateExpect.addresses())
-	{
-		AccountMask addressOptions(true);
-		if(_expectedStateOptions.size())
-		{
-			try
-			{
-				addressOptions = _expectedStateOptions.at(a.first);
-			}
-			catch(std::out_of_range const&)
-			{
-				BOOST_ERROR(TestOutputHelper::get().testName() + " expectedStateOptions map does not match expectedState in checkExpectedState!");
-				break;
-			}
-		}
+    for (auto const& a: _stateExpect.addresses())
+    {
+        AccountMask addressOptions(true);
+        if(_expectedStateOptions.size())
+        {
+            try
+            {
+                addressOptions = _expectedStateOptions.at(a.first);
+            }
+            catch(std::out_of_range const&)
+            {
+                BOOST_ERROR(TestOutputHelper::get().testName() + " expectedStateOptions map does not match expectedState in checkExpectedState!");
+                break;
+            }
+        }
 
-		if (addressOptions.shouldExist())
-		{
-			CHECK(_statePost.addressInUse(a.first), TestOutputHelper::get().testName() +  " Compare States: " << a.first << " missing expected address!");
-		}
-		else
-		{
-			CHECK(!_statePost.addressInUse(a.first), TestOutputHelper::get().testName() +  " Compare States: " << a.first << " address not expected to exist!");
-		}
+        if (addressOptions.shouldExist())
+        {
+            CHECK(_statePost.addressInUse(a.first), TestOutputHelper::get().testName() +  " Compare States: " << a.first << " missing expected address!");
+        }
+        else
+        {
+            CHECK(!_statePost.addressInUse(a.first), TestOutputHelper::get().testName() +  " Compare States: " << a.first << " address not expected to exist!");
+        }
 
-		if (_statePost.addressInUse(a.first))
-		{
+        if (_statePost.addressInUse(a.first))
+        {
 
-			if (addressOptions.hasBalance())
-				CHECK((_stateExpect.balance(a.first) == _statePost.balance(a.first)),
-				TestOutputHelper::get().testName() + " Check State: " << a.first <<  ": incorrect balance " << _statePost.balance(a.first) << ", expected " << _stateExpect.balance(a.first));
+            if (addressOptions.hasBalance())
+                CHECK((_stateExpect.balance(a.first) == _statePost.balance(a.first)),
+                TestOutputHelper::get().testName() + " Check State: " << a.first <<  ": incorrect balance " << _statePost.balance(a.first) << ", expected " << _stateExpect.balance(a.first));
 
-			if (addressOptions.hasNonce())
-				CHECK((_stateExpect.getNonce(a.first) == _statePost.getNonce(a.first)),
-				TestOutputHelper::get().testName() + " Check State: " << a.first <<  ": incorrect nonce " << _statePost.getNonce(a.first) << ", expected " << _stateExpect.getNonce(a.first));
+            if (addressOptions.hasNonce())
+                CHECK((_stateExpect.getNonce(a.first) == _statePost.getNonce(a.first)),
+                TestOutputHelper::get().testName() + " Check State: " << a.first <<  ": incorrect nonce " << _statePost.getNonce(a.first) << ", expected " << _stateExpect.getNonce(a.first));
 
-			if (addressOptions.hasStorage())
-			{
-				map<h256, pair<u256, u256>> stateStorage = _statePost.storage(a.first);
-				for (auto const& s: _stateExpect.storage(a.first))
-					CHECK((stateStorage[s.first] == s.second),
-					TestOutputHelper::get().testName() + " Check State: " << a.first << ": incorrect storage [" << toCompactHexPrefixed(s.second.first) << "] = " << toCompactHexPrefixed(stateStorage[s.first].second) << ", expected [" << toCompactHexPrefixed(s.second.first) << "] = " << toCompactHexPrefixed(s.second.second));
+            if (addressOptions.hasStorage())
+            {
+                map<h256, pair<u256, u256>> stateStorage = _statePost.storage(a.first);
+                for (auto const& s: _stateExpect.storage(a.first))
+                    CHECK((stateStorage[s.first] == s.second),
+                    TestOutputHelper::get().testName() + " Check State: " << a.first << ": incorrect storage [" << toCompactHexPrefixed(s.second.first) << "] = " << toCompactHexPrefixed(stateStorage[s.first].second) << ", expected [" << toCompactHexPrefixed(s.second.first) << "] = " << toCompactHexPrefixed(s.second.second));
 
-				//Check for unexpected storage values
-				map<h256, pair<u256, u256>> expectedStorage = _stateExpect.storage(a.first);
-				for (auto const& s: _statePost.storage(a.first))
-					CHECK((expectedStorage[s.first] == s.second),
-					TestOutputHelper::get().testName() + " Check State: " << a.first << ": incorrect storage [" << toCompactHexPrefixed(s.second.first) << "] = " << toCompactHexPrefixed(s.second.second) << ", expected [" << toCompactHexPrefixed(s.second.first) << "] = " << toCompactHexPrefixed(expectedStorage[s.first].second));
-			}
+                //Check for unexpected storage values
+                map<h256, pair<u256, u256>> expectedStorage = _stateExpect.storage(a.first);
+                for (auto const& s: _statePost.storage(a.first))
+                    CHECK((expectedStorage[s.first] == s.second),
+                    TestOutputHelper::get().testName() + " Check State: " << a.first << ": incorrect storage [" << toCompactHexPrefixed(s.second.first) << "] = " << toCompactHexPrefixed(s.second.second) << ", expected [" << toCompactHexPrefixed(s.second.first) << "] = " << toCompactHexPrefixed(expectedStorage[s.first].second));
+            }
 
-			if (addressOptions.hasCode())
-				CHECK((_stateExpect.code(a.first) == _statePost.code(a.first)),
-				TestOutputHelper::get().testName() + " Check State: " << a.first <<  ": incorrect code '" << toHexPrefixed(_statePost.code(a.first)) << "', expected '" << toHexPrefixed(_stateExpect.code(a.first)) << "'");
-		}
-	}
+            if (addressOptions.hasCode())
+                CHECK((_stateExpect.code(a.first) == _statePost.code(a.first)),
+                TestOutputHelper::get().testName() + " Check State: " << a.first <<  ": incorrect code '" << toHexPrefixed(_statePost.code(a.first)) << "', expected '" << toHexPrefixed(_stateExpect.code(a.first)) << "'");
+        }
+    }
 
-	return wasError;
+    return wasError;
 }
 
 void ImportTest::parseJsonStrValueIntoSet(json_spirit::mValue const& _json, set<string>& _out)
 {
-	if (_json.type() == json_spirit::array_type)
-	{
-		for (auto const& val: _json.get_array())
+    if (_json.type() == json_spirit::array_type)
+    {
+        for (auto const& val: _json.get_array())
             _out.emplace(val.get_str());
     }
     else
@@ -579,13 +579,13 @@ void ImportTest::parseJsonStrValueIntoSet(json_spirit::mValue const& _json, set<
 
 void parseJsonIntValueIntoVector(json_spirit::mValue const& _json, vector<int>& _out)
 {
-	if (_json.type() == json_spirit::array_type)
-	{
-		for (auto const& val: _json.get_array())
-			_out.push_back(val.get_int());
-	}
-	else
-		_out.push_back(_json.get_int());
+    if (_json.type() == json_spirit::array_type)
+    {
+        for (auto const& val: _json.get_array())
+            _out.push_back(val.get_int());
+    }
+    else
+        _out.push_back(_json.get_int());
 }
 
 set<string> const& getAllowedNetworks()
@@ -620,7 +620,7 @@ void ImportTest::checkAllowedNetwork(std::set<std::string> const& _networks)
 
 bool ImportTest::checkGeneralTestSection(json_spirit::mObject const& _expects, vector<size_t>& _errorTransactions, string const& _network) const
 {
-	return checkGeneralTestSectionSearch(_expects, _errorTransactions, _network, NULL);
+    return checkGeneralTestSectionSearch(_expects, _errorTransactions, _network, NULL);
 }
 
 bool ImportTest::checkGeneralTestSectionSearch(json_spirit::mObject const& _expects, vector<size_t>& _errorTransactions, string const& _network, TrExpectSection* _search) const
@@ -641,7 +641,7 @@ bool ImportTest::checkGeneralTestSectionSearch(json_spirit::mObject const& _expe
 
     vector<int> d;
     vector<int> g;
-	vector<int> v;
+    vector<int> v;
     set<string> network;
     if (_network.empty())
         parseJsonStrValueIntoSet(_expects.at("network"), network);
@@ -654,43 +654,43 @@ bool ImportTest::checkGeneralTestSectionSearch(json_spirit::mObject const& _expe
         network.size() > 0, TestOutputHelper::get().testName() + " Network array not set!");
 
     if (!Options::get().singleTestNet.empty())
-	{
-		//skip this check if we execute transactions only on another specified network
+    {
+        //skip this check if we execute transactions only on another specified network
         if (!network.count(Options::get().singleTestNet) && !network.count(string{"ALL"}))
             return false;
     }
 
-	if (_expects.count("indexes"))
-	{
+    if (_expects.count("indexes"))
+    {
         BOOST_REQUIRE_MESSAGE(_expects.at("indexes").type() == jsonVType::obj_type,
             "indexes field expected to be json Object!");
         json_spirit::mObject const& indexes = _expects.at("indexes").get_obj();
         parseJsonIntValueIntoVector(indexes.at("data"), d);
-		parseJsonIntValueIntoVector(indexes.at("gas"), g);
-		parseJsonIntValueIntoVector(indexes.at("value"), v);
-		BOOST_CHECK_MESSAGE(d.size() > 0 && g.size() > 0 && v.size() > 0, TestOutputHelper::get().testName() + " Indexes arrays not set!");
+        parseJsonIntValueIntoVector(indexes.at("gas"), g);
+        parseJsonIntValueIntoVector(indexes.at("value"), v);
+        BOOST_CHECK_MESSAGE(d.size() > 0 && g.size() > 0 && v.size() > 0, TestOutputHelper::get().testName() + " Indexes arrays not set!");
 
-		//Skip this check if does not fit to options request
-		Options const& opt = Options::get();
-		if (!inArray(d, opt.trDataIndex) && !inArray(d, -1) && opt.trDataIndex != -1)
-			return false;
-		if (!inArray(g, opt.trGasIndex) && !inArray(g, -1) && opt.trGasIndex != -1)
-			return false;
-		if (!inArray(v, opt.trValueIndex) && !inArray(v, -1) && opt.trValueIndex != -1)
-			return false;
-	}
-	else
-		BOOST_ERROR(TestOutputHelper::get().testName() + " indexes section not set!");
+        //Skip this check if does not fit to options request
+        Options const& opt = Options::get();
+        if (!inArray(d, opt.trDataIndex) && !inArray(d, -1) && opt.trDataIndex != -1)
+            return false;
+        if (!inArray(g, opt.trGasIndex) && !inArray(g, -1) && opt.trGasIndex != -1)
+            return false;
+        if (!inArray(v, opt.trValueIndex) && !inArray(v, -1) && opt.trValueIndex != -1)
+            return false;
+    }
+    else
+        BOOST_ERROR(TestOutputHelper::get().testName() + " indexes section not set!");
 
-	bool foundResults = false;
-	std::vector<transactionToExecute> lookTransactions;
-	if (_search)
-		lookTransactions.push_back(_search->first);
-	else
-		lookTransactions = m_transactions;
-	for(size_t i = 0; i < lookTransactions.size(); i++)
-	{
-		transactionToExecute const& tr = lookTransactions[i];
+    bool foundResults = false;
+    std::vector<transactionToExecute> lookTransactions;
+    if (_search)
+        lookTransactions.push_back(_search->first);
+    else
+        lookTransactions = m_transactions;
+    for(size_t i = 0; i < lookTransactions.size(); i++)
+    {
+        transactionToExecute const& tr = lookTransactions[i];
         if (network.count(netIdToString(tr.netId)) || network.count("ALL"))
             if ((inArray(d, tr.dataInd) || d[0] == -1) && (inArray(g, tr.gasInd) || g[0] == -1) &&
                 (inArray(v, tr.valInd) || v[0] == -1))
@@ -757,42 +757,42 @@ bool ImportTest::checkGeneralTestSectionSearch(json_spirit::mObject const& _expe
                         break;
             }
     }
-	if (!_search) //if search for a single transaction in one of the expect sections then don't need this output.
-		BOOST_CHECK_MESSAGE(foundResults, TestOutputHelper::get().testName() + " Expect results was not found in test execution!");
-	return foundResults;
+    if (!_search) //if search for a single transaction in one of the expect sections then don't need this output.
+        BOOST_CHECK_MESSAGE(foundResults, TestOutputHelper::get().testName() + " Expect results was not found in test execution!");
+    return foundResults;
 }
 
 void ImportTest::traceStateDiff()
 {
-	string network = "ALL";
-	Options const& opt = Options::get();
-	if (!opt.singleTestNet.empty())
-		network = opt.singleTestNet;
+    string network = "ALL";
+    Options const& opt = Options::get();
+    if (!opt.singleTestNet.empty())
+        network = opt.singleTestNet;
 
-	int d = opt.trDataIndex;
-	int g = opt.trGasIndex;
-	int v = opt.trValueIndex;
+    int d = opt.trDataIndex;
+    int g = opt.trGasIndex;
+    int v = opt.trValueIndex;
 
-	for(auto const& tr : m_transactions)
-	{
-		if (network == netIdToString(tr.netId) || network == "ALL")
-		if ((d == tr.dataInd || d == -1) && (g == tr.gasInd || g == -1) && (v == tr.valInd || v == -1))
-		{
-			std::ostringstream log;
-			log << "trNetID: " << netIdToString(tr.netId) << "\n";
-			log << "trDataInd: " << tr.dataInd << " tdGasInd: " << tr.gasInd << " trValInd: " << tr.valInd << "\n";
-			BOOST_LOG(m_logger) << log.str();
-			fillJsonWithStateChange(m_statePre, tr.postState, tr.changeLog); //output std log
-		}
-	}
+    for(auto const& tr : m_transactions)
+    {
+        if (network == netIdToString(tr.netId) || network == "ALL")
+        if ((d == tr.dataInd || d == -1) && (g == tr.gasInd || g == -1) && (v == tr.valInd || v == -1))
+        {
+            std::ostringstream log;
+            log << "trNetID: " << netIdToString(tr.netId) << "\n";
+            log << "trDataInd: " << tr.dataInd << " tdGasInd: " << tr.gasInd << " trValInd: " << tr.valInd << "\n";
+            BOOST_LOG(m_logger) << log.str();
+            fillJsonWithStateChange(m_statePre, tr.postState, tr.changeLog); //output std log
+        }
+    }
 }
 
 int ImportTest::exportTest()
 {
-	int err = 0;
-	vector<size_t> stateIndexesToPrint;
-	if (m_testInputObject.count("expect") > 0)
-	{
+    int err = 0;
+    vector<size_t> stateIndexesToPrint;
+    if (m_testInputObject.count("expect") > 0)
+    {
         BOOST_REQUIRE_MESSAGE(m_testInputObject.at("expect").type() == jsonVType::array_type,
             "expect section is required to be json Array!");
         for (auto const& exp : m_testInputObject.at("expect").get_array())
@@ -804,36 +804,36 @@ int ImportTest::exportTest()
     }
 
     std::map<string, json_spirit::mArray> postState;
-	for(size_t i = 0; i < m_transactions.size(); i++)
-	{
-		transactionToExecute const& tr = m_transactions[i];
-		json_spirit::mObject obj;
-		json_spirit::mObject obj2;
-		obj["data"] = tr.dataInd;
-		obj["gas"] = tr.gasInd;
-		obj["value"] = tr.valInd;
-		obj2["indexes"] = obj;
-		obj2["hash"] = toHexPrefixed(tr.postState.rootHash().asBytes());
-		obj2["logs"] = exportLog(tr.output.second.log());
+    for(size_t i = 0; i < m_transactions.size(); i++)
+    {
+        transactionToExecute const& tr = m_transactions[i];
+        json_spirit::mObject obj;
+        json_spirit::mObject obj2;
+        obj["data"] = tr.dataInd;
+        obj["gas"] = tr.gasInd;
+        obj["value"] = tr.valInd;
+        obj2["indexes"] = obj;
+        obj2["hash"] = toHexPrefixed(tr.postState.rootHash().asBytes());
+        obj2["logs"] = exportLog(tr.output.second.log());
 
-		//Print the post state if transaction has failed on expect section
-		auto it = std::find(std::begin(stateIndexesToPrint), std::end(stateIndexesToPrint), i);
-		if (it != std::end(stateIndexesToPrint))
-			obj2["postState"] = fillJsonWithState(tr.postState);
+        //Print the post state if transaction has failed on expect section
+        auto it = std::find(std::begin(stateIndexesToPrint), std::end(stateIndexesToPrint), i);
+        if (it != std::end(stateIndexesToPrint))
+            obj2["postState"] = fillJsonWithState(tr.postState);
 
-		if (Options::get().statediff)
-			obj2["stateDiff"] = fillJsonWithStateChange(m_statePre, tr.postState, tr.changeLog);
+        if (Options::get().statediff)
+            obj2["stateDiff"] = fillJsonWithStateChange(m_statePre, tr.postState, tr.changeLog);
 
-		postState[netIdToString(tr.netId)].push_back(obj2);
-	}
+        postState[netIdToString(tr.netId)].push_back(obj2);
+    }
 
-	json_spirit::mObject obj;
-	for(std::map<string, json_spirit::mArray>::iterator it = postState.begin(); it != postState.end(); ++it)
-		obj[it->first] = it->second;
+    json_spirit::mObject obj;
+    for(std::map<string, json_spirit::mArray>::iterator it = postState.begin(); it != postState.end(); ++it)
+        obj[it->first] = it->second;
 
-	m_testOutputObject["post"] = obj;
-	m_testOutputObject["pre"] = fillJsonWithState(m_statePre);
-	m_testOutputObject["env"] = makeAllFieldsHex(m_testInputObject.at("env").get_obj());
-	m_testOutputObject["transaction"] = makeAllFieldsHex(m_testInputObject.at("transaction").get_obj());
-	return err;
+    m_testOutputObject["post"] = obj;
+    m_testOutputObject["pre"] = fillJsonWithState(m_statePre);
+    m_testOutputObject["env"] = makeAllFieldsHex(m_testInputObject.at("env").get_obj());
+    m_testOutputObject["transaction"] = makeAllFieldsHex(m_testInputObject.at("transaction").get_obj());
+    return err;
 }

--- a/test/tools/libtesteth/ImportTest.h
+++ b/test/tools/libtesteth/ImportTest.h
@@ -102,6 +102,8 @@ private:
 
     json_spirit::mObject const& m_testInputObject;
 	json_spirit::mObject& m_testOutputObject;
+
+    Logger m_logger{createLogger(5, "state")};
 };
 
 template<class T>

--- a/test/tools/libtesteth/Options.cpp
+++ b/test/tools/libtesteth/Options.cpp
@@ -33,7 +33,7 @@ void printHelp()
     cout << "Usage: \n";
     cout << std::left;
     cout << "\nSetting test suite\n";
-    cout << setw(30) <<	"-t <TestSuite>" << setw(25) << "Execute test operations\n";
+    cout << setw(30) << "-t <TestSuite>" << setw(25) << "Execute test operations\n";
     cout << setw(30) << "-t <TestSuite>/<TestCase>\n";
     cout << setw(30) << "--testpath <PathToTheTestRepo>\n";
 
@@ -335,7 +335,9 @@ Options::Options(int argc, const char** argv)
 
     //Default option
     if (logVerbosity == Verbosity::NiceReport)
-        g_logVerbosity = -1;	//disable cnote but leave cerr and cout
+        g_logVerbosity = -1;    //disable cnote but leave cerr and cout
+
+    setupLogging(g_logVerbosity);
 }
 
 Options const& Options::get(int argc, const char** argv)

--- a/test/tools/libtestutils/Common.cpp
+++ b/test/tools/libtestutils/Common.cpp
@@ -1,18 +1,18 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
  
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
  
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
  
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
  */
 /** @file Common.cpp
  * @author Marek Kotewicz <marek@ethdev.com>
@@ -32,57 +32,57 @@ using namespace dev;
 using namespace dev::test;
 namespace fs = boost::filesystem;
 
-const char* TestChannel::name() { return "TST"; }
-
 boost::filesystem::path dev::test::getTestPath()
 {
-	if (!Options::get().testpath.empty())
-		return Options::get().testpath;
+    if (!Options::get().testpath.empty())
+        return Options::get().testpath;
 
-	string testPath;
-	const char* ptestPath = getenv("ETHEREUM_TEST_PATH");
+    string testPath;
+    const char* ptestPath = getenv("ETHEREUM_TEST_PATH");
 
-	if (ptestPath == nullptr)
-	{
-		ctest << " could not find environment variable ETHEREUM_TEST_PATH \n";
-		testPath = "../../test/jsontests";
-	}
-	else
-		testPath = ptestPath;
+    if (ptestPath == nullptr)
+    {
+        clogSimple(1, "test") << " could not find environment variable ETHEREUM_TEST_PATH \n";
+        testPath = "../../test/jsontests";
+    }
+    else
+        testPath = ptestPath;
 
-	return boost::filesystem::path(testPath);
+    return boost::filesystem::path(testPath);
 }
 
 int dev::test::randomNumber()
 {
-	static std::mt19937 randomGenerator(utcTime());
-	randomGenerator.seed(std::random_device()());
-	return std::uniform_int_distribution<int>(1)(randomGenerator);
+    static std::mt19937 randomGenerator(utcTime());
+    randomGenerator.seed(std::random_device()());
+    return std::uniform_int_distribution<int>(1)(randomGenerator);
 }
 
 Json::Value dev::test::loadJsonFromFile(fs::path const& _path)
 {
-	Json::Reader reader;
-	Json::Value result;
-	string s = dev::contentsString(_path);
-	if (!s.length())
-		ctest << "Contents of " << _path.string() << " is empty. Have you cloned the 'tests' repo branch develop and set ETHEREUM_TEST_PATH to its path?";
-	else
-		ctest << "FIXTURE: loaded test from file: " << _path.string();
+    Json::Reader reader;
+    Json::Value result;
+    string s = dev::contentsString(_path);
+    if (!s.length())
+        clogSimple(1, "test") << "Contents of " << _path.string()
+                              << " is empty. Have you cloned the 'tests' repo branch develop and "
+                                 "set ETHEREUM_TEST_PATH to its path?";
+    else
+        clogSimple(1, "test") << "FIXTURE: loaded test from file: " << _path.string();
 
-	reader.parse(s, result);
-	return result;
+    reader.parse(s, result);
+    return result;
 }
 
 fs::path dev::test::toTestFilePath(std::string const& _filename)
 {
-	return getTestPath() / fs::path(_filename + ".json");
+    return getTestPath() / fs::path(_filename + ".json");
 }
 
 fs::path dev::test::getRandomPath()
 {
-	std::stringstream stream;
-	stream << randomNumber();
-	return getDataDir("EthereumTests") / fs::path(stream.str());
+    std::stringstream stream;
+    stream << randomNumber();
+    return getDataDir("EthereumTests") / fs::path(stream.str());
 }
 

--- a/test/tools/libtestutils/Common.h
+++ b/test/tools/libtestutils/Common.h
@@ -1,18 +1,18 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
  */
 /** @file Common.h
  * @author Marek Kotewicz <marek@ethdev.com>
@@ -31,9 +31,6 @@ namespace dev
 {
 namespace test
 {
-
-struct TestChannel: public LogChannel  { static const char* name(); };
-#define ctest dev::LogOutputStream<dev::test::TestChannel, true>()
 
 boost::filesystem::path getTestPath();
 int randomNumber();

--- a/test/unittests/libethereum/Block.cpp
+++ b/test/unittests/libethereum/Block.cpp
@@ -33,21 +33,6 @@ using namespace dev::test;
 
 BOOST_FIXTURE_TEST_SUITE(BlockSuite, TestOutputHelperFixture)
 
-#if !defined(_WIN32)
-BOOST_AUTO_TEST_CASE(bStructures)
-{
-	BlockChat chat;
-	BlockTrace trace;
-	BlockDetail details;
-	BlockSafeExceptions exeptions;
-
-	BOOST_REQUIRE(string(chat.name()).find("◌") != string::npos);
-	BOOST_REQUIRE(string(trace.name()).find("◎") != string::npos);
-	BOOST_REQUIRE(string(details.name()).find("◌") != string::npos);
-	BOOST_REQUIRE(string(exeptions.name()).find("ℹ") != string::npos);
-}
-#endif
-
 BOOST_FIXTURE_TEST_SUITE(FrontierBlockSuite, FrontierNoProofTestFixture)
 
 BOOST_AUTO_TEST_CASE(bStates)

--- a/test/unittests/libethereum/BlockChain.cpp
+++ b/test/unittests/libethereum/BlockChain.cpp
@@ -37,11 +37,6 @@ BOOST_FIXTURE_TEST_SUITE(BlockChainFrontierSuite, FrontierNoProofTestFixture)
 
 BOOST_AUTO_TEST_CASE(output)
 {
-    BOOST_WARN(string(BlockChainDebug::name()) == string(EthBlue "☍" EthWhite " ◇"));
-    BOOST_WARN(string(BlockChainWarn::name()) == string(EthBlue "☍" EthOnRed EthBlackBold " ✘"));
-    BOOST_WARN(string(BlockChainNote::name()) == string(EthBlue "☍" EthBlue " ℹ"));
-    BOOST_WARN(string(BlockChainChat::name()) == string(EthBlue "☍" EthWhite " ◌"));
-
     TestBlock genesis = TestBlockChain::defaultGenesisBlock();
     TestBlockChain bc(genesis);
 

--- a/test/unittests/libethereum/TransactionQueue.cpp
+++ b/test/unittests/libethereum/TransactionQueue.cpp
@@ -1,18 +1,18 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file transactionqueue.cpp
  * @author Christoph Jentzsch <cj@ethdev.com>
@@ -33,281 +33,275 @@ BOOST_FIXTURE_TEST_SUITE(TransactionQueueSuite, TestOutputHelperFixture)
 
 BOOST_AUTO_TEST_CASE(TransactionEIP86)
 {
-	dev::eth::TransactionQueue txq;
-	Address to = Address("0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b");
-	RLPStream streamRLP;
-	streamRLP.appendList(9);
-	streamRLP << 0 << 10 * szabo << 25000;
-	streamRLP << to << 0 << bytes() << 0 << 0 << 0;
-	Transaction tx0(streamRLP.out(), CheckTransaction::Everything);
-	ImportResult result = txq.import(tx0);
-	BOOST_CHECK(result == ImportResult::ZeroSignature);
-	BOOST_CHECK(txq.knownTransactions().size() == 0);
+    dev::eth::TransactionQueue txq;
+    Address to = Address("0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b");
+    RLPStream streamRLP;
+    streamRLP.appendList(9);
+    streamRLP << 0 << 10 * szabo << 25000;
+    streamRLP << to << 0 << bytes() << 0 << 0 << 0;
+    Transaction tx0(streamRLP.out(), CheckTransaction::Everything);
+    ImportResult result = txq.import(tx0);
+    BOOST_CHECK(result == ImportResult::ZeroSignature);
+    BOOST_CHECK(txq.knownTransactions().size() == 0);
 }
 
 BOOST_AUTO_TEST_CASE(tqMaxNonce)
 {
-	dev::eth::TransactionQueue txq;
+    dev::eth::TransactionQueue txq;
 
-	// from a94f5374fce5edbc8e2a8697c15331677e6ebf0b
-	const u256 gasCost =  10 * szabo;
-	const u256 gas = 25000;
-	Address dest = Address("0x095e7baea6a6c7c4c2dfeb977efac326af552d87");
-	Address to = Address("0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b");
-	Secret sec = Secret("0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8");
-	Transaction tx0(0, gasCost, gas, dest, bytes(), 0, sec );
-	Transaction tx0_1(1, gasCost, gas, dest, bytes(), 0, sec );
-	Transaction tx1(0, gasCost, gas, dest, bytes(), 1, sec );
-	Transaction tx2(0, gasCost, gas, dest, bytes(), 2, sec );
-	Transaction tx9(0, gasCost, gas, dest, bytes(), 9, sec );
+    // from a94f5374fce5edbc8e2a8697c15331677e6ebf0b
+    const u256 gasCost =  10 * szabo;
+    const u256 gas = 25000;
+    Address dest = Address("0x095e7baea6a6c7c4c2dfeb977efac326af552d87");
+    Address to = Address("0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b");
+    Secret sec = Secret("0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8");
+    Transaction tx0(0, gasCost, gas, dest, bytes(), 0, sec );
+    Transaction tx0_1(1, gasCost, gas, dest, bytes(), 0, sec );
+    Transaction tx1(0, gasCost, gas, dest, bytes(), 1, sec );
+    Transaction tx2(0, gasCost, gas, dest, bytes(), 2, sec );
+    Transaction tx9(0, gasCost, gas, dest, bytes(), 9, sec );
 
-	txq.import(tx0);
-	BOOST_CHECK(1 == txq.maxNonce(to));
-	txq.import(tx0);
-	BOOST_CHECK(1 == txq.maxNonce(to));
-	txq.import(tx0_1);
-	BOOST_CHECK(1 == txq.maxNonce(to));
-	txq.import(tx1);
-	BOOST_CHECK(2 == txq.maxNonce(to));
-	txq.import(tx9);
-	BOOST_CHECK(10 == txq.maxNonce(to));
-	txq.import(tx2);
-	BOOST_CHECK(10 == txq.maxNonce(to));
+    txq.import(tx0);
+    BOOST_CHECK(1 == txq.maxNonce(to));
+    txq.import(tx0);
+    BOOST_CHECK(1 == txq.maxNonce(to));
+    txq.import(tx0_1);
+    BOOST_CHECK(1 == txq.maxNonce(to));
+    txq.import(tx1);
+    BOOST_CHECK(2 == txq.maxNonce(to));
+    txq.import(tx9);
+    BOOST_CHECK(10 == txq.maxNonce(to));
+    txq.import(tx2);
+    BOOST_CHECK(10 == txq.maxNonce(to));
 }
 
 BOOST_AUTO_TEST_CASE(tqPriority)
 {
-	dev::eth::TransactionQueue txq;
+    dev::eth::TransactionQueue txq;
 
-	const u256 gasCostCheap =  10 * szabo;
-	const u256 gasCostMed =  20 * szabo;
-	const u256 gasCostHigh =  30 * szabo;
-	const u256 gas = 25000;
-	Address dest = Address("0x095e7baea6a6c7c4c2dfeb977efac326af552d87");
-	Secret sender1 = Secret("0x3333333333333333333333333333333333333333333333333333333333333333");
-	Secret sender2 = Secret("0x4444444444444444444444444444444444444444444444444444444444444444");
-	Transaction tx0(0, gasCostCheap, gas, dest, bytes(), 0, sender1 );
-	Transaction tx0_1(1, gasCostMed, gas, dest, bytes(), 0, sender1 );
-	Transaction tx1(0, gasCostCheap, gas, dest, bytes(), 1, sender1 );
-	Transaction tx2(0, gasCostHigh, gas, dest, bytes(), 0, sender2 );
-	Transaction tx3(0, gasCostCheap + 1, gas, dest, bytes(), 1, sender2 );
-	Transaction tx4(0, gasCostHigh, gas, dest, bytes(), 2, sender1 );
-	Transaction tx5(0, gasCostMed, gas, dest, bytes(), 2, sender2 );
+    const u256 gasCostCheap =  10 * szabo;
+    const u256 gasCostMed =  20 * szabo;
+    const u256 gasCostHigh =  30 * szabo;
+    const u256 gas = 25000;
+    Address dest = Address("0x095e7baea6a6c7c4c2dfeb977efac326af552d87");
+    Secret sender1 = Secret("0x3333333333333333333333333333333333333333333333333333333333333333");
+    Secret sender2 = Secret("0x4444444444444444444444444444444444444444444444444444444444444444");
+    Transaction tx0(0, gasCostCheap, gas, dest, bytes(), 0, sender1 );
+    Transaction tx0_1(1, gasCostMed, gas, dest, bytes(), 0, sender1 );
+    Transaction tx1(0, gasCostCheap, gas, dest, bytes(), 1, sender1 );
+    Transaction tx2(0, gasCostHigh, gas, dest, bytes(), 0, sender2 );
+    Transaction tx3(0, gasCostCheap + 1, gas, dest, bytes(), 1, sender2 );
+    Transaction tx4(0, gasCostHigh, gas, dest, bytes(), 2, sender1 );
+    Transaction tx5(0, gasCostMed, gas, dest, bytes(), 2, sender2 );
 
-	txq.import(tx0);
-	BOOST_CHECK(Transactions { tx0 } == txq.topTransactions(256));
-	txq.import(tx0);
-	BOOST_CHECK(Transactions { tx0 } == txq.topTransactions(256));
-	txq.import(tx0_1);
-	BOOST_CHECK(Transactions { tx0_1 } == txq.topTransactions(256));
-	txq.import(tx1);
-	BOOST_CHECK((Transactions { tx0_1, tx1 }) == txq.topTransactions(256));
-	txq.import(tx2);
-	BOOST_CHECK((Transactions { tx2, tx0_1, tx1 }) == txq.topTransactions(256));
-	txq.import(tx3);
-	BOOST_CHECK((Transactions { tx2, tx0_1, tx1, tx3 }) == txq.topTransactions(256));
-	txq.import(tx4);
-	BOOST_CHECK((Transactions { tx2, tx0_1, tx1, tx3, tx4 }) == txq.topTransactions(256));
-	txq.import(tx5);
-	BOOST_CHECK((Transactions { tx2, tx0_1, tx1, tx3, tx5, tx4 }) == txq.topTransactions(256));
+    txq.import(tx0);
+    BOOST_CHECK(Transactions { tx0 } == txq.topTransactions(256));
+    txq.import(tx0);
+    BOOST_CHECK(Transactions { tx0 } == txq.topTransactions(256));
+    txq.import(tx0_1);
+    BOOST_CHECK(Transactions { tx0_1 } == txq.topTransactions(256));
+    txq.import(tx1);
+    BOOST_CHECK((Transactions { tx0_1, tx1 }) == txq.topTransactions(256));
+    txq.import(tx2);
+    BOOST_CHECK((Transactions { tx2, tx0_1, tx1 }) == txq.topTransactions(256));
+    txq.import(tx3);
+    BOOST_CHECK((Transactions { tx2, tx0_1, tx1, tx3 }) == txq.topTransactions(256));
+    txq.import(tx4);
+    BOOST_CHECK((Transactions { tx2, tx0_1, tx1, tx3, tx4 }) == txq.topTransactions(256));
+    txq.import(tx5);
+    BOOST_CHECK((Transactions { tx2, tx0_1, tx1, tx3, tx5, tx4 }) == txq.topTransactions(256));
 
-	txq.drop(tx0_1.sha3());
-	BOOST_CHECK((Transactions { tx2, tx1, tx3, tx5, tx4 }) == txq.topTransactions(256));
-	txq.drop(tx1.sha3());
-	BOOST_CHECK((Transactions { tx2, tx3, tx5, tx4 }) == txq.topTransactions(256));
-	txq.drop(tx5.sha3());
-	BOOST_CHECK((Transactions { tx2, tx3, tx4 }) == txq.topTransactions(256));
+    txq.drop(tx0_1.sha3());
+    BOOST_CHECK((Transactions { tx2, tx1, tx3, tx5, tx4 }) == txq.topTransactions(256));
+    txq.drop(tx1.sha3());
+    BOOST_CHECK((Transactions { tx2, tx3, tx5, tx4 }) == txq.topTransactions(256));
+    txq.drop(tx5.sha3());
+    BOOST_CHECK((Transactions { tx2, tx3, tx4 }) == txq.topTransactions(256));
 
-	Transaction tx6(0, gasCostMed, gas, dest, bytes(), 20, sender1 );
-	txq.import(tx6);
-	BOOST_CHECK((Transactions { tx2, tx3, tx4, tx6 }) == txq.topTransactions(256));
+    Transaction tx6(0, gasCostMed, gas, dest, bytes(), 20, sender1 );
+    txq.import(tx6);
+    BOOST_CHECK((Transactions { tx2, tx3, tx4, tx6 }) == txq.topTransactions(256));
 
-	Transaction tx7(0, gasCostMed, gas, dest, bytes(), 2, sender2 );
-	txq.import(tx7);
-	// deterministic signature: hash of tx5 and tx7 will be same
-	BOOST_CHECK((Transactions { tx2, tx3, tx4, tx6 }) == txq.topTransactions(256));
+    Transaction tx7(0, gasCostMed, gas, dest, bytes(), 2, sender2 );
+    txq.import(tx7);
+    // deterministic signature: hash of tx5 and tx7 will be same
+    BOOST_CHECK((Transactions { tx2, tx3, tx4, tx6 }) == txq.topTransactions(256));
 
 }
 
 BOOST_AUTO_TEST_CASE(tqFuture)
 {
-	dev::eth::TransactionQueue txq;
+    dev::eth::TransactionQueue txq;
 
-	// from a94f5374fce5edbc8e2a8697c15331677e6ebf0b
-	const u256 gasCostMed =  20 * szabo;
-	const u256 gas = 25000;
-	Address dest = Address("0x095e7baea6a6c7c4c2dfeb977efac326af552d87");
-	Secret sender = Secret("0x3333333333333333333333333333333333333333333333333333333333333333");
-	Transaction tx0(0, gasCostMed, gas, dest, bytes(), 0, sender );
-	Transaction tx1(0, gasCostMed, gas, dest, bytes(), 1, sender );
-	Transaction tx2(0, gasCostMed, gas, dest, bytes(), 2, sender );
-	Transaction tx3(0, gasCostMed, gas, dest, bytes(), 3, sender );
-	Transaction tx4(0, gasCostMed, gas, dest, bytes(), 4, sender );
+    // from a94f5374fce5edbc8e2a8697c15331677e6ebf0b
+    const u256 gasCostMed =  20 * szabo;
+    const u256 gas = 25000;
+    Address dest = Address("0x095e7baea6a6c7c4c2dfeb977efac326af552d87");
+    Secret sender = Secret("0x3333333333333333333333333333333333333333333333333333333333333333");
+    Transaction tx0(0, gasCostMed, gas, dest, bytes(), 0, sender );
+    Transaction tx1(0, gasCostMed, gas, dest, bytes(), 1, sender );
+    Transaction tx2(0, gasCostMed, gas, dest, bytes(), 2, sender );
+    Transaction tx3(0, gasCostMed, gas, dest, bytes(), 3, sender );
+    Transaction tx4(0, gasCostMed, gas, dest, bytes(), 4, sender );
 
-	txq.import(tx0);
-	txq.import(tx1);
-	txq.import(tx2);
-	txq.import(tx3);
-	txq.import(tx4);
-	BOOST_CHECK((Transactions { tx0, tx1, tx2, tx3, tx4 }) == txq.topTransactions(256));
+    txq.import(tx0);
+    txq.import(tx1);
+    txq.import(tx2);
+    txq.import(tx3);
+    txq.import(tx4);
+    BOOST_CHECK((Transactions { tx0, tx1, tx2, tx3, tx4 }) == txq.topTransactions(256));
 
-	txq.setFuture(tx2.sha3());
-	BOOST_CHECK((Transactions { tx0, tx1 }) == txq.topTransactions(256));
+    txq.setFuture(tx2.sha3());
+    BOOST_CHECK((Transactions { tx0, tx1 }) == txq.topTransactions(256));
 
-	Transaction tx2_2(1, gasCostMed, gas, dest, bytes(), 2, sender );
-	txq.import(tx2_2);
-	BOOST_CHECK((Transactions { tx0, tx1, tx2_2, tx3, tx4 }) == txq.topTransactions(256));
+    Transaction tx2_2(1, gasCostMed, gas, dest, bytes(), 2, sender );
+    txq.import(tx2_2);
+    BOOST_CHECK((Transactions { tx0, tx1, tx2_2, tx3, tx4 }) == txq.topTransactions(256));
 }
 
 
 BOOST_AUTO_TEST_CASE(tqLimits)
 {
-	dev::eth::TransactionQueue txq(3, 3);
-	const u256 gasCostMed =  20 * szabo;
-	const u256 gas = 25000;
-	Address dest = Address("0x095e7baea6a6c7c4c2dfeb977efac326af552d87");
-	Secret sender = Secret("0x3333333333333333333333333333333333333333333333333333333333333333");
-	Secret sender2 = Secret("0x4444444444444444444444444444444444444444444444444444444444444444");
-	Transaction tx0(0, gasCostMed, gas, dest, bytes(), 0, sender );
-	Transaction tx1(0, gasCostMed, gas, dest, bytes(), 1, sender );
-	Transaction tx2(0, gasCostMed, gas, dest, bytes(), 2, sender );
-	Transaction tx3(0, gasCostMed, gas, dest, bytes(), 3, sender );
-	Transaction tx4(0, gasCostMed, gas, dest, bytes(), 4, sender );
-	Transaction tx5(0, gasCostMed + 1, gas, dest, bytes(), 0, sender2 );
+    dev::eth::TransactionQueue txq(3, 3);
+    const u256 gasCostMed =  20 * szabo;
+    const u256 gas = 25000;
+    Address dest = Address("0x095e7baea6a6c7c4c2dfeb977efac326af552d87");
+    Secret sender = Secret("0x3333333333333333333333333333333333333333333333333333333333333333");
+    Secret sender2 = Secret("0x4444444444444444444444444444444444444444444444444444444444444444");
+    Transaction tx0(0, gasCostMed, gas, dest, bytes(), 0, sender );
+    Transaction tx1(0, gasCostMed, gas, dest, bytes(), 1, sender );
+    Transaction tx2(0, gasCostMed, gas, dest, bytes(), 2, sender );
+    Transaction tx3(0, gasCostMed, gas, dest, bytes(), 3, sender );
+    Transaction tx4(0, gasCostMed, gas, dest, bytes(), 4, sender );
+    Transaction tx5(0, gasCostMed + 1, gas, dest, bytes(), 0, sender2 );
 
-	txq.import(tx0);
-	txq.import(tx1);
-	txq.import(tx2);
-	txq.import(tx3);
-	txq.import(tx4);
-	txq.import(tx5);
-	BOOST_CHECK((Transactions { tx5, tx0, tx1 }) == txq.topTransactions(256));
+    txq.import(tx0);
+    txq.import(tx1);
+    txq.import(tx2);
+    txq.import(tx3);
+    txq.import(tx4);
+    txq.import(tx5);
+    BOOST_CHECK((Transactions { tx5, tx0, tx1 }) == txq.topTransactions(256));
 }
-
-BOOST_AUTO_TEST_CASE(tqOutput)
-{
-	BOOST_REQUIRE(string(TransactionQueueChannel().name()) == string(EthCyan "┉┅▶"));
-}
-
 
 BOOST_AUTO_TEST_CASE(tqImport)
 {
-	TestTransaction testTransaction = TestTransaction::defaultTransaction();
-	TransactionQueue tq;
-	h256Hash known = tq.knownTransactions();
-	BOOST_REQUIRE(known.size() == 0);
+    TestTransaction testTransaction = TestTransaction::defaultTransaction();
+    TransactionQueue tq;
+    h256Hash known = tq.knownTransactions();
+    BOOST_REQUIRE(known.size() == 0);
 
-	ImportResult ir = tq.import(testTransaction.transaction().rlp());
-	BOOST_REQUIRE(ir == ImportResult::Success);
-	known = tq.knownTransactions();
-	BOOST_REQUIRE(known.size() == 1);
+    ImportResult ir = tq.import(testTransaction.transaction().rlp());
+    BOOST_REQUIRE(ir == ImportResult::Success);
+    known = tq.knownTransactions();
+    BOOST_REQUIRE(known.size() == 1);
 
-	ir = tq.import(testTransaction.transaction().rlp());
-	BOOST_REQUIRE(ir == ImportResult::AlreadyKnown);
+    ir = tq.import(testTransaction.transaction().rlp());
+    BOOST_REQUIRE(ir == ImportResult::AlreadyKnown);
 
-	bytes rlp = testTransaction.transaction().rlp();
-	rlp.at(0) = 03;
-	ir = tq.import(rlp);
-	BOOST_REQUIRE(ir == ImportResult::Malformed);
+    bytes rlp = testTransaction.transaction().rlp();
+    rlp.at(0) = 03;
+    ir = tq.import(rlp);
+    BOOST_REQUIRE(ir == ImportResult::Malformed);
 
-	known = tq.knownTransactions();
-	BOOST_REQUIRE(known.size() == 1);
+    known = tq.knownTransactions();
+    BOOST_REQUIRE(known.size() == 1);
 
-	TestTransaction testTransaction2 = TestTransaction::defaultTransaction(1, 2);
-	TestTransaction testTransaction3 = TestTransaction::defaultTransaction(1, 1);
-	TestTransaction testTransaction4 = TestTransaction::defaultTransaction(1, 4);
-	ir = tq.import(testTransaction2.transaction().rlp());
-	ir = tq.import(testTransaction3.transaction().rlp());
-	BOOST_REQUIRE(ir == ImportResult::OverbidGasPrice);
-	ir = tq.import(testTransaction4.transaction().rlp());
-	known = tq.knownTransactions();
-	BOOST_REQUIRE(known.size() == 1);
-	Transactions ts = tq.topTransactions(4);
-	BOOST_REQUIRE(ts.size() == 1);
-	BOOST_REQUIRE(Transaction(ts.at(0)).gasPrice() == 4);
+    TestTransaction testTransaction2 = TestTransaction::defaultTransaction(1, 2);
+    TestTransaction testTransaction3 = TestTransaction::defaultTransaction(1, 1);
+    TestTransaction testTransaction4 = TestTransaction::defaultTransaction(1, 4);
+    ir = tq.import(testTransaction2.transaction().rlp());
+    ir = tq.import(testTransaction3.transaction().rlp());
+    BOOST_REQUIRE(ir == ImportResult::OverbidGasPrice);
+    ir = tq.import(testTransaction4.transaction().rlp());
+    known = tq.knownTransactions();
+    BOOST_REQUIRE(known.size() == 1);
+    Transactions ts = tq.topTransactions(4);
+    BOOST_REQUIRE(ts.size() == 1);
+    BOOST_REQUIRE(Transaction(ts.at(0)).gasPrice() == 4);
 
-	tq.setFuture(Transaction(ts.at(0)).sha3());
-	Address from = Transaction(ts.at(0)).from();
-	ts = tq.topTransactions(4);
-	BOOST_REQUIRE(ts.size() == 0);
-	BOOST_REQUIRE(tq.waiting(from) == 1);
+    tq.setFuture(Transaction(ts.at(0)).sha3());
+    Address from = Transaction(ts.at(0)).from();
+    ts = tq.topTransactions(4);
+    BOOST_REQUIRE(ts.size() == 0);
+    BOOST_REQUIRE(tq.waiting(from) == 1);
 }
 
 BOOST_AUTO_TEST_CASE(tqDrop)
 {
-	TransactionQueue tq;
-	TestTransaction testTransaction = TestTransaction::defaultTransaction();
-	tq.dropGood(testTransaction.transaction());
-	tq.import(testTransaction.transaction().rlp());
-	BOOST_REQUIRE(tq.topTransactions(4).size() == 1);
-	tq.dropGood(testTransaction.transaction());
-	BOOST_REQUIRE(tq.topTransactions(4).size() == 0);
+    TransactionQueue tq;
+    TestTransaction testTransaction = TestTransaction::defaultTransaction();
+    tq.dropGood(testTransaction.transaction());
+    tq.import(testTransaction.transaction().rlp());
+    BOOST_REQUIRE(tq.topTransactions(4).size() == 1);
+    tq.dropGood(testTransaction.transaction());
+    BOOST_REQUIRE(tq.topTransactions(4).size() == 0);
 }
 
 BOOST_AUTO_TEST_CASE(tqLimit)
 {
-	TransactionQueue tq(5, 3);
-	Address from;
-	for (size_t i = 1; i < 7; i++)
-	{
-		TestTransaction testTransaction = TestTransaction::defaultTransaction(i);
-		ImportResult res = tq.import(testTransaction.transaction());
-		from = testTransaction.transaction().from();
-		BOOST_REQUIRE(res == ImportResult::Success);
-	}
+    TransactionQueue tq(5, 3);
+    Address from;
+    for (size_t i = 1; i < 7; i++)
+    {
+        TestTransaction testTransaction = TestTransaction::defaultTransaction(i);
+        ImportResult res = tq.import(testTransaction.transaction());
+        from = testTransaction.transaction().from();
+        BOOST_REQUIRE(res == ImportResult::Success);
+    }
 
-	//5 is imported and 6th is dropped
-	BOOST_REQUIRE(tq.waiting(from) == 5);
+    //5 is imported and 6th is dropped
+    BOOST_REQUIRE(tq.waiting(from) == 5);
 
-	Transactions topTr = tq.topTransactions(10);
-	BOOST_REQUIRE(topTr.size() == 5);
+    Transactions topTr = tq.topTransactions(10);
+    BOOST_REQUIRE(topTr.size() == 5);
 
-	for (int i = topTr.size() - 1; i >= 0 ; i--)
-		tq.setFuture(topTr.at(i).sha3());
+    for (int i = topTr.size() - 1; i >= 0 ; i--)
+        tq.setFuture(topTr.at(i).sha3());
 
-	topTr = tq.topTransactions(10);
-	BOOST_REQUIRE(topTr.size() == 0);
+    topTr = tq.topTransactions(10);
+    BOOST_REQUIRE(topTr.size() == 0);
 
-	TestTransaction testTransaction = TestTransaction::defaultTransaction(7);
-	BOOST_REQUIRE(tq.waiting(from) == 5);
+    TestTransaction testTransaction = TestTransaction::defaultTransaction(7);
+    BOOST_REQUIRE(tq.waiting(from) == 5);
 
-	//Drop out of bound feauture
-	ImportResult res = tq.import(testTransaction.transaction());
-	BOOST_REQUIRE(res == ImportResult::Success);
+    //Drop out of bound feauture
+    ImportResult res = tq.import(testTransaction.transaction());
+    BOOST_REQUIRE(res == ImportResult::Success);
 
-	//future list size is now 3  + 1 imported transaction
-	BOOST_REQUIRE(tq.waiting(testTransaction.transaction().from()) == 4);
+    //future list size is now 3  + 1 imported transaction
+    BOOST_REQUIRE(tq.waiting(testTransaction.transaction().from()) == 4);
 
-	topTr = tq.topTransactions(10);
-	BOOST_REQUIRE(topTr.size() == 1); // 1 imported transaction
+    topTr = tq.topTransactions(10);
+    BOOST_REQUIRE(topTr.size() == 1); // 1 imported transaction
 }
 
 BOOST_AUTO_TEST_CASE(tqEqueue)
 {
-	TransactionQueue tq;
-	TestTransaction testTransaction = TestTransaction::defaultTransaction();
+    TransactionQueue tq;
+    TestTransaction testTransaction = TestTransaction::defaultTransaction();
 
-	bytes payloadToDecode = testTransaction.transaction().rlp();
+    bytes payloadToDecode = testTransaction.transaction().rlp();
 
-	RLPStream rlpStream(2);
-	rlpStream.appendRaw(payloadToDecode);
-	rlpStream.appendRaw(payloadToDecode);
+    RLPStream rlpStream(2);
+    rlpStream.appendRaw(payloadToDecode);
+    rlpStream.appendRaw(payloadToDecode);
 
-	RLP tRlp(rlpStream.out());
+    RLP tRlp(rlpStream.out());
 
-	//check that Transaction could be recreated from the RLP
-	Transaction tRlpTransaction(payloadToDecode, CheckTransaction::Cheap);
-	BOOST_REQUIRE(tRlpTransaction.data() == testTransaction.transaction().data());
+    //check that Transaction could be recreated from the RLP
+    Transaction tRlpTransaction(payloadToDecode, CheckTransaction::Cheap);
+    BOOST_REQUIRE(tRlpTransaction.data() == testTransaction.transaction().data());
 
-	//try to import transactions
-	string hashStr = "01020304050607080910111213141516171819202122232425262728293031320102030405060708091011121314151617181920212223242526272829303132";
-	tq.enqueue(tRlp, h512(hashStr));
-	tq.enqueue(tRlp, h512(hashStr));
-	std::this_thread::sleep_for(std::chrono::seconds(1));
+    //try to import transactions
+    string hashStr = "01020304050607080910111213141516171819202122232425262728293031320102030405060708091011121314151617181920212223242526272829303132";
+    tq.enqueue(tRlp, h512(hashStr));
+    tq.enqueue(tRlp, h512(hashStr));
+    std::this_thread::sleep_for(std::chrono::seconds(1));
 
-	//at least 1 transaction should be imported through RLP
-	Transactions topTr = tq.topTransactions(10);
-	BOOST_REQUIRE(topTr.size() == 1);
+    //at least 1 transaction should be imported through RLP
+    Transactions topTr = tq.topTransactions(10);
+    BOOST_REQUIRE(topTr.size() == 1);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This PR accumulates all smaller PRs related to rewriting logging system using boost.log

- [x] Create basic logging primitives in `Log.h`
- [x] Custom `operator<<` for log stream to apply special formatting to logged values - this will replace `LogOutputStreamBase::append()` methods
- [x] Change all logging statements to use new logging
- [ ] Rename `clogSimple` to `clog`
- [ ] Replace `ThreadContext` mechanism with some additional log context attributes
- [ ] `setupLogging()` in all executables
- [ ] Get rid of global verbosity variable (make it argument to `setupLogging()` instead)
- [ ] Separate global logger for critical errors, also probably remove `cdebug`, `clog`, `cnote`, `ctrace` or leave only one of them
- [ ] Handle exceptions from logging system
- [ ] new command line parameter for filtering channels (probably create program options group to handle it easily in all tools)

### Summary of changes noticeable to user
- Names of many channels will be changed, all channels will have readable names to allow filtering by channel (e.g. there will be `warn` instead of `  ✘`)
- Channel names won't be colored, so log will be less colorful overall
- Some special values like URLs and error messages will be not colored (those that used `LogTag` stream manipulator), primitive types like `int`s won't be colored; some others e.g. `h256 ` stay colored though.
- Outputting  `std::string`s won't automatically add quotation marks around; they also won't be colored.
- "AutoSpacing" feature is removed - it allowed to output to log stream not caring about spaces between values, like `cwarn << "Transaction hash" << hash << "already imported";` Now spaces need to be explicit like `cwarn << "Transaction hash " << hash << " already imported";` I'll try to change this in all log messages, but I might miss some.
- Some channels were supposed to be visible only in Debug build (the ones with `LogChannel::debug == true`) - but this was working only for Windows, where `NDEBUG` macro is defined in debug, for other platforms debug channels were visible in Release, too. This difference is removed, channel visibility will depend only on filtering, but not on build type.

Log message line will look like
```
2018-04-17 12:15:59 eth timer Block import 5123675 3184 ms
```
(`eth` is the name of the thread, `timer` is the name of the channel)