### PR TITLE
Improve handling of future blocks in sync

### DIFF
--- a/libdevcore/CommonData.h
+++ b/libdevcore/CommonData.h
@@ -358,4 +358,9 @@ bool contains(T const& _t, V const& _v)
 	return std::end(_t) != std::find(std::begin(_t), std::end(_t), _v);
 }
 
+template <class V>
+bool contains(std::unordered_set<V> const& _set, V const& _v)
+{
+    return _set.find(_v) != _set.end();
+}
 }

--- a/libethereum/BlockChainSync.cpp
+++ b/libethereum/BlockChainSync.cpp
@@ -694,8 +694,10 @@ void BlockChainSync::collectBlocks()
         case ImportResult::UnknownParent:
             if (headers.first + i > m_lastImportedBlock)
             {
-                LOG(m_logger) << "Already known or future time unknown or unknown parent, block #"
-                              << headers.first + i << ". Resetting sync.";
+                logImported(success, future, got, unknown);
+                LOG(m_logger)
+                    << "Already known or future time & unknown parent or unknown parent, block #"
+                    << headers.first + i << ". Resetting sync.";
                 resetSync();
                 m_haveCommonHeader = false; // fork detected, search for common header again
             }
@@ -705,8 +707,7 @@ void BlockChainSync::collectBlocks()
         }
     }
 
-    LOG(m_logger) << dec << success << " imported OK, " << unknown << " with unknown parents, "
-                  << future << " with future timestamps, " << got << " already known received.";
+    logImported(success, future, got, unknown);
 
     if (host().bq().unknownFull())
     {
@@ -734,6 +735,13 @@ void BlockChainSync::collectBlocks()
         completeSync();
     }
     DEV_INVARIANT_CHECK_HERE;
+}
+
+void BlockChainSync::logImported(
+    unsigned _success, unsigned _future, unsigned _got, unsigned _unknown)
+{
+    LOG(m_logger) << dec << _success << " imported OK, " << _unknown << " with unknown parents, "
+                  << _future << " with future timestamps, " << _got << " already known received.";
 }
 
 void BlockChainSync::onPeerNewBlock(std::shared_ptr<EthereumPeer> _peer, RLP const& _r)

--- a/libethereum/BlockChainSync.h
+++ b/libethereum/BlockChainSync.h
@@ -106,6 +106,7 @@ private:
     void collectBlocks();
     bool requestDaoForkBlockHeader(std::shared_ptr<EthereumPeer> _peer);
     bool verifyDaoChallengeResponse(RLP const& _r);
+    void logImported(unsigned _success, unsigned _future, unsigned _got, unsigned _unknown);
 
 private:
     struct Header

--- a/libethereum/BlockQueue.h
+++ b/libethereum/BlockQueue.h
@@ -178,18 +178,21 @@ public:
         m_size += _blockData.size();
     }
 
+    // returns removed (hash, block data) pairs
     std::vector<std::pair<h256, bytes>> removeByKeyEqual(KeyType const& _key)
     {
         auto const equalRange = m_map.equal_range(_key);
         return removeRange(equalRange.first, equalRange.second);
     }
 
+    // returns removed (hash, block data) pairs
     std::vector<std::pair<h256, bytes>> removeByKeyNotGreater(KeyType const& _key)
     {
         return removeRange(m_map.begin(), m_map.upper_bound(_key));
     }
 
 private:
+    // map of key to (hash, block data) pairs
     using BlockMultimap = std::multimap<KeyType, std::pair<h256, bytes>>;
 
     std::vector<std::pair<h256, bytes>> removeRange(typename BlockMultimap::iterator _begin, typename BlockMultimap::iterator _end)
@@ -304,6 +307,7 @@ private:
     SizedBlockMap<h256> m_unknown;										///< For blocks that have an unknown parent; we map their parent hash to the block stuff, and insert once the block appears.
     h256Hash m_knownBad;												///< Set of blocks that we know will never be valid.
     SizedBlockMap<time_t> m_future;										///< Set of blocks that are not yet valid. Ordered by timestamp
+    h256Hash m_futureSet;  ///< Set of all blocks that are not yet valid.
     Signal<> m_onReady;													///< Called when a subsequent call to import blocks will return a non-empty container. Be nice and exit fast.
     Signal<> m_onRoomAvailable;											///< Called when space for new blocks becomes availabe after a drain. Be nice and exit fast.
 


### PR DESCRIPTION
Sometimes during sync several blocks with a future timestamp arrive in a row. In this case `BlockQueue` marks the first one as "future block" (adds it to `m_future` and returns `FutureTimeKnown` from `import()`), but for the following ones it's parent is not present neither in blockchain nor in already verified blocks, so it returns `FutureTimeUnknown`, i.e. future time and parent unknown. Then `BlockChainSync` resets the sync interpreting this as block with unknown parent encountered.

The fix is for each future block to check whether it's parent is also future block, and return  `FutureTimeKnown` (future time and parent known) if it is. 
In this case sync continues further without resetting, and future blocks will be imported eventually.