### PR TITLE
Add "gasUsed" data to the LocalisedTransactionReceipt class (fix #4956)

### DIFF
--- a/libethereum/BasicGasPricer.cpp
+++ b/libethereum/BasicGasPricer.cpp
@@ -53,7 +53,7 @@ void BasicGasPricer::update(BlockChain const& _bc)
 			for (auto const& tr: r[1])
 			{
 				Transaction tx(tr.data(), CheckTransaction::None);
-				u256 gu = brs.receipts[i].gasUsed();
+				u256 gu = brs.receipts[i].cumulativeGasUsed();
 				dist[tx.gasPrice()] += gu;
 				total += gu;
 				i++;

--- a/libethereum/Block.h
+++ b/libethereum/Block.h
@@ -291,7 +291,7 @@ private:
 	void applyRewards(std::vector<BlockHeader> const& _uncleBlockHeaders, u256 const& _blockReward);
 
 	/// @returns gas used by transactions thus far executed.
-	u256 gasUsed() const { return m_receipts.size() ? m_receipts.back().gasUsed() : 0; }
+	u256 gasUsed() const { return m_receipts.size() ? m_receipts.back().cumulativeGasUsed() : 0; }
 
 	/// Performs irregular modifications right after initialization, e.g. to implement a hard fork.
 	void performIrregularModifications();

--- a/libethereum/ClientBase.cpp
+++ b/libethereum/ClientBase.cpp
@@ -358,9 +358,7 @@ LocalisedTransactionReceipt ClientBase::localisedTransactionReceipt(h256 const& 
 	TransactionReceipt tr = bc().transactionReceipt(tl.first, tl.second);
 	u256 gasUsed = tr.cumulativeGasUsed();
 	if (tl.second > 0)
-	{
 		gasUsed -= bc().transactionReceipt(tl.first, tl.second - 1).cumulativeGasUsed();
-	}
 	return LocalisedTransactionReceipt(
 		tr,
 		t.sha3(),

--- a/libethereum/ClientBase.cpp
+++ b/libethereum/ClientBase.cpp
@@ -356,12 +356,18 @@ LocalisedTransactionReceipt ClientBase::localisedTransactionReceipt(h256 const& 
 	std::pair<h256, unsigned> tl = bc().transactionLocation(_transactionHash);
 	Transaction t = Transaction(bc().transaction(tl.first, tl.second), CheckTransaction::Cheap);
 	TransactionReceipt tr = bc().transactionReceipt(tl.first, tl.second);
+	u256 gasUsed = tr.cumulativeGasUsed();
+	if (tl.second > 0)
+	{
+		gasUsed -= bc().transactionReceipt(tl.first, tl.second - 1).cumulativeGasUsed();
+	}
 	return LocalisedTransactionReceipt(
 		tr,
 		t.sha3(),
 		tl.first,
 		numberFromHash(tl.first),
 		tl.second,
+		gasUsed,
 		toAddress(t.from(), t.nonce()));
 }
 

--- a/libethereum/Executive.cpp
+++ b/libethereum/Executive.cpp
@@ -161,7 +161,7 @@ Executive::Executive(Block& _s, LastBlockHashesFace const& _lh, unsigned _level)
 
 Executive::Executive(State& io_s, Block const& _block, unsigned _txIndex, BlockChain const& _bc, unsigned _level):
     m_s(createIntermediateState(io_s, _block, _txIndex, _bc)),
-    m_envInfo(_block.info(), _bc.lastBlockHashes(), _txIndex ? _block.receipt(_txIndex - 1).gasUsed() : 0),
+    m_envInfo(_block.info(), _bc.lastBlockHashes(), _txIndex ? _block.receipt(_txIndex - 1).cumulativeGasUsed() : 0),
     m_depth(_level),
     m_sealEngine(*_bc.sealEngine())
 {

--- a/libethereum/TransactionReceipt.cpp
+++ b/libethereum/TransactionReceipt.cpp
@@ -105,7 +105,7 @@ std::ostream& dev::eth::operator<<(std::ostream& _out, TransactionReceipt const&
 		_out << "Status: " << _r.statusCode() << std::endl;
 	else
 		_out << "Root: " << _r.stateRoot() << std::endl;
-	_out << "Gas used: " << _r.gasUsed() << std::endl;
+	_out << "Gas used: " << _r.cumulativeGasUsed() << std::endl;
 	_out << "Logs: " << _r.log().size() << " entries:" << std::endl;
 	for (LogEntry const& i: _r.log())
 	{

--- a/libethereum/TransactionReceipt.h
+++ b/libethereum/TransactionReceipt.h
@@ -51,7 +51,7 @@ public:
 	/// @returns the status code.
 	/// @throw TransactionReceiptVersionError when the receipt has a state root instead of a status code.
 	uint8_t statusCode() const;
-	u256 const& gasUsed() const { return m_gasUsed; }
+	u256 const& cumulativeGasUsed() const { return m_gasUsed; }
 	LogBloom const& bloom() const { return m_bloom; }
 	LogEntries const& log() const { return m_log; }
 
@@ -79,6 +79,7 @@ public:
 		h256 const& _blockHash,
 		BlockNumber _blockNumber,
 		unsigned _transactionIndex,
+		u256 const& _gasUsed,
 		Address const& _contractAddress = Address()
 	):
 		TransactionReceipt(_t),
@@ -86,6 +87,7 @@ public:
 		m_blockHash(_blockHash),
 		m_blockNumber(_blockNumber),
 		m_transactionIndex(_transactionIndex),
+		m_gasUsed(_gasUsed),
 		m_contractAddress(_contractAddress)
 	{
 		LogEntries entries = log();
@@ -104,6 +106,7 @@ public:
 	h256 const& blockHash() const { return m_blockHash; }
 	BlockNumber blockNumber() const { return m_blockNumber; }
 	unsigned transactionIndex() const { return m_transactionIndex; }
+	u256 const& gasUsed() const { return m_gasUsed; }
 	Address const& contractAddress() const { return m_contractAddress; }
 	LocalisedLogEntries const& localisedLogs() const { return m_localisedLogs; };
 
@@ -112,6 +115,7 @@ private:
 	h256 m_blockHash;
 	BlockNumber m_blockNumber;
 	unsigned m_transactionIndex = 0;
+	u256 m_gasUsed;
 	Address m_contractAddress;
 	LocalisedLogEntries m_localisedLogs;
 };

--- a/libweb3jsonrpc/Debug.cpp
+++ b/libweb3jsonrpc/Debug.cpp
@@ -69,7 +69,7 @@ Json::Value Debug::traceBlock(Block const& _block, Json::Value const& _json)
 	{
 		Transaction t = _block.pending()[k];
 
-		u256 const gasUsed = k ? _block.receipt(k - 1).gasUsed() : 0;
+		u256 const gasUsed = k ? _block.receipt(k - 1).cumulativeGasUsed() : 0;
 		EnvInfo envInfo(_block.info(), m_eth.blockChain().lastBlockHashes(), gasUsed);
 		Executive e(s, envInfo, *m_eth.blockChain().sealEngine());
 

--- a/libweb3jsonrpc/JsonHelper.cpp
+++ b/libweb3jsonrpc/JsonHelper.cpp
@@ -187,7 +187,7 @@ Json::Value toJson(dev::eth::TransactionReceipt const& _t)
         res["status"] = toString(_t.statusCode());
     else
         res["stateRoot"] = toJS(_t.stateRoot());
-    res["gasUsed"] = toJS(_t.gasUsed());
+    res["gasUsed"] = toJS(_t.cumulativeGasUsed());
     res["bloom"] = toJS(_t.bloom());
     res["log"] = dev::toJson(_t.log());
     return res;
@@ -200,7 +200,7 @@ Json::Value toJson(dev::eth::LocalisedTransactionReceipt const& _t)
     res["transactionIndex"] = _t.transactionIndex();
     res["blockHash"] = toJS(_t.blockHash());
     res["blockNumber"] = _t.blockNumber();
-    res["cumulativeGasUsed"] = toJS(_t.gasUsed());
+    res["cumulativeGasUsed"] = toJS(_t.cumulativeGasUsed());
     res["gasUsed"] = toJS(_t.gasUsed());
     res["contractAddress"] = toJS(_t.contractAddress());
     res["logs"] = dev::toJson(_t.localisedLogs());


### PR DESCRIPTION
Fixes #4956 

Add "gasUsed" data (the amount of gas used by a transaction) to the LocalisedTransactionReceipt class so that one can access this data via the web3 APIs. Note that without these changes, one only has access to "cumulative gas used" data. As a part of these changes, I've also renamed the "gasUsed()" getter in the TransactionReceipt class to "cumulativeGasUsed()" so that its name more accurately reflects what's being returned.

I've verified my changes locally by retrieving a transaction receipt and verifying that gasUsed and cumulativeGasUsed are different, and that gasUsed accurately reflects the amount of gas used by the transaction.
