### PR TITLE
Change exit calls to returns in testeth, closes #4667

### DIFF
--- a/test/tools/libtesteth/ImportTest.cpp
+++ b/test/tools/libtesteth/ImportTest.cpp
@@ -608,7 +608,7 @@ void ImportTest::checkAllowedNetwork(string const& _network)
         // Can't use boost at this point
         std::cerr << TestOutputHelper::get().testName() + " Specified Network not found: "
                   << _network << "\n";
-        return 1;
+        return;
     }
 }
 

--- a/test/tools/libtesteth/ImportTest.cpp
+++ b/test/tools/libtesteth/ImportTest.cpp
@@ -608,7 +608,7 @@ void ImportTest::checkAllowedNetwork(string const& _network)
         // Can't use boost at this point
         std::cerr << TestOutputHelper::get().testName() + " Specified Network not found: "
                   << _network << "\n";
-        exit(1);
+        return 1;
     }
 }
 

--- a/test/tools/libtesteth/Options.cpp
+++ b/test/tools/libtesteth/Options.cpp
@@ -127,12 +127,12 @@ Options::Options(int argc, const char** argv)
         if (arg == "--help")
         {
             printHelp();
-            exit(0);
+			return;
         }
         else if (arg == "--version")
         {
             printVersion();
-            exit(0);
+			return;
         }
         else if (arg == "--vm" || arg == "--evmc")
         {
@@ -147,7 +147,7 @@ Options::Options(int argc, const char** argv)
             g_logVerbosity = 13;
 #else
             cerr << "--vmtrace option requires a build with cmake -DVMTRACE=1\n";
-            exit(1);
+			return;
 #endif
         }
         else if (arg == "--jsontrace")
@@ -232,7 +232,7 @@ Options::Options(int argc, const char** argv)
             else
             {
                 std::cerr << "Options file not found! Default options at: tests/src/randomCodeOptions.json\n";
-                exit(0);
+                return;
             }
         }
         else if (arg == "-t")
@@ -272,11 +272,11 @@ Options::Options(int argc, const char** argv)
             if (maxCodes > 1000 || maxCodes <= 0)
             {
                 cerr << "Argument for the option is invalid! (use range: 1...1000)\n";
-                exit(1);
+                return;
             }
             test::RandomCodeOptions options;
             cout << test::RandomCode::get().generate(maxCodes, options) << "\n";
-            exit(0);
+            return;
         }
         else if (arg == "--createRandomTest")
         {
@@ -309,7 +309,7 @@ Options::Options(int argc, const char** argv)
         else if (seenSeparator)
         {
             cerr << "Unknown option: " + arg << "\n";
-            exit(1);
+            return;
         }
     }
 
@@ -322,7 +322,7 @@ Options::Options(int argc, const char** argv)
             cerr << "--createRandomTest cannot be used with any of the options: " <<
                     "trValueIndex, trGasIndex, trDataIndex, nonetwork, singleTest, all, " <<
                     "stats, filltests, fillchain \n";
-            exit(1);
+            return;
         }
     }
     else

--- a/test/tools/libtesteth/boostTest.cpp
+++ b/test/tools/libtesteth/boostTest.cpp
@@ -136,7 +136,7 @@ int main(int argc, const char* argv[])
     catch (dev::test::InvalidOption const& e)
     {
         std::cerr << *boost::get_error_info<errinfo_comment>(e) << "\n";
-        exit(1);
+        return 1;
     }
 
     dev::test::Options const& opt = dev::test::Options::get();


### PR DESCRIPTION
return should be used over exit calls because return guarentees the destructor is called for locally scoped objects. 