### PR TITLE
Log verbosities should only be Error, Warning, Info, Debug, Trace

### DIFF
--- a/libdevcore/Common.cpp
+++ b/libdevcore/Common.cpp
@@ -43,11 +43,8 @@ TimerHelper::~TimerHelper()
 {
     auto e = std::chrono::high_resolution_clock::now() - m_t;
     if (!m_ms || e > chrono::milliseconds(m_ms))
-    {
-        Logger logger{createLogger(0, "timer")};
-        LOG(logger) << m_id << " " << chrono::duration_cast<chrono::milliseconds>(e).count()
-                    << " ms";
-    }
+        clog(VerbosityDebug, "timer")
+            << m_id << " " << chrono::duration_cast<chrono::milliseconds>(e).count() << " ms";
 }
 
 int64_t utcTime()

--- a/libdevcore/Log.h
+++ b/libdevcore/Log.h
@@ -109,7 +109,7 @@ BOOST_LOG_INLINE_GLOBAL_LOGGER_DEFAULT(
 
 struct LoggingOptions
 {
-    int verbosity = 0;
+    int verbosity = VerbosityInfo;
     strings includeChannels;
     strings excludeChannels;
 };

--- a/libdevcore/Log.h
+++ b/libdevcore/Log.h
@@ -63,6 +63,7 @@ std::string getThreadName();
 
 enum Verbosity
 {
+    VerbositySilent = -1,
     VerbosityError = 0,
     VerbosityWarning = 1,
     VerbosityInfo = 2,

--- a/libdevcore/Log.h
+++ b/libdevcore/Log.h
@@ -14,12 +14,6 @@
     You should have received a copy of the GNU General Public License
     along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** @file Log.h
- * @author Gav Wood <i@gavwood.com>
- * @date 2014
- *
- * The logging subsystem.
- */
 
 #pragma once
 
@@ -67,30 +61,44 @@ std::string getThreadName();
 
 #define LOG BOOST_LOG
 
+enum Verbosity
+{
+    VerbosityError = 0,
+    VerbosityWarning = 1,
+    VerbosityInfo = 2,
+    VerbosityDebug = 3,
+    VerbosityTrace = 4,
+};
+
 // Simple cout-like stream objects for accessing common log channels.
 // Thread-safe
-BOOST_LOG_INLINE_GLOBAL_LOGGER_CTOR_ARGS(g_debugLogger,
+BOOST_LOG_INLINE_GLOBAL_LOGGER_CTOR_ARGS(g_errorLogger,
     boost::log::sources::severity_channel_logger_mt<>,
-    (boost::log::keywords::severity = 0)(boost::log::keywords::channel = "debug"))
-#define cdebug LOG(dev::g_debugLogger::get())
-
-BOOST_LOG_INLINE_GLOBAL_LOGGER_CTOR_ARGS(g_noteLogger,
-    boost::log::sources::severity_channel_logger_mt<>,
-    (boost::log::keywords::severity = 1)(boost::log::keywords::channel = "note"))
-#define cnote LOG(dev::g_noteLogger::get())
+    (boost::log::keywords::severity = VerbosityError)(boost::log::keywords::channel = "error"))
+#define cerror LOG(dev::g_errorLogger::get())
 
 BOOST_LOG_INLINE_GLOBAL_LOGGER_CTOR_ARGS(g_warnLogger,
     boost::log::sources::severity_channel_logger_mt<>,
-    (boost::log::keywords::severity = 0)(boost::log::keywords::channel = "warn"))
+    (boost::log::keywords::severity = VerbosityWarning)(boost::log::keywords::channel = "warn"))
 #define cwarn LOG(dev::g_warnLogger::get())
+
+BOOST_LOG_INLINE_GLOBAL_LOGGER_CTOR_ARGS(g_noteLogger,
+    boost::log::sources::severity_channel_logger_mt<>,
+    (boost::log::keywords::severity = VerbosityInfo)(boost::log::keywords::channel = "info"))
+#define cnote LOG(dev::g_noteLogger::get())
+
+BOOST_LOG_INLINE_GLOBAL_LOGGER_CTOR_ARGS(g_debugLogger,
+    boost::log::sources::severity_channel_logger_mt<>,
+    (boost::log::keywords::severity = VerbosityDebug)(boost::log::keywords::channel = "debug"))
+#define cdebug LOG(dev::g_debugLogger::get())
 
 BOOST_LOG_INLINE_GLOBAL_LOGGER_CTOR_ARGS(g_traceLogger,
     boost::log::sources::severity_channel_logger_mt<>,
-    (boost::log::keywords::severity = 4)(boost::log::keywords::channel = "trace"))
+    (boost::log::keywords::severity = VerbosityTrace)(boost::log::keywords::channel = "trace"))
 #define ctrace LOG(dev::g_traceLogger::get())
 
 // Simple macro to log to any channel a message without creating a logger object
-// e.g. clog(0, "channel") << "message";
+// e.g. clog(VerbosityInfo, "channel") << "message";
 // Thread-safe
 BOOST_LOG_INLINE_GLOBAL_LOGGER_DEFAULT(
     g_clogLogger, boost::log::sources::severity_channel_logger_mt<>);

--- a/libdevcore/LoggingProgramOptions.cpp
+++ b/libdevcore/LoggingProgramOptions.cpp
@@ -25,8 +25,8 @@ po::options_description createLoggingProgramOptions(unsigned _lineLength, Loggin
 {
     po::options_description optionsDescr("Logging Options", _lineLength);
     auto addLoggingOption = optionsDescr.add_options();
-    addLoggingOption("log-verbosity,v", po::value<int>(&_options.verbosity)->value_name("<0 - 15>"),
-        "Set the log verbosity from 0 to 15 (default: 1).");
+    addLoggingOption("log-verbosity,v", po::value<int>(&_options.verbosity)->value_name("<0 - 4>"),
+        "Set the log verbosity from 0 to 4 (default: 2).");
     addLoggingOption("log-channels",
         po::value<std::vector<std::string>>(&_options.includeChannels)
             ->value_name("<channel_list>")

--- a/libdevcore/OverlayDB.h
+++ b/libdevcore/OverlayDB.h
@@ -35,7 +35,7 @@ class OverlayDB: public MemoryDB
 public:
     explicit OverlayDB(std::unique_ptr<db::DatabaseFace> _db = nullptr)
       : m_db(_db.release(), [](db::DatabaseFace* db) {
-            clog(14, "overlaydb") << "Closing state DB";
+            clog(VerbosityDebug, "overlaydb") << "Closing state DB";
             delete db;
         })
     {}

--- a/libethashseal/EthashAux.cpp
+++ b/libethashseal/EthashAux.cpp
@@ -149,7 +149,7 @@ EthashAux::FullAllocation::FullAllocation(ethash_light_t _light, ethash_callback
 //	cdebug << "Called OK.";
     if (!full)
     {
-        clog(1, "DAG") << "DAG Generation Failure. Reason: " << strerror(errno);
+        clog(VerbosityWarning, "DAG") << "DAG Generation Failure. Reason: " << strerror(errno);
         BOOST_THROW_EXCEPTION(ExternalFunctionFailure() << errinfo_externalFunction("ethash_full_new"));
     }
 }
@@ -167,7 +167,7 @@ bytesConstRef EthashAux::FullAllocation::data() const
 static std::function<int(unsigned)> s_dagCallback;
 static int dagCallbackShim(unsigned _p)
 {
-    clog(1, "DAG") << "Generating DAG file. Progress: " << toString(_p) << "%";
+    clog(VerbosityInfo, "DAG") << "Generating DAG file. Progress: " << toString(_p) << "%";
     return s_dagCallback ? s_dagCallback(_p) : 0;
 }
 

--- a/libethcore/BlockHeader.h
+++ b/libethcore/BlockHeader.h
@@ -212,7 +212,7 @@ private:
     mutable h256 m_hashWithout;		///< (Memoised) SHA3 hash of the block header without seal.
     mutable Mutex m_hashLock;		///< A lock for both m_hash and m_hashWithout.
 
-    mutable Logger m_logger{createLogger(9, "blockhdr")};
+    mutable Logger m_logger{createLogger(VerbosityDebug, "blockhdr")};
 };
 
 inline std::ostream& operator<<(std::ostream& _out, BlockHeader const& _bi)

--- a/libethereum/Block.h
+++ b/libethereum/Block.h
@@ -312,8 +312,8 @@ private:
 
     SealEngineFace* m_sealEngine = nullptr;		///< The chain's seal engine.
 
-    Logger m_logger{createLogger(5, "block")};
-    Logger m_loggerDetailed{createLogger(14, "block")};
+    Logger m_logger{createLogger(VerbosityDebug, "block")};
+    Logger m_loggerDetailed{createLogger(VerbosityTrace, "block")};
 };
 
 

--- a/libethereum/BlockChain.cpp
+++ b/libethereum/BlockChain.cpp
@@ -551,14 +551,14 @@ void BlockChain::insert(VerifiedBlockRef _block, bytesConstRef _receipts, bool _
     if (!pd)
     {
         auto pdata = pd.rlp();
-        LOG(m_loggerDebug) << "Details is returning false despite block known: " << RLP(pdata);
+        LOG(m_loggerError) << "Details is returning false despite block known: " << RLP(pdata);
         auto parentBlock = block(_block.info.parentHash());
-        LOG(m_loggerDebug) << "isKnown: " << isKnown(_block.info.parentHash());
-        LOG(m_loggerDebug) << "last/number: " << m_lastBlockNumber << " " << m_lastBlockHash << " "
+        LOG(m_loggerError) << "isKnown: " << isKnown(_block.info.parentHash());
+        LOG(m_loggerError) << "last/number: " << m_lastBlockNumber << " " << m_lastBlockHash << " "
                            << _block.info.number();
-        LOG(m_loggerDebug) << "Block: " << BlockHeader(&parentBlock);
-        LOG(m_loggerDebug) << "RLP: " << RLP(parentBlock);
-        LOG(m_loggerDebug) << "DATABASE CORRUPTION: CRITICAL FAILURE";
+        LOG(m_loggerError) << "Block: " << BlockHeader(&parentBlock);
+        LOG(m_loggerError) << "RLP: " << RLP(parentBlock);
+        LOG(m_loggerError) << "DATABASE CORRUPTION: CRITICAL FAILURE";
         exit(-1);
     }
 
@@ -645,14 +645,14 @@ ImportRoute BlockChain::import(VerifiedBlockRef const& _block, OverlayDB const& 
     if (!pd)
     {
         auto pdata = pd.rlp();
-        LOG(m_loggerDebug) << "Details is returning false despite block known: " << RLP(pdata);
+        LOG(m_loggerError) << "Details is returning false despite block known: " << RLP(pdata);
         auto parentBlock = block(_block.info.parentHash());
-        LOG(m_loggerDebug) << "isKnown: " << isKnown(_block.info.parentHash());
-        LOG(m_loggerDebug) << "last/number: " << m_lastBlockNumber << " " << m_lastBlockHash << " "
+        LOG(m_loggerError) << "isKnown: " << isKnown(_block.info.parentHash());
+        LOG(m_loggerError) << "last/number: " << m_lastBlockNumber << " " << m_lastBlockHash << " "
                            << _block.info.number();
-        LOG(m_loggerDebug) << "Block: " << BlockHeader(&parentBlock);
-        LOG(m_loggerDebug) << "RLP: " << RLP(parentBlock);
-        LOG(m_loggerDebug) << "DATABASE CORRUPTION: CRITICAL FAILURE";
+        LOG(m_loggerError) << "Block: " << BlockHeader(&parentBlock);
+        LOG(m_loggerError) << "RLP: " << RLP(parentBlock);
+        LOG(m_loggerError) << "DATABASE CORRUPTION: CRITICAL FAILURE";
         exit(-1);
     }
 
@@ -899,9 +899,9 @@ ImportRoute BlockChain::insertBlockAndExtras(VerifiedBlockRef const& _block, byt
 #if ETH_PARANOIA
     if (isKnown(_block.info.hash()) && !details(_block.info.hash()))
     {
-        LOG(m_loggerDebug) << "Known block just inserted has no details.";
-        LOG(m_loggerDebug) << "Block: " << _block.info;
-        LOG(m_loggerDebug) << "DATABASE CORRUPTION: CRITICAL FAILURE";
+        LOG(m_loggerError) << "Known block just inserted has no details.";
+        LOG(m_loggerError) << "Block: " << _block.info;
+        LOG(m_loggerError) << "DATABASE CORRUPTION: CRITICAL FAILURE";
         exit(-1);
     }
 
@@ -912,9 +912,9 @@ ImportRoute BlockChain::insertBlockAndExtras(VerifiedBlockRef const& _block, byt
     }
     catch (...)
     {
-        LOG(m_loggerDebug) << "Failed to initialise State object form imported block.";
-        LOG(m_loggerDebug) << "Block: " << _block.info;
-        LOG(m_loggerDebug) << "DATABASE CORRUPTION: CRITICAL FAILURE";
+        LOG(m_loggerError) << "Failed to initialise State object form imported block.";
+        LOG(m_loggerError) << "Block: " << _block.info;
+        LOG(m_loggerError) << "DATABASE CORRUPTION: CRITICAL FAILURE";
         exit(-1);
     }
 #endif // ETH_PARANOIA

--- a/libethereum/BlockChain.h
+++ b/libethereum/BlockChain.h
@@ -417,9 +417,9 @@ private:
 
     boost::filesystem::path m_dbPath;
 
-    mutable Logger m_logger{createLogger(3, "chain")};
-    mutable Logger m_loggerDetail{createLogger(5, "chain")};
-    mutable Logger m_loggerDebug{createLogger(0, "chain")};
+    mutable Logger m_logger{createLogger(VerbosityDebug, "chain")};
+    mutable Logger m_loggerDetail{createLogger(VerbosityTrace, "chain")};
+    mutable Logger m_loggerError{createLogger(VerbosityError, "chain")};
 
     friend std::ostream& operator<<(std::ostream& _out, BlockChain const& _bc);
 };

--- a/libethereum/BlockChainSync.cpp
+++ b/libethereum/BlockChainSync.cpp
@@ -509,7 +509,8 @@ void BlockChainSync::onPeerBlockHeaders(std::shared_ptr<EthereumPeer> _peer, RLP
             {
                 // Start of the header chain in m_headers doesn't match our known chain,
                 // probably we've downloaded other fork
-                clog(0, "sync") << "Unknown parent of the downloaded headers, restarting sync";
+                clog(VerbosityWarning, "sync")
+                    << "Unknown parent of the downloaded headers, restarting sync";
                 restartSync();
                 return;
             }
@@ -526,8 +527,8 @@ void BlockChainSync::onPeerBlockHeaders(std::shared_ptr<EthereumPeer> _peer, RLP
                 if ((prevBlock && prevBlock->hash != info.parentHash()) || (blockNumber == m_lastImportedBlock + 1 && info.parentHash() != m_lastImportedBlockHash))
                 {
                     // mismatching parent id, delete the previous block and don't add this one
-                    clog(0, "sync") << "Unknown block header " << blockNumber << " " << info.hash()
-                                    << " (Restart syncing)";
+                    clog(VerbosityWarning, "sync") << "Unknown block header " << blockNumber << " "
+                                                   << info.hash() << " (Restart syncing)";
                     _peer->addRating(-1);
                     restartSync();
                     return ;
@@ -696,7 +697,7 @@ void BlockChainSync::collectBlocks()
 
     if (host().bq().unknownFull())
     {
-        clog(0, "sync") << "Too many unknown blocks, restarting sync";
+        clog(VerbosityWarning, "sync") << "Too many unknown blocks, restarting sync";
         restartSync();
         return;
     }

--- a/libethereum/BlockChainSync.cpp
+++ b/libethereum/BlockChainSync.cpp
@@ -246,7 +246,7 @@ void BlockChainSync::syncPeer(std::shared_ptr<EthereumPeer> _peer, bool _force)
 {
     if (_peer->m_asking != Asking::Nothing)
     {
-        LOG(m_loggerVerbose) << "Can't sync with this peer - outstanding asks.";
+        LOG(m_loggerDetail) << "Can't sync with this peer - outstanding asks.";
         return;
     }
 
@@ -291,7 +291,7 @@ void BlockChainSync::requestBlocks(std::shared_ptr<EthereumPeer> _peer)
     clearPeerDownload(_peer);
     if (host().bq().knownFull())
     {
-        LOG(m_loggerVerbose) << "Waiting for block queue before downloading blocks";
+        LOG(m_loggerDetail) << "Waiting for block queue before downloading blocks";
         pauseSync();
         return;
     }
@@ -467,12 +467,12 @@ void BlockChainSync::onPeerBlockHeaders(std::shared_ptr<EthereumPeer> _peer, RLP
     }
     if (m_state == SyncState::Waiting)
     {
-        LOG(m_loggerVerbose) << "Ignored blocks while waiting";
+        LOG(m_loggerDetail) << "Ignored blocks while waiting";
         return;
     }
     if (itemCount == 0)
     {
-        LOG(m_loggerVerbose) << "Peer does not have the blocks requested";
+        LOG(m_loggerDetail) << "Peer does not have the blocks requested";
         _peer->addRating(-1);
     }
     for (unsigned i = 0; i < itemCount; i++)
@@ -598,12 +598,12 @@ void BlockChainSync::onPeerBlockBodies(std::shared_ptr<EthereumPeer> _peer, RLP 
     }
     if (m_state == SyncState::Waiting)
     {
-        LOG(m_loggerVerbose) << "Ignored blocks while waiting";
+        LOG(m_loggerDetail) << "Ignored blocks while waiting";
         return;
     }
     if (itemCount == 0)
     {
-        LOG(m_loggerVerbose) << "Peer does not have the blocks requested";
+        LOG(m_loggerDetail) << "Peer does not have the blocks requested";
         _peer->addRating(-1);
     }
     for (unsigned i = 0; i < itemCount; i++)
@@ -617,7 +617,7 @@ void BlockChainSync::onPeerBlockBodies(std::shared_ptr<EthereumPeer> _peer, RLP 
         auto iter = m_headerIdToNumber.find(id);
         if (iter == m_headerIdToNumber.end() || !haveItem(m_headers, iter->second))
         {
-            LOG(m_loggerVerbose) << "Ignored unknown block body";
+            LOG(m_loggerDetail) << "Ignored unknown block body";
             continue;
         }
         unsigned blockNumber = iter->second;
@@ -740,7 +740,7 @@ void BlockChainSync::onPeerNewBlock(std::shared_ptr<EthereumPeer> _peer, RLP con
     unsigned blockNumber = static_cast<unsigned>(info.number());
     if (blockNumber > (m_lastImportedBlock + 1))
     {
-        LOG(m_loggerVerbose) << "Received unknown new block";
+        LOG(m_loggerDetail) << "Received unknown new block";
         syncPeer(_peer, true);
         return;
     }

--- a/libethereum/BlockChainSync.h
+++ b/libethereum/BlockChainSync.h
@@ -160,9 +160,8 @@ private:
     h256 m_lastImportedBlockHash;				///< Last imported block hash
     u256 m_syncingTotalDifficulty;				///< Highest peer difficulty
 
-    Logger m_logger{createLogger(4, "sync")};
-    Logger m_loggerDetail{createLogger(5, "sync")};
-    Logger m_loggerVerbose{createLogger(13, "sync")};
+    Logger m_logger{createLogger(VerbosityDebug, "sync")};
+    Logger m_loggerDetail{createLogger(VerbosityTrace, "sync")};
 
 private:
     static char const* const s_stateNames[static_cast<int>(SyncState::Size)];

--- a/libethereum/BlockQueue.h
+++ b/libethereum/BlockQueue.h
@@ -320,8 +320,8 @@ private:
     u256 m_difficulty;													///< Total difficulty of blocks in the queue
     u256 m_drainingDifficulty;											///< Total difficulty of blocks in draining
 
-    Logger m_logger{createLogger(4, "bq")};
-    Logger m_loggerDetail{createLogger(7, "bq")};
+    Logger m_logger{createLogger(VerbosityDebug, "bq")};
+    Logger m_loggerDetail{createLogger(VerbosityTrace, "bq")};
 };
 
 std::ostream& operator<<(std::ostream& _out, BlockQueueStatus const& _s);

--- a/libethereum/Client.h
+++ b/libethereum/Client.h
@@ -347,8 +347,8 @@ protected:
 
     bytes m_extraData;
 
-    Logger m_logger{createLogger(2, "client")};
-    Logger m_loggerDetail{createLogger(7, "client")};
+    Logger m_logger{createLogger(VerbosityInfo, "client")};
+    Logger m_loggerDetail{createLogger(VerbosityDebug, "client")};
 };
 
 }

--- a/libethereum/ClientBase.h
+++ b/libethereum/ClientBase.h
@@ -186,7 +186,7 @@ protected:
                                                             ///< The dictionary of special filters and their additional data
     std::map<unsigned, ClientWatch> m_watches;				///< Each and every watch - these reference a filter.
 
-    Logger m_loggerWatch{createLogger(7, "watch")};
+    Logger m_loggerWatch{createLogger(VerbosityDebug, "watch")};
 };
 
 }}

--- a/libethereum/EthereumHost.cpp
+++ b/libethereum/EthereumHost.cpp
@@ -59,7 +59,7 @@ public:
         catch (FailedInvariant const&)
         {
             // "fix" for https://github.com/ethereum/webthree-umbrella/issues/300
-            cnetwarn << "Failed invariant during sync, restarting sync";
+            cwarn << "Failed invariant during sync, restarting sync";
             m_sync->restartSync();
         }
     }
@@ -92,7 +92,7 @@ public:
         catch (FailedInvariant const&)
         {
             // "fix" for https://github.com/ethereum/webthree-umbrella/issues/300
-            cnetwarn << "Failed invariant during sync, restarting sync";
+            cwarn << "Failed invariant during sync, restarting sync";
             m_sync->restartSync();
         }
     }
@@ -106,7 +106,7 @@ public:
         catch (FailedInvariant const&)
         {
             // "fix" for https://github.com/ethereum/webthree-umbrella/issues/300
-            cnetwarn << "Failed invariant during sync, restarting sync";
+            cwarn << "Failed invariant during sync, restarting sync";
             m_sync->restartSync();
         }
     }
@@ -120,7 +120,7 @@ public:
         catch (FailedInvariant const&)
         {
             // "fix" for https://github.com/ethereum/webthree-umbrella/issues/300
-            cnetwarn << "Failed invariant during sync, restarting sync";
+            cwarn << "Failed invariant during sync, restarting sync";
             m_sync->restartSync();
         }
     }
@@ -134,7 +134,7 @@ public:
         catch (FailedInvariant const&)
         {
             // "fix" for https://github.com/ethereum/webthree-umbrella/issues/300
-            cnetwarn << "Failed invariant during sync, restarting sync";
+            cwarn << "Failed invariant during sync, restarting sync";
             m_sync->restartSync();
         }
     }
@@ -303,7 +303,7 @@ public:
             }
         }
         if (count > 20 && n == 0)
-            cnetwarn << "all " << count << " unknown blocks requested; peer on different chain?";
+            cnetlog << "all " << count << " unknown blocks requested; peer on different chain?";
         else
             cnetlog << n << " blocks known and returned; " << (numBodiesToSend - n)
                     << " blocks unknown; " << (count > c_maxBlocks ? count - c_maxBlocks : 0)

--- a/libethereum/EthereumHost.cpp
+++ b/libethereum/EthereumHost.cpp
@@ -155,7 +155,7 @@ private:
     shared_ptr<BlockChainSync> m_sync;
     TransactionQueue& m_tq;
 
-    Logger m_logger{createLogger(6, "host")};
+    Logger m_logger{createLogger(VerbosityDebug, "host")};
 };
 
 class EthereumHostData: public EthereumHostDataFace

--- a/libethereum/EthereumHost.h
+++ b/libethereum/EthereumHost.h
@@ -137,7 +137,7 @@ private:
     std::shared_ptr<EthereumHostDataFace> m_hostData;
     std::shared_ptr<EthereumPeerObserverFace> m_peerObserver;
 
-    Logger m_logger{createLogger(6, "host")};
+    Logger m_logger{createLogger(VerbosityDebug, "host")};
 };
 
 }

--- a/libethereum/EthereumPeer.cpp
+++ b/libethereum/EthereumPeer.cpp
@@ -147,7 +147,7 @@ void EthereumPeer::requestBlockHeaders(unsigned _startNumber, unsigned _count, u
 {
     if (m_asking != Asking::Nothing)
     {
-        cnetwarn << "Asking headers while requesting " << ::toString(m_asking);
+        cnetlog << "Asking headers while requesting " << ::toString(m_asking);
     }
     setAsking(Asking::BlockHeaders);
     RLPStream s;
@@ -162,7 +162,7 @@ void EthereumPeer::requestBlockHeaders(h256 const& _startHash, unsigned _count, 
 {
     if (m_asking != Asking::Nothing)
     {
-        cnetwarn << "Asking headers while requesting " << ::toString(m_asking);
+        cnetlog << "Asking headers while requesting " << ::toString(m_asking);
     }
     setAsking(Asking::BlockHeaders);
     RLPStream s;
@@ -193,8 +193,7 @@ void EthereumPeer::requestByHashes(h256s const& _hashes, Asking _asking, Subprot
 {
     if (m_asking != Asking::Nothing)
     {
-        cnetwarn << "Asking " << ::toString(_asking) << " while requesting "
-                 << ::toString(m_asking);
+        cnetlog << "Asking " << ::toString(_asking) << " while requesting " << ::toString(m_asking);
     }
     setAsking(_asking);
     if (_hashes.size())
@@ -434,12 +433,12 @@ bool EthereumPeer::interpret(unsigned _id, RLP const& _r)
     }
     catch (Exception const&)
     {
-        cnetwarn << "Peer causing an Exception: "
-                 << boost::current_exception_diagnostic_information() << " " << _r;
+        cnetlog << "Peer causing an Exception: "
+                << boost::current_exception_diagnostic_information() << " " << _r;
     }
     catch (std::exception const& _e)
     {
-        cnetwarn << "Peer causing an exception: " << _e.what() << " " << _r;
+        cnetlog << "Peer causing an exception: " << _e.what() << " " << _r;
     }
 
     return true;

--- a/libethereum/EthereumPeer.h
+++ b/libethereum/EthereumPeer.h
@@ -196,7 +196,7 @@ private:
 	std::weak_ptr<EthereumHostDataFace> m_hostData;
 
     /// Logger for messages about impolite behaivour of peers.
-    Logger m_loggerImpolite{createLogger(3, "impolite")};
+    Logger m_loggerImpolite{createLogger(VerbosityDebug, "impolite")};
 };
 
 }

--- a/libethereum/Executive.h
+++ b/libethereum/Executive.h
@@ -211,9 +211,9 @@ private:
     Address m_newAddress;
     size_t m_savepoint = 0;
 
-    Logger m_execLogger{createLogger(1, "exec")};
-    Logger m_detailsLogger{createLogger(14, "exec")};
-    Logger m_vmTraceLogger{createLogger(11, "vmtrace")};
+    Logger m_execLogger{createLogger(VerbosityDebug, "exec")};
+    Logger m_detailsLogger{createLogger(VerbosityTrace, "exec")};
+    Logger m_vmTraceLogger{createLogger(VerbosityTrace, "vmtrace")};
 };
 
 }

--- a/libethereum/ImportPerformanceLogger.h
+++ b/libethereum/ImportPerformanceLogger.h
@@ -52,8 +52,8 @@ public:
 		double const totalElapsed = m_totalTimer.elapsed();
 		if (totalElapsed > 0.5)
 		{
-			cnote << "SLOW IMPORT: { " << constructReport(totalElapsed, _additionalValues) << " }";
-		}
+            cdebug << "SLOW IMPORT: { " << constructReport(totalElapsed, _additionalValues) << " }";
+        }
 	}
 
 private:

--- a/libethereum/SnapshotImporter.h
+++ b/libethereum/SnapshotImporter.h
@@ -50,7 +50,7 @@ private:
     StateImporterFace& m_stateImporter;
     BlockChainImporterFace& m_blockChainImporter;
 
-    Logger m_logger{createLogger(1, "snap")};
+    Logger m_logger{createLogger(VerbosityInfo, "snap")};
 };
 
 }

--- a/libethereum/State.cpp
+++ b/libethereum/State.cpp
@@ -79,7 +79,7 @@ OverlayDB State::openDB(fs::path const& _basePath, h256 const& _genesisHash, Wit
 
     if (_we == WithExisting::Kill)
     {
-        clog(14, "statedb") << "Killing state database (WithExisting::Kill).";
+        clog(VerbosityDebug, "statedb") << "Killing state database (WithExisting::Kill).";
         fs::remove_all(path / fs::path("state"));
     }
 
@@ -90,7 +90,7 @@ OverlayDB State::openDB(fs::path const& _basePath, h256 const& _genesisHash, Wit
     try
     {
         std::unique_ptr<db::DatabaseFace> db(new db::DBImpl(path / fs::path("state")));
-        clog(14, "statedb") << "Opened state DB.";
+        clog(VerbosityTrace, "statedb") << "Opened state DB.";
         return OverlayDB(std::move(db));
     }
     catch (boost::exception const& ex)

--- a/libethereum/TransactionQueue.h
+++ b/libethereum/TransactionQueue.h
@@ -209,8 +209,8 @@ private:
     mutable Mutex x_queue;                           ///< Verification queue mutex
     std::atomic<bool> m_aborting = {false};          ///< Exit condition for verifier.
 
-    Logger m_logger{createLogger(4, "tq")};
-    Logger m_loggerDetail{createLogger(7, "tq")};
+    Logger m_logger{createLogger(VerbosityInfo, "tq")};
+    Logger m_loggerDetail{createLogger(VerbosityDebug, "tq")};
 };
 
 }

--- a/libethereum/WarpHostCapability.cpp
+++ b/libethereum/WarpHostCapability.cpp
@@ -303,7 +303,7 @@ private:
 
     std::unique_ptr<boost::fibers::fiber> m_downloadFiber;
 
-    Logger m_logger{createLogger(1, "snap")};
+    Logger m_logger{createLogger(VerbosityInfo, "snap")};
 };
 
 }  // namespace

--- a/libethereum/WarpPeerCapability.cpp
+++ b/libethereum/WarpPeerCapability.cpp
@@ -152,12 +152,12 @@ bool WarpPeerCapability::interpret(unsigned _id, RLP const& _r)
     }
     catch (Exception const&)
     {
-        cnetwarn << "Warp Peer causing an Exception: "
-                 << boost::current_exception_diagnostic_information() << " " << _r;
+        cnetlog << "Warp Peer causing an Exception: "
+                << boost::current_exception_diagnostic_information() << " " << _r;
     }
     catch (std::exception const& _e)
     {
-        cnetwarn << "Warp Peer causing an exception: " << _e.what() << " " << _r;
+        cnetlog << "Warp Peer causing an exception: " << _e.what() << " " << _r;
     }
 
     return true;

--- a/libp2p/Common.h
+++ b/libp2p/Common.h
@@ -85,8 +85,6 @@ struct ECDHEError: virtual Exception {};
         boost::log::sources::severity_channel_logger_mt<>,     \
         (boost::log::keywords::severity = SEVERITY)(boost::log::keywords::channel = "net"))
 
-NET_GLOBAL_LOGGER(netwarn, VerbosityWarning)
-#define cnetwarn LOG(dev::p2p::g_netwarnLogger::get())
 NET_GLOBAL_LOGGER(netnote, VerbosityInfo)
 #define cnetnote LOG(dev::p2p::g_netnoteLogger::get())
 NET_GLOBAL_LOGGER(netlog, VerbosityDebug)

--- a/libp2p/Common.h
+++ b/libp2p/Common.h
@@ -85,13 +85,13 @@ struct ECDHEError: virtual Exception {};
         boost::log::sources::severity_channel_logger_mt<>,     \
         (boost::log::keywords::severity = SEVERITY)(boost::log::keywords::channel = "net"))
 
-NET_GLOBAL_LOGGER(netwarn, 0)
+NET_GLOBAL_LOGGER(netwarn, VerbosityWarning)
 #define cnetwarn LOG(dev::p2p::g_netwarnLogger::get())
-NET_GLOBAL_LOGGER(netnote, 2)
+NET_GLOBAL_LOGGER(netnote, VerbosityInfo)
 #define cnetnote LOG(dev::p2p::g_netnoteLogger::get())
-NET_GLOBAL_LOGGER(netlog, 4)
+NET_GLOBAL_LOGGER(netlog, VerbosityDebug)
 #define cnetlog LOG(dev::p2p::g_netlogLogger::get())
-NET_GLOBAL_LOGGER(netdetails, 10)
+NET_GLOBAL_LOGGER(netdetails, VerbosityTrace)
 #define cnetdetails LOG(dev::p2p::g_netdetailsLogger::get())
 
 enum PacketType

--- a/libp2p/Host.cpp
+++ b/libp2p/Host.cpp
@@ -133,7 +133,7 @@ void Host::start()
     if (isWorking())
         return;
 
-    cnetwarn << "Network start failed!";
+    cwarn << "Network start failed!";
     doneWorking();
 }
 
@@ -310,7 +310,7 @@ void Host::startPeerSession(Public const& _id, RLP const& _rlp, unique_ptr<RLPXF
                 if(s->isConnected())
                 {
                     // Already connected.
-                    cnetwarn << "Session already exists for peer with id " << _id;
+                    cnetlog << "Session already exists for peer with id " << _id;
                     ps->disconnect(DuplicatePeer);
                     return;
                 }
@@ -409,14 +409,14 @@ void Host::determinePublic()
         
         if (lset && natIFAddr != laddr)
             // if listen address is set, Host will use it, even if upnp returns different
-            cnetwarn << "Listen address " << laddr << " differs from local address " << natIFAddr
-                     << " returned by UPnP!";
+            cwarn << "Listen address " << laddr << " differs from local address " << natIFAddr
+                  << " returned by UPnP!";
 
         if (pset && ep.address() != paddr)
         {
             // if public address is set, Host will advertise it, even if upnp returns different
-            cnetwarn << "Specified public address " << paddr << " differs from external address "
-                     << ep.address() << " returned by UPnP!";
+            cwarn << "Specified public address " << paddr << " differs from external address "
+                  << ep.address() << " returned by UPnP!";
             ep.address(paddr);
         }
     }
@@ -466,11 +466,11 @@ void Host::runAcceptor()
             }
             catch (Exception const& _e)
             {
-                cnetwarn << "ERROR: " << diagnostic_information(_e);
+                cwarn << "ERROR: " << diagnostic_information(_e);
             }
             catch (std::exception const& _e)
             {
-                cnetwarn << "ERROR: " << _e.what();
+                cwarn << "ERROR: " << _e.what();
             }
 
             if (!success)

--- a/libp2p/Host.h
+++ b/libp2p/Host.h
@@ -350,7 +350,7 @@ private:
 
 	ReputationManager m_repMan;
 
-    Logger m_logger{createLogger(6, "net")};
+    Logger m_logger{createLogger(VerbosityDebug, "net")};
 };
 
 }

--- a/libp2p/Network.cpp
+++ b/libp2p/Network.cpp
@@ -55,7 +55,7 @@ std::set<bi::address> Network::getInterfaceAddresses()
     char ac[80];
     if (gethostname(ac, sizeof(ac)) == SOCKET_ERROR)
     {
-        cnetwarn << "Error " << WSAGetLastError() << " when getting local host name.";
+        cnetlog << "Error " << WSAGetLastError() << " when getting local host name.";
         WSACleanup();
         BOOST_THROW_EXCEPTION(NoNetworking());
     }
@@ -63,7 +63,7 @@ std::set<bi::address> Network::getInterfaceAddresses()
     struct hostent* phe = gethostbyname(ac);
     if (phe == 0)
     {
-        cnetwarn << "Bad host lookup.";
+        cnetlog << "Bad host lookup.";
         WSACleanup();
         BOOST_THROW_EXCEPTION(NoNetworking());
     }
@@ -207,7 +207,7 @@ bi::tcp::endpoint Network::traverseNAT(std::set<bi::address> const& _ifAddresses
             upnpEP = bi::tcp::endpoint(eIPAddr, (unsigned short)extPort);
         }
         else
-            cnetwarn << "Couldn't punch through NAT (or no NAT in place).";
+            cnetlog << "Couldn't punch through NAT (or no NAT in place).";
     }
 
     return upnpEP;
@@ -241,7 +241,7 @@ bi::tcp::endpoint Network::resolveHost(string const& _addr)
         auto it = r.resolve({bi::tcp::v4(), split[0], toString(port)}, ec);
         if (ec)
         {
-            cnetwarn << "Error resolving host address... " << _addr << " : " << ec.message();
+            cnetlog << "Error resolving host address... " << _addr << " : " << ec.message();
             return bi::tcp::endpoint();
         }
         else

--- a/libp2p/NodeTable.cpp
+++ b/libp2p/NodeTable.cpp
@@ -397,8 +397,8 @@ void NodeTable::onReceived(UDPSocketFace*, bi::udp::endpoint const& _from, bytes
             return;
         if (packet->isExpired())
         {
-            LOG(m_loggerWarn) << "Invalid packet (timestamp in the past) from "
-                              << _from.address().to_string() << ":" << _from.port();
+            LOG(m_logger) << "Invalid packet (timestamp in the past) from "
+                          << _from.address().to_string() << ":" << _from.port();
             return;
         }
 
@@ -524,13 +524,13 @@ void NodeTable::onReceived(UDPSocketFace*, bi::udp::endpoint const& _from, bytes
     }
     catch (std::exception const& _e)
     {
-        LOG(m_loggerWarn) << "Exception processing message from " << _from.address().to_string()
-                          << ":" << _from.port() << ": " << _e.what();
+        LOG(m_logger) << "Exception processing message from " << _from.address().to_string() << ":"
+                      << _from.port() << ": " << _e.what();
     }
     catch (...)
     {
-        LOG(m_loggerWarn) << "Exception processing message from " << _from.address().to_string()
-                          << ":" << _from.port();
+        LOG(m_logger) << "Exception processing message from " << _from.address().to_string() << ":"
+                      << _from.port();
     }
 }
 

--- a/libp2p/NodeTable.cpp
+++ b/libp2p/NodeTable.cpp
@@ -62,8 +62,8 @@ NodeTable::NodeTable(ba::io_service& _io, KeyPair const& _alias, NodeIPEndpoint 
     }
     catch (std::exception const& _e)
     {
-        cnetwarn << "Exception connecting NodeTable socket: " << _e.what();
-        cnetwarn << "Discovery disabled.";
+        cwarn << "Exception connecting NodeTable socket: " << _e.what();
+        cwarn << "Discovery disabled.";
     }
 }
     
@@ -499,7 +499,7 @@ void NodeTable::onReceived(UDPSocketFace*, bi::udp::endpoint const& _from, bytes
                     Neighbours out(_from, nearest, offset, nlimit);
                     out.sign(m_secret);
                     if (out.data.size() > 1280)
-                        cnetwarn << "Sending truncated datagram, size: " << out.data.size();
+                        cnetlog << "Sending truncated datagram, size: " << out.data.size();
                     m_socketPointer->send(out);
                 }
                 break;

--- a/libp2p/NodeTable.cpp
+++ b/libp2p/NodeTable.cpp
@@ -204,8 +204,9 @@ void NodeTable::doDiscover(NodeID _node, unsigned _round, shared_ptr<set<shared_
     {
         if (_ec)
             // we can't use m_logger here, because captured this might be already destroyed
-            clog(10, "discov") << "Discovery timer was probably cancelled: " << _ec.value() << " "
-                               << _ec.message();
+            clog(VerbosityDebug, "discov")
+                << "Discovery timer was probably cancelled: " << _ec.value() << " "
+                << _ec.message();
 
         if (_ec.value() == boost::asio::error::operation_aborted || m_timers.isStopped())
             return;
@@ -539,8 +540,9 @@ void NodeTable::doCheckEvictions()
     {
         if (_ec)
             // we can't use m_logger here, because captured this might be already destroyed
-            clog(10, "discov") << "Check Evictions timer was probably cancelled: " << _ec.value()
-                               << " " << _ec.message();
+            clog(VerbosityDebug, "discov")
+                << "Check Evictions timer was probably cancelled: " << _ec.value() << " "
+                << _ec.message();
 
         if (_ec.value() == boost::asio::error::operation_aborted || m_timers.isStopped())
             return;
@@ -572,8 +574,9 @@ void NodeTable::doDiscovery()
     {
         if (_ec)
             // we can't use m_logger here, because captured this might be already destroyed
-            clog(10, "discov") << "Discovery timer was probably cancelled: " << _ec.value() << " "
-                               << _ec.message();
+            clog(VerbosityDebug, "discov")
+                << "Discovery timer was probably cancelled: " << _ec.value() << " "
+                << _ec.message();
 
         if (_ec.value() == boost::asio::error::operation_aborted || m_timers.isStopped())
             return;

--- a/libp2p/NodeTable.h
+++ b/libp2p/NodeTable.h
@@ -275,8 +275,7 @@ private:
     std::shared_ptr<NodeSocket> m_socket;							///< Shared pointer for our UDPSocket; ASIO requires shared_ptr.
     NodeSocket* m_socketPointer;									///< Set to m_socket.get(). Socket is created in constructor and disconnected in destructor to ensure access to pointer is safe.
 
-    Logger m_logger{createLogger(10, "discov")};
-    Logger m_loggerWarn{createLogger(0, "discov")};
+    Logger m_logger{createLogger(VerbosityDebug, "discov")};
 
     DeadlineOps m_timers; ///< this should be the last member - it must be destroyed first
 };

--- a/libp2p/RLPxHandshake.cpp
+++ b/libp2p/RLPxHandshake.cpp
@@ -414,7 +414,7 @@ void RLPXHandshake::transition(boost::system::error_code _ech)
                         }
                         catch (std::exception const& _e)
                         {
-                            cnetwarn << "Handshake causing an exception: " << _e.what();
+                            cnetlog << "Handshake causing an exception: " << _e.what();
                             m_nextState = Error;
                             transition();
                         }

--- a/libp2p/RLPxHandshake.h
+++ b/libp2p/RLPxHandshake.h
@@ -143,7 +143,7 @@ protected:
     std::shared_ptr<RLPXSocket> m_socket;		///< Socket.
     boost::asio::deadline_timer m_idleTimer;	///< Timer which enforces c_timeout.
 
-    Logger m_logger{createLogger(10, "net")};
+    Logger m_logger{createLogger(VerbosityTrace, "net")};
 };
     
 }

--- a/libp2p/Session.cpp
+++ b/libp2p/Session.cpp
@@ -119,7 +119,7 @@ template <class T> vector<T> randomSelection(vector<T> const& _t, unsigned _n)
 bool Session::readPacket(uint16_t _capId, PacketType _t, RLP const& _r)
 {
     m_lastReceived = chrono::steady_clock::now();
-    clog(14, "net") << "-> " << _t << " " << _r;
+    clog(VerbosityTrace, "net") << "-> " << _t << " " << _r;
     try // Generic try-catch block designed to capture RLP format errors - TODO: give decent diagnostics, make a bit more specific over what is caught.
     {
         // v4 frame headers are useless, offset packet type used
@@ -217,7 +217,7 @@ bool Session::checkPacket(bytesConstRef _msg)
 void Session::send(bytes&& _msg)
 {
     bytesConstRef msg(&_msg);
-    clog(15, "net") << "<- " << RLP(msg.cropped(1));
+    clog(VerbosityTrace, "net") << "<- " << RLP(msg.cropped(1));
     if (!checkPacket(msg))
         cnetwarn << "INVALID PACKET CONSTRUCTED!";
 

--- a/libp2p/UDP.h
+++ b/libp2p/UDP.h
@@ -203,7 +203,7 @@ void UDPSocket<Handler, MaxDatagramSize>::doRead()
             return disconnectWithError(_ec);
         
         if (_ec != boost::system::errc::success)
-            cnetwarn << "Receiving UDP message failed. " << _ec.value() << " : " << _ec.message();
+            cnetlog << "Receiving UDP message failed. " << _ec.value() << " : " << _ec.message();
 
         if (_len)
             m_host.onReceived(this, m_recvEndpoint, bytesConstRef(m_recvData.data(), _len));
@@ -226,7 +226,7 @@ void UDPSocket<Handler, MaxDatagramSize>::doWrite()
             return disconnectWithError(_ec);
         
         if (_ec != boost::system::errc::success)
-            cnetwarn << "Failed delivering UDP message. " << _ec.value() << " : " << _ec.message();
+            cnetlog << "Failed delivering UDP message. " << _ec.value() << " : " << _ec.message();
 
         Guard l(x_sendQ);
         m_sendQ.pop_front();

--- a/libweb3jsonrpc/IpcServerBase.cpp
+++ b/libweb3jsonrpc/IpcServerBase.cpp
@@ -85,7 +85,7 @@ template <class S> bool IpcServerBase<S>::SendResponse(string const& _response, 
         else
             fullyWritten = true;
     } while (!fullyWritten && !errorOccured);
-    clog(10, "rpc") << _response;
+    clog(VerbosityTrace, "rpc") << _response;
     return fullyWritten && !errorOccured;
 }
 
@@ -136,7 +136,7 @@ template <class S> void IpcServerBase<S>::GenerateResponse(S _connection)
                 {
                     std::string r = request.substr(0, i + 1);
                     request.erase(0, i + 1);
-                    clog(10, "rpc") << r;
+                    clog(VerbosityTrace, "rpc") << r;
                     OnRequest(r, reinterpret_cast<void*>((intptr_t)_connection));
                     i = 0;
                     continue;

--- a/test/tools/jsontests/vm.h
+++ b/test/tools/jsontests/vm.h
@@ -86,7 +86,7 @@ public:
     u256 gas;
     u256 execGas;
 
-    mutable Logger m_logger{createLogger(11, "EVM")};
+    mutable Logger m_logger{createLogger(VerbosityTrace, "EVM")};
 };
 
 class VmTestSuite: public TestSuite

--- a/test/tools/libtesteth/BlockChainHelper.cpp
+++ b/test/tools/libtesteth/BlockChainHelper.cpp
@@ -465,7 +465,7 @@ void TestBlock::populateFrom(TestBlock const& _original)
     }
     catch (BlockStateUndefined const& _ex)
     {
-        clog(7, "net") << _ex.what() << " copying block with null state";
+        clog(VerbosityDebug, "net") << _ex.what() << " copying block with null state";
     }
     m_testTransactions = _original.testTransactions();
     m_transactionQueue.clear();

--- a/test/tools/libtesteth/FillJsonFunctions.cpp
+++ b/test/tools/libtesteth/FillJsonFunctions.cpp
@@ -164,8 +164,7 @@ json_spirit::mObject fillJsonWithStateChange(
             log << (*it).second.str();
     }
 
-    Logger logger{createLogger(5, "state")};
-    LOG(logger) << log.str();
+    clog(VerbosityInfo, "state") << log.str();
     return oState;
 }
 

--- a/test/tools/libtesteth/ImportTest.h
+++ b/test/tools/libtesteth/ImportTest.h
@@ -103,7 +103,7 @@ private:
     json_spirit::mObject const& m_testInputObject;
 	json_spirit::mObject& m_testOutputObject;
 
-    Logger m_logger{createLogger(5, "state")};
+    Logger m_logger{createLogger(VerbosityInfo, "state")};
 };
 
 template<class T>

--- a/test/tools/libtesteth/Options.cpp
+++ b/test/tools/libtesteth/Options.cpp
@@ -87,12 +87,12 @@ void Options::setVerbosity(int _level)
     logOptions.verbosity = verbosity;
     if (_level <= 0)
     {
-        logOptions.verbosity = -1;
+        logOptions.verbosity = VerbositySilent;
         std::cout.rdbuf(nullOstream.rdbuf());
         std::cerr.rdbuf(nullOstream.rdbuf());
     }
     else if (_level == 1 || _level == 2)
-        logOptions.verbosity = -1;
+        logOptions.verbosity = VerbositySilent;
     dev::setupLogging(logOptions);
 }
 
@@ -167,7 +167,7 @@ Options::Options(int argc, const char** argv)
         {
 #if ETH_VMTRACE
             vmtrace = true;
-            verbosity = std::max(verbosity, 13);
+            verbosity = VerbosityTrace;
 #else
             cerr << "--vmtrace option requires a build with cmake -DVMTRACE=1\n";
             exit(1);
@@ -272,7 +272,7 @@ Options::Options(int argc, const char** argv)
         else if (arg == "--statediff")
         {
             statediff = true;
-            verbosity = std::max(verbosity, 5);
+            verbosity = VerbosityTrace;
         }
         else if (arg == "--randomcode")
         {

--- a/test/tools/libtestutils/Common.cpp
+++ b/test/tools/libtestutils/Common.cpp
@@ -42,7 +42,8 @@ boost::filesystem::path dev::test::getTestPath()
 
     if (ptestPath == nullptr)
     {
-        clog(1, "test") << " could not find environment variable ETHEREUM_TEST_PATH \n";
+        clog(VerbosityWarning, "test")
+            << " could not find environment variable ETHEREUM_TEST_PATH \n";
         testPath = "../../test/jsontests";
     }
     else
@@ -64,11 +65,12 @@ Json::Value dev::test::loadJsonFromFile(fs::path const& _path)
     Json::Value result;
     string s = dev::contentsString(_path);
     if (!s.length())
-        clog(1, "test") << "Contents of " << _path.string()
-                        << " is empty. Have you cloned the 'tests' repo branch develop and "
-                           "set ETHEREUM_TEST_PATH to its path?";
+        clog(VerbosityWarning, "test")
+            << "Contents of " << _path.string()
+            << " is empty. Have you cloned the 'tests' repo branch develop and "
+               "set ETHEREUM_TEST_PATH to its path?";
     else
-        clog(1, "test") << "FIXTURE: loaded test from file: " << _path.string();
+        clog(VerbosityWarning, "test") << "FIXTURE: loaded test from file: " << _path.string();
 
     reader.parse(s, result);
     return result;


### PR DESCRIPTION
Part of log refactoring #4984 

Minor tweaks of verbosities included:
- "SLOW IMPORT" messages changed to `VerbosityDebug` (so not displayed by default)
- Network-related warnings that had verbosity 0, now will also have `VerbosityDebug` and not displayed by default

cc @winsvega 