### PR TITLE
Fix bug where newly submitted transactions aren't immediately visible when calling web3.eth.pendingTransactions

### DIFF
--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -783,6 +783,11 @@ void Client::flushTransactions()
     doWork();
 }
 
+Transactions Client::pending() const
+{
+    return m_tq.topTransactions(m_tq.status().current);
+}
+
 SyncStatus Client::syncStatus() const
 {
     auto h = m_host.lock();

--- a/libethereum/Client.h
+++ b/libethereum/Client.h
@@ -91,7 +91,7 @@ public:
     /// Get information on this chain.
     ChainParams const& chainParams() const { return bc().chainParams(); }
 
-    virtual ImportResult injectTransaction(bytes const& _rlp, IfDropped _id = IfDropped::Ignore) override { prepareForTransaction(); return m_tq.import(_rlp, _id); }
+    ImportResult injectTransaction(bytes const& _rlp, IfDropped _id = IfDropped::Ignore) override { prepareForTransaction(); return m_tq.import(_rlp, _id); }
 
     /// Resets the gas pricer to some other object.
     void setGasPricer(std::shared_ptr<GasPricer> _gp) { m_gp = _gp; }
@@ -99,21 +99,24 @@ public:
 
     /// Submits the given transaction.
     /// @returns the new transaction's hash.
-    virtual std::pair<h256, Address> submitTransaction(TransactionSkeleton const& _t, Secret const& _secret) override;
+    std::pair<h256, Address> submitTransaction(TransactionSkeleton const& _t, Secret const& _secret) override;
 
     /// Makes the given call. Nothing is recorded into the state.
-    virtual ExecutionResult call(Address const& _secret, u256 _value, Address _dest, bytes const& _data, u256 _gas, u256 _gasPrice, BlockNumber _blockNumber, FudgeFactor _ff = FudgeFactor::Strict) override;
+    ExecutionResult call(Address const& _secret, u256 _value, Address _dest, bytes const& _data, u256 _gas, u256 _gasPrice, BlockNumber _blockNumber, FudgeFactor _ff = FudgeFactor::Strict) override;
 
     /// Blocks until all pending transactions have been processed.
-    virtual void flushTransactions() override;
+    void flushTransactions() override;
+
+    /// Retrieve pending transactions
+    Transactions pending() const override;
 
     /// Queues a block for import.
     ImportResult queueBlock(bytes const& _block, bool _isSafe = false);
 
     /// Get the remaining gas limit in this block.
-    virtual u256 gasLimitRemaining() const override { return m_postSeal.gasLimitRemaining(); }
+    u256 gasLimitRemaining() const override { return m_postSeal.gasLimitRemaining(); }
     /// Get the gas bid price
-    virtual u256 gasBidPrice() const override { return m_gp->bid(); }
+    u256 gasBidPrice() const override { return m_gp->bid(); }
 
     // [PRIVATE API - only relevant for base clients, not available in general]
     /// Get the block.
@@ -141,8 +144,8 @@ public:
     // Sealing stuff:
     // Note: "mining"/"miner" is deprecated. Use "sealing"/"sealer".
 
-    virtual Address author() const override { ReadGuard l(x_preSeal); return m_preSeal.author(); }
-    virtual void setAuthor(Address const& _us) override { WriteGuard l(x_preSeal); m_preSeal.setAuthor(_us); }
+    Address author() const override { ReadGuard l(x_preSeal); return m_preSeal.author(); }
+    void setAuthor(Address const& _us) override { WriteGuard l(x_preSeal); m_preSeal.setAuthor(_us); }
 
     /// Type of sealers available for this seal engine.
     strings sealers() const { return sealEngine()->sealers(); }
@@ -202,7 +205,7 @@ public:
     /// Queues a function to be executed in the main thread (that owns the blockchain, etc).
     void executeInMainThread(std::function<void()> const& _function);
 
-    virtual Block block(h256 const& _block) const override;
+    Block block(h256 const& _block) const override;
     using ClientBase::block;
 
     /// should be called after the constructor of the most derived class finishes.
@@ -220,9 +223,9 @@ protected:
 
     /// Returns the state object for the full block (i.e. the terminal state) for index _h.
     /// Works properly with LatestBlock and PendingBlock.
-    virtual Block preSeal() const override { ReadGuard l(x_preSeal); return m_preSeal; }
-    virtual Block postSeal() const override { ReadGuard l(x_postSeal); return m_postSeal; }
-    virtual void prepareForTransaction() override;
+    Block preSeal() const override { ReadGuard l(x_preSeal); return m_preSeal; }
+    Block postSeal() const override { ReadGuard l(x_postSeal); return m_postSeal; }
+    void prepareForTransaction() override;
 
     /// Collate the changed filters for the bloom filter of the given pending transaction.
     /// Insert any filters that are activated into @a o_changed.

--- a/libethereum/ClientBase.cpp
+++ b/libethereum/ClientBase.cpp
@@ -420,11 +420,6 @@ unsigned ClientBase::number() const
     return bc().number();
 }
 
-Transactions ClientBase::pending() const
-{
-    return postSeal().pending();
-}
-
 h256s ClientBase::pendingHashes() const
 {
     return h256s() + postSeal().pendingHashes();

--- a/libethereum/ClientBase.h
+++ b/libethereum/ClientBase.h
@@ -114,13 +114,14 @@ public:
     LocalisedTransactionReceipt localisedTransactionReceipt(h256 const& _transactionHash) const override;
     std::pair<h256, unsigned> transactionLocation(h256 const& _transactionHash) const override;
     Transactions transactions(h256 _blockHash) const override;
+    Transactions transactions(BlockNumber _block) const override { if (_block == PendingBlock) return postSeal().pending(); return transactions(hashFromNumber(_block)); }
     TransactionHashes transactionHashes(h256 _blockHash) const override;
     BlockHeader uncle(h256 _blockHash, unsigned _i) const override;
     UncleHashes uncleHashes(h256 _blockHash) const override;
     unsigned transactionCount(h256 _blockHash) const override;
+    unsigned transactionCount(BlockNumber _block) const override { if (_block == PendingBlock) { auto p = postSeal().pending(); return p.size(); } return transactionCount(hashFromNumber(_block)); }
     unsigned uncleCount(h256 _blockHash) const override;
     unsigned number() const override;
-    Transactions pending() const override;
     h256s pendingHashes() const override;
     BlockHeader pendingInfo() const override;
     BlockDetails pendingDetails() const override;

--- a/libethereum/Interface.h
+++ b/libethereum/Interface.h
@@ -162,8 +162,10 @@ public:
 	virtual BlockHeader uncle(h256 _blockHash, unsigned _i) const = 0;
 	virtual UncleHashes uncleHashes(h256 _blockHash) const = 0;
 	virtual unsigned transactionCount(h256 _blockHash) const = 0;
+	virtual unsigned transactionCount(BlockNumber _block) const = 0;
 	virtual unsigned uncleCount(h256 _blockHash) const = 0;
 	virtual Transactions transactions(h256 _blockHash) const = 0;
+	virtual Transactions transactions(BlockNumber _block) const = 0;
 	virtual TransactionHashes transactionHashes(h256 _blockHash) const = 0;
 
 	virtual BlockHeader pendingInfo() const { return BlockHeader(); }
@@ -174,8 +176,6 @@ public:
 	BlockHeader blockInfo(BlockNumber _block) const;
 	BlockDetails blockDetails(BlockNumber _block) const;
 	Transaction transaction(BlockNumber _block, unsigned _i) const { auto p = transactions(_block); return _i < p.size() ? p[_i] : Transaction(); }
-	unsigned transactionCount(BlockNumber _block) const { if (_block == PendingBlock) { auto p = pending(); return p.size(); } return transactionCount(hashFromNumber(_block)); }
-	Transactions transactions(BlockNumber _block) const { if (_block == PendingBlock) return pending(); return transactions(hashFromNumber(_block)); }
 	TransactionHashes transactionHashes(BlockNumber _block) const { if (_block == PendingBlock) return pendingHashes(); return transactionHashes(hashFromNumber(_block)); }
 	BlockHeader uncle(BlockNumber _block, unsigned _i) const { return uncle(hashFromNumber(_block), _i); }
 	UncleHashes uncleHashes(BlockNumber _block) const { return uncleHashes(hashFromNumber(_block)); }
@@ -186,7 +186,7 @@ public:
 	/// @returns The height of the chain.
 	virtual unsigned number() const = 0;
 
-	/// Get a map containing each of the pending transactions.
+	/// Get a map containing each of the pending transactions (transactions from accounts managed by this node which have not yet made it into a mined block)
 	/// @TODO: Remove in favour of transactions().
 	virtual Transactions pending() const = 0;
 	virtual h256s pendingHashes() const = 0;

--- a/libweb3jsonrpc/Eth.cpp
+++ b/libweb3jsonrpc/Eth.cpp
@@ -135,7 +135,7 @@ Json::Value Eth::eth_pendingTransactions()
 {
 	//Return list of transaction that being sent by local accounts
 	Transactions ours;
-	for (Transaction const& pending:dynamic_cast<Client*>(client())->pending())
+	for (Transaction const& pending:client()->pending())
 	{
 		for (Address const& account:m_ethAccounts.allAccounts())
 		{

--- a/libweb3jsonrpc/Eth.cpp
+++ b/libweb3jsonrpc/Eth.cpp
@@ -135,7 +135,7 @@ Json::Value Eth::eth_pendingTransactions()
 {
 	//Return list of transaction that being sent by local accounts
 	Transactions ours;
-	for (Transaction const& pending:client()->pending())
+	for (Transaction const& pending:dynamic_cast<Client*>(client())->pending())
 	{
 		for (Address const& account:m_ethAccounts.allAccounts())
 		{

--- a/test/tools/libtestutils/FixedClient.h
+++ b/test/tools/libtestutils/FixedClient.h
@@ -38,9 +38,10 @@ class FixedClient: public dev::eth::ClientBase
 {
 public:
     FixedClient(eth::BlockChain const& _bc, eth::Block const& _block) :  m_bc(_bc), m_block(_block) {}
-
+    
     // stub
     void flushTransactions() override {}
+    eth::Transactions pending() const override { eth::Transactions res; return res; }
     eth::BlockChain& bc() override
     {
         BOOST_THROW_EXCEPTION(InterfaceNotSupported() << errinfo_interface("FixedClient::bc()"));


### PR DESCRIPTION
Fix #5008

Update eth so that `web3.eth.pendingTransactions` returns transactions from the client's transaction queue rather than the pending block (which, from what I understand, is the block currently being mined). The impact being that one can now immediately see transactions they send vs having to wait until the client fully syncs and the transactions are being included in a block. Note that the transactions returned by `web3.eth.pendingTransactions` are the transactions sent by the accounts managed by the local eth node.

These changes bring eth's `web3.eth.pendingTransactions` behavior more in line with geth, though there is still at least 1 difference - geth doesn't return transactions with future nonces (i.e. a nonce value that's more than 1 greater than the most recent transaction mined for a particular account) while eth does. Unfortunately I don't think that eth can match geth's behavior without significant changes due to when eth evaluates nonces as being current vs future. I'll file a new issue to track this which will contain more details.

Note that I chose to override `ClientBase::Pending` rather than modifying the function because the `Client `subclass has access to the transaction queue (`m_tq`) while `ClientBase `does not.

I tested my changes locally on an eth instance whose blockchain was out-of-date by at least a few hours, here's the behavior without the changes:

```
> web3.eth.sendTransaction({from: web3.personal.listAccounts[0], to:'0x884ae368b946a7e5b11462b1333248388b463cc3', value:1000})
"0xe45dbfebd35d94dd2e27c51992aaef298f5e8a76f32e48923520844029ca6923"
> web3.eth.pendingTransactions
[]
```

...and with the changes:

```
> web3.eth.sendTransaction({to: '0x884ae368b946a7e5b11462b1333248388b463cc3', value:1000})
"0xa07aca4779fbfdda17112a8f064ea13d17a883bc220e6782c95edca41d522ee8"
> web3.eth.pendingTransactions
[{
    blockHash: null,
    blockNumber: 0,
    data: "0x0000000000000000000000000000000000000000000000000000000000000000",
    from: "0xec75ed1426d02b0237385b596cb3a55e6bbe6c3e",
    gas: 939109,
    gasPrice: 20000000000,
    hash: "0xa07aca4779fbfdda17112a8f064ea13d17a883bc220e6782c95edca41d522ee8",
    nonce: 3,
    r: "0x0ecd54bea95340d5845802fd2ef40065409905c1494d25498c9bb824f6ce00ad",
    s: "0x528ee3a7d1f7c2b5d17e67d8af7f996f4ede78f76822d02ec6f755617e02489b",
    sighash: "0xd0d22bb6a2e8565a62f8d323d26273a72e1e188b08873d4e55b11b78bac8e5c0",
    to: "0x884ae368b946a7e5b11462b1333248388b463cc3",
    transactionIndex: 0,
    v: "0x\x01",
    value: 1000
}]

```
