### PR TITLE
Fix syncing from the single node in the private network

### DIFF
--- a/libethereum/BlockChainSync.cpp
+++ b/libethereum/BlockChainSync.cpp
@@ -492,12 +492,12 @@ void BlockChainSync::onPeerBlockHeaders(std::shared_ptr<EthereumPeer> _peer, RLP
         }
         if (haveItem(m_headers, blockNumber))
         {
-            LOG(m_logger) << "Skipping header " << blockNumber;
+            LOG(m_logger) << "Skipping header " << blockNumber << " (already downloaded)";
             continue;
         }
         if (blockNumber <= m_lastImportedBlock && m_haveCommonHeader)
         {
-            LOG(m_logger) << "Skipping header " << blockNumber;
+            LOG(m_logger) << "Skipping header " << blockNumber << " (already imported)";
             continue;
         }
         if (blockNumber > m_highestBlock)
@@ -698,7 +698,7 @@ void BlockChainSync::collectBlocks()
         }
     }
 
-    LOG(m_logger) << dec << success << "imported OK, " << unknown << " with unknown parents, "
+    LOG(m_logger) << dec << success << " imported OK, " << unknown << " with unknown parents, "
                   << future << " with future timestamps, " << got << " already known received.";
 
     if (host().bq().unknownFull())
@@ -747,6 +747,9 @@ void BlockChainSync::onPeerNewBlock(std::shared_ptr<EthereumPeer> _peer, RLP con
     if (blockNumber > (m_lastImportedBlock + 1))
     {
         LOG(m_loggerDetail) << "Received unknown new block";
+        // Update the hash of highest known block of the peer.
+        // syncPeer will then request the highest block header to properly restart syncing
+        _peer->m_latestHash = h;
         syncPeer(_peer, true);
         return;
     }

--- a/libethereum/EthereumPeer.cpp
+++ b/libethereum/EthereumPeer.cpp
@@ -147,13 +147,13 @@ void EthereumPeer::requestBlockHeaders(unsigned _startNumber, unsigned _count, u
 {
     if (m_asking != Asking::Nothing)
     {
-        cnetlog << "Asking headers while requesting " << ::toString(m_asking);
+        LOG(m_logger) << "Asking headers while requesting " << ::toString(m_asking);
     }
     setAsking(Asking::BlockHeaders);
     RLPStream s;
     prep(s, GetBlockHeadersPacket, 4) << _startNumber << _count << _skip << (_reverse ? 1 : 0);
-    cnetlog << "Requesting " << _count << " block headers starting from " << _startNumber
-            << (_reverse ? " in reverse" : "");
+    LOG(m_logger) << "Requesting " << _count << " block headers starting from " << _startNumber
+                  << (_reverse ? " in reverse" : "");
     m_lastAskedHeaders = _count;
     sealAndSend(s);
 }
@@ -162,13 +162,13 @@ void EthereumPeer::requestBlockHeaders(h256 const& _startHash, unsigned _count, 
 {
     if (m_asking != Asking::Nothing)
     {
-        cnetlog << "Asking headers while requesting " << ::toString(m_asking);
+        LOG(m_logger) << "Asking headers while requesting " << ::toString(m_asking);
     }
     setAsking(Asking::BlockHeaders);
     RLPStream s;
     prep(s, GetBlockHeadersPacket, 4) << _startHash << _count << _skip << (_reverse ? 1 : 0);
-    cnetlog << "Requesting " << _count << " block headers starting from " << _startHash
-            << (_reverse ? " in reverse" : "");
+    LOG(m_logger) << "Requesting " << _count << " block headers starting from " << _startHash
+                  << (_reverse ? " in reverse" : "");
     m_lastAskedHeaders = _count;
     sealAndSend(s);
 }
@@ -193,7 +193,8 @@ void EthereumPeer::requestByHashes(h256s const& _hashes, Asking _asking, Subprot
 {
     if (m_asking != Asking::Nothing)
     {
-        cnetlog << "Asking " << ::toString(_asking) << " while requesting " << ::toString(m_asking);
+        LOG(m_logger) << "Asking " << ::toString(_asking) << " while requesting "
+                      << ::toString(m_asking);
     }
     setAsking(_asking);
     if (_hashes.size())
@@ -262,8 +263,8 @@ bool EthereumPeer::interpret(unsigned _id, RLP const& _r)
         if (m_peerCapabilityVersion == m_hostProtocolVersion)
             m_protocolVersion = m_hostProtocolVersion;
 
-        cnetlog << "Status: " << m_protocolVersion << " / " << m_networkId << " / " << m_genesisHash
-                << ", TD: " << m_totalDifficulty << " = " << m_latestHash;
+        LOG(m_logger) << "Status: " << m_protocolVersion << " / " << m_networkId << " / "
+                      << m_genesisHash << ", TD: " << m_totalDifficulty << " = " << m_latestHash;
         setIdle();
         observer->onPeerStatus(dynamic_pointer_cast<EthereumPeer>(dynamic_pointer_cast<EthereumPeer>(shared_from_this())));
         break;

--- a/libethereum/EthereumPeer.h
+++ b/libethereum/EthereumPeer.h
@@ -195,6 +195,7 @@ private:
 	std::weak_ptr<EthereumPeerObserverFace> m_observer;
 	std::weak_ptr<EthereumHostDataFace> m_hostData;
 
+    Logger m_logger{createLogger(VerbosityDebug, "peer")};
     /// Logger for messages about impolite behaivour of peers.
     Logger m_loggerImpolite{createLogger(VerbosityDebug, "impolite")};
 };


### PR DESCRIPTION
Sometimes when node is synced and continues to keep up with the chain head (getting new blocks through eth NewBlock message), it gets the block several blocks higher than currently known to `BlockCainSync`, i.e. our node falls behind the current chain head.

 In this case `BlockChainSync` starts the full sync form this node. The full sync starts with getting the highest block's header. But highest bock's hash of the peer is set only in Status message handler (when peer connects) and doesn't change afterwards. So restarted sync requests already known header and then it's stuck.

The fix is to update `EthereumPeer::m_latestHash` when we receive new highest block as NewBlock message.