### PR TITLE
Refactor logging - get rid of VerbosityHolder

### DIFF
--- a/libdevcore/Log.h
+++ b/libdevcore/Log.h
@@ -39,14 +39,6 @@ namespace dev
 /// The logging system's current verbosity.
 extern int g_logVerbosity;
 
-/// Temporary changes system's verbosity for specific function. Restores the old verbosity when function returns.
-/// Not thread-safe, use with caution!
-struct VerbosityHolder
-{
-    VerbosityHolder(int _temporaryValue, bool _force = false): oldLogVerbosity(g_logVerbosity) { if (g_logVerbosity >= 0 || _force) g_logVerbosity = _temporaryValue; }
-    ~VerbosityHolder() { g_logVerbosity = oldLogVerbosity; }
-    int oldLogVerbosity;
-};
 
 /// Set the current thread's log name.
 ///
@@ -120,14 +112,12 @@ inline Logger createLogger(int _severity, std::string const& _channel)
     return Logger(
         boost::log::keywords::severity = _severity, boost::log::keywords::channel = _channel);
 }
-}
 
 // Adds the context string to all log messages in the scope
 #define LOG_SCOPED_CONTEXT(context) \
     BOOST_LOG_SCOPED_THREAD_ATTR("Context", boost::log::attributes::constant<std::string>(context));
 
-namespace dev
-{
+
 // Below overloads for both const and non-const references are needed, because without overload for
 // non-const reference generic operator<<(formatting_ostream& _strm, T& _value) will be preferred by
 // overload resolution.

--- a/test/tools/libtesteth/Options.cpp
+++ b/test/tools/libtesteth/Options.cpp
@@ -241,8 +241,6 @@ Options::Options(int argc, const char** argv)
             throwIfNoArgumentFollows();
             rCurrentTestSuite = std::string{argv[++i]};
         }
-        else if (arg == "--nonetwork")
-            nonetwork = true;
         else if (arg == "-d")
         {
             throwIfNoArgumentFollows();
@@ -316,11 +314,11 @@ Options::Options(int argc, const char** argv)
     //check restrickted options
     if (createRandomTest)
     {
-        if (trValueIndex >= 0 || trGasIndex >= 0 || trDataIndex >= 0 || nonetwork || singleTest
-            || all || stats || filltests || fillchain)
+        if (trValueIndex >= 0 || trGasIndex >= 0 || trDataIndex >= 0 || singleTest || all ||
+            stats || filltests || fillchain)
         {
             cerr << "--createRandomTest cannot be used with any of the options: " <<
-                    "trValueIndex, trGasIndex, trDataIndex, nonetwork, singleTest, all, " <<
+                    "trValueIndex, trGasIndex, trDataIndex, singleTest, all, " <<
                     "stats, filltests, fillchain \n";
             exit(1);
         }

--- a/test/tools/libtesteth/Options.h
+++ b/test/tools/libtesteth/Options.h
@@ -68,7 +68,6 @@ public:
     int trGasIndex;		///< GeneralState gas
     int trValueIndex;	///< GeneralState value
     bool all = false;	///< Running every test, including time consuming ones.
-    bool nonetwork = false;///< For libp2p
     /// @}
 
     /// Get reference to options

--- a/test/unittests/libp2p/capability.cpp
+++ b/test/unittests/libp2p/capability.cpp
@@ -37,126 +37,119 @@ using namespace dev::p2p;
 
 struct P2PFixture: public TestOutputHelperFixture
 {
-	P2PFixture() { dev::p2p::NodeIPEndpoint::test_allowLocal = true; }
-	~P2PFixture() { dev::p2p::NodeIPEndpoint::test_allowLocal = false; }
+    P2PFixture() { dev::p2p::NodeIPEndpoint::test_allowLocal = true; }
+    ~P2PFixture() { dev::p2p::NodeIPEndpoint::test_allowLocal = false; }
 };
 
 class TestCapability: public Capability
 {
 public:
-	TestCapability(std::shared_ptr<SessionFace> _s, HostCapabilityFace* _h, unsigned _idOffset, CapDesc const&): Capability(_s, _h, _idOffset), m_cntReceivedMessages(0), m_testSum(0) {}
-	virtual ~TestCapability() {}
-	int countReceivedMessages() { return m_cntReceivedMessages; }
-	int testSum() { return m_testSum; }
-	static std::string name() { return "test"; }
-	static u256 version() { return 2; }
-	static unsigned messageCount() { return UserPacket + 1; }
-	void sendTestMessage(int _i) { RLPStream s; sealAndSend(prep(s, UserPacket, 1) << _i); }
+    TestCapability(std::shared_ptr<SessionFace> _s, HostCapabilityFace* _h, unsigned _idOffset, CapDesc const&): Capability(_s, _h, _idOffset), m_cntReceivedMessages(0), m_testSum(0) {}
+    virtual ~TestCapability() {}
+    int countReceivedMessages() { return m_cntReceivedMessages; }
+    int testSum() { return m_testSum; }
+    static std::string name() { return "test"; }
+    static u256 version() { return 2; }
+    static unsigned messageCount() { return UserPacket + 1; }
+    void sendTestMessage(int _i) { RLPStream s; sealAndSend(prep(s, UserPacket, 1) << _i); }
 
 protected:
-	virtual bool interpret(unsigned _id, RLP const& _r) override;
+    virtual bool interpret(unsigned _id, RLP const& _r) override;
 
-	int m_cntReceivedMessages;
-	int m_testSum;
+    int m_cntReceivedMessages;
+    int m_testSum;
 };
 
 bool TestCapability::interpret(unsigned _id, RLP const& _r) 
 {
-	//cnote << "Capability::interpret(): custom message received";
-	++m_cntReceivedMessages;
-	m_testSum += _r[0].toInt();
-	BOOST_ASSERT(_id == UserPacket);
-	return (_id == UserPacket);
+    //cnote << "Capability::interpret(): custom message received";
+    ++m_cntReceivedMessages;
+    m_testSum += _r[0].toInt();
+    BOOST_ASSERT(_id == UserPacket);
+    return (_id == UserPacket);
 }
 
 class TestHostCapability: public HostCapability<TestCapability>, public Worker
 {
 public:
-	TestHostCapability(): Worker("test") {}
-	virtual ~TestHostCapability() {}
+    TestHostCapability(): Worker("test") {}
+    virtual ~TestHostCapability() {}
 
-	void sendTestMessage(NodeID const& _id, int _x)
-	{
-		for (auto i: peerSessions())
-			if (_id == i.second->id)
-				capabilityFromSession<TestCapability>(*i.first)->sendTestMessage(_x);
-	}
+    void sendTestMessage(NodeID const& _id, int _x)
+    {
+        for (auto i: peerSessions())
+            if (_id == i.second->id)
+                capabilityFromSession<TestCapability>(*i.first)->sendTestMessage(_x);
+    }
 
-	std::pair<int, int> retrieveTestData(NodeID const& _id)
-	{ 
-		int cnt = 0;
-		int checksum = 0;
-		for (auto i: peerSessions())
-			if (_id == i.second->id)
-			{
-				cnt += capabilityFromSession<TestCapability>(*i.first)->countReceivedMessages();
-				checksum += capabilityFromSession<TestCapability>(*i.first)->testSum();
-			}
+    std::pair<int, int> retrieveTestData(NodeID const& _id)
+    { 
+        int cnt = 0;
+        int checksum = 0;
+        for (auto i: peerSessions())
+            if (_id == i.second->id)
+            {
+                cnt += capabilityFromSession<TestCapability>(*i.first)->countReceivedMessages();
+                checksum += capabilityFromSession<TestCapability>(*i.first)->testSum();
+            }
 
-		return std::pair<int, int>(cnt, checksum);
-	}
+        return std::pair<int, int>(cnt, checksum);
+    }
 };
 
 BOOST_FIXTURE_TEST_SUITE(p2pCapability, P2PFixture)
 
 BOOST_AUTO_TEST_CASE(capability)
 {
-	if (test::Options::get().nonetwork)
-	{
-		clog << "Skipping test p2pCapability/capability. --nonetwork flag is set.\n";
-		return;
-	}
+    cnote << "Testing Capability...";
 
-	VerbosityHolder verbosityHolder(10);
-	cnote << "Testing Capability...";
+    int const step = 10;
+    const char* const localhost = "127.0.0.1";
+    NetworkPreferences prefs1(localhost, 0, false);
+    NetworkPreferences prefs2(localhost, 0, false);
+    Host host1("Test", prefs1);
+    Host host2("Test", prefs2);
+    auto thc1 = host1.registerCapability(make_shared<TestHostCapability>());
+    auto thc2 = host2.registerCapability(make_shared<TestHostCapability>());
+    host1.start();	
+    host2.start();
+    auto port1 = host1.listenPort();
+    auto port2 = host2.listenPort();
+    BOOST_REQUIRE(port1);
+    BOOST_REQUIRE(port2);	
+    BOOST_REQUIRE_NE(port1, port2);
 
-	int const step = 10;
-	const char* const localhost = "127.0.0.1";
-	NetworkPreferences prefs1(localhost, 0, false);
-	NetworkPreferences prefs2(localhost, 0, false);
-	Host host1("Test", prefs1);
-	Host host2("Test", prefs2);
-	auto thc1 = host1.registerCapability(make_shared<TestHostCapability>());
-	auto thc2 = host2.registerCapability(make_shared<TestHostCapability>());
-	host1.start();	
-	host2.start();
-	auto port1 = host1.listenPort();
-	auto port2 = host2.listenPort();
-	BOOST_REQUIRE(port1);
-	BOOST_REQUIRE(port2);	
-	BOOST_REQUIRE_NE(port1, port2);
+    for (unsigned i = 0; i < 3000; i += step)
+    {
+        this_thread::sleep_for(chrono::milliseconds(step));
 
-	for (unsigned i = 0; i < 3000; i += step)
-	{
-		this_thread::sleep_for(chrono::milliseconds(step));
+        if (host1.isStarted() && host2.isStarted())
+            break;
+    }
 
-		if (host1.isStarted() && host2.isStarted())
-			break;
-	}
+    BOOST_REQUIRE(host1.isStarted() && host2.isStarted());
+    host1.requirePeer(host2.id(), NodeIPEndpoint(bi::address::from_string(localhost), port2, port2));
 
-	BOOST_REQUIRE(host1.isStarted() && host2.isStarted());
-	host1.requirePeer(host2.id(), NodeIPEndpoint(bi::address::from_string(localhost), port2, port2));
+    // Wait for up to 12 seconds, to give the hosts time to connect to each other.
+    for (unsigned i = 0; i < 12000; i += step)
+    {
+        this_thread::sleep_for(chrono::milliseconds(step));
 
-	// Wait for up to 12 seconds, to give the hosts time to connect to each other.
-	for (unsigned i = 0; i < 12000; i += step)
-	{
-		this_thread::sleep_for(chrono::milliseconds(step));
+        if ((host1.peerCount() > 0) && (host2.peerCount() > 0))
+            break;
+    }
 
-		if ((host1.peerCount() > 0) && (host2.peerCount() > 0))
-			break;
-	}
+    BOOST_REQUIRE(host1.peerCount() > 0 && host2.peerCount() > 0);
 
-	BOOST_REQUIRE(host1.peerCount() > 0 && host2.peerCount() > 0);
+    int const target = 64;
+    int checksum = 0;
+    for (int i = 0; i < target; checksum += i++)
+        thc2->sendTestMessage(host1.id(), i);
 
-	int const target = 64;
-	int checksum = 0;
-	for (int i = 0; i < target; checksum += i++)
-		thc2->sendTestMessage(host1.id(), i);
-
-	this_thread::sleep_for(chrono::seconds(target / 64 + 1));
-	std::pair<int, int> testData = thc1->retrieveTestData(host2.id());
-	BOOST_REQUIRE_EQUAL(target, testData.first);
-	BOOST_REQUIRE_EQUAL(checksum, testData.second);
+    this_thread::sleep_for(chrono::seconds(target / 64 + 1));
+    std::pair<int, int> testData = thc1->retrieveTestData(host2.id());
+    BOOST_REQUIRE_EQUAL(target, testData.first);
+    BOOST_REQUIRE_EQUAL(checksum, testData.second);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/unittests/libp2p/peer.cpp
+++ b/test/unittests/libp2p/peer.cpp
@@ -1,18 +1,18 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file peer.cpp
  * @author Gav Wood <i@gavwood.com>
@@ -36,28 +36,28 @@ using namespace dev::p2p;
 
 struct P2PPeerFixture: public TestOutputHelperFixture
 {
-	P2PPeerFixture() { dev::p2p::NodeIPEndpoint::test_allowLocal = true; }
-	~P2PPeerFixture() { dev::p2p::NodeIPEndpoint::test_allowLocal = false; }
+    P2PPeerFixture() { dev::p2p::NodeIPEndpoint::test_allowLocal = true; }
+    ~P2PPeerFixture() { dev::p2p::NodeIPEndpoint::test_allowLocal = false; }
 };
 
 class TestCap: public Capability
 {
 public:
-	TestCap(std::shared_ptr<SessionFace> _s, HostCapabilityFace* _h, unsigned _idOffset, CapDesc const&): Capability(_s, _h, _idOffset) {}
-	virtual ~TestCap() {}
-	static std::string name() { return "p2pTestCapability"; }
-	static u256 version() { return 2; }
-	static unsigned messageCount() { return UserPacket + 1; }
+    TestCap(std::shared_ptr<SessionFace> _s, HostCapabilityFace* _h, unsigned _idOffset, CapDesc const&): Capability(_s, _h, _idOffset) {}
+    virtual ~TestCap() {}
+    static std::string name() { return "p2pTestCapability"; }
+    static u256 version() { return 2; }
+    static unsigned messageCount() { return UserPacket + 1; }
 
 protected:
-	virtual bool interpret(unsigned _id, RLP const& _r) override { return _id > 0 || _r.size() > 0; }
+    virtual bool interpret(unsigned _id, RLP const& _r) override { return _id > 0 || _r.size() > 0; }
 };
 
 class TestHostCap: public HostCapability<TestCap>, public Worker
 {
 public:
-	TestHostCap(): Worker("test") {}
-	virtual ~TestHostCap() {}
+    TestHostCap(): Worker("test") {}
+    virtual ~TestHostCap() {}
 };
 
 BOOST_AUTO_TEST_SUITE(libp2p)
@@ -65,149 +65,127 @@ BOOST_FIXTURE_TEST_SUITE(p2p, P2PPeerFixture)
 
 BOOST_AUTO_TEST_CASE(host)
 {
-	if (test::Options::get().nonetwork)
-	{
-		clog << "Skipping test libp2p/p2p/host. --nonetwork flag is set.\n";
-		return;
-	}
+    Host host1("Test", NetworkPreferences("127.0.0.1", 0, false));
+    host1.start();
+    auto host1port = host1.listenPort();
+    BOOST_REQUIRE(host1port);
 
-	VerbosityHolder setTemporaryLevel(10);
+    Host host2("Test", NetworkPreferences("127.0.0.1", 0, false));
+    host2.start();
+    auto host2port = host2.listenPort();
+    BOOST_REQUIRE(host2port);
+    
+    BOOST_REQUIRE_NE(host1port, host2port);
 
-	Host host1("Test", NetworkPreferences("127.0.0.1", 0, false));
-	host1.start();
-	auto host1port = host1.listenPort();
-	BOOST_REQUIRE(host1port);
+    host1.registerCapability(make_shared<TestHostCap>());
+    host2.registerCapability(make_shared<TestHostCap>());
+    
+    auto node2 = host2.id();
+    int const step = 10;
 
-	Host host2("Test", NetworkPreferences("127.0.0.1", 0, false));
-	host2.start();
-	auto host2port = host2.listenPort();
-	BOOST_REQUIRE(host2port);
-	
-	BOOST_REQUIRE_NE(host1port, host2port);
+    // Wait for up to 6 seconds, to give the hosts time to start.
+    for (unsigned i = 0; i < 6000; i += step)
+    {
+        this_thread::sleep_for(chrono::milliseconds(step));
 
-	host1.registerCapability(make_shared<TestHostCap>());
-	host2.registerCapability(make_shared<TestHostCap>());
-	
-	auto node2 = host2.id();
-	int const step = 10;
+        if (host1.isStarted() && host2.isStarted())
+            break;
+    }
 
-	// Wait for up to 6 seconds, to give the hosts time to start.
-	for (unsigned i = 0; i < 6000; i += step)
-	{
-		this_thread::sleep_for(chrono::milliseconds(step));
+    BOOST_REQUIRE(host1.isStarted() && host2.isStarted());
+    
+    // Wait for up to 6 seconds, to give the hosts time to get their network connection established
+    for (unsigned i = 0; i < 6000; i += step)
+    {
+        this_thread::sleep_for(chrono::milliseconds(step));
 
-		if (host1.isStarted() && host2.isStarted())
-			break;
-	}
+        if (host1.haveNetwork() && host2.haveNetwork())
+            break;
+    }
 
-	BOOST_REQUIRE(host1.isStarted() && host2.isStarted());
-	
-	// Wait for up to 6 seconds, to give the hosts time to get their network connection established
-	for (unsigned i = 0; i < 6000; i += step)
-	{
-		this_thread::sleep_for(chrono::milliseconds(step));
+    BOOST_REQUIRE(host1.haveNetwork() && host2.haveNetwork());
+    host1.addNode(node2, NodeIPEndpoint(bi::address::from_string("127.0.0.1"), host2port, host2port));
 
-		if (host1.haveNetwork() && host2.haveNetwork())
-			break;
-	}
+    // Wait for up to 24 seconds, to give the hosts time to find each other
+    for (unsigned i = 0; i < 24000; i += step)
+    {
+        this_thread::sleep_for(chrono::milliseconds(step));
 
-	BOOST_REQUIRE(host1.haveNetwork() && host2.haveNetwork());
-	host1.addNode(node2, NodeIPEndpoint(bi::address::from_string("127.0.0.1"), host2port, host2port));
+        if ((host1.peerCount() > 0) && (host2.peerCount() > 0))
+            break;
+    }
 
-	// Wait for up to 24 seconds, to give the hosts time to find each other
-	for (unsigned i = 0; i < 24000; i += step)
-	{
-		this_thread::sleep_for(chrono::milliseconds(step));
-
-		if ((host1.peerCount() > 0) && (host2.peerCount() > 0))
-			break;
-	}
-
-	BOOST_REQUIRE_EQUAL(host1.peerCount(), 1);
-	BOOST_REQUIRE_EQUAL(host2.peerCount(), 1);
+    BOOST_REQUIRE_EQUAL(host1.peerCount(), 1);
+    BOOST_REQUIRE_EQUAL(host2.peerCount(), 1);
 }
 
 BOOST_AUTO_TEST_CASE(networkConfig)
 {
-	if (test::Options::get().nonetwork)
-	{
-		clog << "Skipping test libp2p/p2p/networkConfig. --nonetwork flag is set.\n";
-		return;
-	}
-
-	Host save("Test", NetworkPreferences(false));
-	bytes store(save.saveNetwork());
-	
-	Host restore("Test", NetworkPreferences(false), bytesConstRef(&store));
-	BOOST_REQUIRE(save.id() == restore.id());
+    Host save("Test", NetworkPreferences(false));
+    bytes store(save.saveNetwork());
+    
+    Host restore("Test", NetworkPreferences(false), bytesConstRef(&store));
+    BOOST_REQUIRE(save.id() == restore.id());
 }
 
 BOOST_AUTO_TEST_CASE(saveNodes)
 {
-	if (test::Options::get().nonetwork)
-	{
-		clog << "Skipping test libp2p/p2p/saveNodes. --nonetwork flag is set.\n";
-		return;
-	}
+    std::list<Host*> hosts;
+    unsigned const c_step = 10;
+    unsigned const c_nodes = 6;
+    unsigned const c_peers = c_nodes - 1;
+    std::set<short unsigned> ports;
 
-	VerbosityHolder setTemporaryLevel(2);
+    for (unsigned i = 0; i < c_nodes; ++i)
+    {
+        Host* h = new Host("Test", NetworkPreferences("127.0.0.1", 0, false));
+        h->setIdealPeerCount(10);		
+        h->start(); // starting host is required so listenport is available
+        while (!h->haveNetwork())
+            this_thread::sleep_for(chrono::milliseconds(c_step));
 
-	std::list<Host*> hosts;
-	unsigned const c_step = 10;
-	unsigned const c_nodes = 6;
-	unsigned const c_peers = c_nodes - 1;
-	std::set<short unsigned> ports;
+        BOOST_REQUIRE(h->listenPort());
+        bool inserted = ports.insert(h->listenPort()).second;
+        BOOST_REQUIRE(inserted);
+        h->registerCapability(make_shared<TestHostCap>());
+        hosts.push_back(h);
+    }
+    
+    Host& host = *hosts.front();
+    for (auto const& h: hosts)
+        host.addNode(h->id(), NodeIPEndpoint(bi::address::from_string("127.0.0.1"), h->listenPort(), h->listenPort()));
 
-	for (unsigned i = 0; i < c_nodes; ++i)
-	{
-		Host* h = new Host("Test", NetworkPreferences("127.0.0.1", 0, false));
-		h->setIdealPeerCount(10);		
-		h->start(); // starting host is required so listenport is available
-		while (!h->haveNetwork())
-			this_thread::sleep_for(chrono::milliseconds(c_step));
+    for (unsigned i = 0; i < c_peers * 1000 && host.peerCount() < c_peers; i += c_step)
+        this_thread::sleep_for(chrono::milliseconds(c_step));
 
-		BOOST_REQUIRE(h->listenPort());
-		bool inserted = ports.insert(h->listenPort()).second;
-		BOOST_REQUIRE(inserted);
-		h->registerCapability(make_shared<TestHostCap>());
-		hosts.push_back(h);
-	}
-	
-	Host& host = *hosts.front();
-	for (auto const& h: hosts)
-		host.addNode(h->id(), NodeIPEndpoint(bi::address::from_string("127.0.0.1"), h->listenPort(), h->listenPort()));
+    Host& host2 = *hosts.back();
+    for (auto const& h: hosts)
+        host2.addNode(h->id(), NodeIPEndpoint(bi::address::from_string("127.0.0.1"), h->listenPort(), h->listenPort()));
 
-	for (unsigned i = 0; i < c_peers * 1000 && host.peerCount() < c_peers; i += c_step)
-		this_thread::sleep_for(chrono::milliseconds(c_step));
+    for (unsigned i = 0; i < c_peers * 2000 && host2.peerCount() < c_peers; i += c_step)
+        this_thread::sleep_for(chrono::milliseconds(c_step));
 
-	Host& host2 = *hosts.back();
-	for (auto const& h: hosts)
-		host2.addNode(h->id(), NodeIPEndpoint(bi::address::from_string("127.0.0.1"), h->listenPort(), h->listenPort()));
+    BOOST_CHECK_EQUAL(host.peerCount(), c_peers);
+    BOOST_CHECK_EQUAL(host2.peerCount(), c_peers);
 
-	for (unsigned i = 0; i < c_peers * 2000 && host2.peerCount() < c_peers; i += c_step)
-		this_thread::sleep_for(chrono::milliseconds(c_step));
+    bytes firstHostNetwork(host.saveNetwork());
+    bytes secondHostNetwork(host.saveNetwork());	
+    BOOST_REQUIRE_EQUAL(sha3(firstHostNetwork), sha3(secondHostNetwork));	
+    
+    RLP r(firstHostNetwork);
+    BOOST_REQUIRE(r.itemCount() == 3);
+    BOOST_REQUIRE(r[0].toInt<unsigned>() == dev::p2p::c_protocolVersion);
+    BOOST_REQUIRE_EQUAL(r[1].toBytes().size(), 32); // secret
+    BOOST_REQUIRE(r[2].itemCount() >= c_nodes);
+    
+    for (auto i: r[2])
+    {
+        BOOST_REQUIRE(i.itemCount() == 4 || i.itemCount() == 11);
+        BOOST_REQUIRE(i[0].size() == 4 || i[0].size() == 16);
+    }
 
-	BOOST_CHECK_EQUAL(host.peerCount(), c_peers);
-	BOOST_CHECK_EQUAL(host2.peerCount(), c_peers);
-
-	bytes firstHostNetwork(host.saveNetwork());
-	bytes secondHostNetwork(host.saveNetwork());	
-	BOOST_REQUIRE_EQUAL(sha3(firstHostNetwork), sha3(secondHostNetwork));	
-	
-	RLP r(firstHostNetwork);
-	BOOST_REQUIRE(r.itemCount() == 3);
-	BOOST_REQUIRE(r[0].toInt<unsigned>() == dev::p2p::c_protocolVersion);
-	BOOST_REQUIRE_EQUAL(r[1].toBytes().size(), 32); // secret
-	BOOST_REQUIRE(r[2].itemCount() >= c_nodes);
-	
-	for (auto i: r[2])
-	{
-		BOOST_REQUIRE(i.itemCount() == 4 || i.itemCount() == 11);
-		BOOST_REQUIRE(i[0].size() == 4 || i[0].size() == 16);
-	}
-
-	for (auto host: hosts)
-		delete host;
+    for (auto host: hosts)
+        delete host;
 }
 
 BOOST_AUTO_TEST_SUITE_END()
@@ -216,78 +194,70 @@ BOOST_FIXTURE_TEST_SUITE(p2pPeer, P2PPeerFixture)
 
 BOOST_AUTO_TEST_CASE(requirePeer)
 {
-	if (test::Options::get().nonetwork)
-	{
-		clog << "Skipping test libp2p/p2pPeer/requirePeer. --nonetwork flag is set.\n";
-		return;
-	}
+    unsigned const step = 10;
+    const char* const localhost = "127.0.0.1";
+    NetworkPreferences prefs1(localhost, 0, false);
+    NetworkPreferences prefs2(localhost, 0, false);
+    Host host1("Test", prefs1);
+    Host host2("Test", prefs2);
+    host1.start();
+    host2.start();
+    auto node2 = host2.id();
+    auto port1 = host1.listenPort();
+    auto port2 = host2.listenPort();
+    BOOST_REQUIRE(port1);
+    BOOST_REQUIRE(port2);
+    BOOST_REQUIRE_NE(port1, port2);
 
-	VerbosityHolder setTemporaryLevel(10);
+    host1.registerCapability(make_shared<TestHostCap>());
+    host2.registerCapability(make_shared<TestHostCap>());
 
-	unsigned const step = 10;
-	const char* const localhost = "127.0.0.1";
-	NetworkPreferences prefs1(localhost, 0, false);
-	NetworkPreferences prefs2(localhost, 0, false);
-	Host host1("Test", prefs1);
-	Host host2("Test", prefs2);
-	host1.start();
-	host2.start();
-	auto node2 = host2.id();
-	auto port1 = host1.listenPort();
-	auto port2 = host2.listenPort();
-	BOOST_REQUIRE(port1);
-	BOOST_REQUIRE(port2);
-	BOOST_REQUIRE_NE(port1, port2);
+    host1.requirePeer(node2, NodeIPEndpoint(bi::address::from_string(localhost), port2, port2));
 
-	host1.registerCapability(make_shared<TestHostCap>());
-	host2.registerCapability(make_shared<TestHostCap>());
+    // Wait for up to 12 seconds, to give the hosts time to connect to each other.
+    for (unsigned i = 0; i < 12000; i += step)
+    {
+        this_thread::sleep_for(chrono::milliseconds(step));
 
-	host1.requirePeer(node2, NodeIPEndpoint(bi::address::from_string(localhost), port2, port2));
+        if ((host1.peerCount() > 0) && (host2.peerCount() > 0))
+            break;
+    }
 
-	// Wait for up to 12 seconds, to give the hosts time to connect to each other.
-	for (unsigned i = 0; i < 12000; i += step)
-	{
-		this_thread::sleep_for(chrono::milliseconds(step));
+    auto host1peerCount = host1.peerCount();
+    auto host2peerCount = host2.peerCount();
+    BOOST_REQUIRE_EQUAL(host1peerCount, 1);
+    BOOST_REQUIRE_EQUAL(host2peerCount, 1);
 
-		if ((host1.peerCount() > 0) && (host2.peerCount() > 0))
-			break;
-	}
+    PeerSessionInfos sis1 = host1.peerSessionInfo();
+    PeerSessionInfos sis2 = host2.peerSessionInfo();
 
-	auto host1peerCount = host1.peerCount();
-	auto host2peerCount = host2.peerCount();
-	BOOST_REQUIRE_EQUAL(host1peerCount, 1);
-	BOOST_REQUIRE_EQUAL(host2peerCount, 1);
+    BOOST_REQUIRE_EQUAL(sis1.size(), 1);
+    BOOST_REQUIRE_EQUAL(sis2.size(), 1);
 
-	PeerSessionInfos sis1 = host1.peerSessionInfo();
-	PeerSessionInfos sis2 = host2.peerSessionInfo();
+    Peers peers1 = host1.getPeers();
+    Peers peers2 = host2.getPeers();
+    BOOST_REQUIRE_EQUAL(peers1.size(), 1);
+    BOOST_REQUIRE_EQUAL(peers2.size(), 1);
 
-	BOOST_REQUIRE_EQUAL(sis1.size(), 1);
-	BOOST_REQUIRE_EQUAL(sis2.size(), 1);
+    DisconnectReason disconnect1 = peers1[0].lastDisconnect();
+    DisconnectReason disconnect2 = peers2[0].lastDisconnect();
+    BOOST_REQUIRE_EQUAL(disconnect1, disconnect2);
 
-	Peers peers1 = host1.getPeers();
-	Peers peers2 = host2.getPeers();
-	BOOST_REQUIRE_EQUAL(peers1.size(), 1);
-	BOOST_REQUIRE_EQUAL(peers2.size(), 1);
+    host1.relinquishPeer(node2);
 
-	DisconnectReason disconnect1 = peers1[0].lastDisconnect();
-	DisconnectReason disconnect2 = peers2[0].lastDisconnect();
-	BOOST_REQUIRE_EQUAL(disconnect1, disconnect2);
+    // Wait for up to 6 seconds, to give the hosts time to disconnect from each other.
+    for (unsigned i = 0; i < 6000; i += step)
+    {
+        this_thread::sleep_for(chrono::milliseconds(step));
 
-	host1.relinquishPeer(node2);
+        if ((host1.peerCount() == 0) && (host2.peerCount() == 0))
+            break;
+    }
 
-	// Wait for up to 6 seconds, to give the hosts time to disconnect from each other.
-	for (unsigned i = 0; i < 6000; i += step)
-	{
-		this_thread::sleep_for(chrono::milliseconds(step));
-
-		if ((host1.peerCount() == 0) && (host2.peerCount() == 0))
-			break;
-	}
-
-	host1peerCount = host1.peerCount();
-	host2peerCount = host2.peerCount();
-	BOOST_REQUIRE_EQUAL(host1peerCount, 1);
-	BOOST_REQUIRE_EQUAL(host2peerCount, 1);
+    host1peerCount = host1.peerCount();
+    host2peerCount = host2.peerCount();
+    BOOST_REQUIRE_EQUAL(host1peerCount, 1);
+    BOOST_REQUIRE_EQUAL(host2peerCount, 1);
 }
 
 BOOST_AUTO_TEST_SUITE_END()
@@ -296,27 +266,21 @@ BOOST_FIXTURE_TEST_SUITE(peerTypes, TestOutputHelperFixture)
 
 BOOST_AUTO_TEST_CASE(emptySharedPeer)
 {
-	if (test::Options::get().nonetwork)
-	{
-		clog << "Skipping test libp2p/peerTypes/emptySharedPeer. --nonetwork flag is set.\n";
-		return;
-	}
-
-	shared_ptr<Peer> p;
-	BOOST_REQUIRE(!p);
-	
-	std::map<NodeID, std::shared_ptr<Peer>> peers;
-	p = peers[NodeID()];
-	BOOST_REQUIRE(!p);
-	
-	p.reset(new Peer(UnspecifiedNode));
-	BOOST_REQUIRE(!p->id);
-	BOOST_REQUIRE(!*p);
-	
-	p.reset(new Peer(Node(NodeID(EmptySHA3), UnspecifiedNodeIPEndpoint)));
-	BOOST_REQUIRE(!(!*p));
-	BOOST_REQUIRE(*p);
-	BOOST_REQUIRE(p);
+    shared_ptr<Peer> p;
+    BOOST_REQUIRE(!p);
+    
+    std::map<NodeID, std::shared_ptr<Peer>> peers;
+    p = peers[NodeID()];
+    BOOST_REQUIRE(!p);
+    
+    p.reset(new Peer(UnspecifiedNode));
+    BOOST_REQUIRE(!p->id);
+    BOOST_REQUIRE(!*p);
+    
+    p.reset(new Peer(Node(NodeID(EmptySHA3), UnspecifiedNodeIPEndpoint)));
+    BOOST_REQUIRE(!(!*p));
+    BOOST_REQUIRE(*p);
+    BOOST_REQUIRE(p);
 }
 
 BOOST_AUTO_TEST_SUITE_END()
@@ -324,33 +288,33 @@ BOOST_AUTO_TEST_SUITE_END()
 
 int peerTest(int argc, char** argv)
 {
-	Public remoteAlias;
-	short listenPort = 30304;
-	string remoteHost;
-	short remotePort = 30304;
-	
-	for (int i = 1; i < argc; ++i)
-	{
-		string arg = argv[i];
-		if (arg == "-l" && i + 1 < argc)
-			listenPort = (short)atoi(argv[++i]);
-		else if (arg == "-r" && i + 1 < argc)
-			remoteHost = argv[++i];
-		else if (arg == "-p" && i + 1 < argc)
-			remotePort = (short)atoi(argv[++i]);
-		else if (arg == "-ra" && i + 1 < argc)
-			remoteAlias = Public(dev::fromHex(argv[++i]));
-		else
-			remoteHost = argv[i];
-	}
+    Public remoteAlias;
+    short listenPort = 30304;
+    string remoteHost;
+    short remotePort = 30304;
+    
+    for (int i = 1; i < argc; ++i)
+    {
+        string arg = argv[i];
+        if (arg == "-l" && i + 1 < argc)
+            listenPort = (short)atoi(argv[++i]);
+        else if (arg == "-r" && i + 1 < argc)
+            remoteHost = argv[++i];
+        else if (arg == "-p" && i + 1 < argc)
+            remotePort = (short)atoi(argv[++i]);
+        else if (arg == "-ra" && i + 1 < argc)
+            remoteAlias = Public(dev::fromHex(argv[++i]));
+        else
+            remoteHost = argv[i];
+    }
 
-	Host ph("Test", NetworkPreferences(listenPort));
+    Host ph("Test", NetworkPreferences(listenPort));
 
-	if (!remoteHost.empty() && !remoteAlias)
-		ph.addNode(remoteAlias, NodeIPEndpoint(bi::address::from_string(remoteHost), remotePort, remotePort));
+    if (!remoteHost.empty() && !remoteAlias)
+        ph.addNode(remoteAlias, NodeIPEndpoint(bi::address::from_string(remoteHost), remotePort, remotePort));
 
-	this_thread::sleep_for(chrono::milliseconds(200));
+    this_thread::sleep_for(chrono::milliseconds(200));
 
-	return 0;
+    return 0;
 }
 


### PR DESCRIPTION
Part of log refactoring #4984

`VerbosityHolder` was used for temporary changing the log verbosity. Currently it's used only in unit tests, not sure what for, and just removing it doesn't affect anything at least at default verbosity.
(It might be that it improves output of testeth for these tests at higher verbosity, but then it should be done some other way. CI doesn't use higher verbosity and me neither and I don't feel like untangling it right now)

Also I removed the rest of `--nonetwork` flag support from `testeth`.