### PR TITLE
string test_getLogHash(txHash)

### DIFF
--- a/libweb3jsonrpc/Test.cpp
+++ b/libweb3jsonrpc/Test.cpp
@@ -43,7 +43,7 @@ string logEntriesToLogHash(eth::LogEntries const& _logs)
     s.appendList(_logs.size());
     for (eth::LogEntry const& l : _logs)
         l.streamRLP(s);
-    return toHexPrefixed(sha3(s.out()));
+    return toJS(sha3(s.out()));
 }
 }
 
@@ -59,13 +59,21 @@ string Test::test_getLogHash(string const& _txHash)
         BOOST_THROW_EXCEPTION(JsonRpcException(Errors::ERROR_RPC_INVALID_PARAMS));
     }
 
-    if (m_eth.blockChain().isKnownTransaction(txHash))
+    try
     {
-        LocalisedTransaction t = m_eth.localisedTransaction(txHash);
-        BlockReceipts const& blockReceipts = m_eth.blockChain().receipts(t.blockHash());
-        if (blockReceipts.receipts.size() != 0)
-            return logEntriesToLogHash(blockReceipts.receipts[t.transactionIndex()].log());
+        if (m_eth.blockChain().isKnownTransaction(txHash))
+        {
+                LocalisedTransaction t = m_eth.localisedTransaction(txHash);
+                BlockReceipts const& blockReceipts = m_eth.blockChain().receipts(t.blockHash());
+                if (blockReceipts.receipts.size() != 0)
+                    return logEntriesToLogHash(blockReceipts.receipts[t.transactionIndex()].log());
+        }
     }
+    catch(...)
+    {
+        BOOST_THROW_EXCEPTION(JsonRpcException(Errors::ERROR_RPC_INTERNAL_ERROR));
+    }
+
     return toJS(dev::EmptyListSHA3);
 }
 

--- a/libweb3jsonrpc/Test.cpp
+++ b/libweb3jsonrpc/Test.cpp
@@ -49,32 +49,32 @@ string logEntriesToLogHash(eth::LogEntries const& _logs)
 
 string Test::test_getLogHash(string const& _txHash)
 {
-    h256 txHash;
     try
     {
-        txHash = h256(_txHash);
-    }
-    catch (...)
-    {
-        BOOST_THROW_EXCEPTION(JsonRpcException(Errors::ERROR_RPC_INVALID_PARAMS));
-    }
+        h256 txHash;
+        try
+        {
+            txHash = h256(_txHash);
+        }
+        catch (BadHexCharacter const&)
+        {
+            throw JsonRpcException(Errors::ERROR_RPC_INVALID_PARAMS);
+        }
 
-    try
-    {
         if (m_eth.blockChain().isKnownTransaction(txHash))
         {
-                LocalisedTransaction t = m_eth.localisedTransaction(txHash);
-                BlockReceipts const& blockReceipts = m_eth.blockChain().receipts(t.blockHash());
-                if (blockReceipts.receipts.size() != 0)
-                    return logEntriesToLogHash(blockReceipts.receipts[t.transactionIndex()].log());
+            LocalisedTransaction t = m_eth.localisedTransaction(txHash);
+            BlockReceipts const& blockReceipts = m_eth.blockChain().receipts(t.blockHash());
+            if (blockReceipts.receipts.size() != 0)
+                return logEntriesToLogHash(blockReceipts.receipts[t.transactionIndex()].log());
         }
+        return toJS(dev::EmptyListSHA3);
     }
-    catch(...)
+    catch (std::exception const& ex)
     {
-        BOOST_THROW_EXCEPTION(JsonRpcException(Errors::ERROR_RPC_INTERNAL_ERROR));
+        cwarn << ex.what();
+        throw JsonRpcException(Errors::ERROR_RPC_INTERNAL_ERROR);
     }
-
-    return toJS(dev::EmptyListSHA3);
 }
 
 bool Test::test_setChainParams(Json::Value const& param1)

--- a/libweb3jsonrpc/Test.h
+++ b/libweb3jsonrpc/Test.h
@@ -42,9 +42,9 @@ public:
 	{
 		return RPCModules{RPCModule{"test", "1.0"}};
 	}
-
-	virtual bool test_setChainParams(const Json::Value &param1) override;
-	virtual bool test_mineBlocks(int _number) override;
+    virtual std::string test_getLogHash(std::string const& _param1) override;
+    virtual bool test_setChainParams(const Json::Value& _param1) override;
+    virtual bool test_mineBlocks(int _number) override;
 	virtual bool test_modifyTimestamp(int _timestamp) override;
 	virtual bool test_addBlock(std::string const& _rlp) override;
 	virtual bool test_rewindToBlock(int _number) override;

--- a/libweb3jsonrpc/Test.h
+++ b/libweb3jsonrpc/Test.h
@@ -1,18 +1,18 @@
 /*
-	This file is part of cpp-ethereum.
+        This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+        cpp-ethereum is free software: you can redistribute it and/or modify
+        it under the terms of the GNU General Public License as published by
+        the Free Software Foundation, either version 3 of the License, or
+        (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+        cpp-ethereum is distributed in the hope that it will be useful,
+        but WITHOUT ANY WARRANTY; without even the implied warranty of
+        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+        GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+        You should have received a copy of the GNU General Public License
+        along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file Test.h
  * @authors:
@@ -37,20 +37,20 @@ namespace rpc
 class Test: public TestFace
 {
 public:
-	Test(eth::Client& _eth);
-	virtual RPCModules implementedModules() const override
-	{
-		return RPCModules{RPCModule{"test", "1.0"}};
-	}
+    Test(eth::Client& _eth);
+    virtual RPCModules implementedModules() const override
+    {
+        return RPCModules{RPCModule{"test", "1.0"}};
+    }
     virtual std::string test_getLogHash(std::string const& _param1) override;
     virtual bool test_setChainParams(const Json::Value& _param1) override;
     virtual bool test_mineBlocks(int _number) override;
-	virtual bool test_modifyTimestamp(int _timestamp) override;
-	virtual bool test_addBlock(std::string const& _rlp) override;
-	virtual bool test_rewindToBlock(int _number) override;
+    virtual bool test_modifyTimestamp(int _timestamp) override;
+    virtual bool test_addBlock(std::string const& _rlp) override;
+    virtual bool test_rewindToBlock(int _number) override;
 
 private:
-	eth::Client& m_eth;
+    eth::Client& m_eth;
 };
 
 }

--- a/libweb3jsonrpc/TestFace.h
+++ b/libweb3jsonrpc/TestFace.h
@@ -14,13 +14,21 @@ namespace dev {
             public:
                 TestFace()
                 {
+                    this->bindAndAddMethod(
+                        jsonrpc::Procedure("test_getLogHash", jsonrpc::PARAMS_BY_POSITION,
+                            jsonrpc::JSON_BOOLEAN, "param1", jsonrpc::JSON_STRING, NULL),
+                        &dev::rpc::TestFace::test_getLogHashI);
                     this->bindAndAddMethod(jsonrpc::Procedure("test_setChainParams", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_BOOLEAN, "param1",jsonrpc::JSON_OBJECT, NULL), &dev::rpc::TestFace::test_setChainParamsI);
                     this->bindAndAddMethod(jsonrpc::Procedure("test_mineBlocks", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_BOOLEAN, "param1",jsonrpc::JSON_INTEGER, NULL), &dev::rpc::TestFace::test_mineBlocksI);
                     this->bindAndAddMethod(jsonrpc::Procedure("test_modifyTimestamp", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_BOOLEAN, "param1",jsonrpc::JSON_INTEGER, NULL), &dev::rpc::TestFace::test_modifyTimestampI);
                     this->bindAndAddMethod(jsonrpc::Procedure("test_addBlock", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_BOOLEAN, "param1",jsonrpc::JSON_STRING, NULL), &dev::rpc::TestFace::test_addBlockI);
                     this->bindAndAddMethod(jsonrpc::Procedure("test_rewindToBlock", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_BOOLEAN, "param1",jsonrpc::JSON_INTEGER, NULL), &dev::rpc::TestFace::test_rewindToBlockI);
                 }
-
+                inline virtual void test_getLogHashI(
+                    const Json::Value& request, Json::Value& response)
+                {
+                    response = this->test_getLogHash(request[0u].asString());
+                }
                 inline virtual void test_setChainParamsI(const Json::Value &request, Json::Value &response)
                 {
                     response = this->test_setChainParams(request[0u]);
@@ -41,6 +49,7 @@ namespace dev {
                 {
                     response = this->test_rewindToBlock(request[0u].asInt());
                 }
+                virtual std::string test_getLogHash(const std::string& param1) = 0;
                 virtual bool test_setChainParams(const Json::Value& param1) = 0;
                 virtual bool test_mineBlocks(int param1) = 0;
                 virtual bool test_modifyTimestamp(int param1) = 0;

--- a/libweb3jsonrpc/test.json
+++ b/libweb3jsonrpc/test.json
@@ -1,4 +1,5 @@
 [
+{ "name": "test_getLogHash", "params": [""], "order": [], "returns": ""},
 { "name": "test_setChainParams", "params": [{}], "order": [], "returns": false},
 { "name": "test_mineBlocks", "params": [0], "returns": false },
 { "name": "test_modifyTimestamp", "params": [0], "returns": false },


### PR DESCRIPTION
`string test_getLogHash(string _txHash)`
Get pre-calculated log has of the _txHash. hash of emptyRLPList if transaction not found.
Log hash could be calculated from transaction receipt, but some transactions has too many logs, so we need a method to get just the log hash.

looks like this would be an optional method. because it is not required for state tests to check log hash.

https://github.com/ethereum/retesteth/issues/7