### PR TITLE
parse different versions of genesis config

### DIFF
--- a/libethcore/ChainOperationParams.cpp
+++ b/libethcore/ChainOperationParams.cpp
@@ -43,6 +43,7 @@ PrecompiledContract::PrecompiledContract(
 
 ChainOperationParams::ChainOperationParams():
 	m_blockReward("0x4563918244F40000"),
+	m_allowRewardOverwrite(true),
 	minGasLimit(0x1388),
 	maxGasLimit("0x7fffffffffffffff"),
 	gasLimitBoundDivisor(0x0400),
@@ -73,7 +74,7 @@ EVMSchedule const& ChainOperationParams::scheduleForBlockNumber(u256 const& _blo
 
 u256 ChainOperationParams::blockReward(EVMSchedule const& _schedule) const
 {
-	if (_schedule.blockRewardOverwrite)
+	if (_schedule.blockRewardOverwrite && m_allowRewardOverwrite)
 		return *_schedule.blockRewardOverwrite;
 	else
 		return m_blockReward;

--- a/libethcore/ChainOperationParams.h
+++ b/libethcore/ChainOperationParams.h
@@ -77,10 +77,13 @@ struct ChainOperationParams
 	/// General chain params.
 private:
 	u256 m_blockReward;
+	bool m_allowRewardOverwrite; //allow overwrite of the block reward that is set in genesis.json
+
 public:
 	EVMSchedule const& scheduleForBlockNumber(u256 const& _blockNumber) const;
 	u256 blockReward(EVMSchedule const& _schedule) const;
 	void setBlockReward(u256 const& _newBlockReward);
+	void setBlockRewardOvewrite(bool _ovewrite) { m_allowRewardOverwrite = _ovewrite; }
 	u256 maximumExtraDataSize = 1024;
 	u256 accountStartNonce = 0;
 	bool tieBreakingGas = true;

--- a/libethcore/Exceptions.h
+++ b/libethcore/Exceptions.h
@@ -80,6 +80,8 @@ DEV_SIMPLE_EXCEPTION(InvalidTransactionReceiptFormat);
 DEV_SIMPLE_EXCEPTION(TransactionReceiptVersionError);
 DEV_SIMPLE_EXCEPTION(BlockNotFound);
 DEV_SIMPLE_EXCEPTION(UnknownParent);
+DEV_SIMPLE_EXCEPTION(MissingField);
+DEV_SIMPLE_EXCEPTION(UnknownConfig);
 DEV_SIMPLE_EXCEPTION(AddressAlreadyUsed);
 
 DEV_SIMPLE_EXCEPTION(DatabaseAlreadyOpen);


### PR DESCRIPTION
parse test genesis format
https://github.com/ethereum/retesteth/issues/4

```
# Genesis config for running a StateTest via RPC
{
       "version" : "1",
       "params": {
            "miningMethod" : "NoProof",
	    "forkRules" : "Frontier",
            "blockReward" : "0x00"
       },
       "genesis" : {
            "coinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
            "gasLimit" : "0x0f4240",
            "timestamp" : "0x03e8"
       },
       "state": {
            "0x095e7baea6a6c7c4c2dfeb977efac326af552d87" : {
                "balance" : "0x0de0b6b3a76586a0",
                "code" : "0x6001600101600055",
                "nonce" : "0x00",
                "storage" : {
                    "0x00" : "0x02"
                }
            },
            "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba" : {
                "balance" : "0x29a2241af62ca034",
                "code" : "",
                "nonce" : "0x00",
                "storage" : {
                }
            }
       }
}
```