### PR TITLE
test_getBlockStatus

### DIFF
--- a/libethereum/ClientTest.cpp
+++ b/libethereum/ClientTest.cpp
@@ -46,7 +46,9 @@ ClientTest::ClientTest(ChainParams const& _params, int _networkID, p2p::Host* _h
     TransactionQueue::Limits const& _limits)
   : Client(
         _params, _networkID, _host, _gpForAdoption, _dbPath, std::string(), _forceAction, _limits)
-{}
+{
+    m_lastBlockStatus = BlockStatus::Idle;
+}
 
 ClientTest::~ClientTest()
 {
@@ -102,6 +104,7 @@ void ClientTest::modifyTimestamp(int64_t _timestamp)
 void ClientTest::mineBlocks(unsigned _count)
 {
     m_blocksToMine = _count;
+    m_lastBlockStatus = BlockStatus::Mining;
     startSealing();
 }
 
@@ -109,8 +112,11 @@ void ClientTest::onNewBlocks(h256s const& _blocks, h256Hash& io_changed)
 {
     Client::onNewBlocks(_blocks, io_changed);
 
-    if(--m_blocksToMine <= 0)
+    if (--m_blocksToMine <= 0)
+    {
+        m_lastBlockStatus = BlockStatus::Success;
         stopSealing();
+    }
 }
 
 bool ClientTest::completeSync()

--- a/libethereum/ClientTest.h
+++ b/libethereum/ClientTest.h
@@ -36,7 +36,14 @@ DEV_SIMPLE_EXCEPTION(ImportBlockFailed);
 class ClientTest: public Client
 {
 public:
-	/// Trivial forwarding constructor.
+    enum BlockStatus
+    {
+        Idle,
+        Mining,
+        Error,
+        Success
+    };
+    /// Trivial forwarding constructor.
 	ClientTest(
 		ChainParams const& _params,
 		int _networkID,
@@ -54,10 +61,12 @@ public:
 	void rewindToBlock(unsigned _number);
     h256 importRawBlock(std::string const& _blockRLP);
     bool completeSync();
+    BlockStatus getLastBlockStatus() const { return m_lastBlockStatus; }
 
 protected:
 	unsigned m_blocksToMine;
-	virtual void onNewBlocks(h256s const& _blocks, h256Hash& io_changed) override;
+    BlockStatus m_lastBlockStatus;
+    virtual void onNewBlocks(h256s const& _blocks, h256Hash& io_changed) override;
 };
 
 ClientTest& asClientTest(Interface& _c);

--- a/libweb3jsonrpc/Test.h
+++ b/libweb3jsonrpc/Test.h
@@ -42,6 +42,7 @@ public:
     {
         return RPCModules{RPCModule{"test", "1.0"}};
     }
+    virtual std::string test_getBlockStatus(std::string const& _blockHash) override;
     virtual std::string test_getLogHash(std::string const& _param1) override;
     virtual std::string test_importRawBlock(std::string const& _blockRLP) override;
     virtual bool test_setChainParams(const Json::Value& _param1) override;

--- a/libweb3jsonrpc/TestFace.h
+++ b/libweb3jsonrpc/TestFace.h
@@ -15,6 +15,10 @@ namespace dev {
                 TestFace()
                 {
                     this->bindAndAddMethod(
+                        jsonrpc::Procedure("test_getBlockStatus", jsonrpc::PARAMS_BY_POSITION,
+                            jsonrpc::JSON_STRING, "param1", jsonrpc::JSON_STRING, NULL),
+                        &dev::rpc::TestFace::test_getBlockStatusI);
+                    this->bindAndAddMethod(
                         jsonrpc::Procedure("test_getLogHash", jsonrpc::PARAMS_BY_POSITION,
                             jsonrpc::JSON_BOOLEAN, "param1", jsonrpc::JSON_STRING, NULL),
                         &dev::rpc::TestFace::test_getLogHashI);
@@ -26,6 +30,11 @@ namespace dev {
                     this->bindAndAddMethod(jsonrpc::Procedure("test_mineBlocks", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_BOOLEAN, "param1",jsonrpc::JSON_INTEGER, NULL), &dev::rpc::TestFace::test_mineBlocksI);
                     this->bindAndAddMethod(jsonrpc::Procedure("test_modifyTimestamp", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_BOOLEAN, "param1",jsonrpc::JSON_INTEGER, NULL), &dev::rpc::TestFace::test_modifyTimestampI);
                     this->bindAndAddMethod(jsonrpc::Procedure("test_rewindToBlock", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_BOOLEAN, "param1",jsonrpc::JSON_INTEGER, NULL), &dev::rpc::TestFace::test_rewindToBlockI);
+                }
+                inline virtual void test_getBlockStatusI(
+                    const Json::Value& request, Json::Value& response)
+                {
+                    response = this->test_getBlockStatus(request[0u].asString());
                 }
                 inline virtual void test_getLogHashI(
                     const Json::Value& request, Json::Value& response)
@@ -53,6 +62,7 @@ namespace dev {
                 {
                     response = this->test_rewindToBlock(request[0u].asInt());
                 }
+                virtual std::string test_getBlockStatus(const std::string& param1) = 0;
                 virtual std::string test_getLogHash(const std::string& param1) = 0;
                 virtual std::string test_importRawBlock(const std::string& param1) = 0;
                 virtual bool test_setChainParams(const Json::Value& param1) = 0;

--- a/libweb3jsonrpc/test.json
+++ b/libweb3jsonrpc/test.json
@@ -1,4 +1,5 @@
 [
+{ "name": "test_getBlockStatus", "params": [""], "order": [], "returns": ""},
 { "name": "test_getLogHash", "params": [""], "order": [], "returns": ""},
 { "name": "test_importRawBlock", "params": [""], "order": [], "returns": ""},
 { "name": "test_setChainParams", "params": [{}], "order": [], "returns": false},


### PR DESCRIPTION
returns the status of a last block that has been mined or imported in the test mode.

required for upcoming malicious block tests that will try to import a block and check that client has reported an error upon reading that block. 

also should be used in soltest instead of waiting for the blocknumber to change. 
because if mining goes wrong, blocknumber will not change and soltest would wait for a long time for blocknumber to update. 