### PR TITLE
Log synchronously in Debug

### DIFF
--- a/libdevcore/Log.cpp
+++ b/libdevcore/Log.cpp
@@ -29,12 +29,21 @@
 #include <boost/log/attributes/clock.hpp>
 #include <boost/log/attributes/function.hpp>
 #include <boost/log/expressions.hpp>
-#include <boost/log/sinks/async_frontend.hpp>
 #include <boost/log/sinks/text_ostream_backend.hpp>
 #include <boost/log/sources/global_logger_storage.hpp>
 #include <boost/log/sources/severity_channel_logger.hpp>
 #include <boost/log/support/date_time.hpp>
 #include <boost/log/utility/exception_handler.hpp>
+
+#if defined(NDEBUG)
+#include <boost/log/sinks/async_frontend.hpp>
+template <class T>
+using log_sink = boost::log::sinks::asynchronous_sink<T>;
+#else
+#include <boost/log/sinks/sync_frontend.hpp>
+template <class T>
+using log_sink = boost::log::sinks::synchronous_sink<T>;
+#endif
 
 namespace dev
 {
@@ -80,8 +89,7 @@ BOOST_LOG_ATTRIBUTE_KEYWORD(timestamp, "TimeStamp", boost::posix_time::ptime)
 
 void setupLogging(LoggingOptions const& _options)
 {
-    auto sink = boost::make_shared<
-        boost::log::sinks::asynchronous_sink<boost::log::sinks::text_ostream_backend>>();
+    auto sink = boost::make_shared<log_sink<boost::log::sinks::text_ostream_backend>>();
 
     boost::shared_ptr<std::ostream> stream{&std::cout, boost::null_deleter{}};
     sink->locked_backend()->add_stream(stream);


### PR DESCRIPTION
I think it's more convenient in the debugger when all log messages are output synchronously and you see exactly what already happened in the log when you trace.

So I keep async logging only in Release.