### PR TITLE
EVMC tracing for interpreter

### DIFF
--- a/libevm/EVMC.cpp
+++ b/libevm/EVMC.cpp
@@ -21,6 +21,36 @@ EVM::EVM(evmc_instance* _instance) noexcept : m_instance(_instance)
         m_instance->set_option(m_instance, pair.first.c_str(), pair.second.c_str());
 }
 
+EVMC::EVMC(evmc_instance* _instance) : EVM(_instance)
+{
+    static constexpr auto tracer = [](evmc_tracer_context * context, int depth, int step,
+        size_t code_offset, evmc_status_code status_code, int64_t gas_left, size_t stack_num_items,
+        const evmc_uint256be* pushed_stack_item, size_t memory_size,
+        size_t changed_memory_offset, size_t changed_memory_size,
+        const uint8_t* changed_memory) noexcept {
+
+        EVMC* evmc = reinterpret_cast<EVMC*>(context);
+
+        // TODO: It might be easier to just pass instruction from VM.
+        InstructionInfo instrInfo = instructionInfo(static_cast<Instruction>(evmc->m_code[code_offset]));
+
+        std::cerr << "EVMC " << depth << " " << step << " " << code_offset << " " << instrInfo.name << " " << status_code
+                  << " " << gas_left << " " << stack_num_items;
+
+        if (pushed_stack_item)
+            std::cerr << " +[" << fromEvmC(*pushed_stack_item) << "]";
+
+        std::cerr << " " << memory_size << "\n";
+
+        (void)changed_memory_offset;
+        (void)changed_memory_size;
+        (void)changed_memory_size;
+        (void)changed_memory;
+    };
+
+    _instance->set_tracer(_instance, tracer, reinterpret_cast<evmc_tracer_context*>(this));
+}
+
 owning_bytes_ref EVMC::exec(u256& io_gas, ExtVMFace& _ext, const OnOpFunc& _onOp)
 {
     assert(_ext.envInfo().number() >= 0);
@@ -34,6 +64,8 @@ owning_bytes_ref EVMC::exec(u256& io_gas, ExtVMFace& _ext, const OnOpFunc& _onOp
     assert(io_gas <= int64max);
     assert(_ext.envInfo().gasLimit() <= int64max);
     assert(_ext.depth <= static_cast<size_t>(std::numeric_limits<int32_t>::max()));
+
+    m_code = bytesConstRef{&_ext.code};
 
     auto gas = static_cast<int64_t>(io_gas);
     EVM::Result r = execute(_ext, gas);

--- a/libevm/EVMC.h
+++ b/libevm/EVMC.h
@@ -91,9 +91,12 @@ private:
 class EVMC : public EVM, public VMFace
 {
 public:
-    explicit EVMC(evmc_instance* _instance) : EVM(_instance) {}
+    explicit EVMC(evmc_instance* _instance);
 
     owning_bytes_ref exec(u256& io_gas, ExtVMFace& _ext, OnOpFunc const& _onOp) final;
+
+private:
+    bytesConstRef m_code;
 };
 }
 }

--- a/libevm/VM.cpp
+++ b/libevm/VM.cpp
@@ -91,9 +91,35 @@ VM::VM()
         aleth_get_buildinfo()->project_version,
         ::destroy,
         ::execute,
+        setTracer,
         nullptr,
     }
 {}
+
+void VM::setTracer(
+    evmc_instance* _instance, evmc_trace_callback _callback, evmc_tracer_context* _context) noexcept
+{
+    auto vm = static_cast<dev::eth::VM*>(_instance);
+    vm->m_trace = _callback;
+    vm->m_traceContext = _context;
+}
+
+void VM::trace() noexcept
+{
+    if (m_trace)
+    {
+        InstructionMetric const& metric = c_metrics[static_cast<size_t>(m_OP)];
+        evmc_uint256be topStackItem;
+        evmc_uint256be const* pushedStackItem = nullptr;
+        if (metric.ret == 1)
+        {
+            topStackItem = toEvmC(m_SPP[0]);
+            pushedStackItem = &topStackItem;
+        }
+        m_trace(m_traceContext, m_message->depth, m_step++, m_PC, EVMC_SUCCESS, m_io_gas,
+            m_stackEnd - m_SPP, pushedStackItem, m_mem.size(), 0, 0, nullptr);
+    }
+}
 
 uint64_t VM::memNeed(u256 _offset, u256 _size)
 {
@@ -387,6 +413,7 @@ void VM::interpretCases()
             updateIOGas();
 
             m_SPP[0] = (u256)*(h256 const*)(m_mem.data() + (unsigned)m_SP[0]);
+            trace();
         }
         NEXT
 
@@ -397,6 +424,7 @@ void VM::interpretCases()
             updateIOGas();
 
             *(h256*)&m_mem[(unsigned)m_SP[0]] = (h256)m_SP[1];
+            trace();
         }
         NEXT
 
@@ -1530,11 +1558,14 @@ void VM::interpretCases()
             // get val at two-byte offset into const pool and advance pc by one-byte remainder
             TRACE_OP(2, m_PC, m_OP);
             unsigned off;
-            ++m_PC;
-            off = m_code[m_PC++] << 8;
-            off |= m_code[m_PC++];
-            m_PC += m_code[m_PC];
+            uint64_t pc = m_PC;
+            ++pc;
+            off = m_code[pc++] << 8;
+            off |= m_code[pc++];
+            pc += m_code[pc];
             m_SPP[0] = m_pool[off];
+            trace();
+            m_PC = pc;
             TRACE_VAL(2, "Retrieved pooled const", m_SPP[0]);
 #else
             throwBadInstruction();
@@ -1546,9 +1577,9 @@ void VM::interpretCases()
         {
             ON_OP();
             updateIOGas();
-            ++m_PC;
-            m_SPP[0] = m_code[m_PC];
-            ++m_PC;
+            m_SPP[0] = m_code[m_PC + 1];
+            trace();
+            m_PC += 2;
         }
         CONTINUE
 
@@ -1594,6 +1625,8 @@ void VM::interpretCases()
             // bytes to handle "out of code" push data here.
             for (++m_PC; numBytes--; ++m_PC)
                 m_SPP[0] = (m_SPP[0] << 8) | m_code[m_PC];
+
+            trace();
         }
         CONTINUE
 
@@ -1722,6 +1755,7 @@ void VM::interpretCases()
 
             updateSSGas();
             updateIOGas();
+            trace();
 
             evmc_uint256be key = toEvmC(m_SP[0]);
             evmc_uint256be value = toEvmC(m_SP[1]);

--- a/libevm/VM.h
+++ b/libevm/VM.h
@@ -92,7 +92,6 @@ private:
     void copyCode(int);
     typedef void (VM::*MemFnPtr)();
     MemFnPtr m_bounce = nullptr;
-    uint64_t m_nSteps = 0;
 
     // return bytes
     owning_bytes_ref m_output;
@@ -137,6 +136,15 @@ private:
     uint64_t m_runGas = 0;
     uint64_t m_newMemSize = 0;
     uint64_t m_copyMemSize = 0;
+
+    // EVMC tracing.
+    int m_step = 0;
+    evmc_trace_callback m_trace = nullptr;
+    evmc_tracer_context* m_traceContext = nullptr;
+    static void setTracer(evmc_instance* _instance, evmc_trace_callback _callback,
+        evmc_tracer_context* _context) noexcept;
+
+    void trace() noexcept;
 
     // initialize interpreter
     void initEntry();


### PR DESCRIPTION
This is a preview of the EVMC feature https://github.com/ethereum/evmc/pull/32.

I picked up single VM test as an example: VMTests/vmIOandFlowOperations/mstore0

"Classic" VM trace:
```
test/testeth -t VMTests/vmIOandFlowOperations -- --vmtrace --singletest mstore0 --vm legacy        
Running tests using path: "/home/chfast/Projects/ethereum/cpp-ethereum/test/jsontests"
Running 1 test case...
Test Case "vmIOandFlowOperations": 
100%
TEST mstore0:
2018-06-05 18:26:00 testeth EVM 
    STACK
    MEMORY
    STORAGE

2018-06-05 18:26:00 testeth EVM  | 0 | @0f572e52… | #1 | 0000 : PUSHC | 100000 | -3 | 0x32 ]
2018-06-05 18:26:00 testeth EVM 
    STACK
ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
    MEMORY
    STORAGE

2018-06-05 18:26:00 testeth EVM  | 0 | @0f572e52… | #2 | 0021 : PUSH1 | 99997 | -3 | 0x32 ]
2018-06-05 18:26:00 testeth EVM 
    STACK
ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
0000000000000000000000000000000000000000000000000000000000000001
    MEMORY
    STORAGE

2018-06-05 18:26:00 testeth EVM  | 0 | @0f572e52… | #3 | 0023 : MSTORE | 99994 | -3 | 0x32 ]
2018-06-05 18:26:00 testeth EVM 
    STACK
    MEMORY
0000 ???????? 00 ff ff ff ff ff ff ff 
0008 ???????? ff ff ff ff ff ff ff ff 
0010 ???????? ff ff ff ff ff ff ff ff 
0018 ???????? ff ff ff ff ff ff ff ff 
0020 ???????? ff 00 00 00 00 00 00 00 
0028 ???????? 00 00 00 00 00 00 00 00 
0030 ???????? 00 00 00 00 00 00 00 00 
0038 ???????? 00 00 00 00 00 00 00 00 
    STORAGE

2018-06-05 18:26:00 testeth EVM  | 0 | @0f572e52… | #4 | 0024 : PUSH1 | 99985 | -3 | 0x32 ]
2018-06-05 18:26:00 testeth EVM 
    STACK
0000000000000000000000000000000000000000000000000000000000000001
    MEMORY
0000 ???????? 00 ff ff ff ff ff ff ff 
0008 ???????? ff ff ff ff ff ff ff ff 
0010 ???????? ff ff ff ff ff ff ff ff 
0018 ???????? ff ff ff ff ff ff ff ff 
0020 ???????? ff 00 00 00 00 00 00 00 
0028 ???????? 00 00 00 00 00 00 00 00 
0030 ???????? 00 00 00 00 00 00 00 00 
0038 ???????? 00 00 00 00 00 00 00 00 
    STORAGE

2018-06-05 18:26:00 testeth EVM  | 0 | @0f572e52… | #5 | 0026 : MLOAD | 99982 | -3 | 0x32 ]
2018-06-05 18:26:00 testeth EVM 
    STACK
ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
    MEMORY
0000 ???????? 00 ff ff ff ff ff ff ff 
0008 ???????? ff ff ff ff ff ff ff ff 
0010 ???????? ff ff ff ff ff ff ff ff 
0018 ???????? ff ff ff ff ff ff ff ff 
0020 ???????? ff 00 00 00 00 00 00 00 
0028 ???????? 00 00 00 00 00 00 00 00 
0030 ???????? 00 00 00 00 00 00 00 00 
0038 ???????? 00 00 00 00 00 00 00 00 
    STORAGE

2018-06-05 18:26:00 testeth EVM  | 0 | @0f572e52… | #6 | 0027 : PUSH1 | 99979 | -3 | 0x32 ]
2018-06-05 18:26:00 testeth EVM 
    STACK
ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
0000000000000000000000000000000000000000000000000000000000000001
    MEMORY
0000 ???????? 00 ff ff ff ff ff ff ff 
0008 ???????? ff ff ff ff ff ff ff ff 
0010 ???????? ff ff ff ff ff ff ff ff 
0018 ???????? ff ff ff ff ff ff ff ff 
0020 ???????? ff 00 00 00 00 00 00 00 
0028 ???????? 00 00 00 00 00 00 00 00 
0030 ???????? 00 00 00 00 00 00 00 00 
0038 ???????? 00 00 00 00 00 00 00 00 
    STORAGE

2018-06-05 18:26:00 testeth EVM  | 0 | @0f572e52… | #7 | 0029 : SSTORE | 99976 | -0 | 0x32 ]
2018-06-05 18:26:00 testeth EVM 
    STACK
    MEMORY
0000 ???????? 00 ff ff ff ff ff ff ff 
0008 ???????? ff ff ff ff ff ff ff ff 
0010 ???????? ff ff ff ff ff ff ff ff 
0018 ???????? ff ff ff ff ff ff ff ff 
0020 ???????? ff 00 00 00 00 00 00 00 
0028 ???????? 00 00 00 00 00 00 00 00 
0030 ???????? 00 00 00 00 00 00 00 00 
0038 ???????? 00 00 00 00 00 00 00 00 
    STORAGE
0x1: 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF

2018-06-05 18:26:00 testeth EVM  | 0 | @0f572e52… | #8 | 002a : STOP | 79976 | -0 | 0x32 ]
2018-06-05 18:26:00 testeth overlaydb Closing state DB
2018-06-05 18:26:00 testeth overlaydb Closing state DB

*** No errors detected
```

EVMC trace:
```
test/testeth -t VMTests/vmIOandFlowOperations -- --vmtrace --singletest mstore0 --vm interpreter
Running tests using path: "/home/chfast/Projects/ethereum/cpp-ethereum/test/jsontests"
Running 1 test case...
Test Case "vmIOandFlowOperations": 
100%
TEST mstore0:
EVMC 0 0 0 PUSH32 0 99997 1 +[115792089237316195423570985008687907853269984665640564039457584007913129639935] 0
EVMC 0 1 33 PUSH1 0 99994 2 +[1] 0
EVMC 0 2 35 MSTORE 0 99985 0 64
EVMC 0 3 36 PUSH1 0 99982 1 +[1] 64
EVMC 0 4 38 MLOAD 0 99979 1 +[115792089237316195423570985008687907853269984665640564039457584007913129639935] 64
EVMC 0 5 39 PUSH1 0 99976 2 +[1] 64
EVMC 0 6 41 SSTORE 0 79976 0 64
2018-06-05 18:26:32 testeth overlaydb Closing state DB
2018-06-05 18:26:32 testeth overlaydb Closing state DB
```
