### PR TITLE
Refactor logging - libp2p

### DIFF
--- a/libethereum/EthereumHost.cpp
+++ b/libethereum/EthereumHost.cpp
@@ -178,9 +178,9 @@ public:
         if (_blockId.size() == 32) // block id is a hash
         {
             blockHash = _blockId.toHash<h256>();
-            cnetmessage << "GetBlockHeaders (block (hash): " << blockHash
-                << ", maxHeaders: " << _maxHeaders
-                << ", skip: " << _skip << ", reverse: " << _reverse << ")";
+            cnetlog << "GetBlockHeaders (block (hash): " << blockHash
+                    << ", maxHeaders: " << _maxHeaders << ", skip: " << _skip
+                    << ", reverse: " << _reverse << ")";
 
             if (!m_chain.isKnown(blockHash))
                 blockHash = {};
@@ -208,9 +208,8 @@ public:
         else // block id is a number
         {
             auto n = _blockId.toInt<bigint>();
-            cnetmessage << "GetBlockHeaders (" << n
-            << " max: " << _maxHeaders
-            << " skip: " << _skip << (_reverse ? " reverse" : "") << ")";
+            cnetlog << "GetBlockHeaders (" << n << " max: " << _maxHeaders << " skip: " << _skip
+                    << (_reverse ? " reverse" : "") << ")";
 
             if (!_reverse)
             {
@@ -310,9 +309,9 @@ public:
         if (count > 20 && n == 0)
             cnetwarn << "all " << count << " unknown blocks requested; peer on different chain?";
         else
-            cnetmessage
-                << n << " blocks known and returned; " << (numBodiesToSend - n) << " blocks unknown; "
-                << (count > c_maxBlocks ? count - c_maxBlocks : 0) << " blocks ignored";
+            cnetlog << n << " blocks known and returned; " << (numBodiesToSend - n)
+                    << " blocks unknown; " << (count > c_maxBlocks ? count - c_maxBlocks : 0)
+                    << " blocks ignored";
 
         return make_pair(rlp, n);
     }
@@ -334,7 +333,8 @@ public:
                 data.push_back(move(node));
             }
         }
-        cnetmessage << data.size() << " nodes known and returned; " << (numItemsToSend - data.size()) << " unknown; " << (count > c_maxNodes ? count - c_maxNodes : 0) << " ignored";
+        cnetlog << data.size() << " nodes known and returned; " << (numItemsToSend - data.size())
+                << " unknown; " << (count > c_maxNodes ? count - c_maxNodes : 0) << " ignored";
 
         return data;
     }
@@ -357,7 +357,9 @@ public:
                 ++n;
             }
         }
-        cnetmessage << n << " receipt lists known and returned; " << (numItemsToSend - n) << " unknown; " << (count > c_maxReceipts ? count - c_maxReceipts : 0) << " ignored";
+        cnetlog << n << " receipt lists known and returned; " << (numItemsToSend - n)
+                << " unknown; " << (count > c_maxReceipts ? count - c_maxReceipts : 0)
+                << " ignored";
 
         return make_pair(rlp, n);
     }

--- a/libethereum/EthereumHost.cpp
+++ b/libethereum/EthereumHost.cpp
@@ -1,18 +1,18 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file EthereumHost.cpp
  * @author Gav Wood <i@gavwood.com>
@@ -54,599 +54,601 @@ namespace
 class EthereumPeerObserver: public EthereumPeerObserverFace
 {
 public:
-	EthereumPeerObserver(shared_ptr<BlockChainSync> _sync, TransactionQueue& _tq): m_sync(_sync), m_tq(_tq) {}
+    EthereumPeerObserver(shared_ptr<BlockChainSync> _sync, TransactionQueue& _tq): m_sync(_sync), m_tq(_tq) {}
 
-	void onPeerStatus(std::shared_ptr<EthereumPeer> _peer) override
-	{
-		try
-		{
-			m_sync->onPeerStatus(_peer);
-		}
-		catch (FailedInvariant const&)
-		{
-			// "fix" for https://github.com/ethereum/webthree-umbrella/issues/300
-			clog(NetWarn) << "Failed invariant during sync, restarting sync";
-			m_sync->restartSync();
-		}
-	}
+    void onPeerStatus(std::shared_ptr<EthereumPeer> _peer) override
+    {
+        try
+        {
+            m_sync->onPeerStatus(_peer);
+        }
+        catch (FailedInvariant const&)
+        {
+            // "fix" for https://github.com/ethereum/webthree-umbrella/issues/300
+            cnetwarn << "Failed invariant during sync, restarting sync";
+            m_sync->restartSync();
+        }
+    }
 
-	void onPeerTransactions(std::shared_ptr<EthereumPeer> _peer, RLP const& _r) override
-	{
-		unsigned itemCount = _r.itemCount();
-		clog(EthereumHostTrace) << "Transactions (" << dec << itemCount << "entries)";
-		m_tq.enqueue(_r, _peer->id());
-	}
+    void onPeerTransactions(std::shared_ptr<EthereumPeer> _peer, RLP const& _r) override
+    {
+        unsigned itemCount = _r.itemCount();
+        clog(EthereumHostTrace) << "Transactions (" << dec << itemCount << "entries)";
+        m_tq.enqueue(_r, _peer->id());
+    }
 
-	void onPeerAborting() override
-	{
-		try
-		{
-			m_sync->onPeerAborting();
-		}
-		catch (Exception&)
-		{
-			cwarn << "Exception on peer destruciton: " << boost::current_exception_diagnostic_information();
-		}
-	}
+    void onPeerAborting() override
+    {
+        try
+        {
+            m_sync->onPeerAborting();
+        }
+        catch (Exception&)
+        {
+            cwarn << "Exception on peer destruciton: " << boost::current_exception_diagnostic_information();
+        }
+    }
 
-	void onPeerBlockHeaders(std::shared_ptr<EthereumPeer> _peer, RLP const& _headers) override
-	{
-		try
-		{
-			m_sync->onPeerBlockHeaders(_peer, _headers);
-		}
-		catch (FailedInvariant const&)
-		{
-			// "fix" for https://github.com/ethereum/webthree-umbrella/issues/300
-			clog(NetWarn) << "Failed invariant during sync, restarting sync";
-			m_sync->restartSync();
-		}
-	}
+    void onPeerBlockHeaders(std::shared_ptr<EthereumPeer> _peer, RLP const& _headers) override
+    {
+        try
+        {
+            m_sync->onPeerBlockHeaders(_peer, _headers);
+        }
+        catch (FailedInvariant const&)
+        {
+            // "fix" for https://github.com/ethereum/webthree-umbrella/issues/300
+            cnetwarn << "Failed invariant during sync, restarting sync";
+            m_sync->restartSync();
+        }
+    }
 
-	void onPeerBlockBodies(std::shared_ptr<EthereumPeer> _peer, RLP const& _r) override
-	{
-		try
-		{
-			m_sync->onPeerBlockBodies(_peer, _r);
-		}
-		catch (FailedInvariant const&)
-		{
-			// "fix" for https://github.com/ethereum/webthree-umbrella/issues/300
-			clog(NetWarn) << "Failed invariant during sync, restarting sync";
-			m_sync->restartSync();
-		}
-	}
+    void onPeerBlockBodies(std::shared_ptr<EthereumPeer> _peer, RLP const& _r) override
+    {
+        try
+        {
+            m_sync->onPeerBlockBodies(_peer, _r);
+        }
+        catch (FailedInvariant const&)
+        {
+            // "fix" for https://github.com/ethereum/webthree-umbrella/issues/300
+            cnetwarn << "Failed invariant during sync, restarting sync";
+            m_sync->restartSync();
+        }
+    }
 
-	void onPeerNewHashes(std::shared_ptr<EthereumPeer> _peer, std::vector<std::pair<h256, u256>> const& _hashes) override
-	{
-		try
-		{
-			m_sync->onPeerNewHashes(_peer, _hashes);
-		}
-		catch (FailedInvariant const&)
-		{
-			// "fix" for https://github.com/ethereum/webthree-umbrella/issues/300
-			clog(NetWarn) << "Failed invariant during sync, restarting sync";
-			m_sync->restartSync();
-		}
-	}
+    void onPeerNewHashes(std::shared_ptr<EthereumPeer> _peer, std::vector<std::pair<h256, u256>> const& _hashes) override
+    {
+        try
+        {
+            m_sync->onPeerNewHashes(_peer, _hashes);
+        }
+        catch (FailedInvariant const&)
+        {
+            // "fix" for https://github.com/ethereum/webthree-umbrella/issues/300
+            cnetwarn << "Failed invariant during sync, restarting sync";
+            m_sync->restartSync();
+        }
+    }
 
-	void onPeerNewBlock(std::shared_ptr<EthereumPeer> _peer, RLP const& _r) override
-	{
-		try
-		{
-			m_sync->onPeerNewBlock(_peer, _r);
-		}
-		catch (FailedInvariant const&)
-		{
-			// "fix" for https://github.com/ethereum/webthree-umbrella/issues/300
-			clog(NetWarn) << "Failed invariant during sync, restarting sync";
-			m_sync->restartSync();
-		}
-	}
+    void onPeerNewBlock(std::shared_ptr<EthereumPeer> _peer, RLP const& _r) override
+    {
+        try
+        {
+            m_sync->onPeerNewBlock(_peer, _r);
+        }
+        catch (FailedInvariant const&)
+        {
+            // "fix" for https://github.com/ethereum/webthree-umbrella/issues/300
+            cnetwarn << "Failed invariant during sync, restarting sync";
+            m_sync->restartSync();
+        }
+    }
 
-	void onPeerNodeData(std::shared_ptr<EthereumPeer> /* _peer */, RLP const& _r) override
-	{
-		unsigned itemCount = _r.itemCount();
-		clog(EthereumHostTrace) << "Node Data (" << dec << itemCount << "entries)";
-	}
+    void onPeerNodeData(std::shared_ptr<EthereumPeer> /* _peer */, RLP const& _r) override
+    {
+        unsigned itemCount = _r.itemCount();
+        clog(EthereumHostTrace) << "Node Data (" << dec << itemCount << "entries)";
+    }
 
-	void onPeerReceipts(std::shared_ptr<EthereumPeer> /* _peer */, RLP const& _r) override
-	{
-		unsigned itemCount = _r.itemCount();
-		clog(EthereumHostTrace) << "Receipts (" << dec << itemCount << "entries)";
-	}
+    void onPeerReceipts(std::shared_ptr<EthereumPeer> /* _peer */, RLP const& _r) override
+    {
+        unsigned itemCount = _r.itemCount();
+        clog(EthereumHostTrace) << "Receipts (" << dec << itemCount << "entries)";
+    }
 
 private:
-	shared_ptr<BlockChainSync> m_sync;
-	TransactionQueue& m_tq;
+    shared_ptr<BlockChainSync> m_sync;
+    TransactionQueue& m_tq;
 };
 
 class EthereumHostData: public EthereumHostDataFace
 {
 public:
-	EthereumHostData(BlockChain const& _chain, OverlayDB const& _db): m_chain(_chain), m_db(_db) {}
+    EthereumHostData(BlockChain const& _chain, OverlayDB const& _db): m_chain(_chain), m_db(_db) {}
 
-	pair<bytes, unsigned> blockHeaders(RLP const& _blockId, unsigned _maxHeaders, u256 _skip, bool _reverse) const override
-	{
-		auto numHeadersToSend = _maxHeaders;
+    pair<bytes, unsigned> blockHeaders(RLP const& _blockId, unsigned _maxHeaders, u256 _skip, bool _reverse) const override
+    {
+        auto numHeadersToSend = _maxHeaders;
 
-		auto step = static_cast<unsigned>(_skip) + 1;
-		assert(step > 0 && "step must not be 0");
+        auto step = static_cast<unsigned>(_skip) + 1;
+        assert(step > 0 && "step must not be 0");
 
-		h256 blockHash;
-		if (_blockId.size() == 32) // block id is a hash
-		{
-			blockHash = _blockId.toHash<h256>();
-			clog(NetMessageSummary) << "GetBlockHeaders (block (hash): " << blockHash
-				<< ", maxHeaders: " << _maxHeaders
-				<< ", skip: " << _skip << ", reverse: " << _reverse << ")";
+        h256 blockHash;
+        if (_blockId.size() == 32) // block id is a hash
+        {
+            blockHash = _blockId.toHash<h256>();
+            clog(NetMessageSummary) << "GetBlockHeaders (block (hash): " << blockHash
+                << ", maxHeaders: " << _maxHeaders
+                << ", skip: " << _skip << ", reverse: " << _reverse << ")";
 
-			if (!m_chain.isKnown(blockHash))
-				blockHash = {};
-			else if (!_reverse)
-			{
-				auto n = m_chain.number(blockHash);
-				if (numHeadersToSend == 0)
-					blockHash = {};
-				else if (n != 0 || blockHash == m_chain.genesisHash())
-				{
-					auto top = n + uint64_t(step) * numHeadersToSend - 1;
-					auto lastBlock = m_chain.number();
-					if (top > lastBlock)
-					{
-						numHeadersToSend = (lastBlock - n) / step + 1;
-						top = n + step * (numHeadersToSend - 1);
-					}
-					assert(top <= lastBlock && "invalid top block calculated");
-					blockHash = m_chain.numberHash(static_cast<unsigned>(top)); // override start block hash with the hash of the top block we have
-				}
-				else
-					blockHash = {};
-			}
-		}
-		else // block id is a number
-		{
-			auto n = _blockId.toInt<bigint>();
-			clog(NetMessageSummary) << "GetBlockHeaders (" << n
-			<< "max: " << _maxHeaders
-			<< "skip: " << _skip << (_reverse ? "reverse" : "") << ")";
+            if (!m_chain.isKnown(blockHash))
+                blockHash = {};
+            else if (!_reverse)
+            {
+                auto n = m_chain.number(blockHash);
+                if (numHeadersToSend == 0)
+                    blockHash = {};
+                else if (n != 0 || blockHash == m_chain.genesisHash())
+                {
+                    auto top = n + uint64_t(step) * numHeadersToSend - 1;
+                    auto lastBlock = m_chain.number();
+                    if (top > lastBlock)
+                    {
+                        numHeadersToSend = (lastBlock - n) / step + 1;
+                        top = n + step * (numHeadersToSend - 1);
+                    }
+                    assert(top <= lastBlock && "invalid top block calculated");
+                    blockHash = m_chain.numberHash(static_cast<unsigned>(top)); // override start block hash with the hash of the top block we have
+                }
+                else
+                    blockHash = {};
+            }
+        }
+        else // block id is a number
+        {
+            auto n = _blockId.toInt<bigint>();
+            clog(NetMessageSummary) << "GetBlockHeaders (" << n
+            << "max: " << _maxHeaders
+            << "skip: " << _skip << (_reverse ? "reverse" : "") << ")";
 
-			if (!_reverse)
-			{
-				auto lastBlock = m_chain.number();
-				if (n > lastBlock || numHeadersToSend == 0)
-					blockHash = {};
-				else
-				{
-					bigint top = n + uint64_t(step) * (numHeadersToSend - 1);
-					if (top > lastBlock)
-					{
-						numHeadersToSend = (lastBlock - static_cast<unsigned>(n)) / step + 1;
-						top = n + step * (numHeadersToSend - 1);
-					}
-					assert(top <= lastBlock && "invalid top block calculated");
-					blockHash = m_chain.numberHash(static_cast<unsigned>(top)); // override start block hash with the hash of the top block we have
-				}
-			}
-			else if (n <= std::numeric_limits<unsigned>::max())
-				blockHash = m_chain.numberHash(static_cast<unsigned>(n));
-			else
-				blockHash = {};
-		}
+            if (!_reverse)
+            {
+                auto lastBlock = m_chain.number();
+                if (n > lastBlock || numHeadersToSend == 0)
+                    blockHash = {};
+                else
+                {
+                    bigint top = n + uint64_t(step) * (numHeadersToSend - 1);
+                    if (top > lastBlock)
+                    {
+                        numHeadersToSend = (lastBlock - static_cast<unsigned>(n)) / step + 1;
+                        top = n + step * (numHeadersToSend - 1);
+                    }
+                    assert(top <= lastBlock && "invalid top block calculated");
+                    blockHash = m_chain.numberHash(static_cast<unsigned>(top)); // override start block hash with the hash of the top block we have
+                }
+            }
+            else if (n <= std::numeric_limits<unsigned>::max())
+                blockHash = m_chain.numberHash(static_cast<unsigned>(n));
+            else
+                blockHash = {};
+        }
 
-		auto nextHash = [this](h256 _h, unsigned _step)
-		{
-			static const unsigned c_blockNumberUsageLimit = 1000;
+        auto nextHash = [this](h256 _h, unsigned _step)
+        {
+            static const unsigned c_blockNumberUsageLimit = 1000;
 
-			const auto lastBlock = m_chain.number();
-			const auto limitBlock = lastBlock > c_blockNumberUsageLimit ? lastBlock - c_blockNumberUsageLimit : 0; // find the number of the block below which we don't expect BC changes.
+            const auto lastBlock = m_chain.number();
+            const auto limitBlock = lastBlock > c_blockNumberUsageLimit ? lastBlock - c_blockNumberUsageLimit : 0; // find the number of the block below which we don't expect BC changes.
 
-			while (_step) // parent hash traversal
-			{
-				auto details = m_chain.details(_h);
-				if (details.number < limitBlock)
-					break; // stop using parent hash traversal, fallback to using block numbers
-				_h = details.parent;
-				--_step;
-			}
+            while (_step) // parent hash traversal
+            {
+                auto details = m_chain.details(_h);
+                if (details.number < limitBlock)
+                    break; // stop using parent hash traversal, fallback to using block numbers
+                _h = details.parent;
+                --_step;
+            }
 
-			if (_step) // still need lower block
-			{
-				auto n = m_chain.number(_h);
-				if (n >= _step)
-					_h = m_chain.numberHash(n - _step);
-				else
-					_h = {};
-			}
+            if (_step) // still need lower block
+            {
+                auto n = m_chain.number(_h);
+                if (n >= _step)
+                    _h = m_chain.numberHash(n - _step);
+                else
+                    _h = {};
+            }
 
 
-			return _h;
-		};
+            return _h;
+        };
 
-		bytes rlp;
-		unsigned itemCount = 0;
-		vector<h256> hashes;
-		for (unsigned i = 0; i != numHeadersToSend; ++i)
-		{
-			if (!blockHash || !m_chain.isKnown(blockHash))
-				break;
+        bytes rlp;
+        unsigned itemCount = 0;
+        vector<h256> hashes;
+        for (unsigned i = 0; i != numHeadersToSend; ++i)
+        {
+            if (!blockHash || !m_chain.isKnown(blockHash))
+                break;
 
-			hashes.push_back(blockHash);
-			++itemCount;
+            hashes.push_back(blockHash);
+            ++itemCount;
 
-			blockHash = nextHash(blockHash, step);
-		}
+            blockHash = nextHash(blockHash, step);
+        }
 
-		for (unsigned i = 0; i < hashes.size() && rlp.size() < c_maxPayload; ++i)
-			rlp += m_chain.headerData(hashes[_reverse ? i : hashes.size() - 1 - i]);
+        for (unsigned i = 0; i < hashes.size() && rlp.size() < c_maxPayload; ++i)
+            rlp += m_chain.headerData(hashes[_reverse ? i : hashes.size() - 1 - i]);
 
-		return make_pair(rlp, itemCount);
-	}
+        return make_pair(rlp, itemCount);
+    }
 
-	pair<bytes, unsigned> blockBodies(RLP const& _blockHashes) const override
-	{
-		unsigned const count = static_cast<unsigned>(_blockHashes.itemCount());
+    pair<bytes, unsigned> blockBodies(RLP const& _blockHashes) const override
+    {
+        unsigned const count = static_cast<unsigned>(_blockHashes.itemCount());
 
-		bytes rlp;
-		unsigned n = 0;
-		auto numBodiesToSend = std::min(count, c_maxBlocks);
-		for (unsigned i = 0; i < numBodiesToSend && rlp.size() < c_maxPayload; ++i)
-		{
-			auto h = _blockHashes[i].toHash<h256>();
-			if (m_chain.isKnown(h))
-			{
-				bytes blockBytes = m_chain.block(h);
-				RLP block{blockBytes};
-				RLPStream body;
-				body.appendList(2);
-				body.appendRaw(block[1].data()); // transactions
-				body.appendRaw(block[2].data()); // uncles
-				auto bodyBytes = body.out();
-				rlp.insert(rlp.end(), bodyBytes.begin(), bodyBytes.end());
-				++n;
-			}
-		}
-		if (count > 20 && n == 0)
-			clog(NetWarn) << "all" << count << "unknown blocks requested; peer on different chain?";
-		else
-			clog(NetMessageSummary) << n << "blocks known and returned;" << (numBodiesToSend - n) << "blocks unknown;" << (count > c_maxBlocks ? count - c_maxBlocks : 0) << "blocks ignored";
+        bytes rlp;
+        unsigned n = 0;
+        auto numBodiesToSend = std::min(count, c_maxBlocks);
+        for (unsigned i = 0; i < numBodiesToSend && rlp.size() < c_maxPayload; ++i)
+        {
+            auto h = _blockHashes[i].toHash<h256>();
+            if (m_chain.isKnown(h))
+            {
+                bytes blockBytes = m_chain.block(h);
+                RLP block{blockBytes};
+                RLPStream body;
+                body.appendList(2);
+                body.appendRaw(block[1].data()); // transactions
+                body.appendRaw(block[2].data()); // uncles
+                auto bodyBytes = body.out();
+                rlp.insert(rlp.end(), bodyBytes.begin(), bodyBytes.end());
+                ++n;
+            }
+        }
+        if (count > 20 && n == 0)
+            cnetwarn << "all " << count << " unknown blocks requested; peer on different chain?";
+        else
+            clog(NetMessageSummary)
+                << n << "blocks known and returned;" << (numBodiesToSend - n) << "blocks unknown;"
+                << (count > c_maxBlocks ? count - c_maxBlocks : 0) << "blocks ignored";
 
-		return make_pair(rlp, n);
-	}
+        return make_pair(rlp, n);
+    }
 
-	strings nodeData(RLP const& _dataHashes) const override
-	{
-		unsigned const count = static_cast<unsigned>(_dataHashes.itemCount());
+    strings nodeData(RLP const& _dataHashes) const override
+    {
+        unsigned const count = static_cast<unsigned>(_dataHashes.itemCount());
 
-		strings data;
-		size_t payloadSize = 0;
-		auto numItemsToSend = std::min(count, c_maxNodes);
-		for (unsigned i = 0; i < numItemsToSend && payloadSize < c_maxPayload; ++i)
-		{
-			auto h = _dataHashes[i].toHash<h256>();
-			auto node = m_db.lookup(h);
-			if (!node.empty())
-			{
-				payloadSize += node.length();
-				data.push_back(move(node));
-			}
-		}
-		clog(NetMessageSummary) << data.size() << " nodes known and returned;" << (numItemsToSend - data.size()) << " unknown;" << (count > c_maxNodes ? count - c_maxNodes : 0) << " ignored";
+        strings data;
+        size_t payloadSize = 0;
+        auto numItemsToSend = std::min(count, c_maxNodes);
+        for (unsigned i = 0; i < numItemsToSend && payloadSize < c_maxPayload; ++i)
+        {
+            auto h = _dataHashes[i].toHash<h256>();
+            auto node = m_db.lookup(h);
+            if (!node.empty())
+            {
+                payloadSize += node.length();
+                data.push_back(move(node));
+            }
+        }
+        clog(NetMessageSummary) << data.size() << " nodes known and returned;" << (numItemsToSend - data.size()) << " unknown;" << (count > c_maxNodes ? count - c_maxNodes : 0) << " ignored";
 
-		return data;
-	}
+        return data;
+    }
 
-	pair<bytes, unsigned> receipts(RLP const& _blockHashes) const override
-	{
-		unsigned const count = static_cast<unsigned>(_blockHashes.itemCount());
+    pair<bytes, unsigned> receipts(RLP const& _blockHashes) const override
+    {
+        unsigned const count = static_cast<unsigned>(_blockHashes.itemCount());
 
-		bytes rlp;
-		unsigned n = 0;
-		auto numItemsToSend = std::min(count, c_maxReceipts);
-		for (unsigned i = 0; i < numItemsToSend && rlp.size() < c_maxPayload; ++i)
-		{
-			auto h = _blockHashes[i].toHash<h256>();
-			if (m_chain.isKnown(h))
-			{
-				auto const receipts = m_chain.receipts(h);
-				auto receiptsRlpList = receipts.rlp();
-				rlp.insert(rlp.end(), receiptsRlpList.begin(), receiptsRlpList.end());
-				++n;
-			}
-		}
-		clog(NetMessageSummary) << n << " receipt lists known and returned;" << (numItemsToSend - n) << " unknown;" << (count > c_maxReceipts ? count - c_maxReceipts : 0) << " ignored";
+        bytes rlp;
+        unsigned n = 0;
+        auto numItemsToSend = std::min(count, c_maxReceipts);
+        for (unsigned i = 0; i < numItemsToSend && rlp.size() < c_maxPayload; ++i)
+        {
+            auto h = _blockHashes[i].toHash<h256>();
+            if (m_chain.isKnown(h))
+            {
+                auto const receipts = m_chain.receipts(h);
+                auto receiptsRlpList = receipts.rlp();
+                rlp.insert(rlp.end(), receiptsRlpList.begin(), receiptsRlpList.end());
+                ++n;
+            }
+        }
+        clog(NetMessageSummary) << n << " receipt lists known and returned;" << (numItemsToSend - n) << " unknown;" << (count > c_maxReceipts ? count - c_maxReceipts : 0) << " ignored";
 
-		return make_pair(rlp, n);
-	}
+        return make_pair(rlp, n);
+    }
 
 private:
-	BlockChain const& m_chain;
-	OverlayDB const& m_db;
+    BlockChain const& m_chain;
+    OverlayDB const& m_db;
 };
 
 }
 
 EthereumHost::EthereumHost(BlockChain const& _ch, OverlayDB const& _db, TransactionQueue& _tq, BlockQueue& _bq, u256 _networkId):
-	HostCapability<EthereumPeer>(),
-	Worker		("ethsync"),
-	m_chain		(_ch),
-	m_db(_db),
-	m_tq		(_tq),
-	m_bq		(_bq),
-	m_networkId	(_networkId),
-	m_hostData(make_shared<EthereumHostData>(m_chain, m_db))
+    HostCapability<EthereumPeer>(),
+    Worker		("ethsync"),
+    m_chain		(_ch),
+    m_db(_db),
+    m_tq		(_tq),
+    m_bq		(_bq),
+    m_networkId	(_networkId),
+    m_hostData(make_shared<EthereumHostData>(m_chain, m_db))
 {
-	// TODO: Composition would be better. Left like that to avoid initialization
-	//       issues as BlockChainSync accesses other EthereumHost members.
-	m_sync.reset(new BlockChainSync(*this));
-	m_peerObserver = make_shared<EthereumPeerObserver>(m_sync, m_tq);
-	m_latestBlockSent = _ch.currentHash();
-	m_tq.onImport([this](ImportResult _ir, h256 const& _h, h512 const& _nodeId) { onTransactionImported(_ir, _h, _nodeId); });
+    // TODO: Composition would be better. Left like that to avoid initialization
+    //       issues as BlockChainSync accesses other EthereumHost members.
+    m_sync.reset(new BlockChainSync(*this));
+    m_peerObserver = make_shared<EthereumPeerObserver>(m_sync, m_tq);
+    m_latestBlockSent = _ch.currentHash();
+    m_tq.onImport([this](ImportResult _ir, h256 const& _h, h512 const& _nodeId) { onTransactionImported(_ir, _h, _nodeId); });
 }
 
 EthereumHost::~EthereumHost()
 {
-	terminate();
+    terminate();
 }
 
 bool EthereumHost::ensureInitialised()
 {
-	if (!m_latestBlockSent)
-	{
-		// First time - just initialise.
-		m_latestBlockSent = m_chain.currentHash();
-		clog(EthereumHostTrace) << "Initialising: latest=" << m_latestBlockSent;
+    if (!m_latestBlockSent)
+    {
+        // First time - just initialise.
+        m_latestBlockSent = m_chain.currentHash();
+        clog(EthereumHostTrace) << "Initialising: latest=" << m_latestBlockSent;
 
-		Guard l(x_transactions);
-		m_transactionsSent = m_tq.knownTransactions();
-		return true;
-	}
-	return false;
+        Guard l(x_transactions);
+        m_transactionsSent = m_tq.knownTransactions();
+        return true;
+    }
+    return false;
 }
 
 void EthereumHost::reset()
 {
-	m_sync->abortSync();
+    m_sync->abortSync();
 
-	m_latestBlockSent = h256();
-	Guard tl(x_transactions);
-	m_transactionsSent.clear();
+    m_latestBlockSent = h256();
+    Guard tl(x_transactions);
+    m_transactionsSent.clear();
 }
 
 void EthereumHost::completeSync()
 {
-	m_sync->completeSync();
+    m_sync->completeSync();
 }
 
 void EthereumHost::doWork()
 {
-	bool netChange = ensureInitialised();
-	auto h = m_chain.currentHash();
-	// If we've finished our initial sync (including getting all the blocks into the chain so as to reduce invalid transactions), start trading transactions & blocks
-	if (!isSyncing() && m_chain.isKnown(m_latestBlockSent))
-	{
-		if (m_newTransactions)
-		{
-			m_newTransactions = false;
-			maintainTransactions();
-		}
-		if (m_newBlocks)
-		{
-			m_newBlocks = false;
-			maintainBlocks(h);
-		}
-	}
+    bool netChange = ensureInitialised();
+    auto h = m_chain.currentHash();
+    // If we've finished our initial sync (including getting all the blocks into the chain so as to reduce invalid transactions), start trading transactions & blocks
+    if (!isSyncing() && m_chain.isKnown(m_latestBlockSent))
+    {
+        if (m_newTransactions)
+        {
+            m_newTransactions = false;
+            maintainTransactions();
+        }
+        if (m_newBlocks)
+        {
+            m_newBlocks = false;
+            maintainBlocks(h);
+        }
+    }
 
-	time_t  now = std::chrono::system_clock::to_time_t(chrono::system_clock::now());
-	if (now - m_lastTick >= 1)
-	{
-		m_lastTick = now;
-		foreachPeer([](std::shared_ptr<EthereumPeer> _p) { _p->tick(); return true; });
-	}
+    time_t  now = std::chrono::system_clock::to_time_t(chrono::system_clock::now());
+    if (now - m_lastTick >= 1)
+    {
+        m_lastTick = now;
+        foreachPeer([](std::shared_ptr<EthereumPeer> _p) { _p->tick(); return true; });
+    }
 
 //	return netChange;
-	// TODO: Figure out what to do with netChange.
-	(void)netChange;
+    // TODO: Figure out what to do with netChange.
+    (void)netChange;
 }
 
 void EthereumHost::maintainTransactions()
 {
-	// Send any new transactions.
-	unordered_map<std::shared_ptr<EthereumPeer>, std::vector<size_t>> peerTransactions;
-	auto ts = m_tq.topTransactions(c_maxSendTransactions);
-	{
-		Guard l(x_transactions);
-		for (size_t i = 0; i < ts.size(); ++i)
-		{
-			auto const& t = ts[i];
-			bool unsent = !m_transactionsSent.count(t.sha3());
-			auto peers = get<1>(randomSelection(0, [&](EthereumPeer* p) { return p->m_requireTransactions || (unsent && !p->m_knownTransactions.count(t.sha3())); }));
-			for (auto const& p: peers)
-				peerTransactions[p].push_back(i);
-		}
-		for (auto const& t: ts)
-			m_transactionsSent.insert(t.sha3());
-	}
-	foreachPeer([&](shared_ptr<EthereumPeer> _p)
-	{
-		bytes b;
-		unsigned n = 0;
-		for (auto const& i: peerTransactions[_p])
-		{
-			_p->m_knownTransactions.insert(ts[i].sha3());
-			b += ts[i].rlp();
-			++n;
-		}
+    // Send any new transactions.
+    unordered_map<std::shared_ptr<EthereumPeer>, std::vector<size_t>> peerTransactions;
+    auto ts = m_tq.topTransactions(c_maxSendTransactions);
+    {
+        Guard l(x_transactions);
+        for (size_t i = 0; i < ts.size(); ++i)
+        {
+            auto const& t = ts[i];
+            bool unsent = !m_transactionsSent.count(t.sha3());
+            auto peers = get<1>(randomSelection(0, [&](EthereumPeer* p) { return p->m_requireTransactions || (unsent && !p->m_knownTransactions.count(t.sha3())); }));
+            for (auto const& p: peers)
+                peerTransactions[p].push_back(i);
+        }
+        for (auto const& t: ts)
+            m_transactionsSent.insert(t.sha3());
+    }
+    foreachPeer([&](shared_ptr<EthereumPeer> _p)
+    {
+        bytes b;
+        unsigned n = 0;
+        for (auto const& i: peerTransactions[_p])
+        {
+            _p->m_knownTransactions.insert(ts[i].sha3());
+            b += ts[i].rlp();
+            ++n;
+        }
 
-		_p->clearKnownTransactions();
+        _p->clearKnownTransactions();
 
-		if (n || _p->m_requireTransactions)
-		{
-			RLPStream ts;
-			_p->prep(ts, TransactionsPacket, n).appendRaw(b, n);
-			_p->sealAndSend(ts);
-			clog(EthereumHostTrace) << "Sent" << n << "transactions to " << _p->session()->info().clientVersion;
-		}
-		_p->m_requireTransactions = false;
-		return true;
-	});
+        if (n || _p->m_requireTransactions)
+        {
+            RLPStream ts;
+            _p->prep(ts, TransactionsPacket, n).appendRaw(b, n);
+            _p->sealAndSend(ts);
+            clog(EthereumHostTrace) << "Sent" << n << "transactions to " << _p->session()->info().clientVersion;
+        }
+        _p->m_requireTransactions = false;
+        return true;
+    });
 }
 
 void EthereumHost::foreachPeer(std::function<bool(std::shared_ptr<EthereumPeer>)> const& _f) const
 {
-	//order peers by protocol, rating, connection age
-	auto sessions = peerSessions();
-	auto sessionLess = [](std::pair<std::shared_ptr<SessionFace>, std::shared_ptr<Peer>> const& _left, std::pair<std::shared_ptr<SessionFace>, std::shared_ptr<Peer>> const& _right)
-		{ return _left.first->rating() == _right.first->rating() ? _left.first->connectionTime() < _right.first->connectionTime() : _left.first->rating() > _right.first->rating(); };
+    //order peers by protocol, rating, connection age
+    auto sessions = peerSessions();
+    auto sessionLess = [](std::pair<std::shared_ptr<SessionFace>, std::shared_ptr<Peer>> const& _left, std::pair<std::shared_ptr<SessionFace>, std::shared_ptr<Peer>> const& _right)
+        { return _left.first->rating() == _right.first->rating() ? _left.first->connectionTime() < _right.first->connectionTime() : _left.first->rating() > _right.first->rating(); };
 
-	std::sort(sessions.begin(), sessions.end(), sessionLess);
-	for (auto s: sessions)
-		if (!_f(capabilityFromSession<EthereumPeer>(*s.first)))
-			return;
+    std::sort(sessions.begin(), sessions.end(), sessionLess);
+    for (auto s: sessions)
+        if (!_f(capabilityFromSession<EthereumPeer>(*s.first)))
+            return;
 
-	sessions = peerSessions(c_oldProtocolVersion); //TODO: remove once v61+ is common
-	std::sort(sessions.begin(), sessions.end(), sessionLess);
-	for (auto s: sessions)
-		if (!_f(capabilityFromSession<EthereumPeer>(*s.first, c_oldProtocolVersion)))
-			return;
+    sessions = peerSessions(c_oldProtocolVersion); //TODO: remove once v61+ is common
+    std::sort(sessions.begin(), sessions.end(), sessionLess);
+    for (auto s: sessions)
+        if (!_f(capabilityFromSession<EthereumPeer>(*s.first, c_oldProtocolVersion)))
+            return;
 }
 
 tuple<vector<shared_ptr<EthereumPeer>>, vector<shared_ptr<EthereumPeer>>, vector<shared_ptr<SessionFace>>> EthereumHost::randomSelection(unsigned _percent, std::function<bool(EthereumPeer*)> const& _allow)
 {
-	vector<shared_ptr<EthereumPeer>> chosen;
-	vector<shared_ptr<EthereumPeer>> allowed;
-	vector<shared_ptr<SessionFace>> sessions;
+    vector<shared_ptr<EthereumPeer>> chosen;
+    vector<shared_ptr<EthereumPeer>> allowed;
+    vector<shared_ptr<SessionFace>> sessions;
 
-	size_t peerCount = 0;
-	foreachPeer([&](std::shared_ptr<EthereumPeer> _p)
-	{
-		if (_allow(_p.get()))
-		{
-			allowed.push_back(_p);
-			sessions.push_back(_p->session());
-		}
-		++peerCount;
-		return true;
-	});
+    size_t peerCount = 0;
+    foreachPeer([&](std::shared_ptr<EthereumPeer> _p)
+    {
+        if (_allow(_p.get()))
+        {
+            allowed.push_back(_p);
+            sessions.push_back(_p->session());
+        }
+        ++peerCount;
+        return true;
+    });
 
-	size_t chosenSize = (peerCount * _percent + 99) / 100;
-	chosen.reserve(chosenSize);
-	for (unsigned i = chosenSize; i && allowed.size(); i--)
-	{
-		unsigned n = rand() % allowed.size();
-		chosen.push_back(std::move(allowed[n]));
-		allowed.erase(allowed.begin() + n);
-	}
-	return make_tuple(move(chosen), move(allowed), move(sessions));
+    size_t chosenSize = (peerCount * _percent + 99) / 100;
+    chosen.reserve(chosenSize);
+    for (unsigned i = chosenSize; i && allowed.size(); i--)
+    {
+        unsigned n = rand() % allowed.size();
+        chosen.push_back(std::move(allowed[n]));
+        allowed.erase(allowed.begin() + n);
+    }
+    return make_tuple(move(chosen), move(allowed), move(sessions));
 }
 
 void EthereumHost::maintainBlocks(h256 const& _currentHash)
 {
-	// Send any new blocks.
-	auto detailsFrom = m_chain.details(m_latestBlockSent);
-	auto detailsTo = m_chain.details(_currentHash);
-	if (detailsFrom.totalDifficulty < detailsTo.totalDifficulty)
-	{
-		if (diff(detailsFrom.number, detailsTo.number) < 20)
-		{
-			// don't be sending more than 20 "new" blocks. if there are any more we were probably waaaay behind.
-			clog(EthereumHostTrace) << "Sending a new block (current is" << _currentHash << ", was" << m_latestBlockSent << ")";
+    // Send any new blocks.
+    auto detailsFrom = m_chain.details(m_latestBlockSent);
+    auto detailsTo = m_chain.details(_currentHash);
+    if (detailsFrom.totalDifficulty < detailsTo.totalDifficulty)
+    {
+        if (diff(detailsFrom.number, detailsTo.number) < 20)
+        {
+            // don't be sending more than 20 "new" blocks. if there are any more we were probably waaaay behind.
+            clog(EthereumHostTrace) << "Sending a new block (current is" << _currentHash << ", was" << m_latestBlockSent << ")";
 
-			h256s blocks = get<0>(m_chain.treeRoute(m_latestBlockSent, _currentHash, false, false, true));
+            h256s blocks = get<0>(m_chain.treeRoute(m_latestBlockSent, _currentHash, false, false, true));
 
-			auto s = randomSelection(25, [&](EthereumPeer* p){
-				DEV_GUARDED(p->x_knownBlocks)
-					return !p->m_knownBlocks.count(_currentHash);
-				return false;
-			});
-			for (shared_ptr<EthereumPeer> const& p: get<0>(s))
-				for (auto const& b: blocks)
-				{
-					RLPStream ts;
-					p->prep(ts, NewBlockPacket, 2).appendRaw(m_chain.block(b), 1).append(m_chain.details(b).totalDifficulty);
+            auto s = randomSelection(25, [&](EthereumPeer* p){
+                DEV_GUARDED(p->x_knownBlocks)
+                    return !p->m_knownBlocks.count(_currentHash);
+                return false;
+            });
+            for (shared_ptr<EthereumPeer> const& p: get<0>(s))
+                for (auto const& b: blocks)
+                {
+                    RLPStream ts;
+                    p->prep(ts, NewBlockPacket, 2).appendRaw(m_chain.block(b), 1).append(m_chain.details(b).totalDifficulty);
 
-					Guard l(p->x_knownBlocks);
-					p->sealAndSend(ts);
-					p->m_knownBlocks.clear();
-				}
-			for (shared_ptr<EthereumPeer> const& p: get<1>(s))
-			{
-				RLPStream ts;
-				p->prep(ts, NewBlockHashesPacket, blocks.size());
-				for (auto const& b: blocks)
-				{
-					ts.appendList(2);
-					ts.append(b);
-					ts.append(m_chain.number(b));
-				}
+                    Guard l(p->x_knownBlocks);
+                    p->sealAndSend(ts);
+                    p->m_knownBlocks.clear();
+                }
+            for (shared_ptr<EthereumPeer> const& p: get<1>(s))
+            {
+                RLPStream ts;
+                p->prep(ts, NewBlockHashesPacket, blocks.size());
+                for (auto const& b: blocks)
+                {
+                    ts.appendList(2);
+                    ts.append(b);
+                    ts.append(m_chain.number(b));
+                }
 
-				Guard l(p->x_knownBlocks);
-				p->sealAndSend(ts);
-				p->m_knownBlocks.clear();
-			}
-		}
-		m_latestBlockSent = _currentHash;
-	}
+                Guard l(p->x_knownBlocks);
+                p->sealAndSend(ts);
+                p->m_knownBlocks.clear();
+            }
+        }
+        m_latestBlockSent = _currentHash;
+    }
 }
 
 bool EthereumHost::isSyncing() const
 {
-	return m_sync->isSyncing();
+    return m_sync->isSyncing();
 }
 
 SyncStatus EthereumHost::status() const
 {
-	return m_sync->status();
+    return m_sync->status();
 }
 
 void EthereumHost::onTransactionImported(ImportResult _ir, h256 const& _h, h512 const& _nodeId)
 {
-	auto session = host()->peerSession(_nodeId);
-	if (!session)
-		return;
+    auto session = host()->peerSession(_nodeId);
+    if (!session)
+        return;
 
-	std::shared_ptr<EthereumPeer> peer = capabilityFromSession<EthereumPeer>(*session);
-	if (!peer)
-		peer = capabilityFromSession<EthereumPeer>(*session, c_oldProtocolVersion);
-	if (!peer)
-		return;
+    std::shared_ptr<EthereumPeer> peer = capabilityFromSession<EthereumPeer>(*session);
+    if (!peer)
+        peer = capabilityFromSession<EthereumPeer>(*session, c_oldProtocolVersion);
+    if (!peer)
+        return;
 
-	Guard l(peer->x_knownTransactions);
-	peer->m_knownTransactions.insert(_h);
-	switch (_ir)
-	{
-	case ImportResult::Malformed:
-		peer->addRating(-100);
-		break;
-	case ImportResult::AlreadyKnown:
-		// if we already had the transaction, then don't bother sending it on.
-		DEV_GUARDED(x_transactions)
-			m_transactionsSent.insert(_h);
-		peer->addRating(0);
-		break;
-	case ImportResult::Success:
-		peer->addRating(100);
-		break;
-	default:;
-	}
+    Guard l(peer->x_knownTransactions);
+    peer->m_knownTransactions.insert(_h);
+    switch (_ir)
+    {
+    case ImportResult::Malformed:
+        peer->addRating(-100);
+        break;
+    case ImportResult::AlreadyKnown:
+        // if we already had the transaction, then don't bother sending it on.
+        DEV_GUARDED(x_transactions)
+            m_transactionsSent.insert(_h);
+        peer->addRating(0);
+        break;
+    case ImportResult::Success:
+        peer->addRating(100);
+        break;
+    default:;
+    }
 }
 
 shared_ptr<Capability> EthereumHost::newPeerCapability(shared_ptr<SessionFace> const& _s, unsigned _idOffset, p2p::CapDesc const& _cap)
 {
-	auto ret = HostCapability<EthereumPeer>::newPeerCapability(_s, _idOffset, _cap);
+    auto ret = HostCapability<EthereumPeer>::newPeerCapability(_s, _idOffset, _cap);
 
-	auto cap = capabilityFromSession<EthereumPeer>(*_s, _cap.second);
-	assert(cap);
-	cap->init(
-		protocolVersion(),
-		m_networkId,
-		m_chain.details().totalDifficulty,
-		m_chain.currentHash(),
-		m_chain.genesisHash(),
-		m_hostData,
-		m_peerObserver
-	);
+    auto cap = capabilityFromSession<EthereumPeer>(*_s, _cap.second);
+    assert(cap);
+    cap->init(
+        protocolVersion(),
+        m_networkId,
+        m_chain.details().totalDifficulty,
+        m_chain.currentHash(),
+        m_chain.genesisHash(),
+        m_hostData,
+        m_peerObserver
+    );
 
-	return ret;
+    return ret;
 }

--- a/libethereum/EthereumHost.cpp
+++ b/libethereum/EthereumHost.cpp
@@ -178,7 +178,7 @@ public:
         if (_blockId.size() == 32) // block id is a hash
         {
             blockHash = _blockId.toHash<h256>();
-            clog(NetMessageSummary) << "GetBlockHeaders (block (hash): " << blockHash
+            cnetmessage << "GetBlockHeaders (block (hash): " << blockHash
                 << ", maxHeaders: " << _maxHeaders
                 << ", skip: " << _skip << ", reverse: " << _reverse << ")";
 
@@ -208,9 +208,9 @@ public:
         else // block id is a number
         {
             auto n = _blockId.toInt<bigint>();
-            clog(NetMessageSummary) << "GetBlockHeaders (" << n
-            << "max: " << _maxHeaders
-            << "skip: " << _skip << (_reverse ? "reverse" : "") << ")";
+            cnetmessage << "GetBlockHeaders (" << n
+            << " max: " << _maxHeaders
+            << " skip: " << _skip << (_reverse ? " reverse" : "") << ")";
 
             if (!_reverse)
             {
@@ -310,9 +310,9 @@ public:
         if (count > 20 && n == 0)
             cnetwarn << "all " << count << " unknown blocks requested; peer on different chain?";
         else
-            clog(NetMessageSummary)
-                << n << "blocks known and returned;" << (numBodiesToSend - n) << "blocks unknown;"
-                << (count > c_maxBlocks ? count - c_maxBlocks : 0) << "blocks ignored";
+            cnetmessage
+                << n << " blocks known and returned; " << (numBodiesToSend - n) << " blocks unknown; "
+                << (count > c_maxBlocks ? count - c_maxBlocks : 0) << " blocks ignored";
 
         return make_pair(rlp, n);
     }
@@ -334,7 +334,7 @@ public:
                 data.push_back(move(node));
             }
         }
-        clog(NetMessageSummary) << data.size() << " nodes known and returned;" << (numItemsToSend - data.size()) << " unknown;" << (count > c_maxNodes ? count - c_maxNodes : 0) << " ignored";
+        cnetmessage << data.size() << " nodes known and returned; " << (numItemsToSend - data.size()) << " unknown; " << (count > c_maxNodes ? count - c_maxNodes : 0) << " ignored";
 
         return data;
     }
@@ -357,7 +357,7 @@ public:
                 ++n;
             }
         }
-        clog(NetMessageSummary) << n << " receipt lists known and returned;" << (numItemsToSend - n) << " unknown;" << (count > c_maxReceipts ? count - c_maxReceipts : 0) << " ignored";
+        cnetmessage << n << " receipt lists known and returned; " << (numItemsToSend - n) << " unknown; " << (count > c_maxReceipts ? count - c_maxReceipts : 0) << " ignored";
 
         return make_pair(rlp, n);
     }

--- a/libethereum/EthereumHost.h
+++ b/libethereum/EthereumHost.h
@@ -1,18 +1,18 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file EthereumHost.h
  * @author Gav Wood <i@gavwood.com>
@@ -61,83 +61,83 @@ struct EthereumHostTrace: public LogChannel { static const char* name(); static 
 class EthereumHost: public p2p::HostCapability<EthereumPeer>, Worker
 {
 public:
-	/// Start server, but don't listen.
-	EthereumHost(BlockChain const& _ch, OverlayDB const& _db, TransactionQueue& _tq, BlockQueue& _bq, u256 _networkId);
+    /// Start server, but don't listen.
+    EthereumHost(BlockChain const& _ch, OverlayDB const& _db, TransactionQueue& _tq, BlockQueue& _bq, u256 _networkId);
 
-	/// Will block on network process events.
-	virtual ~EthereumHost();
+    /// Will block on network process events.
+    virtual ~EthereumHost();
 
-	unsigned protocolVersion() const { return c_protocolVersion; }
-	u256 networkId() const { return m_networkId; }
-	void setNetworkId(u256 _n) { m_networkId = _n; }
+    unsigned protocolVersion() const { return c_protocolVersion; }
+    u256 networkId() const { return m_networkId; }
+    void setNetworkId(u256 _n) { m_networkId = _n; }
 
-	void reset();
-	/// Don't sync further - used only in test mode
-	void completeSync();
+    void reset();
+    /// Don't sync further - used only in test mode
+    void completeSync();
 
-	bool isSyncing() const;
-	bool isBanned(p2p::NodeID const& _id) const { return !!m_banned.count(_id); }
+    bool isSyncing() const;
+    bool isBanned(p2p::NodeID const& _id) const { return !!m_banned.count(_id); }
 
-	void noteNewTransactions() { m_newTransactions = true; }
-	void noteNewBlocks() { m_newBlocks = true; }
-	void onBlockImported(BlockHeader const& _info) { m_sync->onBlockImported(_info); }
+    void noteNewTransactions() { m_newTransactions = true; }
+    void noteNewBlocks() { m_newBlocks = true; }
+    void onBlockImported(BlockHeader const& _info) { m_sync->onBlockImported(_info); }
 
-	BlockChain const& chain() const { return m_chain; }
-	OverlayDB const& db() const { return m_db; }
-	BlockQueue& bq() { return m_bq; }
-	BlockQueue const& bq() const { return m_bq; }
-	SyncStatus status() const;
-	h256 latestBlockSent() { return m_latestBlockSent; }
-	static char const* stateName(SyncState _s) { return s_stateNames[static_cast<int>(_s)]; }
+    BlockChain const& chain() const { return m_chain; }
+    OverlayDB const& db() const { return m_db; }
+    BlockQueue& bq() { return m_bq; }
+    BlockQueue const& bq() const { return m_bq; }
+    SyncStatus status() const;
+    h256 latestBlockSent() { return m_latestBlockSent; }
+    static char const* stateName(SyncState _s) { return s_stateNames[static_cast<int>(_s)]; }
 
-	static unsigned const c_oldProtocolVersion;
-	void foreachPeer(std::function<bool(std::shared_ptr<EthereumPeer>)> const& _f) const;
+    static unsigned const c_oldProtocolVersion;
+    void foreachPeer(std::function<bool(std::shared_ptr<EthereumPeer>)> const& _f) const;
 
 protected:
-	std::shared_ptr<p2p::Capability> newPeerCapability(std::shared_ptr<p2p::SessionFace> const& _s, unsigned _idOffset, p2p::CapDesc const& _cap) override;
+    std::shared_ptr<p2p::Capability> newPeerCapability(std::shared_ptr<p2p::SessionFace> const& _s, unsigned _idOffset, p2p::CapDesc const& _cap) override;
 
 private:
-	static char const* const s_stateNames[static_cast<int>(SyncState::Size)];
+    static char const* const s_stateNames[static_cast<int>(SyncState::Size)];
 
-	std::tuple<std::vector<std::shared_ptr<EthereumPeer>>, std::vector<std::shared_ptr<EthereumPeer>>, std::vector<std::shared_ptr<p2p::SessionFace>>> randomSelection(unsigned _percent = 25, std::function<bool(EthereumPeer*)> const& _allow = [](EthereumPeer const*){ return true; });
+    std::tuple<std::vector<std::shared_ptr<EthereumPeer>>, std::vector<std::shared_ptr<EthereumPeer>>, std::vector<std::shared_ptr<p2p::SessionFace>>> randomSelection(unsigned _percent = 25, std::function<bool(EthereumPeer*)> const& _allow = [](EthereumPeer const*){ return true; });
 
-	/// Sync with the BlockChain. It might contain one of our mined blocks, we might have new candidates from the network.
-	virtual void doWork() override;
+    /// Sync with the BlockChain. It might contain one of our mined blocks, we might have new candidates from the network.
+    virtual void doWork() override;
 
-	void maintainTransactions();
-	void maintainBlocks(h256 const& _currentBlock);
-	void onTransactionImported(ImportResult _ir, h256 const& _h, h512 const& _nodeId);
+    void maintainTransactions();
+    void maintainBlocks(h256 const& _currentBlock);
+    void onTransactionImported(ImportResult _ir, h256 const& _h, h512 const& _nodeId);
 
-	///	Check to see if the network peer-state initialisation has happened.
-	bool isInitialised() const { return (bool)m_latestBlockSent; }
+    ///	Check to see if the network peer-state initialisation has happened.
+    bool isInitialised() const { return (bool)m_latestBlockSent; }
 
-	/// Initialises the network peer-state, doing the stuff that needs to be once-only. @returns true if it really was first.
-	bool ensureInitialised();
+    /// Initialises the network peer-state, doing the stuff that needs to be once-only. @returns true if it really was first.
+    bool ensureInitialised();
 
-	virtual void onStarting() override { startWorking(); }
-	virtual void onStopping() override { stopWorking(); }
+    virtual void onStarting() override { startWorking(); }
+    virtual void onStopping() override { stopWorking(); }
 
-	BlockChain const& m_chain;
-	OverlayDB const& m_db;					///< References to DB, needed for some of the Ethereum Protocol responses.
-	TransactionQueue& m_tq;					///< Maintains a list of incoming transactions not yet in a block on the blockchain.
-	BlockQueue& m_bq;						///< Maintains a list of incoming blocks not yet on the blockchain (to be imported).
+    BlockChain const& m_chain;
+    OverlayDB const& m_db;					///< References to DB, needed for some of the Ethereum Protocol responses.
+    TransactionQueue& m_tq;					///< Maintains a list of incoming transactions not yet in a block on the blockchain.
+    BlockQueue& m_bq;						///< Maintains a list of incoming blocks not yet on the blockchain (to be imported).
 
-	u256 m_networkId;
+    u256 m_networkId;
 
-	h256 m_latestBlockSent;
-	h256Hash m_transactionsSent;
+    h256 m_latestBlockSent;
+    h256Hash m_transactionsSent;
 
-	std::unordered_set<p2p::NodeID> m_banned;
+    std::unordered_set<p2p::NodeID> m_banned;
 
-	bool m_newTransactions = false;
-	bool m_newBlocks = false;
+    bool m_newTransactions = false;
+    bool m_newBlocks = false;
 
-	mutable Mutex x_transactions;
-	std::shared_ptr<BlockChainSync> m_sync;
-	std::atomic<time_t> m_lastTick = { 0 };
+    mutable Mutex x_transactions;
+    std::shared_ptr<BlockChainSync> m_sync;
+    std::atomic<time_t> m_lastTick = { 0 };
 
-	std::shared_ptr<EthereumHostDataFace> m_hostData;
-	std::shared_ptr<EthereumPeerObserverFace> m_peerObserver;
+    std::shared_ptr<EthereumHostDataFace> m_hostData;
+    std::shared_ptr<EthereumPeerObserverFace> m_peerObserver;
 };
 
 }

--- a/libethereum/EthereumPeer.cpp
+++ b/libethereum/EthereumPeer.cpp
@@ -147,7 +147,7 @@ void EthereumPeer::requestBlockHeaders(unsigned _startNumber, unsigned _count, u
 {
     if (m_asking != Asking::Nothing)
     {
-        clog(NetWarn) << "Asking headers while requesting " << ::toString(m_asking);
+        cnetwarn << "Asking headers while requesting " << ::toString(m_asking);
     }
     setAsking(Asking::BlockHeaders);
     RLPStream s;
@@ -161,7 +161,7 @@ void EthereumPeer::requestBlockHeaders(h256 const& _startHash, unsigned _count, 
 {
     if (m_asking != Asking::Nothing)
     {
-        clog(NetWarn) << "Asking headers while requesting " << ::toString(m_asking);
+        cnetwarn << "Asking headers while requesting " << ::toString(m_asking);
     }
     setAsking(Asking::BlockHeaders);
     RLPStream s;
@@ -191,7 +191,8 @@ void EthereumPeer::requestByHashes(h256s const& _hashes, Asking _asking, Subprot
 {
     if (m_asking != Asking::Nothing)
     {
-        clog(NetWarn) << "Asking "<< ::toString(_asking) << " while requesting " << ::toString(m_asking);
+        cnetwarn << "Asking " << ::toString(_asking) << " while requesting "
+                 << ::toString(m_asking);
     }
     setAsking(_asking);
     if (_hashes.size())
@@ -429,11 +430,12 @@ bool EthereumPeer::interpret(unsigned _id, RLP const& _r)
     }
     catch (Exception const&)
     {
-        clog(NetWarn) << "Peer causing an Exception:" << boost::current_exception_diagnostic_information() << _r;
+        cnetwarn << "Peer causing an Exception: "
+                 << boost::current_exception_diagnostic_information() << " " << _r;
     }
     catch (std::exception const& _e)
     {
-        clog(NetWarn) << "Peer causing an exception:" << _e.what() << _r;
+        cnetwarn << "Peer causing an exception: " << _e.what() << " " << _r;
     }
 
     return true;

--- a/libethereum/EthereumPeer.cpp
+++ b/libethereum/EthereumPeer.cpp
@@ -261,7 +261,7 @@ bool EthereumPeer::interpret(unsigned _id, RLP const& _r)
         if (m_peerCapabilityVersion == m_hostProtocolVersion)
             m_protocolVersion = m_hostProtocolVersion;
 
-        clog(NetMessageSummary) << "Status:" << m_protocolVersion << "/" << m_networkId << "/" << m_genesisHash << ", TD:" << m_totalDifficulty << "=" << m_latestHash;
+        cnetmessage << "Status: " << m_protocolVersion << " / " << m_networkId << " / " << m_genesisHash << ", TD: " << m_totalDifficulty << " = " << m_latestHash;
         setIdle();
         observer->onPeerStatus(dynamic_pointer_cast<EthereumPeer>(dynamic_pointer_cast<EthereumPeer>(shared_from_this())));
         break;
@@ -310,7 +310,7 @@ bool EthereumPeer::interpret(unsigned _id, RLP const& _r)
     case GetBlockBodiesPacket:
     {
         unsigned count = static_cast<unsigned>(_r.itemCount());
-        clog(NetMessageSummary) << "GetBlockBodies (" << dec << count << "entries)";
+        cnetmessage << "GetBlockBodies (" << dec << count << " entries)";
 
         if (!count)
         {
@@ -347,7 +347,7 @@ bool EthereumPeer::interpret(unsigned _id, RLP const& _r)
     {
         unsigned itemCount = _r.itemCount();
 
-        clog(NetMessageSummary) << "BlockHashes (" << dec << itemCount << "entries)" << (itemCount ? "" : ": NoMoreHashes");
+        cnetmessage << "BlockHashes (" << dec << itemCount << " entries) " << (itemCount ? "" : " : NoMoreHashes");
 
         if (itemCount > c_maxIncomingNewHashes)
         {
@@ -371,7 +371,7 @@ bool EthereumPeer::interpret(unsigned _id, RLP const& _r)
             addRating(-10);
             break;
         }
-        clog(NetMessageSummary) << "GetNodeData (" << dec << count << " entries)";
+        cnetmessage << "GetNodeData (" << dec << count << " entries)";
 
         strings const data = hostData->nodeData(_r);
 
@@ -392,7 +392,7 @@ bool EthereumPeer::interpret(unsigned _id, RLP const& _r)
             addRating(-10);
             break;
         }
-        clog(NetMessageSummary) << "GetReceipts (" << dec << count << " entries)";
+        cnetmessage << "GetReceipts (" << dec << count << " entries)";
 
         pair<bytes, unsigned> const rlpAndItemCount = hostData->receipts(_r);
 

--- a/libethereum/EthereumPeer.cpp
+++ b/libethereum/EthereumPeer.cpp
@@ -299,7 +299,7 @@ bool EthereumPeer::interpret(unsigned _id, RLP const& _r)
     case BlockHeadersPacket:
     {
         if (m_asking != Asking::BlockHeaders)
-            clog(NetImpolite) << "Peer giving us block headers when we didn't ask for them.";
+            LOG(m_loggerImpolite) << "Peer giving us block headers when we didn't ask for them.";
         else
         {
             setIdle();
@@ -314,7 +314,7 @@ bool EthereumPeer::interpret(unsigned _id, RLP const& _r)
 
         if (!count)
         {
-            clog(NetImpolite) << "Zero-entry GetBlockBodies: Not replying.";
+            LOG(m_loggerImpolite) << "Zero-entry GetBlockBodies: Not replying.";
             addRating(-10);
             break;
         }
@@ -330,7 +330,7 @@ bool EthereumPeer::interpret(unsigned _id, RLP const& _r)
     case BlockBodiesPacket:
     {
         if (m_asking != Asking::BlockBodies)
-            clog(NetImpolite) << "Peer giving us block bodies when we didn't ask for them.";
+            LOG(m_loggerImpolite) << "Peer giving us block bodies when we didn't ask for them.";
         else
         {
             setIdle();
@@ -367,7 +367,7 @@ bool EthereumPeer::interpret(unsigned _id, RLP const& _r)
         unsigned count = static_cast<unsigned>(_r.itemCount());
         if (!count)
         {
-            clog(NetImpolite) << "Zero-entry GetNodeData: Not replying.";
+            LOG(m_loggerImpolite) << "Zero-entry GetNodeData: Not replying.";
             addRating(-10);
             break;
         }
@@ -388,7 +388,7 @@ bool EthereumPeer::interpret(unsigned _id, RLP const& _r)
         unsigned count = static_cast<unsigned>(_r.itemCount());
         if (!count)
         {
-            clog(NetImpolite) << "Zero-entry GetReceipts: Not replying.";
+            LOG(m_loggerImpolite) << "Zero-entry GetReceipts: Not replying.";
             addRating(-10);
             break;
         }
@@ -405,7 +405,7 @@ bool EthereumPeer::interpret(unsigned _id, RLP const& _r)
     case NodeDataPacket:
     {
         if (m_asking != Asking::NodeData)
-            clog(NetImpolite) << "Peer giving us node data when we didn't ask for them.";
+            LOG(m_loggerImpolite) << "Peer giving us node data when we didn't ask for them.";
         else
         {
             setIdle();
@@ -416,7 +416,7 @@ bool EthereumPeer::interpret(unsigned _id, RLP const& _r)
     case ReceiptsPacket:
     {
         if (m_asking != Asking::Receipts)
-            clog(NetImpolite) << "Peer giving us receipts when we didn't ask for them.";
+            LOG(m_loggerImpolite) << "Peer giving us receipts when we didn't ask for them.";
         else
         {
             setIdle();

--- a/libethereum/EthereumPeer.cpp
+++ b/libethereum/EthereumPeer.cpp
@@ -65,7 +65,7 @@ EthereumPeer::~EthereumPeer()
 {
     if (m_asking != Asking::Nothing)
     {
-        clog(NetAllDetail) << "Peer aborting while being asked for " << ::toString(m_asking);
+        cnetdetails << "Peer aborting while being asked for " << ::toString(m_asking);
         setRude();
     }
     abortSync();
@@ -284,7 +284,7 @@ bool EthereumPeer::interpret(unsigned _id, RLP const& _r)
 
         if (skip > std::numeric_limits<unsigned>::max() - 1)
         {
-            clog(NetAllDetail) << "Requested block skip is too big: " << skip;
+            cnetdetails << "Requested block skip is too big: " << skip;
             break;
         }
 

--- a/libethereum/EthereumPeer.cpp
+++ b/libethereum/EthereumPeer.cpp
@@ -152,7 +152,7 @@ void EthereumPeer::requestBlockHeaders(unsigned _startNumber, unsigned _count, u
     setAsking(Asking::BlockHeaders);
     RLPStream s;
     prep(s, GetBlockHeadersPacket, 4) << _startNumber << _count << _skip << (_reverse ? 1 : 0);
-    clog(NetMessageDetail) << "Requesting " << _count << " block headers starting from " << _startNumber << (_reverse ? " in reverse" : "");
+    cnetmessage << "Requesting " << _count << " block headers starting from " << _startNumber << (_reverse ? " in reverse" : "");
     m_lastAskedHeaders = _count;
     sealAndSend(s);
 }
@@ -166,7 +166,7 @@ void EthereumPeer::requestBlockHeaders(h256 const& _startHash, unsigned _count, 
     setAsking(Asking::BlockHeaders);
     RLPStream s;
     prep(s, GetBlockHeadersPacket, 4) << _startHash << _count << _skip << (_reverse ? 1 : 0);
-    clog(NetMessageDetail) << "Requesting " << _count << " block headers starting from " << _startHash << (_reverse ? " in reverse" : "");
+    cnetmessage << "Requesting " << _count << " block headers starting from " << _startHash << (_reverse ? " in reverse" : "");
     m_lastAskedHeaders = _count;
     sealAndSend(s);
 }

--- a/libethereum/EthereumPeer.cpp
+++ b/libethereum/EthereumPeer.cpp
@@ -152,7 +152,8 @@ void EthereumPeer::requestBlockHeaders(unsigned _startNumber, unsigned _count, u
     setAsking(Asking::BlockHeaders);
     RLPStream s;
     prep(s, GetBlockHeadersPacket, 4) << _startNumber << _count << _skip << (_reverse ? 1 : 0);
-    cnetmessage << "Requesting " << _count << " block headers starting from " << _startNumber << (_reverse ? " in reverse" : "");
+    cnetlog << "Requesting " << _count << " block headers starting from " << _startNumber
+            << (_reverse ? " in reverse" : "");
     m_lastAskedHeaders = _count;
     sealAndSend(s);
 }
@@ -166,7 +167,8 @@ void EthereumPeer::requestBlockHeaders(h256 const& _startHash, unsigned _count, 
     setAsking(Asking::BlockHeaders);
     RLPStream s;
     prep(s, GetBlockHeadersPacket, 4) << _startHash << _count << _skip << (_reverse ? 1 : 0);
-    cnetmessage << "Requesting " << _count << " block headers starting from " << _startHash << (_reverse ? " in reverse" : "");
+    cnetlog << "Requesting " << _count << " block headers starting from " << _startHash
+            << (_reverse ? " in reverse" : "");
     m_lastAskedHeaders = _count;
     sealAndSend(s);
 }
@@ -261,7 +263,8 @@ bool EthereumPeer::interpret(unsigned _id, RLP const& _r)
         if (m_peerCapabilityVersion == m_hostProtocolVersion)
             m_protocolVersion = m_hostProtocolVersion;
 
-        cnetmessage << "Status: " << m_protocolVersion << " / " << m_networkId << " / " << m_genesisHash << ", TD: " << m_totalDifficulty << " = " << m_latestHash;
+        cnetlog << "Status: " << m_protocolVersion << " / " << m_networkId << " / " << m_genesisHash
+                << ", TD: " << m_totalDifficulty << " = " << m_latestHash;
         setIdle();
         observer->onPeerStatus(dynamic_pointer_cast<EthereumPeer>(dynamic_pointer_cast<EthereumPeer>(shared_from_this())));
         break;
@@ -310,7 +313,7 @@ bool EthereumPeer::interpret(unsigned _id, RLP const& _r)
     case GetBlockBodiesPacket:
     {
         unsigned count = static_cast<unsigned>(_r.itemCount());
-        cnetmessage << "GetBlockBodies (" << dec << count << " entries)";
+        cnetlog << "GetBlockBodies (" << dec << count << " entries)";
 
         if (!count)
         {
@@ -347,7 +350,8 @@ bool EthereumPeer::interpret(unsigned _id, RLP const& _r)
     {
         unsigned itemCount = _r.itemCount();
 
-        cnetmessage << "BlockHashes (" << dec << itemCount << " entries) " << (itemCount ? "" : " : NoMoreHashes");
+        cnetlog << "BlockHashes (" << dec << itemCount << " entries) "
+                << (itemCount ? "" : " : NoMoreHashes");
 
         if (itemCount > c_maxIncomingNewHashes)
         {
@@ -371,7 +375,7 @@ bool EthereumPeer::interpret(unsigned _id, RLP const& _r)
             addRating(-10);
             break;
         }
-        cnetmessage << "GetNodeData (" << dec << count << " entries)";
+        cnetlog << "GetNodeData (" << dec << count << " entries)";
 
         strings const data = hostData->nodeData(_r);
 
@@ -392,7 +396,7 @@ bool EthereumPeer::interpret(unsigned _id, RLP const& _r)
             addRating(-10);
             break;
         }
-        cnetmessage << "GetReceipts (" << dec << count << " entries)";
+        cnetlog << "GetReceipts (" << dec << count << " entries)";
 
         pair<bytes, unsigned> const rlpAndItemCount = hostData->receipts(_r);
 

--- a/libethereum/EthereumPeer.h
+++ b/libethereum/EthereumPeer.h
@@ -194,6 +194,9 @@ private:
 
 	std::weak_ptr<EthereumPeerObserverFace> m_observer;
 	std::weak_ptr<EthereumHostDataFace> m_hostData;
+
+    /// Logger for messages about impolite behaivour of peers.
+    Logger m_loggerImpolite{createLogger(3, "impolite")};
 };
 
 }

--- a/libethereum/WarpPeerCapability.cpp
+++ b/libethereum/WarpPeerCapability.cpp
@@ -153,12 +153,12 @@ bool WarpPeerCapability::interpret(unsigned _id, RLP const& _r)
     }
     catch (Exception const&)
     {
-        clog(p2p::NetWarn) << "Warp Peer causing an Exception:"
-                           << boost::current_exception_diagnostic_information() << _r;
+        cnetwarn << "Warp Peer causing an Exception: "
+                 << boost::current_exception_diagnostic_information() << " " << _r;
     }
     catch (std::exception const& _e)
     {
-        clog(p2p::NetWarn) << "Warp Peer causing an exception:" << _e.what() << _r;
+        cnetwarn << "Warp Peer causing an exception: " << _e.what() << " " << _r;
     }
 
     return true;

--- a/libethereum/WarpPeerCapability.cpp
+++ b/libethereum/WarpPeerCapability.cpp
@@ -85,12 +85,12 @@ bool WarpPeerCapability::interpret(unsigned _id, RLP const& _r)
             m_snapshotHash = _r[5].toHash<h256>();
             m_snapshotNumber = _r[6].toInt<u256>();
 
-            clog(p2p::NetMessageSummary)
+            cnetmessage
                 << "Status: "
-                << "protocol version " << m_protocolVersion << "networkId " << m_networkId
-                << "genesis hash " << m_genesisHash << "total difficulty " << m_totalDifficulty
-                << "latest hash" << m_latestHash << "snapshot hash" << m_snapshotHash
-                << "snapshot number" << m_snapshotNumber;
+                << " protocol version " << m_protocolVersion << " networkId " << m_networkId
+                << " genesis hash " << m_genesisHash << " total difficulty " << m_totalDifficulty
+                << " latest hash " << m_latestHash << " snapshot hash " << m_snapshotHash
+                << " snapshot number " << m_snapshotNumber;
             setIdle();
             observer->onPeerStatus(
                 std::dynamic_pointer_cast<WarpPeerCapability>(shared_from_this()));

--- a/libethereum/WarpPeerCapability.cpp
+++ b/libethereum/WarpPeerCapability.cpp
@@ -85,12 +85,11 @@ bool WarpPeerCapability::interpret(unsigned _id, RLP const& _r)
             m_snapshotHash = _r[5].toHash<h256>();
             m_snapshotNumber = _r[6].toInt<u256>();
 
-            cnetmessage
-                << "Status: "
-                << " protocol version " << m_protocolVersion << " networkId " << m_networkId
-                << " genesis hash " << m_genesisHash << " total difficulty " << m_totalDifficulty
-                << " latest hash " << m_latestHash << " snapshot hash " << m_snapshotHash
-                << " snapshot number " << m_snapshotNumber;
+            cnetlog << "Status: "
+                    << " protocol version " << m_protocolVersion << " networkId " << m_networkId
+                    << " genesis hash " << m_genesisHash << " total difficulty "
+                    << m_totalDifficulty << " latest hash " << m_latestHash << " snapshot hash "
+                    << m_snapshotHash << " snapshot number " << m_snapshotNumber;
             setIdle();
             observer->onPeerStatus(
                 std::dynamic_pointer_cast<WarpPeerCapability>(shared_from_this()));

--- a/libp2p/Capability.cpp
+++ b/libp2p/Capability.cpp
@@ -1,18 +1,18 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file Capability.cpp
  * @author Gav Wood <i@gavwood.com>
@@ -29,32 +29,34 @@ using namespace dev;
 using namespace dev::p2p;
 
 Capability::Capability(std::shared_ptr<SessionFace> _s, HostCapabilityFace* _h, unsigned _idOffset):
-	m_session(_s), m_hostCap(_h), m_idOffset(_idOffset)
+    m_session(_s), m_hostCap(_h), m_idOffset(_idOffset)
 {
-	clog(NetConnect) << "New session for capability" << m_hostCap->name() << "; idOffset:" << m_idOffset;
+    cnetdetails << "New session for capability " << m_hostCap->name()
+                << "; idOffset: " << m_idOffset;
 }
 
 void Capability::disable(std::string const& _problem)
 {
-	clog(NetTriviaSummary) << "DISABLE: Disabling capability '" << m_hostCap->name() << "'. Reason:" << _problem;
-	m_enabled = false;
+    cnetdetails << "DISABLE: Disabling capability '" << m_hostCap->name()
+                << "'. Reason: " << _problem;
+    m_enabled = false;
 }
 
 RLPStream& Capability::prep(RLPStream& _s, unsigned _id, unsigned _args)
 {
-	return _s.appendRaw(bytes(1, _id + m_idOffset)).appendList(_args);
+    return _s.appendRaw(bytes(1, _id + m_idOffset)).appendList(_args);
 }
 
 void Capability::sealAndSend(RLPStream& _s)
 {
-	shared_ptr<SessionFace> session = m_session.lock();
-	if (session)
-		session->sealAndSend(_s);
+    shared_ptr<SessionFace> session = m_session.lock();
+    if (session)
+        session->sealAndSend(_s);
 }
 
 void Capability::addRating(int _r)
 {
-	shared_ptr<SessionFace> session = m_session.lock();
-	if (session)
-		session->addRating(_r);
+    shared_ptr<SessionFace> session = m_session.lock();
+    if (session)
+        session->addRating(_r);
 }

--- a/libp2p/Common.cpp
+++ b/libp2p/Common.cpp
@@ -37,7 +37,6 @@ bool dev::p2p::NodeIPEndpoint::test_allowLocal = false;
 //⊳⊲◀▶■▣▢□▷◁▧▨▩▲◆◉◈◇◎●◍◌○◼☑☒☎☢☣☰☀♽♥♠✩✭❓✔✓✖✕✘✓✔✅⚒⚡⦸⬌∅⁕«««»»»⚙━┅┉▬
 
 #if defined(_WIN32)
-const char* NetWarn::name() { return EthYellow "N" EthRed " X"; }
 const char* NetImpolite::name() { return EthYellow "N" EthRed " !"; }
 const char* NetNote::name() { return EthYellow "N" EthBlue " i"; }
 const char* NetConnect::name() { return EthYellow "N" EthYellow " C"; }
@@ -50,7 +49,6 @@ const char* NetLeft::name() { return EthYellow "N" EthNavy "<-"; }
 const char* NetP2PWarn::name() { return EthYellow "N" EthRed " X"; }
 const char* NetP2PNote::name() { return EthYellow "N" EthBlue " i"; }
 #else
-const char* NetWarn::name() { return EthYellow "⧎" EthRed " ✘"; }
 const char* NetImpolite::name() { return EthYellow "⧎" EthRed " !"; }
 const char* NetNote::name() { return EthYellow "⧎" EthBlue " ℹ"; }
 const char* NetConnect::name() { return EthYellow "⧎" EthYellow " ▢"; }

--- a/libp2p/Common.cpp
+++ b/libp2p/Common.cpp
@@ -37,7 +37,6 @@ bool dev::p2p::NodeIPEndpoint::test_allowLocal = false;
 //⊳⊲◀▶■▣▢□▷◁▧▨▩▲◆◉◈◇◎●◍◌○◼☑☒☎☢☣☰☀♽♥♠✩✭❓✔✓✖✕✘✓✔✅⚒⚡⦸⬌∅⁕«««»»»⚙━┅┉▬
 
 #if defined(_WIN32)
-const char* NetImpolite::name() { return EthYellow "N" EthRed " !"; }
 const char* NetConnect::name() { return EthYellow "N" EthYellow " C"; }
 const char* NetMessageSummary::name() { return EthYellow "N" EthWhite " ."; }
 const char* NetMessageDetail::name() { return EthYellow "N" EthGray " o"; }
@@ -48,7 +47,6 @@ const char* NetLeft::name() { return EthYellow "N" EthNavy "<-"; }
 const char* NetP2PWarn::name() { return EthYellow "N" EthRed " X"; }
 const char* NetP2PNote::name() { return EthYellow "N" EthBlue " i"; }
 #else
-const char* NetImpolite::name() { return EthYellow "⧎" EthRed " !"; }
 const char* NetConnect::name() { return EthYellow "⧎" EthYellow " ▢"; }
 const char* NetMessageSummary::name() { return EthYellow "⧎" EthWhite " ◌"; }
 const char* NetMessageDetail::name() { return EthYellow "⧎" EthGray " ○"; }

--- a/libp2p/Common.cpp
+++ b/libp2p/Common.cpp
@@ -37,12 +37,8 @@ bool dev::p2p::NodeIPEndpoint::test_allowLocal = false;
 //⊳⊲◀▶■▣▢□▷◁▧▨▩▲◆◉◈◇◎●◍◌○◼☑☒☎☢☣☰☀♽♥♠✩✭❓✔✓✖✕✘✓✔✅⚒⚡⦸⬌∅⁕«««»»»⚙━┅┉▬
 
 #if defined(_WIN32)
-const char* NetConnect::name() { return EthYellow "N" EthYellow " C"; }
-const char* NetTriviaSummary::name() { return EthYellow "N" EthGray " O"; }
 const char* NetAllDetail::name() { return EthYellow "N" EthCoal " A"; }
 #else
-const char* NetConnect::name() { return EthYellow "⧎" EthYellow " ▢"; }
-const char* NetTriviaSummary::name() { return EthYellow "⧎" EthGray " ◎"; }
 const char* NetAllDetail::name() { return EthYellow "⧎" EthCoal " ●"; }
 #endif
 

--- a/libp2p/Common.cpp
+++ b/libp2p/Common.cpp
@@ -38,7 +38,6 @@ bool dev::p2p::NodeIPEndpoint::test_allowLocal = false;
 
 #if defined(_WIN32)
 const char* NetImpolite::name() { return EthYellow "N" EthRed " !"; }
-const char* NetNote::name() { return EthYellow "N" EthBlue " i"; }
 const char* NetConnect::name() { return EthYellow "N" EthYellow " C"; }
 const char* NetMessageSummary::name() { return EthYellow "N" EthWhite " ."; }
 const char* NetMessageDetail::name() { return EthYellow "N" EthGray " o"; }
@@ -50,7 +49,6 @@ const char* NetP2PWarn::name() { return EthYellow "N" EthRed " X"; }
 const char* NetP2PNote::name() { return EthYellow "N" EthBlue " i"; }
 #else
 const char* NetImpolite::name() { return EthYellow "⧎" EthRed " !"; }
-const char* NetNote::name() { return EthYellow "⧎" EthBlue " ℹ"; }
 const char* NetConnect::name() { return EthYellow "⧎" EthYellow " ▢"; }
 const char* NetMessageSummary::name() { return EthYellow "⧎" EthWhite " ◌"; }
 const char* NetMessageDetail::name() { return EthYellow "⧎" EthGray " ○"; }

--- a/libp2p/Common.cpp
+++ b/libp2p/Common.cpp
@@ -43,8 +43,6 @@ const char* NetTriviaSummary::name() { return EthYellow "N" EthGray " O"; }
 const char* NetAllDetail::name() { return EthYellow "N" EthCoal " A"; }
 const char* NetRight::name() { return EthYellow "N" EthGreen "->"; }
 const char* NetLeft::name() { return EthYellow "N" EthNavy "<-"; }
-const char* NetP2PWarn::name() { return EthYellow "N" EthRed " X"; }
-const char* NetP2PNote::name() { return EthYellow "N" EthBlue " i"; }
 #else
 const char* NetConnect::name() { return EthYellow "⧎" EthYellow " ▢"; }
 const char* NetMessageDetail::name() { return EthYellow "⧎" EthGray " ○"; }
@@ -52,8 +50,6 @@ const char* NetTriviaSummary::name() { return EthYellow "⧎" EthGray " ◎"; }
 const char* NetAllDetail::name() { return EthYellow "⧎" EthCoal " ●"; }
 const char* NetRight::name() { return EthYellow "⧎" EthGreen "▬▶"; }
 const char* NetLeft::name() { return EthYellow "⧎" EthNavy "◀▬"; }
-const char* NetP2PWarn::name() { return EthYellow "⧎" EthRed " ✘"; }
-const char* NetP2PNote::name() { return EthYellow "⧎" EthBlue " ℹ"; }
 #endif
 
 bool p2p::isPublicAddress(std::string const& _addressToCheck)

--- a/libp2p/Common.cpp
+++ b/libp2p/Common.cpp
@@ -38,18 +38,12 @@ bool dev::p2p::NodeIPEndpoint::test_allowLocal = false;
 
 #if defined(_WIN32)
 const char* NetConnect::name() { return EthYellow "N" EthYellow " C"; }
-const char* NetMessageDetail::name() { return EthYellow "N" EthGray " o"; }
 const char* NetTriviaSummary::name() { return EthYellow "N" EthGray " O"; }
 const char* NetAllDetail::name() { return EthYellow "N" EthCoal " A"; }
-const char* NetRight::name() { return EthYellow "N" EthGreen "->"; }
-const char* NetLeft::name() { return EthYellow "N" EthNavy "<-"; }
 #else
 const char* NetConnect::name() { return EthYellow "⧎" EthYellow " ▢"; }
-const char* NetMessageDetail::name() { return EthYellow "⧎" EthGray " ○"; }
 const char* NetTriviaSummary::name() { return EthYellow "⧎" EthGray " ◎"; }
 const char* NetAllDetail::name() { return EthYellow "⧎" EthCoal " ●"; }
-const char* NetRight::name() { return EthYellow "⧎" EthGreen "▬▶"; }
-const char* NetLeft::name() { return EthYellow "⧎" EthNavy "◀▬"; }
 #endif
 
 bool p2p::isPublicAddress(std::string const& _addressToCheck)

--- a/libp2p/Common.cpp
+++ b/libp2p/Common.cpp
@@ -49,7 +49,6 @@ const char* NetRight::name() { return EthYellow "N" EthGreen "->"; }
 const char* NetLeft::name() { return EthYellow "N" EthNavy "<-"; }
 const char* NetP2PWarn::name() { return EthYellow "N" EthRed " X"; }
 const char* NetP2PNote::name() { return EthYellow "N" EthBlue " i"; }
-const char* NetP2PConnect::name() { return EthYellow "N" EthYellow " C"; }
 #else
 const char* NetWarn::name() { return EthYellow "⧎" EthRed " ✘"; }
 const char* NetImpolite::name() { return EthYellow "⧎" EthRed " !"; }
@@ -63,7 +62,6 @@ const char* NetRight::name() { return EthYellow "⧎" EthGreen "▬▶"; }
 const char* NetLeft::name() { return EthYellow "⧎" EthNavy "◀▬"; }
 const char* NetP2PWarn::name() { return EthYellow "⧎" EthRed " ✘"; }
 const char* NetP2PNote::name() { return EthYellow "⧎" EthBlue " ℹ"; }
-const char* NetP2PConnect::name() { return EthYellow "⧎" EthYellow " ▢"; }
 #endif
 
 bool p2p::isPublicAddress(std::string const& _addressToCheck)

--- a/libp2p/Common.cpp
+++ b/libp2p/Common.cpp
@@ -38,7 +38,6 @@ bool dev::p2p::NodeIPEndpoint::test_allowLocal = false;
 
 #if defined(_WIN32)
 const char* NetConnect::name() { return EthYellow "N" EthYellow " C"; }
-const char* NetMessageSummary::name() { return EthYellow "N" EthWhite " ."; }
 const char* NetMessageDetail::name() { return EthYellow "N" EthGray " o"; }
 const char* NetTriviaSummary::name() { return EthYellow "N" EthGray " O"; }
 const char* NetAllDetail::name() { return EthYellow "N" EthCoal " A"; }
@@ -48,7 +47,6 @@ const char* NetP2PWarn::name() { return EthYellow "N" EthRed " X"; }
 const char* NetP2PNote::name() { return EthYellow "N" EthBlue " i"; }
 #else
 const char* NetConnect::name() { return EthYellow "⧎" EthYellow " ▢"; }
-const char* NetMessageSummary::name() { return EthYellow "⧎" EthWhite " ◌"; }
 const char* NetMessageDetail::name() { return EthYellow "⧎" EthGray " ○"; }
 const char* NetTriviaSummary::name() { return EthYellow "⧎" EthGray " ◎"; }
 const char* NetAllDetail::name() { return EthYellow "⧎" EthCoal " ●"; }

--- a/libp2p/Common.cpp
+++ b/libp2p/Common.cpp
@@ -34,14 +34,6 @@ const dev::p2p::Node dev::p2p::UnspecifiedNode = dev::p2p::Node(NodeID(), Unspec
 
 bool dev::p2p::NodeIPEndpoint::test_allowLocal = false;
 
-//⊳⊲◀▶■▣▢□▷◁▧▨▩▲◆◉◈◇◎●◍◌○◼☑☒☎☢☣☰☀♽♥♠✩✭❓✔✓✖✕✘✓✔✅⚒⚡⦸⬌∅⁕«««»»»⚙━┅┉▬
-
-#if defined(_WIN32)
-const char* NetAllDetail::name() { return EthYellow "N" EthCoal " A"; }
-#else
-const char* NetAllDetail::name() { return EthYellow "⧎" EthCoal " ●"; }
-#endif
-
 bool p2p::isPublicAddress(std::string const& _addressToCheck)
 {
     return _addressToCheck.empty() ? false : isPublicAddress(bi::address::from_string(_addressToCheck));

--- a/libp2p/Common.h
+++ b/libp2p/Common.h
@@ -90,7 +90,6 @@ NET_GLOBAL_LOGGER(netwarn, 0)
 NET_GLOBAL_LOGGER(netnote, 2)
 #define cnetnote LOG(dev::p2p::g_netnoteLogger::get())
 
-struct NetImpolite: public LogChannel { static const char* name(); static const int verbosity = 3; };
 struct NetMessageSummary: public LogChannel { static const char* name(); static const int verbosity = 4; };
 struct NetConnect: public LogChannel { static const char* name(); static const int verbosity = 10; };
 struct NetMessageDetail: public LogChannel { static const char* name(); static const int verbosity = 5; };

--- a/libp2p/Common.h
+++ b/libp2p/Common.h
@@ -80,7 +80,14 @@ struct InvalidPublicIPAddress: virtual dev::Exception {};
 /// The ECDHE agreement failed during RLPx handshake.
 struct ECDHEError: virtual Exception {};
 
-struct NetWarn: public LogChannel { static const char* name(); static const int verbosity = 0; };
+#define NET_GLOBAL_LOGGER(NAME, SEVERITY)                      \
+    BOOST_LOG_INLINE_GLOBAL_LOGGER_CTOR_ARGS(g_##NAME##Logger, \
+        boost::log::sources::severity_channel_logger_mt<>,     \
+        (boost::log::keywords::severity = SEVERITY)(boost::log::keywords::channel = "net"))
+
+NET_GLOBAL_LOGGER(netwarn, 0)
+#define cnetwarn LOG(dev::p2p::g_netwarnLogger::get())
+
 struct NetNote: public LogChannel { static const char* name(); static const int verbosity = 2; };
 struct NetImpolite: public LogChannel { static const char* name(); static const int verbosity = 3; };
 struct NetMessageSummary: public LogChannel { static const char* name(); static const int verbosity = 4; };

--- a/libp2p/Common.h
+++ b/libp2p/Common.h
@@ -87,8 +87,9 @@ struct ECDHEError: virtual Exception {};
 
 NET_GLOBAL_LOGGER(netwarn, 0)
 #define cnetwarn LOG(dev::p2p::g_netwarnLogger::get())
+NET_GLOBAL_LOGGER(netnote, 2)
+#define cnetnote LOG(dev::p2p::g_netnoteLogger::get())
 
-struct NetNote: public LogChannel { static const char* name(); static const int verbosity = 2; };
 struct NetImpolite: public LogChannel { static const char* name(); static const int verbosity = 3; };
 struct NetMessageSummary: public LogChannel { static const char* name(); static const int verbosity = 4; };
 struct NetConnect: public LogChannel { static const char* name(); static const int verbosity = 10; };

--- a/libp2p/Common.h
+++ b/libp2p/Common.h
@@ -90,10 +90,11 @@ NET_GLOBAL_LOGGER(netwarn, 0)
 NET_GLOBAL_LOGGER(netnote, 2)
 #define cnetnote LOG(dev::p2p::g_netnoteLogger::get())
 NET_GLOBAL_LOGGER(netmessage, 4)
+// TODO rename to cnetlog
 #define cnetmessage LOG(dev::p2p::g_netmessageLogger::get())
+NET_GLOBAL_LOGGER(netdetails, 10)
+#define cnetdetails LOG(dev::p2p::g_netdetailsLogger::get())
 
-struct NetConnect: public LogChannel { static const char* name(); static const int verbosity = 10; };
-struct NetTriviaSummary: public LogChannel { static const char* name(); static const int verbosity = 10; };
 struct NetAllDetail: public LogChannel { static const char* name(); static const int verbosity = 13; };
 
 enum PacketType

--- a/libp2p/Common.h
+++ b/libp2p/Common.h
@@ -98,8 +98,6 @@ struct NetTriviaSummary: public LogChannel { static const char* name(); static c
 struct NetAllDetail: public LogChannel { static const char* name(); static const int verbosity = 13; };
 struct NetRight: public LogChannel { static const char* name(); static const int verbosity = 14; };
 struct NetLeft: public LogChannel { static const char* name(); static const int verbosity = 15; };
-struct NetP2PWarn: public LogChannel { static const char* name(); static const int verbosity = 2; };
-struct NetP2PNote: public LogChannel { static const char* name(); static const int verbosity = 6; };
 
 enum PacketType
 {

--- a/libp2p/Common.h
+++ b/libp2p/Common.h
@@ -89,8 +89,9 @@ NET_GLOBAL_LOGGER(netwarn, 0)
 #define cnetwarn LOG(dev::p2p::g_netwarnLogger::get())
 NET_GLOBAL_LOGGER(netnote, 2)
 #define cnetnote LOG(dev::p2p::g_netnoteLogger::get())
+NET_GLOBAL_LOGGER(netmessage, 4)
+#define cnetmessage LOG(dev::p2p::g_netmessageLogger::get())
 
-struct NetMessageSummary: public LogChannel { static const char* name(); static const int verbosity = 4; };
 struct NetConnect: public LogChannel { static const char* name(); static const int verbosity = 10; };
 struct NetMessageDetail: public LogChannel { static const char* name(); static const int verbosity = 5; };
 struct NetTriviaSummary: public LogChannel { static const char* name(); static const int verbosity = 10; };

--- a/libp2p/Common.h
+++ b/libp2p/Common.h
@@ -92,7 +92,6 @@ struct NetRight: public LogChannel { static const char* name(); static const int
 struct NetLeft: public LogChannel { static const char* name(); static const int verbosity = 15; };
 struct NetP2PWarn: public LogChannel { static const char* name(); static const int verbosity = 2; };
 struct NetP2PNote: public LogChannel { static const char* name(); static const int verbosity = 6; };
-struct NetP2PConnect: public LogChannel { static const char* name(); static const int verbosity = 10; };
 
 enum PacketType
 {

--- a/libp2p/Common.h
+++ b/libp2p/Common.h
@@ -89,9 +89,8 @@ NET_GLOBAL_LOGGER(netwarn, 0)
 #define cnetwarn LOG(dev::p2p::g_netwarnLogger::get())
 NET_GLOBAL_LOGGER(netnote, 2)
 #define cnetnote LOG(dev::p2p::g_netnoteLogger::get())
-NET_GLOBAL_LOGGER(netmessage, 4)
-// TODO rename to cnetlog
-#define cnetmessage LOG(dev::p2p::g_netmessageLogger::get())
+NET_GLOBAL_LOGGER(netlog, 4)
+#define cnetlog LOG(dev::p2p::g_netlogLogger::get())
 NET_GLOBAL_LOGGER(netdetails, 10)
 #define cnetdetails LOG(dev::p2p::g_netdetailsLogger::get())
 

--- a/libp2p/Common.h
+++ b/libp2p/Common.h
@@ -95,8 +95,6 @@ NET_GLOBAL_LOGGER(netmessage, 4)
 NET_GLOBAL_LOGGER(netdetails, 10)
 #define cnetdetails LOG(dev::p2p::g_netdetailsLogger::get())
 
-struct NetAllDetail: public LogChannel { static const char* name(); static const int verbosity = 13; };
-
 enum PacketType
 {
     HelloPacket = 0,

--- a/libp2p/Common.h
+++ b/libp2p/Common.h
@@ -93,11 +93,8 @@ NET_GLOBAL_LOGGER(netmessage, 4)
 #define cnetmessage LOG(dev::p2p::g_netmessageLogger::get())
 
 struct NetConnect: public LogChannel { static const char* name(); static const int verbosity = 10; };
-struct NetMessageDetail: public LogChannel { static const char* name(); static const int verbosity = 5; };
 struct NetTriviaSummary: public LogChannel { static const char* name(); static const int verbosity = 10; };
 struct NetAllDetail: public LogChannel { static const char* name(); static const int verbosity = 13; };
-struct NetRight: public LogChannel { static const char* name(); static const int verbosity = 14; };
-struct NetLeft: public LogChannel { static const char* name(); static const int verbosity = 15; };
 
 enum PacketType
 {

--- a/libp2p/Host.cpp
+++ b/libp2p/Host.cpp
@@ -316,8 +316,8 @@ void Host::startPeerSession(Public const& _id, RLP const& _rlp, unique_ptr<RLPXF
         
         if (!peerSlotsAvailable())
         {
-            clog(NetAllDetail) << "Too many peers, can't connect. peer count: " << peerCount()
-                                << " pending peers: " << m_pendingPeerConns.size();
+            cnetdetails << "Too many peers, can't connect. peer count: " << peerCount()
+                        << " pending peers: " << m_pendingPeerConns.size();
             ps->disconnect(TooManyPeers);
             return;
         }

--- a/libp2p/Host.cpp
+++ b/libp2p/Host.cpp
@@ -339,14 +339,14 @@ void Host::startPeerSession(Public const& _id, RLP const& _rlp, unique_ptr<RLPXF
         m_sessions[_id] = ps;
     }
     
-    clog(NetP2PNote) << "p2p.host.peer.register" << _id;
+    LOG(m_logger) << "p2p.host.peer.register " << _id;
 }
 
 void Host::onNodeTableEvent(NodeID const& _n, NodeTableEventType const& _e)
 {
     if (_e == NodeEntryAdded)
     {
-        clog(NetP2PNote) << "p2p.host.nodeTable.events.nodeEntryAdded " << _n;
+        LOG(m_logger) << "p2p.host.nodeTable.events.nodeEntryAdded " << _n;
         if (Node n = nodeFromNodeTable(_n))
         {
             shared_ptr<Peer> p;
@@ -361,7 +361,7 @@ void Host::onNodeTableEvent(NodeID const& _n, NodeTableEventType const& _e)
                 {
                     p = make_shared<Peer>(n);
                     m_peers[_n] = p;
-                    clog(NetP2PNote) << "p2p.host.peers.events.peerAdded " << _n << p->endpoint;
+                    LOG(m_logger) << "p2p.host.peers.events.peerAdded " << _n << " " << p->endpoint;
                 }
             }
             if (peerSlotsAvailable(Egress))
@@ -370,7 +370,7 @@ void Host::onNodeTableEvent(NodeID const& _n, NodeTableEventType const& _e)
     }
     else if (_e == NodeEntryDropped)
     {
-        clog(NetP2PNote) << "p2p.host.nodeTable.events.NodeEntryDropped " << _n;
+        LOG(m_logger) << "p2p.host.nodeTable.events.NodeEntryDropped " << _n;
         RecursiveGuard l(x_sessions);
         if (m_peers.count(_n) && m_peers[_n]->peerType == PeerType::Optional)
             m_peers.erase(_n);
@@ -753,7 +753,7 @@ void Host::startedWorking()
         runAcceptor();
     }
     else
-        clog(NetP2PNote) << "p2p.start.notice id:" << id() << "TCP Listen port is invalid or unavailable.";
+        LOG(m_logger) << "p2p.start.notice id: " << id() << " TCP Listen port is invalid or unavailable.";
 
     auto nodeTable = make_shared<NodeTable>(
         m_ioService,
@@ -766,7 +766,7 @@ void Host::startedWorking()
         m_nodeTable = nodeTable;
     restoreNetwork(&m_restoreNetwork);
 
-    clog(NetP2PNote) << "p2p.started id:" << id();
+    LOG(m_logger) << "p2p.started id: " << id();
 
     run(boost::system::error_code());
 }
@@ -780,8 +780,8 @@ void Host::doWork()
     }
     catch (std::exception const& _e)
     {
-        clog(NetP2PWarn) << "Exception in Network Thread:" << _e.what();
-        clog(NetP2PWarn) << "Network Restart is Recommended.";
+        cwarn << "Exception in Network Thread: " << _e.what();
+        cwarn << "Network Restart is Recommended.";
     }
 }
 

--- a/libp2p/Host.cpp
+++ b/libp2p/Host.cpp
@@ -107,7 +107,7 @@ Host::Host(string const& _clientVersion, KeyPair const& _alias, NetworkPreferenc
     m_alias(_alias),
     m_lastPing(chrono::steady_clock::time_point::min())
 {
-    clog(NetNote) << "Id:" << id();
+    cnetnote << "Id: " << id();
 }
 
 Host::Host(string const& _clientVersion, NetworkPreferences const& _n, bytesConstRef _restoreNetwork):
@@ -393,12 +393,12 @@ void Host::determinePublic()
     bi::tcp::endpoint ep(bi::address(), m_listenPort);
     if (m_netPrefs.traverseNAT && listenIsPublic)
     {
-        clog(NetNote) << "Listen address set to Public address:" << laddr << ". UPnP disabled.";
+        cnetnote << "Listen address set to Public address: " << laddr << ". UPnP disabled.";
         ep.address(laddr);
     }
     else if (m_netPrefs.traverseNAT && publicIsHost)
     {
-        clog(NetNote) << "Public address set to Host configured address:" << paddr << ". UPnP disabled.";
+        cnetnote << "Public address set to Host configured address: " << paddr << ". UPnP disabled.";
         ep.address(paddr);
     }
     else if (m_netPrefs.traverseNAT)

--- a/libp2p/Host.cpp
+++ b/libp2p/Host.cpp
@@ -280,7 +280,7 @@ void Host::startPeerSession(Public const& _id, RLP const& _rlp, unique_ptr<RLPXF
     for (auto cap: caps)
         capslog << "(" << cap.first << "," << dec << cap.second << ")";
 
-    clog(NetMessageSummary) << "Hello: " << clientVersion << "V[" << protocolVersion << "]" << _id << showbase << capslog.str() << dec << listenPort;
+    cnetmessage << "Hello: " << clientVersion << " V[" << protocolVersion << "]" << " " << _id << " " << showbase << capslog.str() << " " << dec << listenPort;
     
     // create session so disconnects are managed
     shared_ptr<SessionFace> ps = make_shared<Session>(this, move(_io), _s, p, PeerSessionInfo({_id, clientVersion, p->endpoint.address.to_string(), listenPort, chrono::steady_clock::duration(), _rlp[2].toSet<CapDesc>(), 0, map<string, string>(), protocolVersion}));

--- a/libp2p/Host.cpp
+++ b/libp2p/Host.cpp
@@ -133,7 +133,7 @@ void Host::start()
     if (isWorking())
         return;
 
-    clog(NetWarn) << "Network start failed!";
+    cnetwarn << "Network start failed!";
     doneWorking();
 }
 
@@ -309,7 +309,7 @@ void Host::startPeerSession(Public const& _id, RLP const& _rlp, unique_ptr<RLPXF
                 if(s->isConnected())
                 {
                     // Already connected.
-                    clog(NetWarn) << "Session already exists for peer with id" << _id;
+                    cnetwarn << "Session already exists for peer with id " << _id;
                     ps->disconnect(DuplicatePeer);
                     return;
                 }
@@ -408,12 +408,14 @@ void Host::determinePublic()
         
         if (lset && natIFAddr != laddr)
             // if listen address is set, Host will use it, even if upnp returns different
-            clog(NetWarn) << "Listen address" << laddr << "differs from local address" << natIFAddr << "returned by UPnP!";
-        
+            cnetwarn << "Listen address " << laddr << " differs from local address " << natIFAddr
+                     << " returned by UPnP!";
+
         if (pset && ep.address() != paddr)
         {
             // if public address is set, Host will advertise it, even if upnp returns different
-            clog(NetWarn) << "Specified public address" << paddr << "differs from external address" << ep.address() << "returned by UPnP!";
+            cnetwarn << "Specified public address " << paddr << " differs from external address "
+                     << ep.address() << " returned by UPnP!";
             ep.address(paddr);
         }
     }
@@ -461,11 +463,11 @@ void Host::runAcceptor()
             }
             catch (Exception const& _e)
             {
-                clog(NetWarn) << "ERROR: " << diagnostic_information(_e);
+                cnetwarn << "ERROR: " << diagnostic_information(_e);
             }
             catch (std::exception const& _e)
             {
-                clog(NetWarn) << "ERROR: " << _e.what();
+                cnetwarn << "ERROR: " << _e.what();
             }
 
             if (!success)

--- a/libp2p/Host.cpp
+++ b/libp2p/Host.cpp
@@ -280,8 +280,9 @@ void Host::startPeerSession(Public const& _id, RLP const& _rlp, unique_ptr<RLPXF
     for (auto cap: caps)
         capslog << "(" << cap.first << "," << dec << cap.second << ")";
 
-    cnetmessage << "Hello: " << clientVersion << " V[" << protocolVersion << "]" << " " << _id << " " << showbase << capslog.str() << " " << dec << listenPort;
-    
+    cnetlog << "Hello: " << clientVersion << " V[" << protocolVersion << "]"
+            << " " << _id << " " << showbase << capslog.str() << " " << dec << listenPort;
+
     // create session so disconnects are managed
     shared_ptr<SessionFace> ps = make_shared<Session>(this, move(_io), _s, p, PeerSessionInfo({_id, clientVersion, p->endpoint.address.to_string(), listenPort, chrono::steady_clock::duration(), _rlp[2].toSet<CapDesc>(), 0, map<string, string>(), protocolVersion}));
     if (protocolVersion < dev::p2p::c_protocolVersion - 1)

--- a/libp2p/Host.h
+++ b/libp2p/Host.h
@@ -349,6 +349,8 @@ private:
 	bool m_dropPeers = false;
 
 	ReputationManager m_repMan;
+
+    Logger m_logger{createLogger(6, "net")};
 };
 
 }

--- a/libp2p/Network.cpp
+++ b/libp2p/Network.cpp
@@ -201,8 +201,8 @@ bi::tcp::endpoint Network::traverseNAT(std::set<bi::address> const& _ifAddresses
         bi::address eIPAddr(bi::address::from_string(eIP));
         if (extPort && eIP != string("0.0.0.0") && !isPrivateAddress(eIPAddr))
         {
-            clog(NetNote) << "Punched through NAT and mapped local port" << _listenPort << "onto external port" << extPort << ".";
-            clog(NetNote) << "External addr:" << eIP;
+            cnetnote << "Punched through NAT and mapped local port " << _listenPort << " onto external port " << extPort << ".";
+            cnetnote << "External addr: " << eIP;
             o_upnpInterfaceAddr = pAddr;
             upnpEP = bi::tcp::endpoint(eIPAddr, (unsigned short)extPort);
         }

--- a/libp2p/Network.cpp
+++ b/libp2p/Network.cpp
@@ -1,18 +1,18 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file Network.cpp
  * @author Alex Leverington <nessence@gmail.com>
@@ -45,208 +45,208 @@ static_assert(BOOST_VERSION >= 106400, "Wrong boost headers version");
 
 std::set<bi::address> Network::getInterfaceAddresses()
 {
-	std::set<bi::address> addresses;
+    std::set<bi::address> addresses;
 
 #if defined(_WIN32)
-	WSAData wsaData;
-	if (WSAStartup(MAKEWORD(1, 1), &wsaData) != 0)
-		BOOST_THROW_EXCEPTION(NoNetworking());
+    WSAData wsaData;
+    if (WSAStartup(MAKEWORD(1, 1), &wsaData) != 0)
+        BOOST_THROW_EXCEPTION(NoNetworking());
 
-	char ac[80];
-	if (gethostname(ac, sizeof(ac)) == SOCKET_ERROR)
-	{
-		clog(NetWarn) << "Error " << WSAGetLastError() << " when getting local host name.";
-		WSACleanup();
-		BOOST_THROW_EXCEPTION(NoNetworking());
-	}
+    char ac[80];
+    if (gethostname(ac, sizeof(ac)) == SOCKET_ERROR)
+    {
+        cnetwarn << "Error " << WSAGetLastError() << " when getting local host name.";
+        WSACleanup();
+        BOOST_THROW_EXCEPTION(NoNetworking());
+    }
 
-	struct hostent* phe = gethostbyname(ac);
-	if (phe == 0)
-	{
-		clog(NetWarn) << "Bad host lookup.";
-		WSACleanup();
-		BOOST_THROW_EXCEPTION(NoNetworking());
-	}
+    struct hostent* phe = gethostbyname(ac);
+    if (phe == 0)
+    {
+        cnetwarn << "Bad host lookup.";
+        WSACleanup();
+        BOOST_THROW_EXCEPTION(NoNetworking());
+    }
 
-	for (int i = 0; phe->h_addr_list[i] != 0; ++i)
-	{
-		struct in_addr addr;
-		memcpy(&addr, phe->h_addr_list[i], sizeof(struct in_addr));
-		char *addrStr = inet_ntoa(addr);
-		bi::address address(bi::address::from_string(addrStr));
-		if (!isLocalHostAddress(address))
-			addresses.insert(address.to_v4());
-	}
+    for (int i = 0; phe->h_addr_list[i] != 0; ++i)
+    {
+        struct in_addr addr;
+        memcpy(&addr, phe->h_addr_list[i], sizeof(struct in_addr));
+        char *addrStr = inet_ntoa(addr);
+        bi::address address(bi::address::from_string(addrStr));
+        if (!isLocalHostAddress(address))
+            addresses.insert(address.to_v4());
+    }
 
-	WSACleanup();
+    WSACleanup();
 #else
-	ifaddrs* ifaddr;
-	if (getifaddrs(&ifaddr) == -1)
-		BOOST_THROW_EXCEPTION(NoNetworking());
+    ifaddrs* ifaddr;
+    if (getifaddrs(&ifaddr) == -1)
+        BOOST_THROW_EXCEPTION(NoNetworking());
 
-	for (auto ifa = ifaddr; ifa != NULL; ifa = ifa->ifa_next)
-	{
-		if (!ifa->ifa_addr || string(ifa->ifa_name) == "lo0" || !(ifa->ifa_flags & IFF_UP))
-			continue;
+    for (auto ifa = ifaddr; ifa != NULL; ifa = ifa->ifa_next)
+    {
+        if (!ifa->ifa_addr || string(ifa->ifa_name) == "lo0" || !(ifa->ifa_flags & IFF_UP))
+            continue;
 
-		if (ifa->ifa_addr->sa_family == AF_INET)
-		{
-			in_addr addr = ((struct sockaddr_in *)ifa->ifa_addr)->sin_addr;
-			boost::asio::ip::address_v4 address(boost::asio::detail::socket_ops::network_to_host_long(addr.s_addr));
-			if (!isLocalHostAddress(address))
-				addresses.insert(address);
-		}
-		else if (ifa->ifa_addr->sa_family == AF_INET6)
-		{
-			sockaddr_in6* sockaddr = ((struct sockaddr_in6 *)ifa->ifa_addr);
-			in6_addr addr = sockaddr->sin6_addr;
-			boost::asio::ip::address_v6::bytes_type bytes;
-			memcpy(&bytes[0], addr.s6_addr, 16);
-			boost::asio::ip::address_v6 address(bytes, sockaddr->sin6_scope_id);
-			if (!isLocalHostAddress(address))
-				addresses.insert(address);
-		}
-	}
+        if (ifa->ifa_addr->sa_family == AF_INET)
+        {
+            in_addr addr = ((struct sockaddr_in *)ifa->ifa_addr)->sin_addr;
+            boost::asio::ip::address_v4 address(boost::asio::detail::socket_ops::network_to_host_long(addr.s_addr));
+            if (!isLocalHostAddress(address))
+                addresses.insert(address);
+        }
+        else if (ifa->ifa_addr->sa_family == AF_INET6)
+        {
+            sockaddr_in6* sockaddr = ((struct sockaddr_in6 *)ifa->ifa_addr);
+            in6_addr addr = sockaddr->sin6_addr;
+            boost::asio::ip::address_v6::bytes_type bytes;
+            memcpy(&bytes[0], addr.s6_addr, 16);
+            boost::asio::ip::address_v6 address(bytes, sockaddr->sin6_scope_id);
+            if (!isLocalHostAddress(address))
+                addresses.insert(address);
+        }
+    }
 
-	if (ifaddr!=NULL)
-		freeifaddrs(ifaddr);
+    if (ifaddr!=NULL)
+        freeifaddrs(ifaddr);
 
 #endif
 
-	return addresses;
+    return addresses;
 }
 
 int Network::tcp4Listen(bi::tcp::acceptor& _acceptor, NetworkPreferences const& _netPrefs)
 {
-	// Due to the complexities of NAT and network environments (multiple NICs, tunnels, etc)
-	// and security concerns automation is the enemy of network configuration.
-	// If a preference cannot be accommodate the network must fail to start.
-	//
-	// Preferred IP: Attempt if set, else, try 0.0.0.0 (all interfaces)
-	// Preferred Port: Attempt if set, else, try c_defaultListenPort or 0 (random)
-	// TODO: throw instead of returning -1 and rename NetworkPreferences to NetworkConfig
-	
-	bi::address listenIP;
-	try
-	{
-		listenIP = _netPrefs.listenIPAddress.empty() ? bi::address_v4() : bi::address::from_string(_netPrefs.listenIPAddress);
-	}
-	catch (...)
-	{
-		cwarn << "Couldn't start accepting connections on host. Failed to accept socket on " << listenIP << ":" << _netPrefs.listenPort << ".\n" << boost::current_exception_diagnostic_information();
-		return -1;
-	}
-	bool requirePort = (bool)_netPrefs.listenPort;
+    // Due to the complexities of NAT and network environments (multiple NICs, tunnels, etc)
+    // and security concerns automation is the enemy of network configuration.
+    // If a preference cannot be accommodate the network must fail to start.
+    //
+    // Preferred IP: Attempt if set, else, try 0.0.0.0 (all interfaces)
+    // Preferred Port: Attempt if set, else, try c_defaultListenPort or 0 (random)
+    // TODO: throw instead of returning -1 and rename NetworkPreferences to NetworkConfig
+    
+    bi::address listenIP;
+    try
+    {
+        listenIP = _netPrefs.listenIPAddress.empty() ? bi::address_v4() : bi::address::from_string(_netPrefs.listenIPAddress);
+    }
+    catch (...)
+    {
+        cwarn << "Couldn't start accepting connections on host. Failed to accept socket on " << listenIP << ":" << _netPrefs.listenPort << ".\n" << boost::current_exception_diagnostic_information();
+        return -1;
+    }
+    bool requirePort = (bool)_netPrefs.listenPort;
 
-	for (unsigned i = 0; i < 2; ++i)
-	{
-		bi::tcp::endpoint endpoint(listenIP, requirePort ? _netPrefs.listenPort : (i ? 0 : c_defaultListenPort));
-		try
-		{
+    for (unsigned i = 0; i < 2; ++i)
+    {
+        bi::tcp::endpoint endpoint(listenIP, requirePort ? _netPrefs.listenPort : (i ? 0 : c_defaultListenPort));
+        try
+        {
 #if defined(_WIN32)
-			bool reuse = false;
+            bool reuse = false;
 #else
-			bool reuse = true;
+            bool reuse = true;
 #endif
-			_acceptor.open(endpoint.protocol());
-			_acceptor.set_option(ba::socket_base::reuse_address(reuse));
-			_acceptor.bind(endpoint);
-			_acceptor.listen();
-			return _acceptor.local_endpoint().port();
-		}
-		catch (...)
-		{
-			// bail if this is first attempt && port was specificed, or second attempt failed (random port)
-			if (i || requirePort)
-			{
-				// both attempts failed
-				cwarn << "Couldn't start accepting connections on host. Failed to accept socket on " << listenIP << ":" << _netPrefs.listenPort << ".\n" << boost::current_exception_diagnostic_information();
-				_acceptor.close();
-				return -1;
-			}
-			
-			_acceptor.close();
-			continue;
-		}
-	}
+            _acceptor.open(endpoint.protocol());
+            _acceptor.set_option(ba::socket_base::reuse_address(reuse));
+            _acceptor.bind(endpoint);
+            _acceptor.listen();
+            return _acceptor.local_endpoint().port();
+        }
+        catch (...)
+        {
+            // bail if this is first attempt && port was specificed, or second attempt failed (random port)
+            if (i || requirePort)
+            {
+                // both attempts failed
+                cwarn << "Couldn't start accepting connections on host. Failed to accept socket on " << listenIP << ":" << _netPrefs.listenPort << ".\n" << boost::current_exception_diagnostic_information();
+                _acceptor.close();
+                return -1;
+            }
+            
+            _acceptor.close();
+            continue;
+        }
+    }
 
-	return -1;
+    return -1;
 }
 
 bi::tcp::endpoint Network::traverseNAT(std::set<bi::address> const& _ifAddresses, unsigned short _listenPort, bi::address& o_upnpInterfaceAddr)
 {
-	asserts(_listenPort != 0);
+    asserts(_listenPort != 0);
 
-	unique_ptr<UPnP> upnp;
-	try
-	{
-		upnp.reset(new UPnP);
-	}
-	// let m_upnp continue as null - we handle it properly.
-	catch (...) {}
+    unique_ptr<UPnP> upnp;
+    try
+    {
+        upnp.reset(new UPnP);
+    }
+    // let m_upnp continue as null - we handle it properly.
+    catch (...) {}
 
-	bi::tcp::endpoint upnpEP;
-	if (upnp && upnp->isValid())
-	{
-		bi::address pAddr;
-		int extPort = 0;
-		for (auto const& addr: _ifAddresses)
-			if (addr.is_v4() && isPrivateAddress(addr) && (extPort = upnp->addRedirect(addr.to_string().c_str(), _listenPort)))
-			{
-				pAddr = addr;
-				break;
-			}
+    bi::tcp::endpoint upnpEP;
+    if (upnp && upnp->isValid())
+    {
+        bi::address pAddr;
+        int extPort = 0;
+        for (auto const& addr: _ifAddresses)
+            if (addr.is_v4() && isPrivateAddress(addr) && (extPort = upnp->addRedirect(addr.to_string().c_str(), _listenPort)))
+            {
+                pAddr = addr;
+                break;
+            }
 
-		auto eIP = upnp->externalIP();
-		bi::address eIPAddr(bi::address::from_string(eIP));
-		if (extPort && eIP != string("0.0.0.0") && !isPrivateAddress(eIPAddr))
-		{
-			clog(NetNote) << "Punched through NAT and mapped local port" << _listenPort << "onto external port" << extPort << ".";
-			clog(NetNote) << "External addr:" << eIP;
-			o_upnpInterfaceAddr = pAddr;
-			upnpEP = bi::tcp::endpoint(eIPAddr, (unsigned short)extPort);
-		}
-		else
-			clog(NetWarn) << "Couldn't punch through NAT (or no NAT in place).";
-	}
+        auto eIP = upnp->externalIP();
+        bi::address eIPAddr(bi::address::from_string(eIP));
+        if (extPort && eIP != string("0.0.0.0") && !isPrivateAddress(eIPAddr))
+        {
+            clog(NetNote) << "Punched through NAT and mapped local port" << _listenPort << "onto external port" << extPort << ".";
+            clog(NetNote) << "External addr:" << eIP;
+            o_upnpInterfaceAddr = pAddr;
+            upnpEP = bi::tcp::endpoint(eIPAddr, (unsigned short)extPort);
+        }
+        else
+            cnetwarn << "Couldn't punch through NAT (or no NAT in place).";
+    }
 
-	return upnpEP;
+    return upnpEP;
 }
 
 bi::tcp::endpoint Network::resolveHost(string const& _addr)
 {
-	static boost::asio::io_service s_resolverIoService;
+    static boost::asio::io_service s_resolverIoService;
 
-	vector<string> split;
-	boost::split(split, _addr, boost::is_any_of(":"));
-	unsigned port = dev::p2p::c_defaultIPPort;
+    vector<string> split;
+    boost::split(split, _addr, boost::is_any_of(":"));
+    unsigned port = dev::p2p::c_defaultIPPort;
 
-	try
-	{
-		if (split.size() > 1)
-			port = static_cast<unsigned>(stoi(split.at(1)));
-	}
-	catch(...) {}
+    try
+    {
+        if (split.size() > 1)
+            port = static_cast<unsigned>(stoi(split.at(1)));
+    }
+    catch(...) {}
 
-	boost::system::error_code ec;
-	bi::address address = bi::address::from_string(split[0], ec);
-	bi::tcp::endpoint ep(bi::address(), port);
-	if (!ec)
-		ep.address(address);
-	else
-	{
-		boost::system::error_code ec;
-		// resolve returns an iterator (host can resolve to multiple addresses)
-		bi::tcp::resolver r(s_resolverIoService);
-		auto it = r.resolve({bi::tcp::v4(), split[0], toString(port)}, ec);
-		if (ec)
-		{
-			clog(NetWarn) << "Error resolving host address..." << LogTag::Url << _addr << ":" << LogTag::Error << ec.message();
-			return bi::tcp::endpoint();
-		}
-		else
-			ep = *it;
-	}
-	return ep;
+    boost::system::error_code ec;
+    bi::address address = bi::address::from_string(split[0], ec);
+    bi::tcp::endpoint ep(bi::address(), port);
+    if (!ec)
+        ep.address(address);
+    else
+    {
+        boost::system::error_code ec;
+        // resolve returns an iterator (host can resolve to multiple addresses)
+        bi::tcp::resolver r(s_resolverIoService);
+        auto it = r.resolve({bi::tcp::v4(), split[0], toString(port)}, ec);
+        if (ec)
+        {
+            cnetwarn << "Error resolving host address... " << _addr << " : " << ec.message();
+            return bi::tcp::endpoint();
+        }
+        else
+            ep = *it;
+    }
+    return ep;
 }
 

--- a/libp2p/NodeTable.cpp
+++ b/libp2p/NodeTable.cpp
@@ -68,8 +68,8 @@ NodeTable::NodeTable(ba::io_service& _io, KeyPair const& _alias, NodeIPEndpoint 
     }
     catch (std::exception const& _e)
     {
-        clog(NetWarn) << "Exception connecting NodeTable socket: " << _e.what();
-        clog(NetWarn) << "Discovery disabled.";
+        cnetwarn << "Exception connecting NodeTable socket: " << _e.what();
+        cnetwarn << "Discovery disabled.";
     }
 }
     
@@ -497,7 +497,7 @@ void NodeTable::onReceived(UDPSocketFace*, bi::udp::endpoint const& _from, bytes
                     Neighbours out(_from, nearest, offset, nlimit);
                     out.sign(m_secret);
                     if (out.data.size() > 1280)
-                        clog(NetWarn) << "Sending truncated datagram, size: " << out.data.size();
+                        cnetwarn << "Sending truncated datagram, size: " << out.data.size();
                     m_socketPointer->send(out);
                 }
                 break;

--- a/libp2p/NodeTable.cpp
+++ b/libp2p/NodeTable.cpp
@@ -478,7 +478,8 @@ void NodeTable::onReceived(UDPSocketFace*, bi::udp::endpoint const& _from, bytes
                     });
                 if (!expected)
                 {
-                    clog(NetConnect) << "Dropping unsolicited neighbours packet from " << _from.address();
+                    cnetdetails << "Dropping unsolicited neighbours packet from "
+                                << _from.address();
                     break;
                 }
 

--- a/libp2p/RLPxHandshake.cpp
+++ b/libp2p/RLPxHandshake.cpp
@@ -30,383 +30,389 @@ using namespace dev::crypto;
 
 void RLPXHandshake::writeAuth()
 {
-	clog(NetP2PConnect) << "p2p.connect.egress sending auth to " << m_socket->remoteEndpoint();
-	m_auth.resize(Signature::size + h256::size + Public::size + h256::size + 1);
-	bytesRef sig(&m_auth[0], Signature::size);
-	bytesRef hepubk(&m_auth[Signature::size], h256::size);
-	bytesRef pubk(&m_auth[Signature::size + h256::size], Public::size);
-	bytesRef nonce(&m_auth[Signature::size + h256::size + Public::size], h256::size);
-	
-	// E(remote-pubk, S(ecdhe-random, ecdh-shared-secret^nonce) || H(ecdhe-random-pubk) || pubk || nonce || 0x0)
-	Secret staticShared;
-	crypto::ecdh::agree(m_host->m_alias.secret(), m_remote, staticShared);
-	sign(m_ecdheLocal.secret(), staticShared.makeInsecure() ^ m_nonce).ref().copyTo(sig);
-	sha3(m_ecdheLocal.pub().ref(), hepubk);
-	m_host->m_alias.pub().ref().copyTo(pubk);
-	m_nonce.ref().copyTo(nonce);
-	m_auth[m_auth.size() - 1] = 0x0;
-	encryptECIES(m_remote, &m_auth, m_authCipher);
+    LOG(m_logger) << "p2p.connect.egress sending auth to " << m_socket->remoteEndpoint();
+    m_auth.resize(Signature::size + h256::size + Public::size + h256::size + 1);
+    bytesRef sig(&m_auth[0], Signature::size);
+    bytesRef hepubk(&m_auth[Signature::size], h256::size);
+    bytesRef pubk(&m_auth[Signature::size + h256::size], Public::size);
+    bytesRef nonce(&m_auth[Signature::size + h256::size + Public::size], h256::size);
+    
+    // E(remote-pubk, S(ecdhe-random, ecdh-shared-secret^nonce) || H(ecdhe-random-pubk) || pubk || nonce || 0x0)
+    Secret staticShared;
+    crypto::ecdh::agree(m_host->m_alias.secret(), m_remote, staticShared);
+    sign(m_ecdheLocal.secret(), staticShared.makeInsecure() ^ m_nonce).ref().copyTo(sig);
+    sha3(m_ecdheLocal.pub().ref(), hepubk);
+    m_host->m_alias.pub().ref().copyTo(pubk);
+    m_nonce.ref().copyTo(nonce);
+    m_auth[m_auth.size() - 1] = 0x0;
+    encryptECIES(m_remote, &m_auth, m_authCipher);
 
-	auto self(shared_from_this());
-	ba::async_write(m_socket->ref(), ba::buffer(m_authCipher), [this, self](boost::system::error_code ec, std::size_t)
-	{
-		transition(ec);
-	});
+    auto self(shared_from_this());
+    ba::async_write(m_socket->ref(), ba::buffer(m_authCipher), [this, self](boost::system::error_code ec, std::size_t)
+    {
+        transition(ec);
+    });
 }
 
 void RLPXHandshake::writeAck()
 {
-	clog(NetP2PConnect) << "p2p.connect.ingress sending ack to " << m_socket->remoteEndpoint();
-	m_ack.resize(Public::size + h256::size + 1);
-	bytesRef epubk(&m_ack[0], Public::size);
-	bytesRef nonce(&m_ack[Public::size], h256::size);
-	m_ecdheLocal.pub().ref().copyTo(epubk);
-	m_nonce.ref().copyTo(nonce);
-	m_ack[m_ack.size() - 1] = 0x0;
-	encryptECIES(m_remote, &m_ack, m_ackCipher);
+    LOG(m_logger) << "p2p.connect.ingress sending ack to " << m_socket->remoteEndpoint();
+    m_ack.resize(Public::size + h256::size + 1);
+    bytesRef epubk(&m_ack[0], Public::size);
+    bytesRef nonce(&m_ack[Public::size], h256::size);
+    m_ecdheLocal.pub().ref().copyTo(epubk);
+    m_nonce.ref().copyTo(nonce);
+    m_ack[m_ack.size() - 1] = 0x0;
+    encryptECIES(m_remote, &m_ack, m_ackCipher);
 
-	auto self(shared_from_this());
-	ba::async_write(m_socket->ref(), ba::buffer(m_ackCipher), [this, self](boost::system::error_code ec, std::size_t)
-	{
-		transition(ec);
-	});
+    auto self(shared_from_this());
+    ba::async_write(m_socket->ref(), ba::buffer(m_ackCipher), [this, self](boost::system::error_code ec, std::size_t)
+    {
+        transition(ec);
+    });
 }
 
 void RLPXHandshake::writeAckEIP8()
 {
-	clog(NetP2PConnect) << "p2p.connect.ingress sending EIP-8 ack to " << m_socket->remoteEndpoint();
+    LOG(m_logger) << "p2p.connect.ingress sending EIP-8 ack to " << m_socket->remoteEndpoint();
 
-	RLPStream rlp;
-	rlp.appendList(3)
-		<< m_ecdheLocal.pub()
-		<< m_nonce
-		<< c_rlpxVersion;
-	m_ack = rlp.out();
-	int padAmount(rand()%100 + 100);
-	m_ack.resize(m_ack.size() + padAmount, 0);
+    RLPStream rlp;
+    rlp.appendList(3)
+        << m_ecdheLocal.pub()
+        << m_nonce
+        << c_rlpxVersion;
+    m_ack = rlp.out();
+    int padAmount(rand()%100 + 100);
+    m_ack.resize(m_ack.size() + padAmount, 0);
 
-	bytes prefix(2);
-	toBigEndian<uint16_t>(m_ack.size() + c_eciesOverhead, prefix);
-	encryptECIES(m_remote, bytesConstRef(&prefix), &m_ack, m_ackCipher);
-	m_ackCipher.insert(m_ackCipher.begin(), prefix.begin(), prefix.end());
-	
-	auto self(shared_from_this());
-	ba::async_write(m_socket->ref(), ba::buffer(m_ackCipher), [this, self](boost::system::error_code ec, std::size_t)
-	{
-		transition(ec);
-	});
+    bytes prefix(2);
+    toBigEndian<uint16_t>(m_ack.size() + c_eciesOverhead, prefix);
+    encryptECIES(m_remote, bytesConstRef(&prefix), &m_ack, m_ackCipher);
+    m_ackCipher.insert(m_ackCipher.begin(), prefix.begin(), prefix.end());
+    
+    auto self(shared_from_this());
+    ba::async_write(m_socket->ref(), ba::buffer(m_ackCipher), [this, self](boost::system::error_code ec, std::size_t)
+    {
+        transition(ec);
+    });
 }
 
 void RLPXHandshake::setAuthValues(Signature const& _sig, Public const& _remotePubk, h256 const& _remoteNonce, uint64_t _remoteVersion)
 {
-	_remotePubk.ref().copyTo(m_remote.ref());
-	_remoteNonce.ref().copyTo(m_remoteNonce.ref());
-	m_remoteVersion = _remoteVersion;
-	Secret sharedSecret;
-	crypto::ecdh::agree(m_host->m_alias.secret(), _remotePubk, sharedSecret);
-	m_ecdheRemote = recover(_sig, sharedSecret.makeInsecure() ^ _remoteNonce);
+    _remotePubk.ref().copyTo(m_remote.ref());
+    _remoteNonce.ref().copyTo(m_remoteNonce.ref());
+    m_remoteVersion = _remoteVersion;
+    Secret sharedSecret;
+    crypto::ecdh::agree(m_host->m_alias.secret(), _remotePubk, sharedSecret);
+    m_ecdheRemote = recover(_sig, sharedSecret.makeInsecure() ^ _remoteNonce);
 }
 
 void RLPXHandshake::readAuth()
 {
-	clog(NetP2PConnect) << "p2p.connect.ingress receiving auth from " << m_socket->remoteEndpoint();
-	m_authCipher.resize(307);
-	auto self(shared_from_this());
-	ba::async_read(m_socket->ref(), ba::buffer(m_authCipher, 307), [this, self](boost::system::error_code ec, std::size_t)
-	{
-		if (ec)
-			transition(ec);
-		else if (decryptECIES(m_host->m_alias.secret(), bytesConstRef(&m_authCipher), m_auth))
-		{
-			bytesConstRef data(&m_auth);
-			Signature sig(data.cropped(0, Signature::size));
-			Public pubk(data.cropped(Signature::size + h256::size, Public::size));
-			h256 nonce(data.cropped(Signature::size + h256::size + Public::size, h256::size));
-			setAuthValues(sig, pubk, nonce, 4);
-			transition();
-		}
-		else
-			readAuthEIP8();
-	});
+    LOG(m_logger) << "p2p.connect.ingress receiving auth from " << m_socket->remoteEndpoint();
+    m_authCipher.resize(307);
+    auto self(shared_from_this());
+    ba::async_read(m_socket->ref(), ba::buffer(m_authCipher, 307), [this, self](boost::system::error_code ec, std::size_t)
+    {
+        if (ec)
+            transition(ec);
+        else if (decryptECIES(m_host->m_alias.secret(), bytesConstRef(&m_authCipher), m_auth))
+        {
+            bytesConstRef data(&m_auth);
+            Signature sig(data.cropped(0, Signature::size));
+            Public pubk(data.cropped(Signature::size + h256::size, Public::size));
+            h256 nonce(data.cropped(Signature::size + h256::size + Public::size, h256::size));
+            setAuthValues(sig, pubk, nonce, 4);
+            transition();
+        }
+        else
+            readAuthEIP8();
+    });
 }
 
 void RLPXHandshake::readAuthEIP8()
 {
-	assert(m_authCipher.size() == 307);
-	uint16_t size(m_authCipher[0]<<8 | m_authCipher[1]);
-	clog(NetP2PConnect) << "p2p.connect.ingress receiving " << size << "bytes EIP-8 auth from " << m_socket->remoteEndpoint();
-	m_authCipher.resize((size_t)size + 2);
-	auto rest = ba::buffer(ba::buffer(m_authCipher) + 307);
-	auto self(shared_from_this());
-	ba::async_read(m_socket->ref(), rest, [this, self](boost::system::error_code ec, std::size_t)
-	{
-		bytesConstRef ct(&m_authCipher);
-		if (ec)
-			transition(ec);
-		else if (decryptECIES(m_host->m_alias.secret(), ct.cropped(0, 2), ct.cropped(2), m_auth))
-		{
-			RLP rlp(m_auth, RLP::ThrowOnFail | RLP::FailIfTooSmall);
-			setAuthValues(
-				rlp[0].toHash<Signature>(),
-				rlp[1].toHash<Public>(),
-				rlp[2].toHash<h256>(),
-				rlp[3].toInt<uint64_t>()
-			);
-			m_nextState = AckAuthEIP8;
-			transition();
-		}
-		else
-		{
-			clog(NetP2PConnect) << "p2p.connect.ingress auth decrypt failed for" << m_socket->remoteEndpoint();
-			m_nextState = Error;
-			transition();
-		}
-	});
+    assert(m_authCipher.size() == 307);
+    uint16_t size(m_authCipher[0]<<8 | m_authCipher[1]);
+    LOG(m_logger) << "p2p.connect.ingress receiving " << size << " bytes EIP-8 auth from "
+                  << m_socket->remoteEndpoint();
+    m_authCipher.resize((size_t)size + 2);
+    auto rest = ba::buffer(ba::buffer(m_authCipher) + 307);
+    auto self(shared_from_this());
+    ba::async_read(m_socket->ref(), rest, [this, self](boost::system::error_code ec, std::size_t)
+    {
+        bytesConstRef ct(&m_authCipher);
+        if (ec)
+            transition(ec);
+        else if (decryptECIES(m_host->m_alias.secret(), ct.cropped(0, 2), ct.cropped(2), m_auth))
+        {
+            RLP rlp(m_auth, RLP::ThrowOnFail | RLP::FailIfTooSmall);
+            setAuthValues(
+                rlp[0].toHash<Signature>(),
+                rlp[1].toHash<Public>(),
+                rlp[2].toHash<h256>(),
+                rlp[3].toInt<uint64_t>()
+            );
+            m_nextState = AckAuthEIP8;
+            transition();
+        }
+        else
+        {
+            LOG(m_logger) << "p2p.connect.ingress auth decrypt failed for "
+                          << m_socket->remoteEndpoint();
+            m_nextState = Error;
+            transition();
+        }
+    });
 }
 
 void RLPXHandshake::readAck()
 {
-	clog(NetP2PConnect) << "p2p.connect.egress receiving ack from " << m_socket->remoteEndpoint();
-	m_ackCipher.resize(210);
-	auto self(shared_from_this());
-	ba::async_read(m_socket->ref(), ba::buffer(m_ackCipher, 210), [this, self](boost::system::error_code ec, std::size_t)
-	{
-		if (ec)
-			transition(ec);
-		else if (decryptECIES(m_host->m_alias.secret(), bytesConstRef(&m_ackCipher), m_ack))
-		{
-			bytesConstRef(&m_ack).cropped(0, Public::size).copyTo(m_ecdheRemote.ref());
-			bytesConstRef(&m_ack).cropped(Public::size, h256::size).copyTo(m_remoteNonce.ref());
-			m_remoteVersion = 4;
-			transition();
-		}
-		else
-			readAckEIP8();
-	});
+    LOG(m_logger) << "p2p.connect.egress receiving ack from " << m_socket->remoteEndpoint();
+    m_ackCipher.resize(210);
+    auto self(shared_from_this());
+    ba::async_read(m_socket->ref(), ba::buffer(m_ackCipher, 210), [this, self](boost::system::error_code ec, std::size_t)
+    {
+        if (ec)
+            transition(ec);
+        else if (decryptECIES(m_host->m_alias.secret(), bytesConstRef(&m_ackCipher), m_ack))
+        {
+            bytesConstRef(&m_ack).cropped(0, Public::size).copyTo(m_ecdheRemote.ref());
+            bytesConstRef(&m_ack).cropped(Public::size, h256::size).copyTo(m_remoteNonce.ref());
+            m_remoteVersion = 4;
+            transition();
+        }
+        else
+            readAckEIP8();
+    });
 }
 
 void RLPXHandshake::readAckEIP8()
 {
-	assert(m_ackCipher.size() == 210);
-	uint16_t size(m_ackCipher[0]<<8 | m_ackCipher[1]);
-	clog(NetP2PConnect) << "p2p.connect.egress receiving " << size << "bytes EIP-8 ack from " << m_socket->remoteEndpoint();
-	m_ackCipher.resize((size_t)size + 2);
-	auto rest = ba::buffer(ba::buffer(m_ackCipher) + 210);
-	auto self(shared_from_this());
-	ba::async_read(m_socket->ref(), rest, [this, self](boost::system::error_code ec, std::size_t)
-	{
-		bytesConstRef ct(&m_ackCipher);
-		if (ec)
-			transition(ec);
-		else if (decryptECIES(m_host->m_alias.secret(), ct.cropped(0, 2), ct.cropped(2), m_ack))
-		{
-			RLP rlp(m_ack, RLP::ThrowOnFail | RLP::FailIfTooSmall);
-			m_ecdheRemote = rlp[0].toHash<Public>();
-			m_remoteNonce = rlp[1].toHash<h256>();
-			m_remoteVersion = rlp[2].toInt<uint64_t>();
-			transition();
-		}
-		else
-		{
-			clog(NetP2PConnect) << "p2p.connect.egress ack decrypt failed for " << m_socket->remoteEndpoint();
-			m_nextState = Error;
-			transition();
-		}
-	});
+    assert(m_ackCipher.size() == 210);
+    uint16_t size(m_ackCipher[0]<<8 | m_ackCipher[1]);
+    LOG(m_logger) << "p2p.connect.egress receiving " << size << " bytes EIP-8 ack from "
+                  << m_socket->remoteEndpoint();
+    m_ackCipher.resize((size_t)size + 2);
+    auto rest = ba::buffer(ba::buffer(m_ackCipher) + 210);
+    auto self(shared_from_this());
+    ba::async_read(m_socket->ref(), rest, [this, self](boost::system::error_code ec, std::size_t)
+    {
+        bytesConstRef ct(&m_ackCipher);
+        if (ec)
+            transition(ec);
+        else if (decryptECIES(m_host->m_alias.secret(), ct.cropped(0, 2), ct.cropped(2), m_ack))
+        {
+            RLP rlp(m_ack, RLP::ThrowOnFail | RLP::FailIfTooSmall);
+            m_ecdheRemote = rlp[0].toHash<Public>();
+            m_remoteNonce = rlp[1].toHash<h256>();
+            m_remoteVersion = rlp[2].toInt<uint64_t>();
+            transition();
+        }
+        else
+        {
+            LOG(m_logger) << "p2p.connect.egress ack decrypt failed for "
+                          << m_socket->remoteEndpoint();
+            m_nextState = Error;
+            transition();
+        }
+    });
 }
 
 void RLPXHandshake::cancel()
 {
-	m_cancel = true;
-	m_idleTimer.cancel();
-	m_socket->close();
-	m_io.reset();
+    m_cancel = true;
+    m_idleTimer.cancel();
+    m_socket->close();
+    m_io.reset();
 }
 
 void RLPXHandshake::error()
 {
-	auto connected = m_socket->isConnected();
-	if (connected && !m_socket->remoteEndpoint().address().is_unspecified())
-		clog(NetP2PConnect) << "Disconnecting " << m_socket->remoteEndpoint() << " (Handshake Failed)";
-	else
-		clog(NetP2PConnect) << "Handshake Failed (Connection reset by peer)";
+    auto connected = m_socket->isConnected();
+    if (connected && !m_socket->remoteEndpoint().address().is_unspecified())
+        LOG(m_logger) << "Disconnecting " << m_socket->remoteEndpoint() << " (Handshake Failed)";
+    else
+        LOG(m_logger) << "Handshake Failed (Connection reset by peer)";
 
-	cancel();
+    cancel();
 }
 
 void RLPXHandshake::transition(boost::system::error_code _ech)
 {
-	// reset timeout
-	m_idleTimer.cancel();
-	
-	if (_ech || m_nextState == Error || m_cancel)
-	{
-		clog(NetP2PConnect) << "Handshake Failed (I/O Error:" << _ech.message() << ")";
-		return error();
-	}
-	
-	auto self(shared_from_this());
-	assert(m_nextState != StartSession);
-	m_idleTimer.expires_from_now(c_timeout);
-	m_idleTimer.async_wait([this, self](boost::system::error_code const& _ec)
-	{
-		if (!_ec)
-		{
-			if (!m_socket->remoteEndpoint().address().is_unspecified())
-				clog(NetP2PConnect) << "Disconnecting " << m_socket->remoteEndpoint() << " (Handshake Timeout)";
-			cancel();
-		}
-	});
-	
-	if (m_nextState == New)
-	{
-		m_nextState = AckAuth;
-		if (m_originated)
-			writeAuth();
-		else
-			readAuth();
-	}
-	else if (m_nextState == AckAuth)
-	{
-		m_nextState = WriteHello;
-		if (m_originated)
-			readAck();
-		else
-			writeAck();
-	}
-	else if (m_nextState == AckAuthEIP8)
-	{
-		m_nextState = WriteHello;
-		if (m_originated)
-			readAck();
-		else
-			writeAckEIP8();
-	}
-	else if (m_nextState == WriteHello)
-	{
-		m_nextState = ReadHello;
-		clog(NetP2PConnect) << (m_originated ? "p2p.connect.egress" : "p2p.connect.ingress") << "sending capabilities handshake";
+    // reset timeout
+    m_idleTimer.cancel();
+    
+    if (_ech || m_nextState == Error || m_cancel)
+    {
+        LOG(m_logger) << "Handshake Failed (I/O Error: " << _ech.message() << ")";
+        return error();
+    }
+    
+    auto self(shared_from_this());
+    assert(m_nextState != StartSession);
+    m_idleTimer.expires_from_now(c_timeout);
+    m_idleTimer.async_wait([this, self](boost::system::error_code const& _ec)
+    {
+        if (!_ec)
+        {
+            if (!m_socket->remoteEndpoint().address().is_unspecified())
+                LOG(m_logger) << "Disconnecting " << m_socket->remoteEndpoint()
+                              << " (Handshake Timeout)";
+            cancel();
+        }
+    });
+    
+    if (m_nextState == New)
+    {
+        m_nextState = AckAuth;
+        if (m_originated)
+            writeAuth();
+        else
+            readAuth();
+    }
+    else if (m_nextState == AckAuth)
+    {
+        m_nextState = WriteHello;
+        if (m_originated)
+            readAck();
+        else
+            writeAck();
+    }
+    else if (m_nextState == AckAuthEIP8)
+    {
+        m_nextState = WriteHello;
+        if (m_originated)
+            readAck();
+        else
+            writeAckEIP8();
+    }
+    else if (m_nextState == WriteHello)
+    {
+        m_nextState = ReadHello;
+        LOG(m_logger) << (m_originated ? "p2p.connect.egress" : "p2p.connect.ingress")
+                      << " sending capabilities handshake";
 
-		/// This pointer will be freed if there is an error otherwise
-		/// it will be passed to Host which will take ownership.
-		m_io.reset(new RLPXFrameCoder(*this));
+        /// This pointer will be freed if there is an error otherwise
+        /// it will be passed to Host which will take ownership.
+        m_io.reset(new RLPXFrameCoder(*this));
 
-		RLPStream s;
-		s.append((unsigned)HelloPacket).appendList(5)
-			<< dev::p2p::c_protocolVersion
-			<< m_host->m_clientVersion
-			<< m_host->caps()
-			<< m_host->listenPort()
-			<< m_host->id();
+        RLPStream s;
+        s.append((unsigned)HelloPacket).appendList(5)
+            << dev::p2p::c_protocolVersion
+            << m_host->m_clientVersion
+            << m_host->caps()
+            << m_host->listenPort()
+            << m_host->id();
 
-		bytes packet;
-		s.swapOut(packet);
-		m_io->writeSingleFramePacket(&packet, m_handshakeOutBuffer);
-		ba::async_write(m_socket->ref(), ba::buffer(m_handshakeOutBuffer), [this, self](boost::system::error_code ec, std::size_t)
-		{
-			transition(ec);
-		});
-	}
-	else if (m_nextState == ReadHello)
-	{
-		// Authenticate and decrypt initial hello frame with initial RLPXFrameCoder
-		// and request m_host to start session.
-		m_nextState = StartSession;
-		
-		// read frame header
-		unsigned const handshakeSize = 32;
-		m_handshakeInBuffer.resize(handshakeSize);
-		ba::async_read(m_socket->ref(), boost::asio::buffer(m_handshakeInBuffer, handshakeSize), [this, self](boost::system::error_code ec, std::size_t)
-		{
-			if (ec)
-				transition(ec);
-			else
-			{
-				if (!m_io)
-				{
-					clog(NetP2PWarn) << "Internal error in handshake: RLPXFrameCoder disappeared.";
-					m_nextState = Error;
-					transition();
-					return;
+        bytes packet;
+        s.swapOut(packet);
+        m_io->writeSingleFramePacket(&packet, m_handshakeOutBuffer);
+        ba::async_write(m_socket->ref(), ba::buffer(m_handshakeOutBuffer), [this, self](boost::system::error_code ec, std::size_t)
+        {
+            transition(ec);
+        });
+    }
+    else if (m_nextState == ReadHello)
+    {
+        // Authenticate and decrypt initial hello frame with initial RLPXFrameCoder
+        // and request m_host to start session.
+        m_nextState = StartSession;
+        
+        // read frame header
+        unsigned const handshakeSize = 32;
+        m_handshakeInBuffer.resize(handshakeSize);
+        ba::async_read(m_socket->ref(), boost::asio::buffer(m_handshakeInBuffer, handshakeSize), [this, self](boost::system::error_code ec, std::size_t)
+        {
+            if (ec)
+                transition(ec);
+            else
+            {
+                if (!m_io)
+                {
+                    clog(NetP2PWarn) << "Internal error in handshake: RLPXFrameCoder disappeared.";
+                    m_nextState = Error;
+                    transition();
+                    return;
 
-				}
-				/// authenticate and decrypt header
-				if (!m_io->authAndDecryptHeader(bytesRef(m_handshakeInBuffer.data(), m_handshakeInBuffer.size())))
-				{
-					m_nextState = Error;
-					transition();
-					return;
-				}
-				
-				clog(NetP2PNote) << (m_originated ? "p2p.connect.egress" : "p2p.connect.ingress") << "recvd hello header";
-				
-				/// check frame size
-				bytes& header = m_handshakeInBuffer;
-				uint32_t frameSize = (uint32_t)(header[2]) | (uint32_t)(header[1])<<8 | (uint32_t)(header[0])<<16;
-				if (frameSize > 1024)
-				{
-					// all future frames: 16777216
-					clog(NetP2PWarn) << (m_originated ? "p2p.connect.egress" : "p2p.connect.ingress") << "hello frame is too large" << frameSize;
-					m_nextState = Error;
-					transition();
-					return;
-				}
-				
-				/// rlp of header has protocol-type, sequence-id[, total-packet-size]
-				bytes headerRLP(header.size() - 3 - h128::size);	// this is always 32 - 3 - 16 = 13. wtf?
-				bytesConstRef(&header).cropped(3).copyTo(&headerRLP);
-				
-				/// read padded frame and mac
-				m_handshakeInBuffer.resize(frameSize + ((16 - (frameSize % 16)) % 16) + h128::size);
-				ba::async_read(m_socket->ref(), boost::asio::buffer(m_handshakeInBuffer, m_handshakeInBuffer.size()), [this, self, headerRLP](boost::system::error_code ec, std::size_t)
-				{
-					m_idleTimer.cancel();
-					
-					if (ec)
-						transition(ec);
-					else
-					{
-						if (!m_io)
-						{
-							clog(NetP2PWarn) << "Internal error in handshake: RLPXFrameCoder disappeared.";
-							m_nextState = Error;
-							transition();
-							return;
+                }
+                /// authenticate and decrypt header
+                if (!m_io->authAndDecryptHeader(bytesRef(m_handshakeInBuffer.data(), m_handshakeInBuffer.size())))
+                {
+                    m_nextState = Error;
+                    transition();
+                    return;
+                }
+                
+                clog(NetP2PNote) << (m_originated ? "p2p.connect.egress" : "p2p.connect.ingress") << "recvd hello header";
+                
+                /// check frame size
+                bytes& header = m_handshakeInBuffer;
+                uint32_t frameSize = (uint32_t)(header[2]) | (uint32_t)(header[1])<<8 | (uint32_t)(header[0])<<16;
+                if (frameSize > 1024)
+                {
+                    // all future frames: 16777216
+                    clog(NetP2PWarn) << (m_originated ? "p2p.connect.egress" : "p2p.connect.ingress") << "hello frame is too large" << frameSize;
+                    m_nextState = Error;
+                    transition();
+                    return;
+                }
+                
+                /// rlp of header has protocol-type, sequence-id[, total-packet-size]
+                bytes headerRLP(header.size() - 3 - h128::size);	// this is always 32 - 3 - 16 = 13. wtf?
+                bytesConstRef(&header).cropped(3).copyTo(&headerRLP);
+                
+                /// read padded frame and mac
+                m_handshakeInBuffer.resize(frameSize + ((16 - (frameSize % 16)) % 16) + h128::size);
+                ba::async_read(m_socket->ref(), boost::asio::buffer(m_handshakeInBuffer, m_handshakeInBuffer.size()), [this, self, headerRLP](boost::system::error_code ec, std::size_t)
+                {
+                    m_idleTimer.cancel();
+                    
+                    if (ec)
+                        transition(ec);
+                    else
+                    {
+                        if (!m_io)
+                        {
+                            clog(NetP2PWarn) << "Internal error in handshake: RLPXFrameCoder disappeared.";
+                            m_nextState = Error;
+                            transition();
+                            return;
 
-						}
-						bytesRef frame(&m_handshakeInBuffer);
-						if (!m_io->authAndDecryptFrame(frame))
-						{
-							clog(NetTriviaSummary) << (m_originated ? "p2p.connect.egress" : "p2p.connect.ingress") << "hello frame: decrypt failed";
-							m_nextState = Error;
-							transition();
-							return;
-						}
-						
-						PacketType packetType = frame[0] == 0x80 ? HelloPacket : (PacketType)frame[0];
-						if (packetType != HelloPacket)
-						{
-							clog(NetTriviaSummary) << (m_originated ? "p2p.connect.egress" : "p2p.connect.ingress") << "hello frame: invalid packet type";
-							m_nextState = Error;
-							transition();
-							return;
-						}
+                        }
+                        bytesRef frame(&m_handshakeInBuffer);
+                        if (!m_io->authAndDecryptFrame(frame))
+                        {
+                            clog(NetTriviaSummary) << (m_originated ? "p2p.connect.egress" : "p2p.connect.ingress") << "hello frame: decrypt failed";
+                            m_nextState = Error;
+                            transition();
+                            return;
+                        }
+                        
+                        PacketType packetType = frame[0] == 0x80 ? HelloPacket : (PacketType)frame[0];
+                        if (packetType != HelloPacket)
+                        {
+                            clog(NetTriviaSummary) << (m_originated ? "p2p.connect.egress" : "p2p.connect.ingress") << "hello frame: invalid packet type";
+                            m_nextState = Error;
+                            transition();
+                            return;
+                        }
 
-						clog(NetTriviaSummary) << (m_originated ? "p2p.connect.egress" : "p2p.connect.ingress") << "hello frame: success. starting session.";
-						try
-						{
-							RLP rlp(frame.cropped(1), RLP::ThrowOnFail | RLP::FailIfTooSmall);
-							m_host->startPeerSession(m_remote, rlp, move(m_io), m_socket);
-						}
-						catch (std::exception const& _e)
-						{
-							clog(NetWarn) << "Handshake causing an exception:" << _e.what();
-							m_nextState = Error;
-							transition();
-						}
-					}
-				});
-			}
-		});
-	}
+                        clog(NetTriviaSummary) << (m_originated ? "p2p.connect.egress" : "p2p.connect.ingress") << "hello frame: success. starting session.";
+                        try
+                        {
+                            RLP rlp(frame.cropped(1), RLP::ThrowOnFail | RLP::FailIfTooSmall);
+                            m_host->startPeerSession(m_remote, rlp, move(m_io), m_socket);
+                        }
+                        catch (std::exception const& _e)
+                        {
+                            clog(NetWarn) << "Handshake causing an exception:" << _e.what();
+                            m_nextState = Error;
+                            transition();
+                        }
+                    }
+                });
+            }
+        });
+    }
 }

--- a/libp2p/RLPxHandshake.cpp
+++ b/libp2p/RLPxHandshake.cpp
@@ -343,16 +343,19 @@ void RLPXHandshake::transition(boost::system::error_code _ech)
                     transition();
                     return;
                 }
-                
-                clog(NetP2PNote) << (m_originated ? "p2p.connect.egress" : "p2p.connect.ingress") << "recvd hello header";
-                
+
+                clog(NetP2PNote) << (m_originated ? "p2p.connect.egress" : "p2p.connect.ingress")
+                                 << " recvd hello header";
+
                 /// check frame size
                 bytes& header = m_handshakeInBuffer;
                 uint32_t frameSize = (uint32_t)(header[2]) | (uint32_t)(header[1])<<8 | (uint32_t)(header[0])<<16;
                 if (frameSize > 1024)
                 {
                     // all future frames: 16777216
-                    clog(NetP2PWarn) << (m_originated ? "p2p.connect.egress" : "p2p.connect.ingress") << "hello frame is too large" << frameSize;
+                    clog(NetP2PWarn)
+                        << (m_originated ? "p2p.connect.egress" : "p2p.connect.ingress")
+                        << " hello frame is too large " << frameSize;
                     m_nextState = Error;
                     transition();
                     return;
@@ -383,7 +386,9 @@ void RLPXHandshake::transition(boost::system::error_code _ech)
                         bytesRef frame(&m_handshakeInBuffer);
                         if (!m_io->authAndDecryptFrame(frame))
                         {
-                            clog(NetTriviaSummary) << (m_originated ? "p2p.connect.egress" : "p2p.connect.ingress") << "hello frame: decrypt failed";
+                            clog(NetTriviaSummary)
+                                << (m_originated ? "p2p.connect.egress" : "p2p.connect.ingress")
+                                << " hello frame: decrypt failed";
                             m_nextState = Error;
                             transition();
                             return;
@@ -392,13 +397,17 @@ void RLPXHandshake::transition(boost::system::error_code _ech)
                         PacketType packetType = frame[0] == 0x80 ? HelloPacket : (PacketType)frame[0];
                         if (packetType != HelloPacket)
                         {
-                            clog(NetTriviaSummary) << (m_originated ? "p2p.connect.egress" : "p2p.connect.ingress") << "hello frame: invalid packet type";
+                            clog(NetTriviaSummary)
+                                << (m_originated ? "p2p.connect.egress" : "p2p.connect.ingress")
+                                << " hello frame: invalid packet type";
                             m_nextState = Error;
                             transition();
                             return;
                         }
 
-                        clog(NetTriviaSummary) << (m_originated ? "p2p.connect.egress" : "p2p.connect.ingress") << "hello frame: success. starting session.";
+                        clog(NetTriviaSummary)
+                            << (m_originated ? "p2p.connect.egress" : "p2p.connect.ingress")
+                            << " hello frame: success. starting session.";
                         try
                         {
                             RLP rlp(frame.cropped(1), RLP::ThrowOnFail | RLP::FailIfTooSmall);
@@ -406,7 +415,7 @@ void RLPXHandshake::transition(boost::system::error_code _ech)
                         }
                         catch (std::exception const& _e)
                         {
-                            clog(NetWarn) << "Handshake causing an exception:" << _e.what();
+                            cnetwarn << "Handshake causing an exception: " << _e.what();
                             m_nextState = Error;
                             transition();
                         }

--- a/libp2p/RLPxHandshake.cpp
+++ b/libp2p/RLPxHandshake.cpp
@@ -386,7 +386,7 @@ void RLPXHandshake::transition(boost::system::error_code _ech)
                         bytesRef frame(&m_handshakeInBuffer);
                         if (!m_io->authAndDecryptFrame(frame))
                         {
-                            clog(NetTriviaSummary)
+                            cnetdetails
                                 << (m_originated ? "p2p.connect.egress" : "p2p.connect.ingress")
                                 << " hello frame: decrypt failed";
                             m_nextState = Error;
@@ -397,7 +397,7 @@ void RLPXHandshake::transition(boost::system::error_code _ech)
                         PacketType packetType = frame[0] == 0x80 ? HelloPacket : (PacketType)frame[0];
                         if (packetType != HelloPacket)
                         {
-                            clog(NetTriviaSummary)
+                            cnetdetails
                                 << (m_originated ? "p2p.connect.egress" : "p2p.connect.ingress")
                                 << " hello frame: invalid packet type";
                             m_nextState = Error;
@@ -405,9 +405,8 @@ void RLPXHandshake::transition(boost::system::error_code _ech)
                             return;
                         }
 
-                        clog(NetTriviaSummary)
-                            << (m_originated ? "p2p.connect.egress" : "p2p.connect.ingress")
-                            << " hello frame: success. starting session.";
+                        cnetdetails << (m_originated ? "p2p.connect.egress" : "p2p.connect.ingress")
+                                    << " hello frame: success. starting session.";
                         try
                         {
                             RLP rlp(frame.cropped(1), RLP::ThrowOnFail | RLP::FailIfTooSmall);

--- a/libp2p/RLPxHandshake.cpp
+++ b/libp2p/RLPxHandshake.cpp
@@ -330,7 +330,7 @@ void RLPXHandshake::transition(boost::system::error_code _ech)
             {
                 if (!m_io)
                 {
-                    clog(NetP2PWarn) << "Internal error in handshake: RLPXFrameCoder disappeared.";
+                    LOG(m_logger) << "Internal error in handshake: RLPXFrameCoder disappeared.";
                     m_nextState = Error;
                     transition();
                     return;
@@ -344,7 +344,7 @@ void RLPXHandshake::transition(boost::system::error_code _ech)
                     return;
                 }
 
-                clog(NetP2PNote) << (m_originated ? "p2p.connect.egress" : "p2p.connect.ingress")
+                LOG(m_logger) << (m_originated ? "p2p.connect.egress" : "p2p.connect.ingress")
                                  << " recvd hello header";
 
                 /// check frame size
@@ -353,7 +353,7 @@ void RLPXHandshake::transition(boost::system::error_code _ech)
                 if (frameSize > 1024)
                 {
                     // all future frames: 16777216
-                    clog(NetP2PWarn)
+                    LOG(m_logger)
                         << (m_originated ? "p2p.connect.egress" : "p2p.connect.ingress")
                         << " hello frame is too large " << frameSize;
                     m_nextState = Error;
@@ -377,7 +377,7 @@ void RLPXHandshake::transition(boost::system::error_code _ech)
                     {
                         if (!m_io)
                         {
-                            clog(NetP2PWarn) << "Internal error in handshake: RLPXFrameCoder disappeared.";
+                            LOG(m_logger) << "Internal error in handshake: RLPXFrameCoder disappeared.";
                             m_nextState = Error;
                             transition();
                             return;

--- a/libp2p/RLPxHandshake.h
+++ b/libp2p/RLPxHandshake.h
@@ -49,100 +49,102 @@ static const unsigned c_rlpxVersion = 4;
  */
 class RLPXHandshake: public std::enable_shared_from_this<RLPXHandshake>
 {
-	friend class RLPXFrameCoder;
+    friend class RLPXFrameCoder;
 
 public:
-	/// Setup incoming connection.
-	RLPXHandshake(Host* _host, std::shared_ptr<RLPXSocket> const& _socket): m_host(_host), m_originated(false), m_socket(_socket), m_idleTimer(m_socket->ref().get_io_service()) { crypto::Nonce::get().ref().copyTo(m_nonce.ref()); }
-	
-	/// Setup outbound connection.
-	RLPXHandshake(Host* _host, std::shared_ptr<RLPXSocket> const& _socket, NodeID _remote): m_host(_host), m_remote(_remote), m_originated(true), m_socket(_socket), m_idleTimer(m_socket->ref().get_io_service()) { crypto::Nonce::get().ref().copyTo(m_nonce.ref()); }
+    /// Setup incoming connection.
+    RLPXHandshake(Host* _host, std::shared_ptr<RLPXSocket> const& _socket): m_host(_host), m_originated(false), m_socket(_socket), m_idleTimer(m_socket->ref().get_io_service()) { crypto::Nonce::get().ref().copyTo(m_nonce.ref()); }
+    
+    /// Setup outbound connection.
+    RLPXHandshake(Host* _host, std::shared_ptr<RLPXSocket> const& _socket, NodeID _remote): m_host(_host), m_remote(_remote), m_originated(true), m_socket(_socket), m_idleTimer(m_socket->ref().get_io_service()) { crypto::Nonce::get().ref().copyTo(m_nonce.ref()); }
 
-	virtual ~RLPXHandshake() = default;
+    virtual ~RLPXHandshake() = default;
 
-	/// Start handshake.
-	void start() { transition(); }
+    /// Start handshake.
+    void start() { transition(); }
 
-	/// Aborts the handshake.
-	void cancel();
+    /// Aborts the handshake.
+    void cancel();
 
 protected:
-	/// Sequential states of handshake
-	enum State
-	{
-		Error = -1,
-		New,
-		AckAuth,
-		AckAuthEIP8,
-		WriteHello,
-		ReadHello,
-		StartSession
-	};
+    /// Sequential states of handshake
+    enum State
+    {
+        Error = -1,
+        New,
+        AckAuth,
+        AckAuthEIP8,
+        WriteHello,
+        ReadHello,
+        StartSession
+    };
 
-	/// Write Auth message to socket and transitions to AckAuth.
-	void writeAuth();
+    /// Write Auth message to socket and transitions to AckAuth.
+    void writeAuth();
 
-	/// Reads Auth message from socket and transitions to AckAuth.
-	void readAuth();
+    /// Reads Auth message from socket and transitions to AckAuth.
+    void readAuth();
 
-	/// Continues reading Auth message in EIP-8 format and transitions to AckAuthEIP8.
-	void readAuthEIP8();
+    /// Continues reading Auth message in EIP-8 format and transitions to AckAuthEIP8.
+    void readAuthEIP8();
 
-	/// Derives ephemeral secret from signature and sets members after Auth has been decrypted.
-	void setAuthValues(Signature const& sig, Public const& remotePubk, h256 const& remoteNonce, uint64_t remoteVersion);
-	
-	/// Write Ack message to socket and transitions to WriteHello.
-	void writeAck();
+    /// Derives ephemeral secret from signature and sets members after Auth has been decrypted.
+    void setAuthValues(Signature const& sig, Public const& remotePubk, h256 const& remoteNonce, uint64_t remoteVersion);
+    
+    /// Write Ack message to socket and transitions to WriteHello.
+    void writeAck();
 
-	/// Write Ack message in EIP-8 format to socket and transitions to WriteHello.
-	void writeAckEIP8();
-	
-	/// Reads Auth message from socket and transitions to WriteHello.
-	void readAck();
+    /// Write Ack message in EIP-8 format to socket and transitions to WriteHello.
+    void writeAckEIP8();
+    
+    /// Reads Auth message from socket and transitions to WriteHello.
+    void readAck();
 
-	/// Continues reading Ack message in EIP-8 format and transitions to WriteHello.
-	void readAckEIP8();
-	
-	/// Closes connection and ends transitions.
-	void error();
-	
-	/// Performs transition for m_nextState.
-	virtual void transition(boost::system::error_code _ech = boost::system::error_code());
+    /// Continues reading Ack message in EIP-8 format and transitions to WriteHello.
+    void readAckEIP8();
+    
+    /// Closes connection and ends transitions.
+    void error();
+    
+    /// Performs transition for m_nextState.
+    virtual void transition(boost::system::error_code _ech = boost::system::error_code());
 
-	/// Timeout for remote to respond to transition events. Enforced by m_idleTimer and refreshed by transition().
-	boost::posix_time::milliseconds const c_timeout = boost::posix_time::milliseconds(1800);
+    /// Timeout for remote to respond to transition events. Enforced by m_idleTimer and refreshed by transition().
+    boost::posix_time::milliseconds const c_timeout = boost::posix_time::milliseconds(1800);
 
-	State m_nextState = New;		///< Current or expected state of transition.
-	bool m_cancel = false;			///< Will be set to true if connection was canceled.
-	
-	Host* m_host;					///< Host which provides m_alias, protocolVersion(), m_clientVersion, caps(), and TCP listenPort().
-	
-	/// Node id of remote host for socket.
-	NodeID m_remote;				///< Public address of remote host.
-	bool m_originated = false;		///< True if connection is outbound.
-	
-	/// Buffers for encoded and decoded handshake phases
-	bytes m_auth;					///< Plaintext of egress or ingress Auth message.
-	bytes m_authCipher;				///< Ciphertext of egress or ingress Auth message.
-	bytes m_ack;					///< Plaintext of egress or ingress Ack message.
-	bytes m_ackCipher;				///< Ciphertext of egress or ingress Ack message.
-	bytes m_handshakeOutBuffer;		///< Frame buffer for egress Hello packet.
-	bytes m_handshakeInBuffer;		///< Frame buffer for ingress Hello packet.
-	
-	KeyPair m_ecdheLocal = KeyPair::create();  ///< Ephemeral ECDH secret and agreement.
-	h256 m_nonce;					///< Nonce generated by this host for handshake.
-	
-	Public m_ecdheRemote;			///< Remote ephemeral public key.
-	h256 m_remoteNonce;				///< Nonce generated by remote host for handshake.
-	uint64_t m_remoteVersion;
-	
-	/// Used to read and write RLPx encrypted frames for last step of handshake authentication.
-	/// Passed onto Host which will take ownership.
-	std::unique_ptr<RLPXFrameCoder> m_io;
-	
-	std::shared_ptr<RLPXSocket> m_socket;		///< Socket.
-	boost::asio::deadline_timer m_idleTimer;	///< Timer which enforces c_timeout.
+    State m_nextState = New;		///< Current or expected state of transition.
+    bool m_cancel = false;			///< Will be set to true if connection was canceled.
+    
+    Host* m_host;					///< Host which provides m_alias, protocolVersion(), m_clientVersion, caps(), and TCP listenPort().
+    
+    /// Node id of remote host for socket.
+    NodeID m_remote;				///< Public address of remote host.
+    bool m_originated = false;		///< True if connection is outbound.
+    
+    /// Buffers for encoded and decoded handshake phases
+    bytes m_auth;					///< Plaintext of egress or ingress Auth message.
+    bytes m_authCipher;				///< Ciphertext of egress or ingress Auth message.
+    bytes m_ack;					///< Plaintext of egress or ingress Ack message.
+    bytes m_ackCipher;				///< Ciphertext of egress or ingress Ack message.
+    bytes m_handshakeOutBuffer;		///< Frame buffer for egress Hello packet.
+    bytes m_handshakeInBuffer;		///< Frame buffer for ingress Hello packet.
+    
+    KeyPair m_ecdheLocal = KeyPair::create();  ///< Ephemeral ECDH secret and agreement.
+    h256 m_nonce;					///< Nonce generated by this host for handshake.
+    
+    Public m_ecdheRemote;			///< Remote ephemeral public key.
+    h256 m_remoteNonce;				///< Nonce generated by remote host for handshake.
+    uint64_t m_remoteVersion;
+    
+    /// Used to read and write RLPx encrypted frames for last step of handshake authentication.
+    /// Passed onto Host which will take ownership.
+    std::unique_ptr<RLPXFrameCoder> m_io;
+    
+    std::shared_ptr<RLPXSocket> m_socket;		///< Socket.
+    boost::asio::deadline_timer m_idleTimer;	///< Timer which enforces c_timeout.
+
+    Logger m_logger{createLogger(10, "net")};
 };
-	
+    
 }
 }

--- a/libp2p/Session.cpp
+++ b/libp2p/Session.cpp
@@ -116,7 +116,7 @@ template <class T> vector<T> randomSelection(vector<T> const& _t, unsigned _n)
 bool Session::readPacket(uint16_t _capId, PacketType _t, RLP const& _r)
 {
     m_lastReceived = chrono::steady_clock::now();
-    clog(NetRight) << _t << _r;
+    clogSimple(14, "net") << "-> " << _t << " " << _r;
     try // Generic try-catch block designed to capture RLP format errors - TODO: give decent diagnostics, make a bit more specific over what is caught.
     {
         // v4 frame headers are useless, offset packet type used
@@ -212,7 +212,7 @@ bool Session::checkPacket(bytesConstRef _msg)
 void Session::send(bytes&& _msg)
 {
     bytesConstRef msg(&_msg);
-    clog(NetLeft) << RLP(msg.cropped(1));
+    clogSimple(15, "net") << "<- " << RLP(msg.cropped(1));
     if (!checkPacket(msg))
         cnetwarn << "INVALID PACKET CONSTRUCTED!";
 

--- a/libp2p/Session.cpp
+++ b/libp2p/Session.cpp
@@ -50,7 +50,7 @@ Session::~Session()
 {
     ThreadContext tc(info().id.abridged());
     ThreadContext tc2(info().clientVersion);
-    cnetmessage << "Closing peer session :-(";
+    cnetlog << "Closing peer session :-(";
     m_peer->m_lastConnected = m_peer->m_lastAttempted - chrono::seconds(1);
 
     // Read-chain finished for one reason or another.
@@ -153,7 +153,7 @@ bool Session::interpret(PacketType _t, RLP const& _r)
         else
         {
             reason = reasonOf(r);
-            cnetmessage << "Disconnect (reason: " << reason << ")";
+            cnetlog << "Disconnect (reason: " << reason << ")";
             drop(DisconnectRequested);
         }
         break;

--- a/libp2p/Session.cpp
+++ b/libp2p/Session.cpp
@@ -160,7 +160,7 @@ bool Session::interpret(PacketType _t, RLP const& _r)
     }
     case PingPacket:
     {
-        clog(NetTriviaSummary) << "Ping" << m_info.id;
+        cnetdetails << "Ping " << m_info.id;
         RLPStream s;
         sealAndSend(prep(s, PongPacket));
         break;
@@ -169,7 +169,9 @@ bool Session::interpret(PacketType _t, RLP const& _r)
         DEV_GUARDED(x_info)
         {
             m_info.lastPing = std::chrono::steady_clock::now() - m_ping;
-            clog(NetTriviaSummary) << "Latency: " << chrono::duration_cast<chrono::milliseconds>(m_info.lastPing).count() << " ms";
+            cnetdetails << "Latency: "
+                        << chrono::duration_cast<chrono::milliseconds>(m_info.lastPing).count()
+                        << " ms";
         }
         break;
     case GetPeersPacket:
@@ -287,7 +289,8 @@ void Session::drop(DisconnectReason _reason)
         try
         {
             boost::system::error_code ec;
-            clog(NetConnect) << "Closing " << socket.remote_endpoint(ec) << "(" << reasonOf(_reason) << ")";
+            cnetdetails << "Closing " << socket.remote_endpoint(ec) << " (" << reasonOf(_reason)
+                        << ")";
             socket.shutdown(boost::asio::ip::tcp::socket::shutdown_both, ec);
             socket.close();
         }
@@ -304,7 +307,7 @@ void Session::drop(DisconnectReason _reason)
 
 void Session::disconnect(DisconnectReason _reason)
 {
-    clog(NetConnect) << "Disconnecting (our reason:" << reasonOf(_reason) << ")";
+    cnetdetails << "Disconnecting (our reason: " << reasonOf(_reason) << ")";
 
     if (m_socket->ref().is_open())
     {
@@ -401,7 +404,7 @@ bool Session::checkRead(std::size_t _expected, boost::system::error_code _ec, st
 {
     if (_ec && _ec.category() != boost::asio::error::get_misc_category() && _ec.value() != boost::asio::error::eof)
     {
-        clog(NetConnect) << "Error reading: " << _ec.message();
+        cnetdetails << "Error reading: " << _ec.message();
         drop(TCPError);
         return false;
     }

--- a/libp2p/Session.cpp
+++ b/libp2p/Session.cpp
@@ -50,7 +50,7 @@ Session::~Session()
 {
     ThreadContext tc(info().id.abridged());
     ThreadContext tc2(info().clientVersion);
-    clog(NetMessageSummary) << "Closing peer session :-(";
+    cnetmessage << "Closing peer session :-(";
     m_peer->m_lastConnected = m_peer->m_lastAttempted - chrono::seconds(1);
 
     // Read-chain finished for one reason or another.
@@ -153,7 +153,7 @@ bool Session::interpret(PacketType _t, RLP const& _r)
         else
         {
             reason = reasonOf(r);
-            clog(NetMessageSummary) << "Disconnect (reason: " << reason << ")";
+            cnetmessage << "Disconnect (reason: " << reason << ")";
             drop(DisconnectRequested);
         }
         break;

--- a/libp2p/UDP.h
+++ b/libp2p/UDP.h
@@ -51,13 +51,13 @@ struct RLPXNote: public LogChannel { static const char* name(); static const int
 class UDPDatagram
 {
 public:
-	UDPDatagram(bi::udp::endpoint const& _ep): locus(_ep) {}
-	UDPDatagram(bi::udp::endpoint const& _ep, bytes _data): data(_data), locus(_ep) {}
-	bi::udp::endpoint const& endpoint() const { return locus; }
+    UDPDatagram(bi::udp::endpoint const& _ep): locus(_ep) {}
+    UDPDatagram(bi::udp::endpoint const& _ep, bytes _data): data(_data), locus(_ep) {}
+    bi::udp::endpoint const& endpoint() const { return locus; }
 
-	bytes data;
+    bytes data;
 protected:
-	bi::udp::endpoint locus;
+    bi::udp::endpoint locus;
 };
 
 /**
@@ -65,18 +65,18 @@ protected:
  */
 struct RLPXDatagramFace: public UDPDatagram
 {
-	static uint32_t futureFromEpoch(std::chrono::seconds _sec) { return static_cast<uint32_t>(std::chrono::duration_cast<std::chrono::seconds>((std::chrono::system_clock::now() + _sec).time_since_epoch()).count()); }
-	static uint32_t secondsSinceEpoch() { return static_cast<uint32_t>(std::chrono::duration_cast<std::chrono::seconds>((std::chrono::system_clock::now()).time_since_epoch()).count()); }
-	static Public authenticate(bytesConstRef _sig, bytesConstRef _rlp);
+    static uint32_t futureFromEpoch(std::chrono::seconds _sec) { return static_cast<uint32_t>(std::chrono::duration_cast<std::chrono::seconds>((std::chrono::system_clock::now() + _sec).time_since_epoch()).count()); }
+    static uint32_t secondsSinceEpoch() { return static_cast<uint32_t>(std::chrono::duration_cast<std::chrono::seconds>((std::chrono::system_clock::now()).time_since_epoch()).count()); }
+    static Public authenticate(bytesConstRef _sig, bytesConstRef _rlp);
 
-	RLPXDatagramFace(bi::udp::endpoint const& _ep): UDPDatagram(_ep) {}
-	virtual ~RLPXDatagramFace() = default;
+    RLPXDatagramFace(bi::udp::endpoint const& _ep): UDPDatagram(_ep) {}
+    virtual ~RLPXDatagramFace() = default;
 
-	virtual h256 sign(Secret const& _from);
-	virtual uint8_t packetType() const = 0;
+    virtual h256 sign(Secret const& _from);
+    virtual uint8_t packetType() const = 0;
 
-	virtual void streamRLP(RLPStream&) const = 0;
-	virtual void interpretRLP(bytesConstRef _bytes) = 0;
+    virtual void streamRLP(RLPStream&) const = 0;
+    virtual void interpretRLP(bytesConstRef _bytes) = 0;
 };
 
 /**
@@ -84,8 +84,8 @@ struct RLPXDatagramFace: public UDPDatagram
  */
 struct UDPSocketFace
 {
-	virtual bool send(UDPDatagram const& _msg) = 0;
-	virtual void disconnect() = 0;
+    virtual bool send(UDPDatagram const& _msg) = 0;
+    virtual void disconnect() = 0;
 };
 
 /**
@@ -93,9 +93,9 @@ struct UDPSocketFace
  */
 struct UDPSocketEvents
 {
-	virtual ~UDPSocketEvents() = default;
-	virtual void onDisconnected(UDPSocketFace*) {}
-	virtual void onReceived(UDPSocketFace*, bi::udp::endpoint const& _from, bytesConstRef _packetData) = 0;
+    virtual ~UDPSocketEvents() = default;
+    virtual void onDisconnected(UDPSocketFace*) {}
+    virtual void onReceived(UDPSocketFace*, bi::udp::endpoint const& _from, bytesConstRef _packetData) = 0;
 };
 
 /**
@@ -109,172 +109,172 @@ template <typename Handler, unsigned MaxDatagramSize>
 class UDPSocket: UDPSocketFace, public std::enable_shared_from_this<UDPSocket<Handler, MaxDatagramSize>>
 {
 public:
-	enum { maxDatagramSize = MaxDatagramSize };
-	static_assert((unsigned)maxDatagramSize < 65507u, "UDP datagrams cannot be larger than 65507 bytes");
+    enum { maxDatagramSize = MaxDatagramSize };
+    static_assert((unsigned)maxDatagramSize < 65507u, "UDP datagrams cannot be larger than 65507 bytes");
 
-	/// Create socket for specific endpoint.
-	UDPSocket(ba::io_service& _io, UDPSocketEvents& _host, bi::udp::endpoint _endpoint): m_host(_host), m_endpoint(_endpoint), m_socket(_io) { m_started.store(false); m_closed.store(true); };
+    /// Create socket for specific endpoint.
+    UDPSocket(ba::io_service& _io, UDPSocketEvents& _host, bi::udp::endpoint _endpoint): m_host(_host), m_endpoint(_endpoint), m_socket(_io) { m_started.store(false); m_closed.store(true); };
 
-	/// Create socket which listens to all ports.
-	UDPSocket(ba::io_service& _io, UDPSocketEvents& _host, unsigned _port): m_host(_host), m_endpoint(bi::udp::v4(), _port), m_socket(_io) { m_started.store(false); m_closed.store(true); };
-	virtual ~UDPSocket() { disconnect(); }
+    /// Create socket which listens to all ports.
+    UDPSocket(ba::io_service& _io, UDPSocketEvents& _host, unsigned _port): m_host(_host), m_endpoint(bi::udp::v4(), _port), m_socket(_io) { m_started.store(false); m_closed.store(true); };
+    virtual ~UDPSocket() { disconnect(); }
 
-	/// Socket will begin listening for and delivering packets
-	void connect();
+    /// Socket will begin listening for and delivering packets
+    void connect();
 
-	/// Send datagram.
-	bool send(UDPDatagram const& _datagram);
+    /// Send datagram.
+    bool send(UDPDatagram const& _datagram);
 
-	/// Returns if socket is open.
-	bool isOpen() { return !m_closed; }
+    /// Returns if socket is open.
+    bool isOpen() { return !m_closed; }
 
-	/// Disconnect socket.
-	void disconnect() { disconnectWithError(boost::asio::error::connection_reset); }
+    /// Disconnect socket.
+    void disconnect() { disconnectWithError(boost::asio::error::connection_reset); }
 
 protected:
-	void doRead();
+    void doRead();
 
-	void doWrite();
+    void doWrite();
 
-	void disconnectWithError(boost::system::error_code _ec);
+    void disconnectWithError(boost::system::error_code _ec);
 
-	std::atomic<bool> m_started;					///< Atomically ensure connection is started once. Start cannot occur unless m_started is false. Managed by start and disconnectWithError.
-	std::atomic<bool> m_closed;					///< Connection availability.
+    std::atomic<bool> m_started;					///< Atomically ensure connection is started once. Start cannot occur unless m_started is false. Managed by start and disconnectWithError.
+    std::atomic<bool> m_closed;					///< Connection availability.
 
-	UDPSocketEvents& m_host;						///< Interface which owns this socket.
-	bi::udp::endpoint m_endpoint;					///< Endpoint which we listen to.
+    UDPSocketEvents& m_host;						///< Interface which owns this socket.
+    bi::udp::endpoint m_endpoint;					///< Endpoint which we listen to.
 
-	Mutex x_sendQ;
-	std::deque<UDPDatagram> m_sendQ;				///< Queue for egress data.
-	std::array<byte, maxDatagramSize> m_recvData;	///< Buffer for ingress data.
-	bi::udp::endpoint m_recvEndpoint;				///< Endpoint data was received from.
-	bi::udp::socket m_socket;						///< Boost asio udp socket.
+    Mutex x_sendQ;
+    std::deque<UDPDatagram> m_sendQ;				///< Queue for egress data.
+    std::array<byte, maxDatagramSize> m_recvData;	///< Buffer for ingress data.
+    bi::udp::endpoint m_recvEndpoint;				///< Endpoint data was received from.
+    bi::udp::socket m_socket;						///< Boost asio udp socket.
 
-	Mutex x_socketError;							///< Mutex for error which can be set from host or IO thread.
-	boost::system::error_code m_socketError;		///< Set when shut down due to error.
+    Mutex x_socketError;							///< Mutex for error which can be set from host or IO thread.
+    boost::system::error_code m_socketError;		///< Set when shut down due to error.
 };
 
 template <typename Handler, unsigned MaxDatagramSize>
 void UDPSocket<Handler, MaxDatagramSize>::connect()
 {
-	bool expect = false;
-	if (!m_started.compare_exchange_strong(expect, true))
-		return;
+    bool expect = false;
+    if (!m_started.compare_exchange_strong(expect, true))
+        return;
 
-	m_socket.open(bi::udp::v4());
-	try
-	{
-		m_socket.bind(m_endpoint);
-	}
-	catch (...)
-	{
-		m_socket.bind(bi::udp::endpoint(bi::udp::v4(), m_endpoint.port()));
-	}
+    m_socket.open(bi::udp::v4());
+    try
+    {
+        m_socket.bind(m_endpoint);
+    }
+    catch (...)
+    {
+        m_socket.bind(bi::udp::endpoint(bi::udp::v4(), m_endpoint.port()));
+    }
 
-	// clear write queue so reconnect doesn't send stale messages
-	Guard l(x_sendQ);
-	m_sendQ.clear();
+    // clear write queue so reconnect doesn't send stale messages
+    Guard l(x_sendQ);
+    m_sendQ.clear();
 
-	m_closed = false;
-	doRead();
+    m_closed = false;
+    doRead();
 }
 
 template <typename Handler, unsigned MaxDatagramSize>
 bool UDPSocket<Handler, MaxDatagramSize>::send(UDPDatagram const& _datagram)
 {
-	if (m_closed)
-		return false;
+    if (m_closed)
+        return false;
 
-	Guard l(x_sendQ);
-	m_sendQ.push_back(_datagram);
-	if (m_sendQ.size() == 1)
-		doWrite();
+    Guard l(x_sendQ);
+    m_sendQ.push_back(_datagram);
+    if (m_sendQ.size() == 1)
+        doWrite();
 
-	return true;
+    return true;
 }
 
 template <typename Handler, unsigned MaxDatagramSize>
 void UDPSocket<Handler, MaxDatagramSize>::doRead()
 {
-	if (m_closed)
-		return;
+    if (m_closed)
+        return;
 
-	auto self(UDPSocket<Handler, MaxDatagramSize>::shared_from_this());
-	m_socket.async_receive_from(boost::asio::buffer(m_recvData), m_recvEndpoint, [this, self](boost::system::error_code _ec, size_t _len)
-	{
-		if (m_closed)
-			return disconnectWithError(_ec);
-		
-		if (_ec != boost::system::errc::success)
-			clog(NetWarn) << "Receiving UDP message failed. " << _ec.value() << ":" << _ec.message();
+    auto self(UDPSocket<Handler, MaxDatagramSize>::shared_from_this());
+    m_socket.async_receive_from(boost::asio::buffer(m_recvData), m_recvEndpoint, [this, self](boost::system::error_code _ec, size_t _len)
+    {
+        if (m_closed)
+            return disconnectWithError(_ec);
+        
+        if (_ec != boost::system::errc::success)
+            cnetwarn << "Receiving UDP message failed. " << _ec.value() << " : " << _ec.message();
 
-		if (_len)
-			m_host.onReceived(this, m_recvEndpoint, bytesConstRef(m_recvData.data(), _len));
-		doRead();
-	});
+        if (_len)
+            m_host.onReceived(this, m_recvEndpoint, bytesConstRef(m_recvData.data(), _len));
+        doRead();
+    });
 }
 
 template <typename Handler, unsigned MaxDatagramSize>
 void UDPSocket<Handler, MaxDatagramSize>::doWrite()
 {
-	if (m_closed)
-		return;
+    if (m_closed)
+        return;
 
-	const UDPDatagram& datagram = m_sendQ[0];
-	auto self(UDPSocket<Handler, MaxDatagramSize>::shared_from_this());
-	bi::udp::endpoint endpoint(datagram.endpoint());
-	m_socket.async_send_to(boost::asio::buffer(datagram.data), endpoint, [this, self, endpoint](boost::system::error_code _ec, std::size_t)
-	{
-		if (m_closed)
-			return disconnectWithError(_ec);
-		
-		if (_ec != boost::system::errc::success)
-			clog(NetWarn) << "Failed delivering UDP message. " << _ec.value() << ":" << _ec.message();
-		
-		Guard l(x_sendQ);
-		m_sendQ.pop_front();
-		if (m_sendQ.empty())
-			return;
-		doWrite();
-	});
+    const UDPDatagram& datagram = m_sendQ[0];
+    auto self(UDPSocket<Handler, MaxDatagramSize>::shared_from_this());
+    bi::udp::endpoint endpoint(datagram.endpoint());
+    m_socket.async_send_to(boost::asio::buffer(datagram.data), endpoint, [this, self, endpoint](boost::system::error_code _ec, std::size_t)
+    {
+        if (m_closed)
+            return disconnectWithError(_ec);
+        
+        if (_ec != boost::system::errc::success)
+            cnetwarn << "Failed delivering UDP message. " << _ec.value() << " : " << _ec.message();
+
+        Guard l(x_sendQ);
+        m_sendQ.pop_front();
+        if (m_sendQ.empty())
+            return;
+        doWrite();
+    });
 }
 
 template <typename Handler, unsigned MaxDatagramSize>
 void UDPSocket<Handler, MaxDatagramSize>::disconnectWithError(boost::system::error_code _ec)
 {
-	// If !started and already stopped, shutdown has already occured. (EOF or Operation canceled)
-	if (!m_started && m_closed && !m_socket.is_open() /* todo: veirfy this logic*/)
-		return;
+    // If !started and already stopped, shutdown has already occured. (EOF or Operation canceled)
+    if (!m_started && m_closed && !m_socket.is_open() /* todo: veirfy this logic*/)
+        return;
 
-	assert(_ec);
-	{
-		// disconnect-operation following prior non-zero errors are ignored
-		Guard l(x_socketError);
-		if (m_socketError != boost::system::error_code())
-			return;
-		m_socketError = _ec;
-	}
-	// TODO: (if non-zero error) schedule high-priority writes
+    assert(_ec);
+    {
+        // disconnect-operation following prior non-zero errors are ignored
+        Guard l(x_socketError);
+        if (m_socketError != boost::system::error_code())
+            return;
+        m_socketError = _ec;
+    }
+    // TODO: (if non-zero error) schedule high-priority writes
 
-	// prevent concurrent disconnect
-	bool expected = true;
-	if (!m_started.compare_exchange_strong(expected, false))
-		return;
+    // prevent concurrent disconnect
+    bool expected = true;
+    if (!m_started.compare_exchange_strong(expected, false))
+        return;
 
-	// set m_closed to true to prevent undeliverable egress messages
-	bool wasClosed = m_closed;
-	m_closed = true;
+    // set m_closed to true to prevent undeliverable egress messages
+    bool wasClosed = m_closed;
+    m_closed = true;
 
-	// close sockets
-	boost::system::error_code ec;
-	m_socket.shutdown(bi::udp::socket::shutdown_both, ec);
-	m_socket.close();
+    // close sockets
+    boost::system::error_code ec;
+    m_socket.shutdown(bi::udp::socket::shutdown_both, ec);
+    m_socket.close();
 
-	// socket never started if it never left stopped-state (pre-handshake)
-	if (wasClosed)
-		return;
+    // socket never started if it never left stopped-state (pre-handshake)
+    if (wasClosed)
+        return;
 
-	m_host.onDisconnected(this);
+    m_host.onDisconnected(this);
 }
 
 }


### PR DESCRIPTION
In general I think it's preferable to use loggers local to the task (say, loggers declared as class members), this way you avoid the overhead of thread-safety needed for global loggers.

libp2p though used the number of channels shared among all classes of the library.
For now I mostly replicated this approach by declaring several global loggers (in `p2p` namespace). Still I simplified it somewhat, reducing the number of loggers (some were merged into one and some I was able to make class members)

All libp2p loggers write to `"net"` channel (to be able to filter all of them out) and vary by verbosity.

It doesn't include node discovery logs from `NodeTable` class, they will still go to another channel I think (in the following PR)