### PR TITLE
 Dynamicaly load EVMC VM provided by --vm <path>

### DIFF
--- a/libevm/CMakeLists.txt
+++ b/libevm/CMakeLists.txt
@@ -19,7 +19,7 @@ set(sources
 
 add_library(evm ${sources})
 
-target_link_libraries(evm PUBLIC ethcore devcore evmc PRIVATE jsoncpp_lib_static Boost::program_options)
+target_link_libraries(evm PUBLIC ethcore devcore evmc PRIVATE jsoncpp_lib_static Boost::program_options ${CMAKE_DL_LIBS})
 
 if(EVM_OPTIMIZE)
     target_compile_definitions(evm PRIVATE EVM_OPTIMIZE)

--- a/libevm/VMFactory.cpp
+++ b/libevm/VMFactory.cpp
@@ -62,28 +62,22 @@ VMKindTableEntry vmKindsTable[] = {
     {VMKind::Hera, "hera"},
 #endif
 };
-}
 
-void validate(boost::any& v, const std::vector<std::string>& values, VMKind* /* target_type */, int)
+void setVMKind(const std::string& name)
 {
-    // Make sure no previous assignment to 'v' was made.
-    po::validators::check_first_occurrence(v);
-
-    // Extract the first string from 'values'. If there is more than
-    // one string, it's an error, and exception will be thrown.
-    const std::string& s = po::validators::get_single_string(values);
-
     for (auto& entry : vmKindsTable)
     {
         // Try to find a match in the table of VMs.
-        if (s == entry.name)
+        if (name == entry.name)
         {
-            v = entry.kind;
+            g_kind = entry.kind;
             return;
         }
     }
 
-    throw po::validation_error(po::validation_error::invalid_option_value);
+    BOOST_THROW_EXCEPTION(
+        po::validation_error(po::validation_error::invalid_option_value, "vm", name, 1));
+}
 }
 
 namespace
@@ -137,10 +131,10 @@ po::options_description vmProgramOptions(unsigned _lineLength)
     auto add = opts.add_options();
 
     add("vm",
-        po::value<VMKind>()
+        po::value<std::string>()
             ->value_name("<name>")
-            ->default_value(VMKind::Legacy, "legacy")
-            ->notifier(VMFactory::setKind),
+            ->default_value("legacy")
+            ->notifier(setVMKind),
         description.data());
 
     add(c_evmcPrefix,

--- a/libevm/VMFactory.h
+++ b/libevm/VMFactory.h
@@ -29,6 +29,7 @@ enum class VMKind
     JIT,
     Hera,
     Legacy,
+    DLL
 };
 
 /// Returns the EVM-C options parsed from command line.


### PR DESCRIPTION
This extends `--vm` option to accept also paths to shared libraries with EVMC VMs. E.g. `--vm libhera.so`.
I wanted separate loading plugins from selecting a VM, but program_options makes it super hard to do. So this is much simpler variant, but might be good enough.

Some code cleanups are possible. 