### PR TITLE
Fix bug where eth rejects transactions with 0 gas price

### DIFF
--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -844,6 +844,10 @@ pair<h256, Address> Client::submitTransaction(TransactionSkeleton const& _t, Sec
 {
     prepareForTransaction();
 
+    // Default gas value meets the intrinsic gas requirements of both
+    // send value and create contract transactions and is the same default
+    // value used by geth and testrpc.
+    const u256 defaultTransactionGas = 90000;
     TransactionSkeleton ts(_t);
     ts.from = toAddress(_secret);
     if (_t.nonce == Invalid256)
@@ -851,7 +855,7 @@ pair<h256, Address> Client::submitTransaction(TransactionSkeleton const& _t, Sec
     if (ts.gasPrice == Invalid256)
         ts.gasPrice = gasBidPrice();
     if (ts.gas == Invalid256)
-        ts.gas = min<u256>(gasLimitRemaining() / 5, ts.gasPrice > 0 ? balanceAt(ts.from) / ts.gasPrice : balanceAt(ts.from) / gasBidPrice());
+        ts.gas = defaultTransactionGas;
 
     Transaction t(ts, _secret);
     m_tq.import(t.rlp());

--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -851,7 +851,7 @@ pair<h256, Address> Client::submitTransaction(TransactionSkeleton const& _t, Sec
     if (ts.gasPrice == Invalid256)
         ts.gasPrice = gasBidPrice();
     if (ts.gas == Invalid256)
-        ts.gas = min<u256>(gasLimitRemaining() / 5, balanceAt(ts.from) / ts.gasPrice);
+        ts.gas = min<u256>(gasLimitRemaining() / 5, ts.gasPrice > 0 ? balanceAt(ts.from) / ts.gasPrice : balanceAt(ts.from) / gasBidPrice());
 
     Transaction t(ts, _secret);
     m_tq.import(t.rlp());


### PR DESCRIPTION
Fix #5059 

It turns out that this is due to a divide-by-zero in `Client::submitTransaction`:

https://github.com/ethereum/cpp-ethereum/blob/8d1c17ba324455c228d90a1997f281be8266adc9/libethereum/Client.cpp#L854

The fix is trivial - fall back to using the value returned by `gasBidPrice()` if `gasPrice `is 0. 