### PR TITLE
Refactor logging - MemoryDB, OverlayDB, Executive, State

### DIFF
--- a/libdevcore/Log.h
+++ b/libdevcore/Log.h
@@ -238,7 +238,7 @@ public:
 #define LOG BOOST_LOG
 
 // Simple cout-like stream objects for accessing common log channels.
-// Dirties the global namespace, but oh so convenient...
+// Thread-safe
 BOOST_LOG_INLINE_GLOBAL_LOGGER_CTOR_ARGS(g_debugLogger,
     boost::log::sources::severity_channel_logger_mt<>,
     (boost::log::keywords::severity = 0)(boost::log::keywords::channel = EthWhite "debug" EthReset))
@@ -260,8 +260,19 @@ BOOST_LOG_INLINE_GLOBAL_LOGGER_CTOR_ARGS(g_traceLogger,
     (boost::log::keywords::severity = 4)(boost::log::keywords::channel = EthGray "trace" EthReset))
 #define ctrace LOG(dev::g_traceLogger::get())
 
+// Simple macro to log to any channel a message without creating a logger object
+// e.g. clog(0, "channel") << "message";
+// Thread-safe
+BOOST_LOG_INLINE_GLOBAL_LOGGER_DEFAULT(
+    g_clogLogger, boost::log::sources::severity_channel_logger_mt<>);
+#define clogSimple(SEVERITY, CHANNEL)                      \
+    BOOST_LOG_STREAM_WITH_PARAMS(dev::g_clogLogger::get(), \
+        (boost::log::keywords::severity = SEVERITY)(boost::log::keywords::channel = CHANNEL))
+
+// Should be called in every executable
 void setupLogging(int _verbosity);
 
+// Simple non-thread-safe logger with fixed severity and channel for each message
 using Logger = boost::log::sources::severity_channel_logger<>;
 inline Logger createLogger(int _severity, std::string const& _channel)
 {

--- a/libdevcore/MemoryDB.cpp
+++ b/libdevcore/MemoryDB.cpp
@@ -1,18 +1,18 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file MemoryDB.cpp
  * @author Gav Wood <i@gavwood.com>
@@ -28,165 +28,162 @@ using namespace dev;
 namespace dev
 {
 
-const char* DBChannel::name() { return "TDB"; }
-const char* DBWarn::name() { return "TDB"; }
-
 std::unordered_map<h256, std::string> MemoryDB::get() const
 {
 #if DEV_GUARDED_DB
-	ReadGuard l(x_this);
+    ReadGuard l(x_this);
 #endif
-	std::unordered_map<h256, std::string> ret;
-	for (auto const& i: m_main)
-		if (!m_enforceRefs || i.second.second > 0)
-			ret.insert(make_pair(i.first, i.second.first));
-	return ret;
+    std::unordered_map<h256, std::string> ret;
+    for (auto const& i: m_main)
+        if (!m_enforceRefs || i.second.second > 0)
+            ret.insert(make_pair(i.first, i.second.first));
+    return ret;
 }
 
 MemoryDB& MemoryDB::operator=(MemoryDB const& _c)
 {
-	if (this == &_c)
-		return *this;
+    if (this == &_c)
+        return *this;
 #if DEV_GUARDED_DB
-	ReadGuard l(_c.x_this);
-	WriteGuard l2(x_this);
+    ReadGuard l(_c.x_this);
+    WriteGuard l2(x_this);
 #endif
-	m_main = _c.m_main;
-	m_aux = _c.m_aux;
-	return *this;
+    m_main = _c.m_main;
+    m_aux = _c.m_aux;
+    return *this;
 }
 
 std::string MemoryDB::lookup(h256 const& _h) const
 {
 #if DEV_GUARDED_DB
-	ReadGuard l(x_this);
+    ReadGuard l(x_this);
 #endif
-	auto it = m_main.find(_h);
-	if (it != m_main.end())
-	{
-		if (!m_enforceRefs || it->second.second > 0)
-			return it->second.first;
-		else
-			cwarn << "Lookup required for value with refcount == 0. This is probably a critical trie issue" << _h;
-	}
-	return std::string();
+    auto it = m_main.find(_h);
+    if (it != m_main.end())
+    {
+        if (!m_enforceRefs || it->second.second > 0)
+            return it->second.first;
+        else
+            cwarn << "Lookup required for value with refcount == 0. This is probably a critical trie issue" << _h;
+    }
+    return std::string();
 }
 
 bool MemoryDB::exists(h256 const& _h) const
 {
 #if DEV_GUARDED_DB
-	ReadGuard l(x_this);
+    ReadGuard l(x_this);
 #endif
-	auto it = m_main.find(_h);
-	if (it != m_main.end() && (!m_enforceRefs || it->second.second > 0))
-		return true;
-	return false;
+    auto it = m_main.find(_h);
+    if (it != m_main.end() && (!m_enforceRefs || it->second.second > 0))
+        return true;
+    return false;
 }
 
 void MemoryDB::insert(h256 const& _h, bytesConstRef _v)
 {
 #if DEV_GUARDED_DB
-	WriteGuard l(x_this);
+    WriteGuard l(x_this);
 #endif
-	auto it = m_main.find(_h);
-	if (it != m_main.end())
-	{
-		it->second.first = _v.toString();
-		it->second.second++;
-	}
-	else
-		m_main[_h] = make_pair(_v.toString(), 1);
+    auto it = m_main.find(_h);
+    if (it != m_main.end())
+    {
+        it->second.first = _v.toString();
+        it->second.second++;
+    }
+    else
+        m_main[_h] = make_pair(_v.toString(), 1);
 #if ETH_PARANOIA
-	dbdebug << "INST" << _h << "=>" << m_main[_h].second;
+    cdebug << "INST" << _h << "=>" << m_main[_h].second;
 #endif
 }
 
 bool MemoryDB::kill(h256 const& _h)
 {
 #if DEV_GUARDED_DB
-	ReadGuard l(x_this);
+    ReadGuard l(x_this);
 #endif
-	if (m_main.count(_h))
-	{
-		if (m_main[_h].second > 0)
-		{
-			m_main[_h].second--;
-			return true;
-		}
+    if (m_main.count(_h))
+    {
+        if (m_main[_h].second > 0)
+        {
+            m_main[_h].second--;
+            return true;
+        }
 #if ETH_PARANOIA
-		else
-		{
-			// If we get to this point, then there was probably a node in the level DB which we need to remove and which we have previously
-			// used as part of the memory-based MemoryDB. Nothing to be worried about *as long as the node exists in the DB*.
-			dbdebug << "NOKILL-WAS" << _h;
-		}
-		dbdebug << "KILL" << _h << "=>" << m_main[_h].second;
-	}
-	else
-	{
-		dbdebug << "NOKILL" << _h;
+        else
+        {
+            // If we get to this point, then there was probably a node in the level DB which we need to remove and which we have previously
+            // used as part of the memory-based MemoryDB. Nothing to be worried about *as long as the node exists in the DB*.
+            cdebug << "NOKILL-WAS" << _h;
+        }
+        cdebug << "KILL" << _h << "=>" << m_main[_h].second;
+    }
+    else
+    {
+        cdebug << "NOKILL" << _h;
 #endif
-	}
-	return false;
+    }
+    return false;
 }
 
 bytes MemoryDB::lookupAux(h256 const& _h) const
 {
 #if DEV_GUARDED_DB
-	ReadGuard l(x_this);
+    ReadGuard l(x_this);
 #endif
-	auto it = m_aux.find(_h);
-	if (it != m_aux.end() && (!m_enforceRefs || it->second.second))
-		return it->second.first;
-	return bytes();
+    auto it = m_aux.find(_h);
+    if (it != m_aux.end() && (!m_enforceRefs || it->second.second))
+        return it->second.first;
+    return bytes();
 }
 
 void MemoryDB::removeAux(h256 const& _h)
 {
 #if DEV_GUARDED_DB
-	WriteGuard l(x_this);
+    WriteGuard l(x_this);
 #endif
-	m_aux[_h].second = false;
+    m_aux[_h].second = false;
 }
 
 void MemoryDB::insertAux(h256 const& _h, bytesConstRef _v)
 {
 #if DEV_GUARDED_DB
-	WriteGuard l(x_this);
+    WriteGuard l(x_this);
 #endif
-	m_aux[_h] = make_pair(_v.toBytes(), true);
+    m_aux[_h] = make_pair(_v.toBytes(), true);
 }
 
 void MemoryDB::purge()
 {
 #if DEV_GUARDED_DB
-	WriteGuard l(x_this);
+    WriteGuard l(x_this);
 #endif
-	// purge m_main
-	for (auto it = m_main.begin(); it != m_main.end(); )
-		if (it->second.second)
-			++it;
-		else
-			it = m_main.erase(it);
+    // purge m_main
+    for (auto it = m_main.begin(); it != m_main.end(); )
+        if (it->second.second)
+            ++it;
+        else
+            it = m_main.erase(it);
 
-	// purge m_aux
-	for (auto it = m_aux.begin(); it != m_aux.end(); )
-		if (it->second.second)
-			++it;
-		else
-			it = m_aux.erase(it);
+    // purge m_aux
+    for (auto it = m_aux.begin(); it != m_aux.end(); )
+        if (it->second.second)
+            ++it;
+        else
+            it = m_aux.erase(it);
 }
 
 h256Hash MemoryDB::keys() const
 {
 #if DEV_GUARDED_DB
-	ReadGuard l(x_this);
+    ReadGuard l(x_this);
 #endif
-	h256Hash ret;
-	for (auto const& i: m_main)
-		if (i.second.second)
-			ret.insert(i.first);
-	return ret;
+    h256Hash ret;
+    for (auto const& i: m_main)
+        if (i.second.second)
+            ret.insert(i.first);
+    return ret;
 }
 
 }

--- a/libdevcore/MemoryDB.h
+++ b/libdevcore/MemoryDB.h
@@ -29,12 +29,6 @@
 namespace dev
 {
 
-struct DBChannel: public LogChannel  { static const char* name(); static const int verbosity = 18; };
-struct DBWarn: public LogChannel  { static const char* name(); static const int verbosity = 1; };
-
-#define dbdebug clog(DBChannel)
-#define dbwarn clog(DBWarn)
-
 class MemoryDB
 {
     friend class EnforceRefs;

--- a/libdevcore/OverlayDB.h
+++ b/libdevcore/OverlayDB.h
@@ -30,14 +30,12 @@
 namespace dev
 {
 
-struct DBDetail: public LogChannel { static const char* name() { return "DBDetail"; } static const int verbosity = 14; };
-
 class OverlayDB: public MemoryDB
 {
 public:
     explicit OverlayDB(std::unique_ptr<db::DatabaseFace> _db = nullptr)
       : m_db(_db.release(), [](db::DatabaseFace* db) {
-            clog(DBDetail) << "Closing state DB";
+            clogSimple(14, "overlaydb") << "Closing state DB";
             delete db;
         })
     {}

--- a/libdevcore/TrieDB.h
+++ b/libdevcore/TrieDB.h
@@ -30,13 +30,6 @@
 namespace dev
 {
 
-struct TrieDBChannel: public LogChannel
-{
-    static const char* name() { return "-T-"; }
-    static const int verbosity = 17;
-};
-#define tdebug clog(TrieDBChannel)
-
 struct InvalidTrie: virtual dev::Exception {};
 
 enum class Verification {

--- a/libethcore/BlockHeader.cpp
+++ b/libethcore/BlockHeader.cpp
@@ -1,18 +1,18 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file BlockHeader.cpp
  * @author Gav Wood <i@gavwood.com>
@@ -38,234 +38,232 @@ BlockHeader::BlockHeader()
 
 BlockHeader::BlockHeader(bytesConstRef _block, BlockDataType _bdt, h256 const& _hashWith)
 {
-	RLP header = _bdt == BlockData ? extractHeader(_block) : RLP(_block);
-	m_hash = _hashWith ? _hashWith : sha3(header.data());
-	populate(header);
+    RLP header = _bdt == BlockData ? extractHeader(_block) : RLP(_block);
+    m_hash = _hashWith ? _hashWith : sha3(header.data());
+    populate(header);
 }
 
 BlockHeader::BlockHeader(BlockHeader const& _other) :
-	m_parentHash(_other.parentHash()),
-	m_sha3Uncles(_other.sha3Uncles()),
-	m_stateRoot(_other.stateRoot()),
-	m_transactionsRoot(_other.transactionsRoot()),
-	m_receiptsRoot(_other.receiptsRoot()),
-	m_logBloom(_other.logBloom()),
-	m_number(_other.number()),
-	m_gasLimit(_other.gasLimit()),
-	m_gasUsed(_other.gasUsed()),
-	m_extraData(_other.extraData()),
-	m_timestamp(_other.timestamp()),
-	m_author(_other.author()),
-	m_difficulty(_other.difficulty()),
-	m_seal(_other.seal()),
-	m_hash(_other.hashRawRead()),
-	m_hashWithout(_other.hashWithoutRawRead())
+    m_parentHash(_other.parentHash()),
+    m_sha3Uncles(_other.sha3Uncles()),
+    m_stateRoot(_other.stateRoot()),
+    m_transactionsRoot(_other.transactionsRoot()),
+    m_receiptsRoot(_other.receiptsRoot()),
+    m_logBloom(_other.logBloom()),
+    m_number(_other.number()),
+    m_gasLimit(_other.gasLimit()),
+    m_gasUsed(_other.gasUsed()),
+    m_extraData(_other.extraData()),
+    m_timestamp(_other.timestamp()),
+    m_author(_other.author()),
+    m_difficulty(_other.difficulty()),
+    m_seal(_other.seal()),
+    m_hash(_other.hashRawRead()),
+    m_hashWithout(_other.hashWithoutRawRead())
 {
-	assert(*this == _other);
+    assert(*this == _other);
 }
 
 BlockHeader& BlockHeader::operator=(BlockHeader const& _other)
 {
-	if (this == &_other)
-		return *this;
-	m_parentHash = _other.parentHash();
-	m_sha3Uncles = _other.sha3Uncles();
-	m_stateRoot = _other.stateRoot();
-	m_transactionsRoot = _other.transactionsRoot();
-	m_receiptsRoot = _other.receiptsRoot();
-	m_logBloom = _other.logBloom();
-	m_number = _other.number();
-	m_gasLimit = _other.gasLimit();
-	m_gasUsed = _other.gasUsed();
-	m_extraData = _other.extraData();
-	m_timestamp = _other.timestamp();
-	m_author = _other.author();
-	m_difficulty = _other.difficulty();
-	std::vector<bytes> seal = _other.seal();
-	{
-		Guard l(m_sealLock);
-		m_seal = std::move(seal);
-	}
-	h256 hash = _other.hashRawRead();
-	h256 hashWithout = _other.hashWithoutRawRead();
-	{
-		Guard l(m_hashLock);
-		m_hash = std::move(hash);
-		m_hashWithout = std::move(hashWithout);
-	}
-	assert(*this == _other);
-	return *this;
+    if (this == &_other)
+        return *this;
+    m_parentHash = _other.parentHash();
+    m_sha3Uncles = _other.sha3Uncles();
+    m_stateRoot = _other.stateRoot();
+    m_transactionsRoot = _other.transactionsRoot();
+    m_receiptsRoot = _other.receiptsRoot();
+    m_logBloom = _other.logBloom();
+    m_number = _other.number();
+    m_gasLimit = _other.gasLimit();
+    m_gasUsed = _other.gasUsed();
+    m_extraData = _other.extraData();
+    m_timestamp = _other.timestamp();
+    m_author = _other.author();
+    m_difficulty = _other.difficulty();
+    std::vector<bytes> seal = _other.seal();
+    {
+        Guard l(m_sealLock);
+        m_seal = std::move(seal);
+    }
+    h256 hash = _other.hashRawRead();
+    h256 hashWithout = _other.hashWithoutRawRead();
+    {
+        Guard l(m_hashLock);
+        m_hash = std::move(hash);
+        m_hashWithout = std::move(hashWithout);
+    }
+    assert(*this == _other);
+    return *this;
 }
 
 void BlockHeader::clear()
 {
-	m_parentHash = h256();
-	m_sha3Uncles = EmptyListSHA3;
-	m_author = Address();
-	m_stateRoot = EmptyTrie;
-	m_transactionsRoot = EmptyTrie;
-	m_receiptsRoot = EmptyTrie;
-	m_logBloom = LogBloom();
-	m_difficulty = 0;
-	m_number = 0;
-	m_gasLimit = 0;
-	m_gasUsed = 0;
-	m_timestamp = -1;
-	m_extraData.clear();
-	m_seal.clear();
-	noteDirty();
+    m_parentHash = h256();
+    m_sha3Uncles = EmptyListSHA3;
+    m_author = Address();
+    m_stateRoot = EmptyTrie;
+    m_transactionsRoot = EmptyTrie;
+    m_receiptsRoot = EmptyTrie;
+    m_logBloom = LogBloom();
+    m_difficulty = 0;
+    m_number = 0;
+    m_gasLimit = 0;
+    m_gasUsed = 0;
+    m_timestamp = -1;
+    m_extraData.clear();
+    m_seal.clear();
+    noteDirty();
 }
 
 h256 BlockHeader::hash(IncludeSeal _i) const
 {
-	h256 dummy;
-	Guard l(m_hashLock);
-	h256& memo = _i == WithSeal ? m_hash : _i == WithoutSeal ? m_hashWithout : dummy;
-	if (!memo)
-	{
-		RLPStream s;
-		streamRLP(s, _i);
-		memo = sha3(s.out());
-	}
-	return memo;
+    h256 dummy;
+    Guard l(m_hashLock);
+    h256& memo = _i == WithSeal ? m_hash : _i == WithoutSeal ? m_hashWithout : dummy;
+    if (!memo)
+    {
+        RLPStream s;
+        streamRLP(s, _i);
+        memo = sha3(s.out());
+    }
+    return memo;
 }
 
 void BlockHeader::streamRLPFields(RLPStream& _s) const
 {
-	_s	<< m_parentHash << m_sha3Uncles << m_author << m_stateRoot << m_transactionsRoot << m_receiptsRoot << m_logBloom
-		<< m_difficulty << m_number << m_gasLimit << m_gasUsed << m_timestamp << m_extraData;
+    _s	<< m_parentHash << m_sha3Uncles << m_author << m_stateRoot << m_transactionsRoot << m_receiptsRoot << m_logBloom
+        << m_difficulty << m_number << m_gasLimit << m_gasUsed << m_timestamp << m_extraData;
 }
 
 void BlockHeader::streamRLP(RLPStream& _s, IncludeSeal _i) const
 {
-	if (_i != OnlySeal)
-	{
-		_s.appendList(BlockHeader::BasicFields + (_i == WithoutSeal ? 0 : m_seal.size()));
-		BlockHeader::streamRLPFields(_s);
-	}
-	if (_i != WithoutSeal)
-		for (unsigned i = 0; i < m_seal.size(); ++i)
-			_s.appendRaw(m_seal[i]);
+    if (_i != OnlySeal)
+    {
+        _s.appendList(BlockHeader::BasicFields + (_i == WithoutSeal ? 0 : m_seal.size()));
+        BlockHeader::streamRLPFields(_s);
+    }
+    if (_i != WithoutSeal)
+        for (unsigned i = 0; i < m_seal.size(); ++i)
+            _s.appendRaw(m_seal[i]);
 }
 
 h256 BlockHeader::headerHashFromBlock(bytesConstRef _block)
 {
-	return sha3(RLP(_block)[0].data());
+    return sha3(RLP(_block)[0].data());
 }
 
 RLP BlockHeader::extractHeader(bytesConstRef _block)
 {
-	RLP root(_block);
-	if (!root.isList())
-		BOOST_THROW_EXCEPTION(InvalidBlockFormat() << errinfo_comment("Block must be a list") << BadFieldError(0, _block.toString()));
-	RLP header = root[0];
-	if (!header.isList())
-		BOOST_THROW_EXCEPTION(InvalidBlockFormat() << errinfo_comment("Block header must be a list") << BadFieldError(0, header.data().toString()));
-	if (!root[1].isList())
-		BOOST_THROW_EXCEPTION(InvalidBlockFormat() << errinfo_comment("Block transactions must be a list") << BadFieldError(1, root[1].data().toString()));
-	if (!root[2].isList())
-		BOOST_THROW_EXCEPTION(InvalidBlockFormat() << errinfo_comment("Block uncles must be a list") << BadFieldError(2, root[2].data().toString()));
-	return header;
+    RLP root(_block);
+    if (!root.isList())
+        BOOST_THROW_EXCEPTION(InvalidBlockFormat() << errinfo_comment("Block must be a list") << BadFieldError(0, _block.toString()));
+    RLP header = root[0];
+    if (!header.isList())
+        BOOST_THROW_EXCEPTION(InvalidBlockFormat() << errinfo_comment("Block header must be a list") << BadFieldError(0, header.data().toString()));
+    if (!root[1].isList())
+        BOOST_THROW_EXCEPTION(InvalidBlockFormat() << errinfo_comment("Block transactions must be a list") << BadFieldError(1, root[1].data().toString()));
+    if (!root[2].isList())
+        BOOST_THROW_EXCEPTION(InvalidBlockFormat() << errinfo_comment("Block uncles must be a list") << BadFieldError(2, root[2].data().toString()));
+    return header;
 }
 
 void BlockHeader::populate(RLP const& _header)
 {
-	int field = 0;
-	try
-	{
-		m_parentHash = _header[field = 0].toHash<h256>(RLP::VeryStrict);
-		m_sha3Uncles = _header[field = 1].toHash<h256>(RLP::VeryStrict);
-		m_author = _header[field = 2].toHash<Address>(RLP::VeryStrict);
-		m_stateRoot = _header[field = 3].toHash<h256>(RLP::VeryStrict);
-		m_transactionsRoot = _header[field = 4].toHash<h256>(RLP::VeryStrict);
-		m_receiptsRoot = _header[field = 5].toHash<h256>(RLP::VeryStrict);
-		m_logBloom = _header[field = 6].toHash<LogBloom>(RLP::VeryStrict);
-		m_difficulty = _header[field = 7].toInt<u256>();
-		m_number = _header[field = 8].toPositiveInt64();
-		m_gasLimit = _header[field = 9].toInt<u256>();
-		m_gasUsed = _header[field = 10].toInt<u256>();
-		m_timestamp = _header[field = 11].toPositiveInt64();
-		m_extraData = _header[field = 12].toBytes();
-		m_seal.clear();
-		for (unsigned i = 13; i < _header.itemCount(); ++i)
-			m_seal.push_back(_header[i].data().toBytes());
-	}
-	catch (Exception const& _e)
-	{
-		_e << errinfo_name("invalid block header format") << BadFieldError(field, toHex(_header[field].data().toBytes()));
-		throw;
-	}
+    int field = 0;
+    try
+    {
+        m_parentHash = _header[field = 0].toHash<h256>(RLP::VeryStrict);
+        m_sha3Uncles = _header[field = 1].toHash<h256>(RLP::VeryStrict);
+        m_author = _header[field = 2].toHash<Address>(RLP::VeryStrict);
+        m_stateRoot = _header[field = 3].toHash<h256>(RLP::VeryStrict);
+        m_transactionsRoot = _header[field = 4].toHash<h256>(RLP::VeryStrict);
+        m_receiptsRoot = _header[field = 5].toHash<h256>(RLP::VeryStrict);
+        m_logBloom = _header[field = 6].toHash<LogBloom>(RLP::VeryStrict);
+        m_difficulty = _header[field = 7].toInt<u256>();
+        m_number = _header[field = 8].toPositiveInt64();
+        m_gasLimit = _header[field = 9].toInt<u256>();
+        m_gasUsed = _header[field = 10].toInt<u256>();
+        m_timestamp = _header[field = 11].toPositiveInt64();
+        m_extraData = _header[field = 12].toBytes();
+        m_seal.clear();
+        for (unsigned i = 13; i < _header.itemCount(); ++i)
+            m_seal.push_back(_header[i].data().toBytes());
+    }
+    catch (Exception const& _e)
+    {
+        _e << errinfo_name("invalid block header format") << BadFieldError(field, toHex(_header[field].data().toBytes()));
+        throw;
+    }
 }
-
-struct BlockInfoDiagnosticsChannel: public LogChannel { static const char* name() { return EthBlue "▧" EthWhite " ◌"; } static const int verbosity = 9; };
 
 void BlockHeader::populateFromParent(BlockHeader const& _parent)
 {
-	m_stateRoot = _parent.stateRoot();
-	m_number = _parent.m_number + 1;
-	m_parentHash = _parent.m_hash;
-	m_gasLimit = _parent.m_gasLimit;
-	m_difficulty = 1;
-	m_gasUsed = 0;
+    m_stateRoot = _parent.stateRoot();
+    m_number = _parent.m_number + 1;
+    m_parentHash = _parent.m_hash;
+    m_gasLimit = _parent.m_gasLimit;
+    m_difficulty = 1;
+    m_gasUsed = 0;
 }
 
 void BlockHeader::verify(Strictness _s, BlockHeader const& _parent, bytesConstRef _block) const
 {
-	if (m_number > ~(unsigned)0)
-		BOOST_THROW_EXCEPTION(InvalidNumber());
+    if (m_number > ~(unsigned)0)
+        BOOST_THROW_EXCEPTION(InvalidNumber());
 
-	if (_s != CheckNothingNew && m_gasUsed > m_gasLimit)
-		BOOST_THROW_EXCEPTION(TooMuchGasUsed() << RequirementError(bigint(m_gasLimit), bigint(m_gasUsed)));
+    if (_s != CheckNothingNew && m_gasUsed > m_gasLimit)
+        BOOST_THROW_EXCEPTION(TooMuchGasUsed() << RequirementError(bigint(m_gasLimit), bigint(m_gasUsed)));
 
-	if (_parent)
-	{
-		if (m_parentHash && _parent.hash() != m_parentHash)
-			BOOST_THROW_EXCEPTION(InvalidParentHash());
+    if (_parent)
+    {
+        if (m_parentHash && _parent.hash() != m_parentHash)
+            BOOST_THROW_EXCEPTION(InvalidParentHash());
 
-		if (m_timestamp <= _parent.m_timestamp)
-			BOOST_THROW_EXCEPTION(InvalidTimestamp());
+        if (m_timestamp <= _parent.m_timestamp)
+            BOOST_THROW_EXCEPTION(InvalidTimestamp());
 
-		if (m_number != _parent.m_number + 1)
-			BOOST_THROW_EXCEPTION(InvalidNumber());
-	}
+        if (m_number != _parent.m_number + 1)
+            BOOST_THROW_EXCEPTION(InvalidNumber());
+    }
 
-	if (_block)
-	{
-		RLP root(_block);
+    if (_block)
+    {
+        RLP root(_block);
 
-		auto txList = root[1];
-		auto expectedRoot = trieRootOver(txList.itemCount(), [&](unsigned i){ return rlp(i); }, [&](unsigned i){ return txList[i].data().toBytes(); });
+        auto txList = root[1];
+        auto expectedRoot = trieRootOver(txList.itemCount(), [&](unsigned i){ return rlp(i); }, [&](unsigned i){ return txList[i].data().toBytes(); });
 
-		clog(BlockInfoDiagnosticsChannel) << "Expected trie root:" << toString(expectedRoot);
-		if (m_transactionsRoot != expectedRoot)
-		{
-			MemoryDB tm;
-			GenericTrieDB<MemoryDB> transactionsTrie(&tm);
-			transactionsTrie.init();
+        LOG(m_logger) << "Expected trie root: " << toString(expectedRoot);
+        if (m_transactionsRoot != expectedRoot)
+        {
+            MemoryDB tm;
+            GenericTrieDB<MemoryDB> transactionsTrie(&tm);
+            transactionsTrie.init();
 
-			vector<bytesConstRef> txs;
+            vector<bytesConstRef> txs;
 
-			for (unsigned i = 0; i < txList.itemCount(); ++i)
-			{
-				RLPStream k;
-				k << i;
+            for (unsigned i = 0; i < txList.itemCount(); ++i)
+            {
+                RLPStream k;
+                k << i;
 
-				transactionsTrie.insert(&k.out(), txList[i].data());
+                transactionsTrie.insert(&k.out(), txList[i].data());
 
-				txs.push_back(txList[i].data());
-				cdebug << toHex(k.out()) << toHex(txList[i].data());
-			}
-			cdebug << "trieRootOver" << expectedRoot;
-			cdebug << "orderedTrieRoot" << orderedTrieRoot(txs);
-			cdebug << "TrieDB" << transactionsTrie.root();
-			cdebug << "Contents:";
-			for (auto const& t: txs)
-				cdebug << toHex(t);
+                txs.push_back(txList[i].data());
+                cdebug << toHex(k.out()) << toHex(txList[i].data());
+            }
+            cdebug << "trieRootOver" << expectedRoot;
+            cdebug << "orderedTrieRoot" << orderedTrieRoot(txs);
+            cdebug << "TrieDB" << transactionsTrie.root();
+            cdebug << "Contents:";
+            for (auto const& t: txs)
+                cdebug << toHex(t);
 
-			BOOST_THROW_EXCEPTION(InvalidTransactionsRoot() << Hash256RequirementError(expectedRoot, m_transactionsRoot));
-		}
-		clog(BlockInfoDiagnosticsChannel) << "Expected uncle hash:" << toString(sha3(root[2].data()));
-		if (m_sha3Uncles != sha3(root[2].data()))
-			BOOST_THROW_EXCEPTION(InvalidUnclesHash() << Hash256RequirementError(sha3(root[2].data()), m_sha3Uncles));
-	}
+            BOOST_THROW_EXCEPTION(InvalidTransactionsRoot() << Hash256RequirementError(expectedRoot, m_transactionsRoot));
+        }
+        LOG(m_logger) << "Expected uncle hash: " << toString(sha3(root[2].data()));
+        if (m_sha3Uncles != sha3(root[2].data()))
+            BOOST_THROW_EXCEPTION(InvalidUnclesHash() << Hash256RequirementError(sha3(root[2].data()), m_sha3Uncles));
+    }
 }

--- a/libethcore/BlockHeader.h
+++ b/libethcore/BlockHeader.h
@@ -1,18 +1,18 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file BlockHeader.h
  * @author Gav Wood <i@gavwood.com>
@@ -21,14 +21,15 @@
 
 #pragma once
 
-#include <algorithm>
+#include "ChainOperationParams.h"
+#include "Common.h"
+#include "Exceptions.h"
 #include <libdevcore/Common.h>
+#include <libdevcore/Guards.h>
+#include <libdevcore/Log.h>
 #include <libdevcore/RLP.h>
 #include <libdevcore/SHA3.h>
-#include <libdevcore/Guards.h>
-#include "Common.h"
-#include "ChainOperationParams.h"
-#include "Exceptions.h"
+#include <algorithm>
 
 namespace dev
 {
@@ -37,37 +38,37 @@ namespace eth
 
 enum IncludeSeal
 {
-	WithoutSeal = 0,
-	WithSeal = 1,
-	OnlySeal = 2
+    WithoutSeal = 0,
+    WithSeal = 1,
+    OnlySeal = 2
 };
 
 enum Strictness
 {
-	CheckEverything,
-	JustSeal,
-	QuickNonce,
-	IgnoreSeal,
-	CheckNothingNew
+    CheckEverything,
+    JustSeal,
+    QuickNonce,
+    IgnoreSeal,
+    CheckNothingNew
 };
 
 // TODO: for implementing soon.
 /*enum Check
 {
-	CheckBasic,
-	CheckExtended,
-	CheckBlock,
-	CheckParent,
-	CheckSeal,
-	CheckSealQuickly,
-	CheckAll = CheckBasic | CheckExtended | CheckBlock | CheckParent | CheckSeal,
+    CheckBasic,
+    CheckExtended,
+    CheckBlock,
+    CheckParent,
+    CheckSeal,
+    CheckSealQuickly,
+    CheckAll = CheckBasic | CheckExtended | CheckBlock | CheckParent | CheckSeal,
 };
 using Checks = FlagSet<Check>;*/
 
 enum BlockDataType
 {
-	HeaderData,
-	BlockData
+    HeaderData,
+    BlockData
 };
 
 DEV_SIMPLE_EXCEPTION(NoHashRecorded);
@@ -95,129 +96,131 @@ DEV_SIMPLE_EXCEPTION(GenesisBlockCannotBeCalculated);
  */
 class BlockHeader
 {
-	friend class BlockChain;
+    friend class BlockChain;
 public:
-	static const unsigned BasicFields = 13;
+    static const unsigned BasicFields = 13;
 
-	BlockHeader();
-	explicit BlockHeader(bytesConstRef _data, BlockDataType _bdt = BlockData, h256 const& _hashWith = h256());
-	explicit BlockHeader(bytes const& _data, BlockDataType _bdt = BlockData, h256 const& _hashWith = h256()): BlockHeader(&_data, _bdt, _hashWith) {}
-	BlockHeader(BlockHeader const& _other);
-	BlockHeader& operator=(BlockHeader const& _other);
+    BlockHeader();
+    explicit BlockHeader(bytesConstRef _data, BlockDataType _bdt = BlockData, h256 const& _hashWith = h256());
+    explicit BlockHeader(bytes const& _data, BlockDataType _bdt = BlockData, h256 const& _hashWith = h256()): BlockHeader(&_data, _bdt, _hashWith) {}
+    BlockHeader(BlockHeader const& _other);
+    BlockHeader& operator=(BlockHeader const& _other);
 
-	static h256 headerHashFromBlock(bytes const& _block) { return headerHashFromBlock(&_block); }
-	static h256 headerHashFromBlock(bytesConstRef _block);
-	static RLP extractHeader(bytesConstRef _block);
+    static h256 headerHashFromBlock(bytes const& _block) { return headerHashFromBlock(&_block); }
+    static h256 headerHashFromBlock(bytesConstRef _block);
+    static RLP extractHeader(bytesConstRef _block);
 
-	explicit operator bool() const { return m_timestamp != Invalid256; }
+    explicit operator bool() const { return m_timestamp != Invalid256; }
 
-	bool operator==(BlockHeader const& _cmp) const
-	{
-		return m_parentHash == _cmp.parentHash() &&
-			m_sha3Uncles == _cmp.sha3Uncles() &&
-			m_author == _cmp.author() &&
-			m_stateRoot == _cmp.stateRoot() &&
-			m_transactionsRoot == _cmp.transactionsRoot() &&
-			m_receiptsRoot == _cmp.receiptsRoot() &&
-			m_logBloom == _cmp.logBloom() &&
-			m_difficulty == _cmp.difficulty() &&
-			m_number == _cmp.number() &&
-			m_gasLimit == _cmp.gasLimit() &&
-			m_gasUsed == _cmp.gasUsed() &&
-			m_timestamp == _cmp.timestamp() &&
-			m_extraData == _cmp.extraData();
-	}
-	bool operator!=(BlockHeader const& _cmp) const { return !operator==(_cmp); }
+    bool operator==(BlockHeader const& _cmp) const
+    {
+        return m_parentHash == _cmp.parentHash() &&
+            m_sha3Uncles == _cmp.sha3Uncles() &&
+            m_author == _cmp.author() &&
+            m_stateRoot == _cmp.stateRoot() &&
+            m_transactionsRoot == _cmp.transactionsRoot() &&
+            m_receiptsRoot == _cmp.receiptsRoot() &&
+            m_logBloom == _cmp.logBloom() &&
+            m_difficulty == _cmp.difficulty() &&
+            m_number == _cmp.number() &&
+            m_gasLimit == _cmp.gasLimit() &&
+            m_gasUsed == _cmp.gasUsed() &&
+            m_timestamp == _cmp.timestamp() &&
+            m_extraData == _cmp.extraData();
+    }
+    bool operator!=(BlockHeader const& _cmp) const { return !operator==(_cmp); }
 
-	void clear();
-	void noteDirty() const { Guard l(m_hashLock); m_hashWithout = m_hash = h256(); }
-	void populateFromParent(BlockHeader const& parent);
+    void clear();
+    void noteDirty() const { Guard l(m_hashLock); m_hashWithout = m_hash = h256(); }
+    void populateFromParent(BlockHeader const& parent);
 
-	// TODO: pull out into abstract class Verifier.
-	void verify(Strictness _s = CheckEverything, BlockHeader const& _parent = BlockHeader(), bytesConstRef _block = bytesConstRef()) const;
-	void verify(Strictness _s, bytesConstRef _block) const { verify(_s, BlockHeader(), _block); }
+    // TODO: pull out into abstract class Verifier.
+    void verify(Strictness _s = CheckEverything, BlockHeader const& _parent = BlockHeader(), bytesConstRef _block = bytesConstRef()) const;
+    void verify(Strictness _s, bytesConstRef _block) const { verify(_s, BlockHeader(), _block); }
 
-	h256 hash(IncludeSeal _i = WithSeal) const;
-	void streamRLP(RLPStream& _s, IncludeSeal _i = WithSeal) const;
+    h256 hash(IncludeSeal _i = WithSeal) const;
+    void streamRLP(RLPStream& _s, IncludeSeal _i = WithSeal) const;
 
-	void setParentHash(h256 const& _v) { m_parentHash = _v; noteDirty(); }
-	void setSha3Uncles(h256 const& _v) { m_sha3Uncles = _v; noteDirty(); }
-	void setTimestamp(int64_t _v) { m_timestamp = _v; noteDirty(); }
-	void setAuthor(Address const& _v) { m_author = _v; noteDirty(); }
-	void setRoots(h256 const& _t, h256 const& _r, h256 const& _u, h256 const& _s) { m_transactionsRoot = _t; m_receiptsRoot = _r; m_stateRoot = _s; m_sha3Uncles = _u; noteDirty(); }
-	void setGasUsed(u256 const& _v) { m_gasUsed = _v; noteDirty(); }
-	void setNumber(int64_t _v) { m_number = _v; noteDirty(); }
-	void setGasLimit(u256 const& _v) { m_gasLimit = _v; noteDirty(); }
-	void setExtraData(bytes const& _v) { m_extraData = _v; noteDirty(); }
-	void setLogBloom(LogBloom const& _v) { m_logBloom = _v; noteDirty(); }
-	void setDifficulty(u256 const& _v) { m_difficulty = _v; noteDirty(); }
-	template <class T> void setSeal(unsigned _offset, T const& _value) { Guard l(m_sealLock); if (m_seal.size() <= _offset) m_seal.resize(_offset + 1); m_seal[_offset] = rlp(_value); noteDirty(); }
-	template <class T> void setSeal(T const& _value) { setSeal(0, _value); }
+    void setParentHash(h256 const& _v) { m_parentHash = _v; noteDirty(); }
+    void setSha3Uncles(h256 const& _v) { m_sha3Uncles = _v; noteDirty(); }
+    void setTimestamp(int64_t _v) { m_timestamp = _v; noteDirty(); }
+    void setAuthor(Address const& _v) { m_author = _v; noteDirty(); }
+    void setRoots(h256 const& _t, h256 const& _r, h256 const& _u, h256 const& _s) { m_transactionsRoot = _t; m_receiptsRoot = _r; m_stateRoot = _s; m_sha3Uncles = _u; noteDirty(); }
+    void setGasUsed(u256 const& _v) { m_gasUsed = _v; noteDirty(); }
+    void setNumber(int64_t _v) { m_number = _v; noteDirty(); }
+    void setGasLimit(u256 const& _v) { m_gasLimit = _v; noteDirty(); }
+    void setExtraData(bytes const& _v) { m_extraData = _v; noteDirty(); }
+    void setLogBloom(LogBloom const& _v) { m_logBloom = _v; noteDirty(); }
+    void setDifficulty(u256 const& _v) { m_difficulty = _v; noteDirty(); }
+    template <class T> void setSeal(unsigned _offset, T const& _value) { Guard l(m_sealLock); if (m_seal.size() <= _offset) m_seal.resize(_offset + 1); m_seal[_offset] = rlp(_value); noteDirty(); }
+    template <class T> void setSeal(T const& _value) { setSeal(0, _value); }
 
-	h256 const& parentHash() const { return m_parentHash; }
-	h256 const& sha3Uncles() const { return m_sha3Uncles; }
-	bool hasUncles() const { return m_sha3Uncles != EmptyListSHA3; }
-	int64_t timestamp() const { return m_timestamp; }
-	Address const& author() const { return m_author; }
-	h256 const& stateRoot() const { return m_stateRoot; }
-	h256 const& transactionsRoot() const { return m_transactionsRoot; }
-	h256 const& receiptsRoot() const { return m_receiptsRoot; }
-	u256 const& gasUsed() const { return m_gasUsed; }
-	int64_t number() const { return m_number; }
-	u256 const& gasLimit() const { return m_gasLimit; }
-	bytes const& extraData() const { return m_extraData; }
-	LogBloom const& logBloom() const { return m_logBloom; }
-	u256 const& difficulty() const { return m_difficulty; }
-	template <class T> T seal(unsigned _offset = 0) const { T ret; Guard l(m_sealLock); if (_offset < m_seal.size()) ret = RLP(m_seal[_offset]).convert<T>(RLP::VeryStrict); return ret; }
+    h256 const& parentHash() const { return m_parentHash; }
+    h256 const& sha3Uncles() const { return m_sha3Uncles; }
+    bool hasUncles() const { return m_sha3Uncles != EmptyListSHA3; }
+    int64_t timestamp() const { return m_timestamp; }
+    Address const& author() const { return m_author; }
+    h256 const& stateRoot() const { return m_stateRoot; }
+    h256 const& transactionsRoot() const { return m_transactionsRoot; }
+    h256 const& receiptsRoot() const { return m_receiptsRoot; }
+    u256 const& gasUsed() const { return m_gasUsed; }
+    int64_t number() const { return m_number; }
+    u256 const& gasLimit() const { return m_gasLimit; }
+    bytes const& extraData() const { return m_extraData; }
+    LogBloom const& logBloom() const { return m_logBloom; }
+    u256 const& difficulty() const { return m_difficulty; }
+    template <class T> T seal(unsigned _offset = 0) const { T ret; Guard l(m_sealLock); if (_offset < m_seal.size()) ret = RLP(m_seal[_offset]).convert<T>(RLP::VeryStrict); return ret; }
 
 private:
-	void populate(RLP const& _header);
-	void streamRLPFields(RLPStream& _s) const;
-	std::vector<bytes> seal() const
-	{
-		Guard l(m_sealLock);
-		return m_seal;
-	}
-	h256 hashRawRead() const
-	{
-		Guard l(m_hashLock);
-		return m_hash;
-	}
-	h256 hashWithoutRawRead() const
-	{
-		Guard l(m_hashLock);
-		return m_hashWithout;
-	}
+    void populate(RLP const& _header);
+    void streamRLPFields(RLPStream& _s) const;
+    std::vector<bytes> seal() const
+    {
+        Guard l(m_sealLock);
+        return m_seal;
+    }
+    h256 hashRawRead() const
+    {
+        Guard l(m_hashLock);
+        return m_hash;
+    }
+    h256 hashWithoutRawRead() const
+    {
+        Guard l(m_hashLock);
+        return m_hashWithout;
+    }
 
-	h256 m_parentHash;
-	h256 m_sha3Uncles;
-	h256 m_stateRoot;
-	h256 m_transactionsRoot;
-	h256 m_receiptsRoot;
-	LogBloom m_logBloom;
-	int64_t m_number = 0;
-	u256 m_gasLimit;
-	u256 m_gasUsed;
-	bytes m_extraData;
-	int64_t m_timestamp = -1;
+    h256 m_parentHash;
+    h256 m_sha3Uncles;
+    h256 m_stateRoot;
+    h256 m_transactionsRoot;
+    h256 m_receiptsRoot;
+    LogBloom m_logBloom;
+    int64_t m_number = 0;
+    u256 m_gasLimit;
+    u256 m_gasUsed;
+    bytes m_extraData;
+    int64_t m_timestamp = -1;
 
-	Address m_author;
-	u256 m_difficulty;
+    Address m_author;
+    u256 m_difficulty;
 
-	std::vector<bytes> m_seal;		///< Additional (RLP-encoded) header fields.
-	mutable Mutex m_sealLock;
+    std::vector<bytes> m_seal;		///< Additional (RLP-encoded) header fields.
+    mutable Mutex m_sealLock;
 
-	mutable h256 m_hash;			///< (Memoised) SHA3 hash of the block header with seal.
-	mutable h256 m_hashWithout;		///< (Memoised) SHA3 hash of the block header without seal.
-	mutable Mutex m_hashLock;		///< A lock for both m_hash and m_hashWithout.
+    mutable h256 m_hash;			///< (Memoised) SHA3 hash of the block header with seal.
+    mutable h256 m_hashWithout;		///< (Memoised) SHA3 hash of the block header without seal.
+    mutable Mutex m_hashLock;		///< A lock for both m_hash and m_hashWithout.
+
+    mutable Logger m_logger{createLogger(9, "blockhdr")};
 };
 
 inline std::ostream& operator<<(std::ostream& _out, BlockHeader const& _bi)
 {
-	_out << _bi.hash(WithoutSeal) << " " << _bi.parentHash() << " " << _bi.sha3Uncles() << " " << _bi.author() << " " << _bi.stateRoot() << " " << _bi.transactionsRoot() << " " <<
-			_bi.receiptsRoot() << " " << _bi.logBloom() << " " << _bi.difficulty() << " " << _bi.number() << " " << _bi.gasLimit() << " " <<
-			_bi.gasUsed() << " " << _bi.timestamp();
-	return _out;
+    _out << _bi.hash(WithoutSeal) << " " << _bi.parentHash() << " " << _bi.sha3Uncles() << " " << _bi.author() << " " << _bi.stateRoot() << " " << _bi.transactionsRoot() << " " <<
+            _bi.receiptsRoot() << " " << _bi.logBloom() << " " << _bi.difficulty() << " " << _bi.number() << " " << _bi.gasLimit() << " " <<
+            _bi.gasUsed() << " " << _bi.timestamp();
+    return _out;
 }
 
 }

--- a/libethereum/Executive.cpp
+++ b/libethereum/Executive.cpp
@@ -258,7 +258,8 @@ bool Executive::execute()
     // Entry point for a user-executed transaction.
 
     // Pay...
-    clog(StateDetail) << "Paying " << formatBalance(m_gasCost) << " from sender for gas (" << m_t.gas() << " gas at " << formatBalance(m_t.gasPrice()) << ")";
+    LOG(m_detailsLogger) << "Paying " << formatBalance(m_gasCost) << " from sender for gas ("
+                         << m_t.gas() << " gas at " << formatBalance(m_t.gasPrice()) << ")";
     m_s.subBalance(m_t.sender(), m_gasCost);
 
     if (m_t.isCreation())
@@ -373,7 +374,7 @@ bool Executive::executeCreate(Address const& _sender, u256 const& _endowment, u2
     bool accountAlreadyExist = (m_s.addressHasCode(m_newAddress) || m_s.getNonce(m_newAddress) > 0);
     if (accountAlreadyExist)
     {
-        clog(StateSafeExceptions) << "Address already used: " << m_newAddress;
+        LOG(m_detailsLogger) << "Address already used: " << m_newAddress;
         m_gas = 0;
         m_excepted = TransactionException::AddressAlreadyUsed;
         revert();
@@ -473,7 +474,7 @@ bool Executive::go(OnOpFunc const& _onOp)
         }
         catch (VMException const& _e)
         {
-            clog(StateSafeExceptions) << "Safe VM Exception. " << diagnostic_information(_e);
+            LOG(m_detailsLogger) << "Safe VM Exception. " << diagnostic_information(_e);
             m_gas = 0;
             m_excepted = toTransactionException(_e);
             revert();

--- a/libethereum/Executive.h
+++ b/libethereum/Executive.h
@@ -211,6 +211,7 @@ private:
     size_t m_savepoint = 0;
 
     Logger m_execLogger{createLogger(1, "exec")};
+    Logger m_detailsLogger{createLogger(14, "exec")};
     Logger m_vmTraceLogger{createLogger(11, "vmtrace")};
 };
 

--- a/libethereum/State.cpp
+++ b/libethereum/State.cpp
@@ -38,9 +38,6 @@ using namespace dev;
 using namespace dev::eth;
 namespace fs = boost::filesystem;
 
-const char* StateSafeExceptions::name() { return EthViolet "⚙" EthBlue " ℹ"; }
-const char* StateDetail::name() { return EthViolet "⚙" EthWhite " ◌"; }
-
 namespace
 {
 
@@ -82,7 +79,7 @@ OverlayDB State::openDB(fs::path const& _basePath, h256 const& _genesisHash, Wit
 
     if (_we == WithExisting::Kill)
     {
-        clog(StateDetail) << "Killing state database (WithExisting::Kill).";
+        clogSimple(14, "statedb") << "Killing state database (WithExisting::Kill).";
         fs::remove_all(path / fs::path("state"));
     }
 
@@ -93,7 +90,7 @@ OverlayDB State::openDB(fs::path const& _basePath, h256 const& _genesisHash, Wit
     try
     {
         std::unique_ptr<db::DatabaseFace> db(new db::DBImpl(path / fs::path("state")));
-        clog(StateDetail) << "Opened state DB.";
+        clogSimple(14, "statedb") << "Opened state DB.";
         return OverlayDB(std::move(db));
     }
     catch (boost::exception const& ex)

--- a/libethereum/State.h
+++ b/libethereum/State.h
@@ -63,9 +63,6 @@ class State;
 class TransactionQueue;
 struct VerifiedBlockRef;
 
-struct StateDetail: public LogChannel { static const char* name(); static const int verbosity = 14; };
-struct StateSafeExceptions: public LogChannel { static const char* name(); static const int verbosity = 21; };
-
 enum class BaseState
 {
     PreExisting,


### PR DESCRIPTION
Also added a simple macro for sending a log message without creating a Logger like this:
```
clogSimple(4, "channel") << "message";
```
I want to rename it to just `clog`, but I need to get rid of the old `clog` macro first (that won't happen before switching most of the log statements to the new system)