### PR TITLE
interpreter: Separate VM instance from execution context

### DIFF
--- a/libaleth-interpreter/CMakeLists.txt
+++ b/libaleth-interpreter/CMakeLists.txt
@@ -19,3 +19,7 @@ add_library(
     VMOpt.cpp
 )
 target_link_libraries(aleth-interpreter PRIVATE devcore aleth-buildinfo evmc::evmc evmc::instructions)
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL GNU)
+    target_compile_options(aleth-interpreter PRIVATE -fstack-usage)
+endif()

--- a/libaleth-interpreter/VM.cpp
+++ b/libaleth-interpreter/VM.cpp
@@ -36,21 +36,21 @@ evmc_result execute(evmc_instance* _instance, evmc_context* _context, evmc_revis
     const evmc_message* _msg, uint8_t const* _code, size_t _codeSize) noexcept
 {
     (void)_instance;
-    dev::eth::VM vm;
+    std::unique_ptr<dev::eth::VM> vm{new dev::eth::VM};
 
     evmc_result result = {};
     dev::eth::owning_bytes_ref output;
 
     try
     {
-        output = vm.exec(_context, _rev, _msg, _code, _codeSize);
+        output = vm->exec(_context, _rev, _msg, _code, _codeSize);
         result.status_code = EVMC_SUCCESS;
-        result.gas_left = vm.m_io_gas;
+        result.gas_left = vm->m_io_gas;
     }
     catch (dev::eth::RevertInstruction& ex)
     {
         result.status_code = EVMC_REVERT;
-        result.gas_left = vm.m_io_gas;
+        result.gas_left = vm->m_io_gas;
         output = ex.output();  // This moves the output from the exception!
     }
     catch (dev::eth::VMException const&)

--- a/libaleth-interpreter/VM.h
+++ b/libaleth-interpreter/VM.h
@@ -59,10 +59,10 @@ struct VMSchedule
     static constexpr int64_t callNewAccount = 25000;
 };
 
-class VM : public evmc_instance
+class VM
 {
 public:
-    VM();
+    VM() = default;
 
     owning_bytes_ref exec(evmc_context* _context, evmc_revision _rev, const evmc_message* _msg,
         uint8_t const* _code, size_t _codeSize);

--- a/libaleth-interpreter/VM.h
+++ b/libaleth-interpreter/VM.h
@@ -67,13 +67,6 @@ public:
     owning_bytes_ref exec(evmc_context* _context, evmc_revision _rev, const evmc_message* _msg,
         uint8_t const* _code, size_t _codeSize);
 
-    bytes const& memory() const { return m_mem; }
-    u256s stack() const {
-        u256s stack(m_SP, m_stackEnd);
-        reverse(stack.begin(), stack.end());
-        return stack;
-    };
-
     uint64_t m_io_gas = 0;
 private:
     evmc_context* m_context = nullptr;


### PR DESCRIPTION
This separates the interpreter instance (which has EVMC vtable and global config) from the execution context (stack, memory, gas counter, etc) to make it EVMC compliant. EVMC requires the VM implementation to allow multiple executions with a single instance so we have to create new execution context for every message. 