### PR TITLE
Add support for eth_chainId

### DIFF
--- a/libethereum/ClientBase.cpp
+++ b/libethereum/ClientBase.cpp
@@ -528,3 +528,8 @@ Block ClientBase::block(BlockNumber _h) const
 		return preSeal();
 	return block(bc().numberHash(_h));
 }
+
+int ClientBase::chainId() const
+{
+	return bc().chainParams().chainID;
+}

--- a/libethereum/ClientBase.h
+++ b/libethereum/ClientBase.h
@@ -174,7 +174,9 @@ public:
     }
 
     Block block(BlockNumber _h) const;
-
+    
+    virtual int chainId() const override;
+    
 protected:
     /// The interface that must be implemented in any class deriving this.
     /// {

--- a/libethereum/ClientBase.h
+++ b/libethereum/ClientBase.h
@@ -82,7 +82,7 @@ public:
     /// Estimate gas usage for call/create.
     /// @param _maxGas An upper bound value for estimation, if not provided default value of c_maxGasEstimate will be used.
     /// @param _callback Optional callback function for progress reporting
-    virtual std::pair<u256, ExecutionResult> estimateGas(Address const& _from, u256 _value, Address _dest, bytes const& _data, int64_t _maxGas, u256 _gasPrice, BlockNumber _blockNumber, GasEstimationCallback const& _callback) override;
+    std::pair<u256, ExecutionResult> estimateGas(Address const& _from, u256 _value, Address _dest, bytes const& _data, int64_t _maxGas, u256 _gasPrice, BlockNumber _blockNumber, GasEstimationCallback const& _callback) override;
 
     using Interface::balanceAt;
     using Interface::countAt;
@@ -91,83 +91,83 @@ public:
     using Interface::codeHashAt;
     using Interface::storageAt;
 
-    virtual u256 balanceAt(Address _a, BlockNumber _block) const override;
-    virtual u256 countAt(Address _a, BlockNumber _block) const override;
-    virtual u256 stateAt(Address _a, u256 _l, BlockNumber _block) const override;
-    virtual h256 stateRootAt(Address _a, BlockNumber _block) const override;
-    virtual bytes codeAt(Address _a, BlockNumber _block) const override;
-    virtual h256 codeHashAt(Address _a, BlockNumber _block) const override;
-    virtual std::map<h256, std::pair<u256, u256>> storageAt(Address _a, BlockNumber _block) const override;
+    u256 balanceAt(Address _a, BlockNumber _block) const override;
+    u256 countAt(Address _a, BlockNumber _block) const override;
+    u256 stateAt(Address _a, u256 _l, BlockNumber _block) const override;
+    h256 stateRootAt(Address _a, BlockNumber _block) const override;
+    bytes codeAt(Address _a, BlockNumber _block) const override;
+    h256 codeHashAt(Address _a, BlockNumber _block) const override;
+    std::map<h256, std::pair<u256, u256>> storageAt(Address _a, BlockNumber _block) const override;
 
-    virtual LocalisedLogEntries logs(unsigned _watchId) const override;
-    virtual LocalisedLogEntries logs(LogFilter const& _filter) const override;
+    LocalisedLogEntries logs(unsigned _watchId) const override;
+    LocalisedLogEntries logs(LogFilter const& _filter) const override;
     virtual void prependLogsFromBlock(LogFilter const& _filter, h256 const& _blockHash, BlockPolarity _polarity, LocalisedLogEntries& io_logs) const;
 
     /// Install, uninstall and query watches.
-    virtual unsigned installWatch(LogFilter const& _filter, Reaping _r = Reaping::Automatic) override;
-    virtual unsigned installWatch(h256 _filterId, Reaping _r = Reaping::Automatic) override;
-    virtual bool uninstallWatch(unsigned _watchId) override;
-    virtual LocalisedLogEntries peekWatch(unsigned _watchId) const override;
-    virtual LocalisedLogEntries checkWatch(unsigned _watchId) override;
+    unsigned installWatch(LogFilter const& _filter, Reaping _r = Reaping::Automatic) override;
+    unsigned installWatch(h256 _filterId, Reaping _r = Reaping::Automatic) override;
+    bool uninstallWatch(unsigned _watchId) override;
+    LocalisedLogEntries peekWatch(unsigned _watchId) const override;
+    LocalisedLogEntries checkWatch(unsigned _watchId) override;
 
-    virtual h256 hashFromNumber(BlockNumber _number) const override;
-    virtual BlockNumber numberFromHash(h256 _blockHash) const override;
-    virtual int compareBlockHashes(h256 _h1, h256 _h2) const override;
-    virtual BlockHeader blockInfo(h256 _hash) const override;
-    virtual BlockDetails blockDetails(h256 _hash) const override;
-    virtual Transaction transaction(h256 _transactionHash) const override;
-    virtual LocalisedTransaction localisedTransaction(h256 const& _transactionHash) const override;
-    virtual Transaction transaction(h256 _blockHash, unsigned _i) const override;
-    virtual LocalisedTransaction localisedTransaction(h256 const& _blockHash, unsigned _i) const override;
-    virtual TransactionReceipt transactionReceipt(h256 const& _transactionHash) const override;
-    virtual LocalisedTransactionReceipt localisedTransactionReceipt(h256 const& _transactionHash) const override;
-    virtual std::pair<h256, unsigned> transactionLocation(h256 const& _transactionHash) const override;
-    virtual Transactions transactions(h256 _blockHash) const override;
-    virtual TransactionHashes transactionHashes(h256 _blockHash) const override;
-    virtual BlockHeader uncle(h256 _blockHash, unsigned _i) const override;
-    virtual UncleHashes uncleHashes(h256 _blockHash) const override;
-    virtual unsigned transactionCount(h256 _blockHash) const override;
-    virtual unsigned uncleCount(h256 _blockHash) const override;
-    virtual unsigned number() const override;
-    virtual Transactions pending() const override;
-    virtual h256s pendingHashes() const override;
-    virtual BlockHeader pendingInfo() const override;
-    virtual BlockDetails pendingDetails() const override;
+    h256 hashFromNumber(BlockNumber _number) const override;
+    BlockNumber numberFromHash(h256 _blockHash) const override;
+    int compareBlockHashes(h256 _h1, h256 _h2) const override;
+    BlockHeader blockInfo(h256 _hash) const override;
+    BlockDetails blockDetails(h256 _hash) const override;
+    Transaction transaction(h256 _transactionHash) const override;
+    LocalisedTransaction localisedTransaction(h256 const& _transactionHash) const override;
+    Transaction transaction(h256 _blockHash, unsigned _i) const override;
+    LocalisedTransaction localisedTransaction(h256 const& _blockHash, unsigned _i) const override;
+    TransactionReceipt transactionReceipt(h256 const& _transactionHash) const override;
+    LocalisedTransactionReceipt localisedTransactionReceipt(h256 const& _transactionHash) const override;
+    std::pair<h256, unsigned> transactionLocation(h256 const& _transactionHash) const override;
+    Transactions transactions(h256 _blockHash) const override;
+    TransactionHashes transactionHashes(h256 _blockHash) const override;
+    BlockHeader uncle(h256 _blockHash, unsigned _i) const override;
+    UncleHashes uncleHashes(h256 _blockHash) const override;
+    unsigned transactionCount(h256 _blockHash) const override;
+    unsigned uncleCount(h256 _blockHash) const override;
+    unsigned number() const override;
+    Transactions pending() const override;
+    h256s pendingHashes() const override;
+    BlockHeader pendingInfo() const override;
+    BlockDetails pendingDetails() const override;
 
-    virtual EVMSchedule evmSchedule() const override { return sealEngine()->evmSchedule(pendingInfo().number()); }
+    EVMSchedule evmSchedule() const override { return sealEngine()->evmSchedule(pendingInfo().number()); }
 
-    virtual ImportResult injectBlock(bytes const& _block) override;
+    ImportResult injectBlock(bytes const& _block) override;
 
     using Interface::addresses;
-    virtual Addresses addresses(BlockNumber _block) const override;
-    virtual u256 gasLimitRemaining() const override;
-    virtual u256 gasBidPrice() const override { return DefaultGasPrice; }
+    Addresses addresses(BlockNumber _block) const override;
+    u256 gasLimitRemaining() const override;
+    u256 gasBidPrice() const override { return DefaultGasPrice; }
 
     /// Get the block author
-    virtual Address author() const override;
+    Address author() const override;
 
-    virtual bool isKnown(h256 const& _hash) const override;
-    virtual bool isKnown(BlockNumber _block) const override;
-    virtual bool isKnownTransaction(h256 const& _transactionHash) const override;
-    virtual bool isKnownTransaction(h256 const& _blockHash, unsigned _i) const override;
+    bool isKnown(h256 const& _hash) const override;
+    bool isKnown(BlockNumber _block) const override;
+    bool isKnownTransaction(h256 const& _transactionHash) const override;
+    bool isKnownTransaction(h256 const& _blockHash, unsigned _i) const override;
 
-    virtual void startSealing() override
+    void startSealing() override
     {
         BOOST_THROW_EXCEPTION(
             InterfaceNotSupported() << errinfo_interface("ClientBase::startSealing"));
     }
-    virtual void stopSealing() override
+    void stopSealing() override
     {
         BOOST_THROW_EXCEPTION(
             InterfaceNotSupported() << errinfo_interface("ClientBase::stopSealing"));
     }
-    virtual bool wouldSeal() const override
+    bool wouldSeal() const override
     {
         BOOST_THROW_EXCEPTION(
             InterfaceNotSupported() << errinfo_interface("ClientBase::wouldSeal"));
     }
 
-    virtual SyncStatus syncStatus() const override
+    SyncStatus syncStatus() const override
     {
         BOOST_THROW_EXCEPTION(
             InterfaceNotSupported() << errinfo_interface("ClientBase::syncStatus"));
@@ -175,7 +175,7 @@ public:
 
     Block block(BlockNumber _h) const;
     
-    virtual int chainId() const override;
+    int chainId() const override;
     
 protected:
     /// The interface that must be implemented in any class deriving this.

--- a/libethereum/Interface.h
+++ b/libethereum/Interface.h
@@ -230,6 +230,9 @@ public:
 	/// Sets the network id.
 	virtual void setNetworkId(u256 const&) {}
 
+	/// Gets the chain id
+	virtual int chainId() const { return 0; }
+
 	/// Get the seal engine.
 	virtual SealEngineFace* sealEngine() const { return nullptr; }
 

--- a/libweb3jsonrpc/Eth.cpp
+++ b/libweb3jsonrpc/Eth.cpp
@@ -656,6 +656,11 @@ Json::Value Eth::eth_syncing()
 	return info;
 }
 
+string Eth::eth_chainId()
+{
+	return toJS(client()->chainId());
+}
+
 bool Eth::eth_submitWork(string const& _nonce, string const&, string const& _mixHash)
 {
 	try

--- a/libweb3jsonrpc/Eth.h
+++ b/libweb3jsonrpc/Eth.h
@@ -117,6 +117,7 @@ public:
 	virtual std::string eth_sendRawTransaction(std::string const& _rlp) override;
 	virtual bool eth_notePassword(std::string const&) override { return false; }
 	virtual Json::Value eth_syncing() override;
+	virtual std::string eth_chainId() override;
 	
 	void setTransactionDefaults(eth::TransactionSkeleton& _t);
 protected:

--- a/libweb3jsonrpc/EthFace.h
+++ b/libweb3jsonrpc/EthFace.h
@@ -65,6 +65,7 @@ namespace dev {
                     this->bindAndAddMethod(jsonrpc::Procedure("eth_notePassword", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_BOOLEAN, "param1",jsonrpc::JSON_STRING, NULL), &dev::rpc::EthFace::eth_notePasswordI);
                     this->bindAndAddMethod(jsonrpc::Procedure("eth_syncing", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_OBJECT,  NULL), &dev::rpc::EthFace::eth_syncingI);
                     this->bindAndAddMethod(jsonrpc::Procedure("eth_estimateGas", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_STRING, "param1",jsonrpc::JSON_OBJECT, NULL), &dev::rpc::EthFace::eth_estimateGasI);
+                    this->bindAndAddMethod(jsonrpc::Procedure("eth_chainId", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_STRING,  NULL), &dev::rpc::EthFace::eth_chainIdI);
                 }
 
                 inline virtual void eth_protocolVersionI(const Json::Value &request, Json::Value &response)
@@ -284,6 +285,11 @@ namespace dev {
                 {
                     response = this->eth_estimateGas(request[0u]);
                 }
+                inline virtual void eth_chainIdI(const Json::Value &request, Json::Value &response)
+                {
+                    (void)request;
+                    response = this->eth_chainId();
+                }
                 virtual std::string eth_protocolVersion() = 0;
                 virtual std::string eth_hashrate() = 0;
                 virtual std::string eth_coinbase() = 0;
@@ -335,6 +341,7 @@ namespace dev {
                 virtual bool eth_notePassword(const std::string& param1) = 0;
                 virtual Json::Value eth_syncing() = 0;
                 virtual std::string eth_estimateGas(const Json::Value& param1) = 0;
+                virtual std::string eth_chainId() = 0;
         };
 
     }

--- a/libweb3jsonrpc/eth.json
+++ b/libweb3jsonrpc/eth.json
@@ -49,7 +49,7 @@
 { "name": "eth_sendRawTransaction", "params": [""], "order": [], "returns": ""},
 { "name": "eth_notePassword", "params": [""], "order": [], "returns": true},
 { "name": "eth_syncing", "params": [], "order": [], "returns": {}},
-{ "name": "eth_estimateGas", "params": [{}], "order": [], "returns": ""}
-
+{ "name": "eth_estimateGas", "params": [{}], "order": [], "returns": ""},
+{ "name": "eth_chainId", "params": [], "order": [], "returns": ""}
 ]
 


### PR DESCRIPTION
Fixes #4810 
Implements https://github.com/ethereum/EIPs/blob/master/EIPS/eip-695.md

I added a `chainId()` function to the `libethereum\Interface` class which returns 0 by default (since chainId values start @ 0x1 with MainNet), along with the corresponding function to `libethereum\ClientBase` which retrieves the current chain id from `BlockChain::chainParams`. I then surfaced the function in the JSON-RPC API by adding it to `libweb3jsonrpc\eth.json` and regenerating `EthFace.h` via `jsonrpcstub`, and removing unnecessary changes from the generated file.

I tested my changes on Ubuntu with eth connected to Ropsten and a JSON-RPC server setup via the `jsonrpcproxy.py` script:

```
localadminuser@ELLIOTT:~$ curl -X POST --data '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}' http://localhost:8545
{"id":1,"jsonrpc":"2.0","result":"0x3"}
localadminuser@ELLIOTT:~$ 
```

