### PR TITLE
Fix bug where Eth::eth_pendingTransactions returns data in wrong format

### DIFF
--- a/libweb3jsonrpc/Eth.cpp
+++ b/libweb3jsonrpc/Eth.cpp
@@ -131,7 +131,7 @@ string Eth::eth_getStorageRoot(string const& _address, string const& _blockNumbe
 	}
 }
 
-string Eth::eth_pendingTransactions()
+Json::Value Eth::eth_pendingTransactions()
 {
 	//Return list of transaction that being sent by local accounts
 	Transactions ours;
@@ -147,7 +147,7 @@ string Eth::eth_pendingTransactions()
 		}
 	}
 
-	return toJS(ours);
+	return toJson(ours);
 }
 
 string Eth::eth_getTransactionCount(string const& _address, string const& _blockNumber)

--- a/libweb3jsonrpc/Eth.h
+++ b/libweb3jsonrpc/Eth.h
@@ -77,7 +77,7 @@ public:
 	virtual std::string eth_getStorageAt(std::string const& _address, std::string const& _position, std::string const& _blockNumber) override;
 	virtual std::string eth_getStorageRoot(std::string const& _address, std::string const& _blockNumber) override;
 	virtual std::string eth_getTransactionCount(std::string const& _address, std::string const& _blockNumber) override;
-	virtual std::string eth_pendingTransactions() override;
+	virtual Json::Value eth_pendingTransactions() override;
 	virtual Json::Value eth_getBlockTransactionCountByHash(std::string const& _blockHash) override;
 	virtual Json::Value eth_getBlockTransactionCountByNumber(std::string const& _blockNumber) override;
 	virtual Json::Value eth_getUncleCountByBlockHash(std::string const& _blockHash) override;

--- a/libweb3jsonrpc/EthFace.h
+++ b/libweb3jsonrpc/EthFace.h
@@ -25,7 +25,7 @@ namespace dev {
                     this->bindAndAddMethod(jsonrpc::Procedure("eth_getStorageAt", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_STRING, "param1",jsonrpc::JSON_STRING,"param2",jsonrpc::JSON_STRING,"param3",jsonrpc::JSON_STRING, NULL), &dev::rpc::EthFace::eth_getStorageAtI);
                     this->bindAndAddMethod(jsonrpc::Procedure("eth_getStorageRoot", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_STRING, "param1",jsonrpc::JSON_STRING,"param2",jsonrpc::JSON_STRING, NULL), &dev::rpc::EthFace::eth_getStorageRootI);
                     this->bindAndAddMethod(jsonrpc::Procedure("eth_getTransactionCount", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_STRING, "param1",jsonrpc::JSON_STRING,"param2",jsonrpc::JSON_STRING, NULL), &dev::rpc::EthFace::eth_getTransactionCountI);
-                    this->bindAndAddMethod(jsonrpc::Procedure("eth_pendingTransactions", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_STRING,  NULL), &dev::rpc::EthFace::eth_pendingTransactionsI);
+                    this->bindAndAddMethod(jsonrpc::Procedure("eth_pendingTransactions", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_ARRAY,  NULL), &dev::rpc::EthFace::eth_pendingTransactionsI);
                     this->bindAndAddMethod(jsonrpc::Procedure("eth_getBlockTransactionCountByHash", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_OBJECT, "param1",jsonrpc::JSON_STRING, NULL), &dev::rpc::EthFace::eth_getBlockTransactionCountByHashI);
                     this->bindAndAddMethod(jsonrpc::Procedure("eth_getBlockTransactionCountByNumber", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_OBJECT, "param1",jsonrpc::JSON_STRING, NULL), &dev::rpc::EthFace::eth_getBlockTransactionCountByNumberI);
                     this->bindAndAddMethod(jsonrpc::Procedure("eth_getUncleCountByBlockHash", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_OBJECT, "param1",jsonrpc::JSON_STRING, NULL), &dev::rpc::EthFace::eth_getUncleCountByBlockHashI);
@@ -301,7 +301,7 @@ namespace dev {
                 virtual std::string eth_getStorageAt(const std::string& param1, const std::string& param2, const std::string& param3) = 0;
                 virtual std::string eth_getStorageRoot(const std::string& param1, const std::string& param2) = 0;
                 virtual std::string eth_getTransactionCount(const std::string& param1, const std::string& param2) = 0;
-                virtual std::string eth_pendingTransactions() = 0;
+                virtual Json::Value eth_pendingTransactions() = 0;
                 virtual Json::Value eth_getBlockTransactionCountByHash(const std::string& param1) = 0;
                 virtual Json::Value eth_getBlockTransactionCountByNumber(const std::string& param1) = 0;
                 virtual Json::Value eth_getUncleCountByBlockHash(const std::string& param1) = 0;

--- a/libweb3jsonrpc/eth.json
+++ b/libweb3jsonrpc/eth.json
@@ -10,7 +10,7 @@
 { "name": "eth_getStorageAt", "params": ["", "", ""], "order": [], "returns": ""},
 { "name": "eth_getStorageRoot", "params": ["", ""], "order": [], "returns": ""},
 { "name": "eth_getTransactionCount", "params": ["", ""], "order": [], "returns" : ""},
-{ "name": "eth_pendingTransactions", "params": [], "order": [], "returns" : ""},
+{ "name": "eth_pendingTransactions", "params": [], "order": [], "returns" : [] },
 { "name": "eth_getBlockTransactionCountByHash", "params": [""], "order": [], "returns" : {}},
 { "name": "eth_getBlockTransactionCountByNumber", "params": [""], "order": [], "returns" : {}},
 { "name": "eth_getUncleCountByBlockHash", "params": [""], "order": [], "returns" : {}},


### PR DESCRIPTION
Fix #4668 

Fix a bug where `Eth::eth_pendingTransactions` is returning a string rather than a JSON array of transaction objects (e.g. `web3.eth.pendingTransactions `returns `["0", "x", "[", "]"]` rather than `[]` when there are no pending transactions). The fix is simple - change the `ToJs()` call in `Eth::eth_pendingTransactions` to a `ToJson()` call.

I've tested my changes locally in both the "no pending transactions" and "pending transaction" cases and verified that the output is largely the same as geth output. Note that there are some minor differences between the geth and cpp-ethereum outputs (e.g. the `v` value is escaped in the cpp-ethereum case but not in the geth case, and `blockNumber` is null in geth and 0 in `cpp-ethereum`) - I suspect that any important discrepancies can be tracked via new issues and addressed in future changes but I'll leave this decision up to the reviewers. 

### No pending transactions: 

- **Geth:**
```
> web3.eth.pendingTransactions
[]
```
- **cpp-ethereum:**
```
> web3.eth.pendingTransactions
[]
```

### 1 pending transaction:
- **Geth:**
```
> web3.eth.pendingTransactions
[{
    blockHash: null,
    blockNumber: null,
    from: "0x1cbb11b72a335b709a61d22bca90f7e54bfcf8b1",
    gas: 90000,
    gasPrice: 10526315789,
    hash: "0x7375026ff56417cb3e9c4c73a705e956174393261dd0ff057e74bd87434e2c72",
    input: "0x",
    nonce: 0,
    r: "0x98e84508f9f79b38cd240841e65486441b6838194c46e429880d02b6ae38951e",
    s: "0x6236869b5e094d36dd5b663f6f86289f7adf7183a708e68c28b135a893970f57",
    to: "0x884ae368b946a7e5b11462b1333248388b463cc3",
    transactionIndex: 0,
    v: "0x2a",
    value: 1000000000000000
}]
```


- **cpp-ethereum:**
```
> web3.eth.pendingTransactions
[{
    blockHash: null,
    blockNumber: 0,
    data: "0x0000000000000000000000000000000000000000000000000000000000000000",
    from: "0xec75ed1426d02b0237385b596cb3a55e6bbe6c3e",
    gas: 275924,
    gasPrice: 20000000000,
    hash: "0xef625e1b091d7933d0b783e1bd757c8408cad59416f4b478e20d8560127c94d5",
    nonce: 0,
    r: "0xaa77bc1412e9f8947078c983cd6ba67e44efc3e927b6f6b4cbe804b98f7f5e04",
    s: "0x1bf75a7c043cafdb68d3ddcba5c2378dcc5a357d8531fbd2d231c9e5b15db4c7",
    sighash: "0x335f04c01e045d636528e31b556979c0189d9b66b7ac56b81d19bc9e4ce85bfd",
    to: "0x884ae368b946a7e5b11462b1333248388b463cc3",
    transactionIndex: 0,
    v: "0x\x01",
    value: 1000000000000000
}]
```

