### PR TITLE
Refactor logging - fix operator<< overloads

### DIFF
--- a/libdevcore/Log.h
+++ b/libdevcore/Log.h
@@ -282,132 +282,120 @@ inline Logger createLogger(int _severity, std::string const& _channel)
 
 
 // Log stream output operators to apply special formatting to the values sent to log
-template <typename CharT, typename TraitsT, typename AllocatorT>
-inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operator<<(
-    boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& _strm, unsigned long _value)
+inline boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _strm, unsigned long _value)
 {
     _strm.stream() << EthBlue << _value << EthReset;
     return _strm;
 }
 
-template <typename CharT, typename TraitsT, typename AllocatorT>
-inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operator<<(
-    boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& _strm, long _value)
+inline boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _strm, long _value)
 {
     _strm.stream() << EthBlue << _value << EthReset;
     return _strm;
 }
 
-template <typename CharT, typename TraitsT, typename AllocatorT>
-inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operator<<(
-    boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& _strm, unsigned int _value)
+inline boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _strm, unsigned int _value)
 {
     _strm.stream() << EthBlue << _value << EthReset;
     return _strm;
 }
 
-template <typename CharT, typename TraitsT, typename AllocatorT>
-inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operator<<(
-    boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& _strm, int _value)
+inline boost::log::formatting_ostream& operator<<(boost::log::formatting_ostream& _strm, int _value)
 {
     _strm.stream() << EthBlue << _value << EthReset;
     return _strm;
 }
 
-template <typename CharT, typename TraitsT, typename AllocatorT>
-inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operator<<(
-    boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& _strm, double _value)
+inline boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _strm, double _value)
 {
     _strm.stream() << EthBlue << _value << EthReset;
     return _strm;
 }
 
-template <typename CharT, typename TraitsT, typename AllocatorT>
-inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operator<<(
-    boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& _strm, bigint const& _value)
+inline boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _strm, bigint const& _value)
 {
     _strm.stream() << EthNavy << _value << EthReset;
     return _strm;
 }
 
-template <typename CharT, typename TraitsT, typename AllocatorT>
-inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operator<<(
-    boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& _strm, u256 const& _value)
+inline boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _strm, u256 const& _value)
 {
     _strm.stream() << EthNavy << _value << EthReset;
     return _strm;
 }
 
-template <typename CharT, typename TraitsT, typename AllocatorT>
-inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operator<<(
-    boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& _strm, u160 const& _value)
+inline boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _strm, u160 const& _value)
 {
     _strm.stream() << EthNavy << _value << EthReset;
     return _strm;
 }
 
-template <typename CharT, typename TraitsT, typename AllocatorT, unsigned HashSize>
-inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operator<<(
-    boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& _strm,
-    FixedHash<HashSize> const& _value)
+template <unsigned N>
+inline boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _strm, FixedHash<N> const& _value)
 {
     _strm.stream() << EthTeal "#" << _value.abridged() << EthReset;
     return _strm;
 }
 
-template <typename CharT, typename TraitsT, typename AllocatorT>
-inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operator<<(
-    boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& _strm, h160 const& _value)
+inline boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _strm, h160 const& _value)
 {
     _strm.stream() << EthRed "@" << _value.abridged() << EthReset;
     return _strm;
 }
 
-template <typename CharT, typename TraitsT, typename AllocatorT>
-inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operator<<(
-    boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& _strm, h256 const& _value)
+inline boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _strm, h256 const& _value)
 {
     _strm.stream() << EthCyan "#" << _value.abridged() << EthReset;
     return _strm;
 }
+inline boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _strm, h256& _value)
+{
+    _strm << const_cast<h256 const&>(_value);
+    return _strm;
+}
 
-template <typename CharT, typename TraitsT, typename AllocatorT>
-inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operator<<(
-    boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& _strm, h512 const& _value)
+inline boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _strm, h512 const& _value)
 {
     _strm.stream() << EthTeal "##" << _value.abridged() << EthReset;
     return _strm;
 }
 
-template <typename CharT, typename TraitsT, typename AllocatorT>
-inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operator<<(
-    boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& _strm,
-    std::string const& _value)
+inline boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _strm, std::string const& _value)
 {
     _strm.stream() << EthGreen "\"" + _value + "\"" EthReset;
     return _strm;
 }
 
-template <typename CharT, typename TraitsT, typename AllocatorT>
-inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operator<<(
-    boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& _strm, bytes const& _value)
+inline boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _strm, bytes const& _value)
 {
     _strm.stream() << EthYellow "%" << toHex(_value) << EthReset;
     return _strm;
 }
 
-template <typename CharT, typename TraitsT, typename AllocatorT>
-inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operator<<(
-    boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& _strm, bytesConstRef _value)
+inline boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _strm, bytesConstRef _value)
 {
     _strm.stream() << EthYellow "%" << toHex(_value) << EthReset;
     return _strm;
 }
 
-template <typename CharT, typename TraitsT, typename AllocatorT, typename T>
-inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operator<<(
-    boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& _strm,
-    std::vector<T> const& _value)
+template <typename T>
+inline boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _strm, std::vector<T> const& _value)
 {
     _strm.stream() << EthWhite "[" EthReset;
     int n = 0;
@@ -420,10 +408,9 @@ inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operato
     return _strm;
 }
 
-template <typename CharT, typename TraitsT, typename AllocatorT, typename T>
-inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operator<<(
-    boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& _strm,
-    std::set<T> const& _value)
+template <typename T>
+inline boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _strm, std::set<T> const& _value)
 {
     _strm.stream() << EthYellow "{" EthReset;
     int n = 0;
@@ -436,10 +423,9 @@ inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operato
     return _strm;
 }
 
-template <typename CharT, typename TraitsT, typename AllocatorT, typename T>
-inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operator<<(
-    boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& _strm,
-    std::unordered_set<T> const& _value)
+template <typename T>
+inline boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _strm, std::unordered_set<T> const& _value)
 {
     _strm.stream() << EthYellow "{" EthReset;
     int n = 0;
@@ -452,10 +438,9 @@ inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operato
     return _strm;
 }
 
-template <typename CharT, typename TraitsT, typename AllocatorT, typename T, typename U>
-inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operator<<(
-    boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& _strm,
-    std::map<T, U> const& _value)
+template <typename T, typename U>
+inline boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _strm, std::map<T, U> const& _value)
 {
     _strm.stream() << EthLime "{" EthReset;
     int n = 0;
@@ -470,10 +455,9 @@ inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operato
     return _strm;
 }
 
-template <typename CharT, typename TraitsT, typename AllocatorT, typename T, typename U>
-inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operator<<(
-    boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& _strm,
-    std::unordered_map<T, U> const& _value)
+template <typename T, typename U>
+inline boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _strm, std::unordered_map<T, U> const& _value)
 {
     _strm << EthLime "{" EthReset;
     int n = 0;
@@ -488,10 +472,9 @@ inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operato
     return _strm;
 }
 
-template <typename CharT, typename TraitsT, typename AllocatorT, typename T, typename U>
-inline boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& operator<<(
-    boost::log::basic_formatting_ostream<CharT, TraitsT, AllocatorT>& _strm,
-    std::pair<T, U> const& _value)
+template <typename T, typename U>
+inline boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _strm, std::pair<T, U> const& _value)
 {
     _strm.stream() << EthPurple "(" EthReset;
     _strm << _value.first;

--- a/libdevcore/Log.h
+++ b/libdevcore/Log.h
@@ -316,10 +316,19 @@ inline boost::log::formatting_ostream& operator<<(
     return _strm;
 }
 
+// Below overloads for both const and non-const references are needed, because without overload for
+// non-const reference generic operator<<(formatting_ostream& _strm, T& _value) will be preferred by
+// overload resolution.
 inline boost::log::formatting_ostream& operator<<(
     boost::log::formatting_ostream& _strm, bigint const& _value)
 {
     _strm.stream() << EthNavy << _value << EthReset;
+    return _strm;
+}
+inline boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _strm, bigint& _value)
+{
+    _strm << const_cast<bigint const&>(_value);
     return _strm;
 }
 
@@ -329,11 +338,23 @@ inline boost::log::formatting_ostream& operator<<(
     _strm.stream() << EthNavy << _value << EthReset;
     return _strm;
 }
+inline boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _strm, u256& _value)
+{
+    _strm << const_cast<u256 const&>(_value);
+    return _strm;
+}
 
 inline boost::log::formatting_ostream& operator<<(
     boost::log::formatting_ostream& _strm, u160 const& _value)
 {
     _strm.stream() << EthNavy << _value << EthReset;
+    return _strm;
+}
+inline boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _strm, u160& _value)
+{
+    _strm << const_cast<u160 const&>(_value);
     return _strm;
 }
 
@@ -344,11 +365,24 @@ inline boost::log::formatting_ostream& operator<<(
     _strm.stream() << EthTeal "#" << _value.abridged() << EthReset;
     return _strm;
 }
+template <unsigned N>
+inline boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _strm, FixedHash<N>& _value)
+{
+    _strm << const_cast<FixedHash<N> const&>(_value);
+    return _strm;
+}
 
 inline boost::log::formatting_ostream& operator<<(
     boost::log::formatting_ostream& _strm, h160 const& _value)
 {
     _strm.stream() << EthRed "@" << _value.abridged() << EthReset;
+    return _strm;
+}
+inline boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _strm, h160& _value)
+{
+    _strm << const_cast<h160 const&>(_value);
     return _strm;
 }
 
@@ -369,6 +403,12 @@ inline boost::log::formatting_ostream& operator<<(
     boost::log::formatting_ostream& _strm, h512 const& _value)
 {
     _strm.stream() << EthTeal "##" << _value.abridged() << EthReset;
+    return _strm;
+}
+inline boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _strm, h512& _value)
+{
+    _strm << const_cast<h512 const&>(_value);
     return _strm;
 }
 

--- a/libdevcore/Log.h
+++ b/libdevcore/Log.h
@@ -279,43 +279,10 @@ inline Logger createLogger(int _severity, std::string const& _channel)
     return Logger(
         boost::log::keywords::severity = _severity, boost::log::keywords::channel = _channel);
 }
-
-
-// Log stream output operators to apply special formatting to the values sent to log
-inline boost::log::formatting_ostream& operator<<(
-    boost::log::formatting_ostream& _strm, unsigned long _value)
-{
-    _strm.stream() << EthBlue << _value << EthReset;
-    return _strm;
 }
 
-inline boost::log::formatting_ostream& operator<<(
-    boost::log::formatting_ostream& _strm, long _value)
+namespace dev
 {
-    _strm.stream() << EthBlue << _value << EthReset;
-    return _strm;
-}
-
-inline boost::log::formatting_ostream& operator<<(
-    boost::log::formatting_ostream& _strm, unsigned int _value)
-{
-    _strm.stream() << EthBlue << _value << EthReset;
-    return _strm;
-}
-
-inline boost::log::formatting_ostream& operator<<(boost::log::formatting_ostream& _strm, int _value)
-{
-    _strm.stream() << EthBlue << _value << EthReset;
-    return _strm;
-}
-
-inline boost::log::formatting_ostream& operator<<(
-    boost::log::formatting_ostream& _strm, double _value)
-{
-    _strm.stream() << EthBlue << _value << EthReset;
-    return _strm;
-}
-
 // Below overloads for both const and non-const references are needed, because without overload for
 // non-const reference generic operator<<(formatting_ostream& _strm, T& _value) will be preferred by
 // overload resolution.
@@ -409,13 +376,6 @@ inline boost::log::formatting_ostream& operator<<(
     boost::log::formatting_ostream& _strm, h512& _value)
 {
     _strm << const_cast<h512 const&>(_value);
-    return _strm;
-}
-
-inline boost::log::formatting_ostream& operator<<(
-    boost::log::formatting_ostream& _strm, std::string const& _value)
-{
-    _strm.stream() << EthGreen "\"" + _value + "\"" EthReset;
     return _strm;
 }
 

--- a/libdevcore/Log.h
+++ b/libdevcore/Log.h
@@ -380,16 +380,30 @@ inline boost::log::formatting_ostream& operator<<(
 }
 
 inline boost::log::formatting_ostream& operator<<(
-    boost::log::formatting_ostream& _strm, bytes const& _value)
+    boost::log::formatting_ostream& _strm, bytesConstRef _value)
 {
     _strm.stream() << EthYellow "%" << toHex(_value) << EthReset;
     return _strm;
 }
+}  // namespace dev
 
-inline boost::log::formatting_ostream& operator<<(
-    boost::log::formatting_ostream& _strm, bytesConstRef _value)
+// Overloads for types of std namespace can't be defined in dev namespace, because they won't be
+// found due to Argument-Dependent Lookup Placing anything into std is not allowed, but we can put
+// them into boost::log
+namespace boost
 {
-    _strm.stream() << EthYellow "%" << toHex(_value) << EthReset;
+namespace log
+{
+inline boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _strm, dev::bytes const& _value)
+{
+    _strm.stream() << EthYellow "%" << dev::toHex(_value) << EthReset;
+    return _strm;
+}
+inline boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _strm, dev::bytes& _value)
+{
+    _strm << const_cast<dev::bytes const&>(_value);
     return _strm;
 }
 
@@ -407,6 +421,13 @@ inline boost::log::formatting_ostream& operator<<(
     _strm.stream() << EthWhite "]" EthReset;
     return _strm;
 }
+template <typename T>
+inline boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _strm, std::vector<T>& _value)
+{
+    _strm << const_cast<std::vector<T> const&>(_value);
+    return _strm;
+}
 
 template <typename T>
 inline boost::log::formatting_ostream& operator<<(
@@ -422,6 +443,13 @@ inline boost::log::formatting_ostream& operator<<(
     _strm.stream() << EthYellow "}" EthReset;
     return _strm;
 }
+template <typename T>
+inline boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _strm, std::set<T>& _value)
+{
+    _strm << const_cast<std::set<T> const&>(_value);
+    return _strm;
+}
 
 template <typename T>
 inline boost::log::formatting_ostream& operator<<(
@@ -435,6 +463,13 @@ inline boost::log::formatting_ostream& operator<<(
         _strm << i;
     }
     _strm.stream() << EthYellow "}" EthReset;
+    return _strm;
+}
+template <typename T>
+inline boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _strm, std::unordered_set<T>& _value)
+{
+    _strm << const_cast<std::unordered_set<T> const&>(_value);
     return _strm;
 }
 
@@ -454,6 +489,13 @@ inline boost::log::formatting_ostream& operator<<(
     _strm.stream() << EthLime "}" EthReset;
     return _strm;
 }
+template <typename T, typename U>
+inline boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _strm, std::map<T, U>& _value)
+{
+    _strm << const_cast<std::map<T, U> const&>(_value);
+    return _strm;
+}
 
 template <typename T, typename U>
 inline boost::log::formatting_ostream& operator<<(
@@ -471,6 +513,13 @@ inline boost::log::formatting_ostream& operator<<(
     _strm << EthLime "}" EthReset;
     return _strm;
 }
+template <typename T, typename U>
+inline boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _strm, std::unordered_map<T, U>& _value)
+{
+    _strm << const_cast<std::unordered_map<T, U> const&>(_value);
+    return _strm;
+}
 
 template <typename T, typename U>
 inline boost::log::formatting_ostream& operator<<(
@@ -483,4 +532,12 @@ inline boost::log::formatting_ostream& operator<<(
     _strm.stream() << EthPurple ")" EthReset;
     return _strm;
 }
+template <typename T, typename U>
+inline boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _strm, std::pair<T, U>& _value)
+{
+    _strm << const_cast<std::pair<T, U> const&>(_value);
+    return _strm;
 }
+}
+}  // namespace boost

--- a/libdevcore/Log.h
+++ b/libdevcore/Log.h
@@ -295,7 +295,8 @@ inline boost::log::formatting_ostream& operator<<(
 inline boost::log::formatting_ostream& operator<<(
     boost::log::formatting_ostream& _strm, bigint& _value)
 {
-    _strm << const_cast<bigint const&>(_value);
+    auto const& constValue = _value;
+    _strm << constValue;
     return _strm;
 }
 
@@ -308,7 +309,8 @@ inline boost::log::formatting_ostream& operator<<(
 inline boost::log::formatting_ostream& operator<<(
     boost::log::formatting_ostream& _strm, u256& _value)
 {
-    _strm << const_cast<u256 const&>(_value);
+    auto const& constValue = _value;
+    _strm << constValue;
     return _strm;
 }
 
@@ -321,7 +323,8 @@ inline boost::log::formatting_ostream& operator<<(
 inline boost::log::formatting_ostream& operator<<(
     boost::log::formatting_ostream& _strm, u160& _value)
 {
-    _strm << const_cast<u160 const&>(_value);
+    auto const& constValue = _value;
+    _strm << constValue;
     return _strm;
 }
 
@@ -336,7 +339,8 @@ template <unsigned N>
 inline boost::log::formatting_ostream& operator<<(
     boost::log::formatting_ostream& _strm, FixedHash<N>& _value)
 {
-    _strm << const_cast<FixedHash<N> const&>(_value);
+    auto const& constValue = _value;
+    _strm << constValue;
     return _strm;
 }
 
@@ -349,7 +353,8 @@ inline boost::log::formatting_ostream& operator<<(
 inline boost::log::formatting_ostream& operator<<(
     boost::log::formatting_ostream& _strm, h160& _value)
 {
-    _strm << const_cast<h160 const&>(_value);
+    auto const& constValue = _value;
+    _strm << constValue;
     return _strm;
 }
 
@@ -362,7 +367,8 @@ inline boost::log::formatting_ostream& operator<<(
 inline boost::log::formatting_ostream& operator<<(
     boost::log::formatting_ostream& _strm, h256& _value)
 {
-    _strm << const_cast<h256 const&>(_value);
+    auto const& constValue = _value;
+    _strm << constValue;
     return _strm;
 }
 
@@ -375,7 +381,8 @@ inline boost::log::formatting_ostream& operator<<(
 inline boost::log::formatting_ostream& operator<<(
     boost::log::formatting_ostream& _strm, h512& _value)
 {
-    _strm << const_cast<h512 const&>(_value);
+    auto const& constValue = _value;
+    _strm << constValue;
     return _strm;
 }
 
@@ -403,7 +410,8 @@ inline boost::log::formatting_ostream& operator<<(
 inline boost::log::formatting_ostream& operator<<(
     boost::log::formatting_ostream& _strm, dev::bytes& _value)
 {
-    _strm << const_cast<dev::bytes const&>(_value);
+    auto const& constValue = _value;
+    _strm << constValue;
     return _strm;
 }
 
@@ -425,7 +433,8 @@ template <typename T>
 inline boost::log::formatting_ostream& operator<<(
     boost::log::formatting_ostream& _strm, std::vector<T>& _value)
 {
-    _strm << const_cast<std::vector<T> const&>(_value);
+    auto const& constValue = _value;
+    _strm << constValue;
     return _strm;
 }
 
@@ -447,7 +456,8 @@ template <typename T>
 inline boost::log::formatting_ostream& operator<<(
     boost::log::formatting_ostream& _strm, std::set<T>& _value)
 {
-    _strm << const_cast<std::set<T> const&>(_value);
+    auto const& constValue = _value;
+    _strm << constValue;
     return _strm;
 }
 
@@ -469,7 +479,8 @@ template <typename T>
 inline boost::log::formatting_ostream& operator<<(
     boost::log::formatting_ostream& _strm, std::unordered_set<T>& _value)
 {
-    _strm << const_cast<std::unordered_set<T> const&>(_value);
+    auto const& constValue = _value;
+    _strm << constValue;
     return _strm;
 }
 
@@ -493,7 +504,8 @@ template <typename T, typename U>
 inline boost::log::formatting_ostream& operator<<(
     boost::log::formatting_ostream& _strm, std::map<T, U>& _value)
 {
-    _strm << const_cast<std::map<T, U> const&>(_value);
+    auto const& constValue = _value;
+    _strm << constValue;
     return _strm;
 }
 
@@ -517,7 +529,8 @@ template <typename T, typename U>
 inline boost::log::formatting_ostream& operator<<(
     boost::log::formatting_ostream& _strm, std::unordered_map<T, U>& _value)
 {
-    _strm << const_cast<std::unordered_map<T, U> const&>(_value);
+    auto const& constValue = _value;
+    _strm << constValue;
     return _strm;
 }
 
@@ -536,7 +549,8 @@ template <typename T, typename U>
 inline boost::log::formatting_ostream& operator<<(
     boost::log::formatting_ostream& _strm, std::pair<T, U>& _value)
 {
-    _strm << const_cast<std::pair<T, U> const&>(_value);
+    auto const& constValue = _value;
+    _strm << constValue;
     return _strm;
 }
 }


### PR DESCRIPTION
0. Define overloads for `formatting_ostream` (char stream) instead of generic `basic_formatting_ostream` to simplify things a bit
1. Remove `operator<<` overloads for primitive types and `std::string` because they already exist in boost.log and we can't redefine them.
2. Add overloads for non-const references aside const references - without it `operator<<` with non-const references gets resolved into generic overload for `T&` defined in boost.log. I haven't found more elegant solution for this.
3. Overloads for the types of `std` namespace can't be defined in `dev` namespace because of Argument-Dependent Lookup. Putting them into `std` is forbidden, so I define them in `boost::log`