### PR TITLE
Fix mining in RPC tests

### DIFF
--- a/libethereum/Block.cpp
+++ b/libethereum/Block.cpp
@@ -837,8 +837,6 @@ bool Block::sealBlock(bytesConstRef _header)
     if (BlockHeader(_header, HeaderData).hash(WithoutSeal) != m_currentBlock.hash(WithoutSeal))
         return false;
 
-    LOG(m_loggerDetailed) << "Sealing block!";
-
     // Compile block:
     RLPStream ret;
     ret.appendList(3);

--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -621,10 +621,10 @@ void Client::rejigSealing()
 
             if (wouldSeal())
             {
-                sealEngine()->onSealGenerated([=](bytes const& header) {
-                    LOG(m_logger) << "Block seal generated";
-                    if (this->submitSealed(header))
-                        m_onBlockSealed(header);
+                sealEngine()->onSealGenerated([=](bytes const& _header) {
+                    LOG(m_logger) << "Block sealed #" << BlockHeader(_header, HeaderData).number();
+                    if (this->submitSealed(_header))
+                        m_onBlockSealed(_header);
                     else
                         LOG(m_logger) << "Submitting block failed...";
                 });

--- a/libethereum/Client.h
+++ b/libethereum/Client.h
@@ -281,6 +281,7 @@ protected:
 
     /// Called after processing blocks by onChainChanged(_ir)
     void resyncStateFromChain();
+    /// Update m_preSeal, m_working, m_postSeal blocks from the latest state of the chain
     void restartMining();
 
     /// Clear working state of transactions

--- a/libethereum/ClientBase.cpp
+++ b/libethereum/ClientBase.cpp
@@ -517,7 +517,7 @@ Block ClientBase::blockByNumber(BlockNumber _h) const
     if (_h == PendingBlock)
         return postSeal();
     else if (_h == LatestBlock)
-        return preSeal();
+        return block(bc().currentHash());
     return block(bc().numberHash(_h));
 }
 

--- a/libweb3jsonrpc/AccountHolder.h
+++ b/libweb3jsonrpc/AccountHolder.h
@@ -138,8 +138,9 @@ public:
 
 	void setAccounts(std::vector<dev::KeyPair> const& _accounts)
 	{
-		for (auto const& i: _accounts)
-			m_accounts[i.address()] = i.secret();
+        m_accounts.clear();
+        for (auto const& i : _accounts)
+            m_accounts[i.address()] = i.secret();
 	}
 
 	dev::AddressHash realAccounts() const override

--- a/test/tools/libtesteth/TestHelper.cpp
+++ b/test/tools/libtesteth/TestHelper.cpp
@@ -60,7 +60,7 @@ void mine(Client& _c, int _numBlocks)
         });
 
     _c.startSealing();
-    allBlocksImported.get_future().get();
+    allBlocksImported.get_future().wait();
 }
 
 void mine(Block& s, BlockChain const& _bc, SealEngineFace* _sealer)

--- a/test/unittests/libweb3jsonrpc/jsonrpc.cpp
+++ b/test/unittests/libweb3jsonrpc/jsonrpc.cpp
@@ -88,7 +88,6 @@ struct JsonRpcFixture : public TestOutputHelperFixture
 
         web3->setIdealPeerCount(5);
 
-        dev::KeyPair coinbase = KeyPair::create();
         web3->ethereum()->setAuthor(coinbase.address());
 
         using FullServer = ModularServer<rpc::EthFace, rpc::NetFace, rpc::Web3Face,
@@ -115,6 +114,7 @@ struct JsonRpcFixture : public TestOutputHelperFixture
     }
 
     unique_ptr<WebThreeDirect> web3;
+    dev::KeyPair coinbase{KeyPair::create()};
     unique_ptr<FixedAccountHolder> accountHolder;
     unique_ptr<rpc::SessionManager> sessionManager;
     std::shared_ptr<eth::TrivialGasPricer> gasPricer;
@@ -210,36 +210,32 @@ BOOST_AUTO_TEST_CASE(jsonrpc_stateAt)
     BOOST_CHECK_EQUAL(web3->ethereum()->stateAt(address, 0, 0), jsToU256(stateAt));
 }
 
-BOOST_AUTO_TEST_CASE(jsonrpc_transact)
+BOOST_AUTO_TEST_CASE(eth_coinbase)
 {
     string coinbase = rpcClient->eth_coinbase();
-    BOOST_CHECK_EQUAL(jsToAddress(coinbase), web3->ethereum()->author());
+    BOOST_REQUIRE_EQUAL(jsToAddress(coinbase), web3->ethereum()->author());
+}
 
+BOOST_AUTO_TEST_CASE(eth_sendTransaction)
+{
+    accountHolder->setAccounts({coinbase});
 
-    dev::KeyPair key = KeyPair::create();
-    auto address = key.address();
-    auto receiver = KeyPair::create();
-    web3->ethereum()->setAuthor(address);
-
-    coinbase = rpcClient->eth_coinbase();
-    BOOST_CHECK_EQUAL(jsToAddress(coinbase), web3->ethereum()->author());
-    BOOST_CHECK_EQUAL(jsToAddress(coinbase), address);
-
-    accountHolder->setAccounts({key});
-    auto balance = web3->ethereum()->balanceAt(address, 0);
-    string balanceString = rpcClient->eth_getBalance(toJS(address), "latest");
+    auto address = coinbase.address();
     auto countAt = jsToU256(rpcClient->eth_getTransactionCount(toJS(address), "latest"));
 
     BOOST_CHECK_EQUAL(countAt, web3->ethereum()->countAt(address));
     BOOST_CHECK_EQUAL(countAt, 0);
+    auto balance = web3->ethereum()->balanceAt(address, 0);
+    string balanceString = rpcClient->eth_getBalance(toJS(address), "latest");
     BOOST_CHECK_EQUAL(toJS(balance), balanceString);
     BOOST_CHECK_EQUAL(jsToDecimal(balanceString), "0");
 
-
     dev::eth::mine(*(web3->ethereum()), 1);
+    BOOST_CHECK_EQUAL(web3->ethereum()->blockByNumber(LatestBlock).author(), address);
     balance = web3->ethereum()->balanceAt(address, LatestBlock);
     balanceString = rpcClient->eth_getBalance(toJS(address), "latest");
 
+    BOOST_REQUIRE_GT(balance, 0);
     BOOST_CHECK_EQUAL(toJS(balance), balanceString);
 
 
@@ -247,6 +243,7 @@ BOOST_AUTO_TEST_CASE(jsonrpc_transact)
     auto gasPrice = 10 * dev::eth::szabo;
     auto gas = EVMSchedule().txGas;
 
+    auto receiver = KeyPair::create();
 
     Json::Value t;
     t["from"] = toJS(address);
@@ -256,7 +253,9 @@ BOOST_AUTO_TEST_CASE(jsonrpc_transact)
     t["gas"] = toJS(gas);
     t["gasPrice"] = toJS(gasPrice);
 
-    rpcClient->eth_sendTransaction(t);
+    std::string txHash = rpcClient->eth_sendTransaction(t);
+    BOOST_REQUIRE(!txHash.empty());
+
     accountHolder->setAccounts({});
     dev::eth::mine(*(web3->ethereum()), 1);
 
@@ -275,9 +274,7 @@ BOOST_AUTO_TEST_CASE(jsonrpc_transact)
 
 BOOST_AUTO_TEST_CASE(simple_contract)
 {
-    KeyPair kp = KeyPair::create();
-    web3->ethereum()->setAuthor(kp.address());
-    accountHolder->setAccounts({kp});
+    accountHolder->setAccounts({coinbase});
 
     dev::eth::mine(*(web3->ethereum()), 1);
 
@@ -315,9 +312,7 @@ BOOST_AUTO_TEST_CASE(simple_contract)
 
 BOOST_AUTO_TEST_CASE(contract_storage)
 {
-    KeyPair kp = KeyPair::create();
-    web3->ethereum()->setAuthor(kp.address());
-    accountHolder->setAccounts({kp});
+    accountHolder->setAccounts({coinbase});
 
     dev::eth::mine(*(web3->ethereum()), 1);
 


### PR DESCRIPTION
This adds to the `Client` ability to send callbacks about mined block and imported block, so that the unit tests can be notified and keep exact track of how many blocks were generated, instead of waiting in the loop.
(This central change is in TestHelper.cpp)

Also some minor changes, e.g. fixing RPC calls for "latest" block.