### PR TITLE
Don't start the sync when not needed

### DIFF
--- a/libethereum/BlockChainSync.cpp
+++ b/libethereum/BlockChainSync.cpp
@@ -226,7 +226,7 @@ void BlockChainSync::onPeerStatus(std::shared_ptr<EthereumPeer> _peer)
         // Before starting to exchange the data with the node, let's verify that it's on our chain
         if (!requestDaoForkBlockHeader(_peer))
             // DAO challenge not needed
-            syncPeer(_peer, true); 
+            syncPeer(_peer, false); 
     }
 }
 

--- a/libethereum/BlockChainSync.cpp
+++ b/libethereum/BlockChainSync.cpp
@@ -226,7 +226,7 @@ void BlockChainSync::onPeerStatus(std::shared_ptr<EthereumPeer> _peer)
         // Before starting to exchange the data with the node, let's verify that it's on our chain
         if (!requestDaoForkBlockHeader(_peer))
             // DAO challenge not needed
-            syncPeer(_peer, false); 
+            syncPeer(_peer, false);
     }
 }
 
@@ -679,7 +679,8 @@ void BlockChainSync::collectBlocks()
             restartSync();
             return;
         case ImportResult::BadChain:
-            LOG(m_logger) << "Block from the bad chain, block #" << headers.first + i << ". Restarting sync.";
+            LOG(m_logger) << "Block from the bad chain, block #" << headers.first + i
+                          << ". Restarting sync.";
             restartSync();
             return;
 
@@ -693,7 +694,8 @@ void BlockChainSync::collectBlocks()
         case ImportResult::UnknownParent:
             if (headers.first + i > m_lastImportedBlock)
             {
-                LOG(m_logger) << "Already known or future time unknown or unknown parent, block #" << headers.first + i << ". Resetting sync.";
+                LOG(m_logger) << "Already known or future time unknown or unknown parent, block #"
+                              << headers.first + i << ". Resetting sync.";
                 resetSync();
                 m_haveCommonHeader = false; // fork detected, search for common header again
             }

--- a/libethereum/BlockChainSync.cpp
+++ b/libethereum/BlockChainSync.cpp
@@ -675,8 +675,11 @@ void BlockChainSync::collectBlocks()
             }
             break;
         case ImportResult::Malformed:
+            LOG(m_logger) << "Malformed block #" << headers.first + i << ". Restarting sync.";
+            restartSync();
+            return;
         case ImportResult::BadChain:
-            LOG(m_logger) << "Malformed or bad chain, block #" << headers.first + i << ". Restarting sync.";
+            LOG(m_logger) << "Block from the bad chain, block #" << headers.first + i << ". Restarting sync.";
             restartSync();
             return;
 

--- a/libethereum/BlockChainSync.cpp
+++ b/libethereum/BlockChainSync.cpp
@@ -676,6 +676,7 @@ void BlockChainSync::collectBlocks()
             break;
         case ImportResult::Malformed:
         case ImportResult::BadChain:
+            LOG(m_logger) << "Malformed or bad chain, block #" << headers.first + i << ". Restarting sync.";
             restartSync();
             return;
 
@@ -689,6 +690,7 @@ void BlockChainSync::collectBlocks()
         case ImportResult::UnknownParent:
             if (headers.first + i > m_lastImportedBlock)
             {
+                LOG(m_logger) << "Already known or future time unknown or unknown parent, block #" << headers.first + i << ". Resetting sync.";
                 resetSync();
                 m_haveCommonHeader = false; // fork detected, search for common header again
             }

--- a/libweb3jsonrpc/IpcServerBase.cpp
+++ b/libweb3jsonrpc/IpcServerBase.cpp
@@ -36,7 +36,7 @@ int const c_bufferSize = 1024;
 template <class S> IpcServerBase<S>::IpcServerBase(string const& _path):
     m_path(_path)
 {
-    clog(VerbosityInfo, "rpc") << "JSONRPC socket path: " << _path;
+    clog(VerbosityInfo, "rpc") << "JSON-RPC socket path: " << _path;
 }
 
 template <class S> bool IpcServerBase<S>::StartListening()

--- a/libweb3jsonrpc/IpcServerBase.cpp
+++ b/libweb3jsonrpc/IpcServerBase.cpp
@@ -36,6 +36,7 @@ int const c_bufferSize = 1024;
 template <class S> IpcServerBase<S>::IpcServerBase(string const& _path):
     m_path(_path)
 {
+    clog(VerbosityInfo, "rpc") << "JSONRPC socket path: " << _path;
 }
 
 template <class S> bool IpcServerBase<S>::StartListening()


### PR DESCRIPTION
In the private network with two nodes, when they connected, the sync was started on both nodes. The node with higher difficulty shouldn't start the sync.