### PR TITLE
Properly revert state changes after internal exception in VM

### DIFF
--- a/libethereum/Block.cpp
+++ b/libethereum/Block.cpp
@@ -315,16 +315,17 @@ pair<TransactionReceipts, bool> Block::sync(BlockChain const& _bc, TransactionQu
     // TRANSACTIONS
     pair<TransactionReceipts, bool> ret;
 
-    auto ts = _tq.topTransactions(c_maxSyncTransactions, m_transactionSet);
-    ret.second = (ts.size() == c_maxSyncTransactions);	// say there's more to the caller if we hit the limit
+    Transactions transactions = _tq.topTransactions(c_maxSyncTransactions, m_transactionSet);
+    ret.second = (transactions.size() == c_maxSyncTransactions);  // say there's more to the caller
+                                                                  // if we hit the limit
 
     assert(_bc.currentHash() == m_currentBlock.parentHash());
     auto deadline =  chrono::steady_clock::now() + chrono::milliseconds(msTimeout);
 
-    for (int goodTxs = max(0, (int)ts.size() - 1); goodTxs < (int)ts.size(); )
+    for (int goodTxs = max(0, (int)transactions.size() - 1); goodTxs < (int)transactions.size();)
     {
         goodTxs = 0;
-        for (auto const& t: ts)
+        for (auto const& t : transactions)
             if (!m_transactionSet.count(t.sha3()))
             {
                 try

--- a/libethereum/Executive.cpp
+++ b/libethereum/Executive.cpp
@@ -494,6 +494,7 @@ bool Executive::go(OnOpFunc const& _onOp)
         {
             cwarn << "Internal VM Error (" << *boost::get_error_info<errinfo_evmcStatusCode>(_e) << ")\n"
                   << diagnostic_information(_e);
+            revert();
             throw;
         }
         catch (Exception const& _e)

--- a/libethereum/State.cpp
+++ b/libethereum/State.cpp
@@ -38,21 +38,6 @@ using namespace dev;
 using namespace dev::eth;
 namespace fs = boost::filesystem;
 
-namespace
-{
-
-/// @returns true when normally halted; false when exceptionally halted.
-bool executeTransaction(Executive& _e, Transaction const& _t, OnOpFunc const& _onOp)
-{
-    _e.initialize(_t);
-
-    if (!_e.execute())
-        _e.go(_onOp);
-    return _e.finalize();
-}
-
-}
-
 State::State(u256 const& _accountStartNonce, OverlayDB const& _db, BaseState _bs):
     m_db(_db),
     m_state(&m_db),
@@ -648,6 +633,26 @@ void State::executeBlockTransactions(Block const& _block, unsigned _txCount, Las
         executeTransaction(e, _block.pending()[i], OnOpFunc());
 
         gasUsed += e.gasUsed();
+    }
+}
+
+/// @returns true when normally halted; false when exceptionally halted; throws when internal VM
+/// exception occurred.
+bool State::executeTransaction(Executive& _e, Transaction const& _t, OnOpFunc const& _onOp)
+{
+    size_t const savept = savepoint();
+    try
+    {
+        _e.initialize(_t);
+
+        if (!_e.execute())
+            _e.go(_onOp);
+        return _e.finalize();
+    }
+    catch (Exception const&)
+    {
+        rollback(savept);
+        throw;
     }
 }
 

--- a/libethereum/State.h
+++ b/libethereum/State.h
@@ -348,6 +348,10 @@ private:
 
     void createAccount(Address const& _address, Account const&& _account);
 
+    /// @returns true when normally halted; false when exceptionally halted; throws when internal VM
+    /// exception occurred.
+    bool executeTransaction(Executive& _e, Transaction const& _t, OnOpFunc const& _onOp);
+
     OverlayDB m_db;								///< Our overlay for the state tree.
     SecureTrieDB<Address, OverlayDB> m_state;	///< Our state tree, as an OverlayDB DB.
     mutable std::unordered_map<Address, Account> m_cache;	///< Our address cache. This stores the states of each address that has (or at least might have) been changed.


### PR DESCRIPTION
Addresses https://github.com/ewasm/hera/issues/259

We should revert the changes in the State in case `InternalVMError` happens, otherwise they can affect the state root of the mined block.