### PR TITLE
eth command line options to filter log by channel

### DIFF
--- a/ethkey/KeyAux.h
+++ b/ethkey/KeyAux.h
@@ -22,16 +22,17 @@
  * CLI module for key management.
  */
 
-#include <thread>
+#include <libdevcore/CommonIO.h>
+#include <libdevcore/FileSystem.h>
+#include <libdevcore/SHA3.h>
+#include <libethcore/KeyManager.h>
+#include <libethcore/TransactionBase.h>
+#include <boost/algorithm/string.hpp>
+#include <boost/algorithm/string/trim_all.hpp>
 #include <chrono>
 #include <fstream>
 #include <iosfwd>
-#include <boost/algorithm/string.hpp>
-#include <boost/algorithm/string/trim_all.hpp>
-#include <libdevcore/SHA3.h>
-#include <libdevcore/FileSystem.h>
-#include <libethcore/KeyManager.h>
-#include <libethcore/TransactionBase.h>
+#include <thread>
 
 using namespace std;
 using namespace dev;

--- a/libdevcore/Log.cpp
+++ b/libdevcore/Log.cpp
@@ -80,22 +80,21 @@ BOOST_LOG_ATTRIBUTE_KEYWORD(context, "Context", std::string)
 BOOST_LOG_ATTRIBUTE_KEYWORD(threadName, "ThreadName", std::string)
 BOOST_LOG_ATTRIBUTE_KEYWORD(timestamp, "TimeStamp", boost::posix_time::ptime)
 
-void setupLogging(int _verbosity, std::vector<std::string> const& _includeChannels /*= {}*/,
-    std::vector<std::string> const& _excludeChannels /*= {}*/)
+void setupLogging(LoggingOptions const& _options)
 {
     auto sink = boost::make_shared<
         boost::log::sinks::asynchronous_sink<boost::log::sinks::text_ostream_backend>>();
 
     boost::shared_ptr<std::ostream> stream{&std::cout, boost::null_deleter{}};
     sink->locked_backend()->add_stream(stream);
-    sink->set_filter([_verbosity, _includeChannels, _excludeChannels](
-                         boost::log::attribute_value_set const& _set) {
-        if (_set["Severity"].extract<int>() > _verbosity)
+    sink->set_filter([_options](boost::log::attribute_value_set const& _set) {
+        if (_set["Severity"].extract<int>() > _options.verbosity)
             return false;
 
         auto const messageChannel = _set[channel];
-        return (_includeChannels.empty() || contains(_includeChannels, messageChannel)) &&
-               !contains(_excludeChannels, messageChannel);
+        return (_options.includeChannels.empty() ||
+                   contains(_options.includeChannels, messageChannel)) &&
+               !contains(_options.excludeChannels, messageChannel);
     });
 
     namespace expr = boost::log::expressions;

--- a/libdevcore/Log.h
+++ b/libdevcore/Log.h
@@ -23,10 +23,11 @@
 
 #pragma once
 
-#include <string>
 #include "CommonIO.h"
 #include "FixedHash.h"
 #include "Terminal.h"
+#include <string>
+#include <vector>
 
 #include <boost/log/attributes/scoped_attribute.hpp>
 #include <boost/log/sources/global_logger_storage.hpp>
@@ -99,7 +100,8 @@ BOOST_LOG_INLINE_GLOBAL_LOGGER_DEFAULT(
 
 
 // Should be called in every executable
-void setupLogging(int _verbosity);
+void setupLogging(int _verbosity, std::vector<std::string> const& _includeChannels = {},
+    std::vector<std::string> const& _excludeChannels = {});
 
 // Simple non-thread-safe logger with fixed severity and channel for each message
 using Logger = boost::log::sources::severity_channel_logger<>;

--- a/libdevcore/Log.h
+++ b/libdevcore/Log.h
@@ -99,9 +99,15 @@ BOOST_LOG_INLINE_GLOBAL_LOGGER_DEFAULT(
         (boost::log::keywords::severity = SEVERITY)(boost::log::keywords::channel = CHANNEL))
 
 
+struct LoggingOptions
+{
+    int verbosity = 0;
+    strings includeChannels;
+    strings excludeChannels;
+};
+
 // Should be called in every executable
-void setupLogging(int _verbosity, std::vector<std::string> const& _includeChannels = {},
-    std::vector<std::string> const& _excludeChannels = {});
+void setupLogging(LoggingOptions const& _options);
 
 // Simple non-thread-safe logger with fixed severity and channel for each message
 using Logger = boost::log::sources::severity_channel_logger<>;

--- a/libdevcore/LoggingProgramOptions.cpp
+++ b/libdevcore/LoggingProgramOptions.cpp
@@ -1,0 +1,44 @@
+/*
+    This file is part of cpp-ethereum.
+
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "LoggingProgramOptions.h"
+
+namespace po = boost::program_options;
+
+namespace dev
+{
+po::options_description createLoggingProgramOptions(unsigned _lineLength, LoggingOptions& _options)
+{
+    po::options_description optionsDescr("Logging Options", _lineLength);
+    auto addLoggingOption = optionsDescr.add_options();
+    addLoggingOption("log-verbosity,v", po::value<int>(&_options.verbosity)->value_name("<0 - 15>"),
+        "Set the log verbosity from 0 to 15 (default: 1).");
+    addLoggingOption("log-channels",
+        po::value<std::vector<std::string>>(&_options.includeChannels)
+            ->value_name("<channel_list>")
+            ->multitoken(),
+        "Space-separated list of the log channels to show (default: show all channels).");
+    addLoggingOption("log-exclude-channels",
+        po::value<std::vector<std::string>>(&_options.excludeChannels)
+            ->value_name("<channel_list>")
+            ->multitoken(),
+        "Space-separated list of the log channels to hide.\n");
+
+    return optionsDescr;
+}
+
+}  // namespace dev

--- a/libdevcore/LoggingProgramOptions.h
+++ b/libdevcore/LoggingProgramOptions.h
@@ -1,0 +1,28 @@
+/*
+    This file is part of cpp-ethereum.
+
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "Log.h"
+#include <boost/program_options/options_description.hpp>
+
+namespace dev
+{
+boost::program_options::options_description createLoggingProgramOptions(
+    unsigned _lineLength, LoggingOptions& _options);
+
+}  // namespace dev

--- a/test/tools/libtesteth/Options.cpp
+++ b/test/tools/libtesteth/Options.cpp
@@ -336,7 +336,9 @@ Options::Options(int argc, const char** argv)
     if (logVerbosity == Verbosity::NiceReport)
         verbosity = -1;  // disable cnote but leave cerr and cout
 
-    setupLogging(verbosity);
+    LoggingOptions logginOptions;
+    logginOptions.verbosity = verbosity;
+    setupLogging(logginOptions);
 }
 
 Options const& Options::get(int argc, const char** argv)


### PR DESCRIPTION
Part of log refactoring #4984

I went with specifying channels as a space-separated list because it's more natural for boost.program_options.
So the command line can be like
```
./eth -v 10 --log-channels host client warn bq --log-exclude-channels net discov
```

Program options group to reuse in other tools is not implemented yet, probably will go to separate PR.