### PR TITLE
Ship the interpreter 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,21 +1,6 @@
-# ------------------------------------------------------------------------------
-# This file is part of cpp-ethereum.
-#
-# cpp-ethereum is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# cpp-ethereum is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>
-#
-# (c) 2014-2016 cpp-ethereum contributors.
-#------------------------------------------------------------------------------
+# Aleth: Ethereum C++ client, tools and libraries.
+# Copyright 2018 Aleth Autors.
+# Licensed under the GNU General Public License, Version 3. See the LICENSE file.
 
 cmake_minimum_required(VERSION 3.5.1)
 
@@ -25,7 +10,13 @@ include(CableBuildType)
 include(CableToolchains)
 include(GNUInstallDirs)
 
-cable_configure_toolchain(DEFAULT cxx11)
+if(UNIX)
+    # Build deps with PIC to allow building shared libraries.
+    set(toolchain cxx11-pic)
+else()
+    set(toolchain cxx11)
+endif()
+cable_configure_toolchain(DEFAULT ${toolchain})
 
 set(ETH_CMAKE_DIR "${CMAKE_CURRENT_LIST_DIR}/cmake" CACHE PATH "The path to the cmake directory")
 list(APPEND CMAKE_MODULE_PATH ${ETH_CMAKE_DIR})

--- a/circle.yml
+++ b/circle.yml
@@ -172,6 +172,25 @@ jobs:
       - *test-evmc-interpreter
       - *upload-coverage-data
 
+  linux-interpreter:
+    environment:
+      - BUILD_TYPE: Release
+      - CXX: g++-6
+      - CC:  gcc-6
+      - GCOV: gcov-6
+      - GENERATOR: Ninja
+      - BUILD_PARALLEL_JOBS: 3
+      - TEST_PARALLEL_JOBS: 4
+      - CMAKE_OPTIONS: -DTOOLCHAIN=cxx11-pic -DALETH_INTERPRETER_SHARED=ON
+    docker:
+      - image: ethereum/cpp-build-env:2
+    steps:
+      - checkout
+      - *update-submodules
+      - *environment-info
+      - *configure
+      - *build
+
   macos-xcode90:
     environment:
       - CXX: clang++
@@ -209,3 +228,4 @@ workflows:
       - macos-xcode90
       - linux-clang6
       - linux-gcc6
+      - linux-interpreter

--- a/circle.yml
+++ b/circle.yml
@@ -46,7 +46,7 @@ defaults:
       working_directory: ~/build
       command: |
         ETHEREUM_TEST_PATH=~/project/test/jsontests \
-        test/testeth -t GeneralStateTests -- --vm interpreter
+        test/testeth -t GeneralStateTests -- --vm libaleth-interpreter/libaleth-interpreter.so
 
   store-package: &store-package
     store_artifacts:
@@ -122,6 +122,7 @@ jobs:
       - GENERATOR: Ninja
       - BUILD_PARALLEL_JOBS: 8
       - TEST_PARALLEL_JOBS: 8
+      - CMAKE_OPTIONS: -DALETH_INTERPRETER_SHARED=ON
     docker:
       - image: ethereum/cpp-build-env:2
     steps:
@@ -169,27 +170,7 @@ jobs:
       - *save-deps-cache
       - *store-package
       - *test
-      - *test-evmc-interpreter
       - *upload-coverage-data
-
-  linux-interpreter:
-    environment:
-      - BUILD_TYPE: Release
-      - CXX: g++-6
-      - CC:  gcc-6
-      - GCOV: gcov-6
-      - GENERATOR: Ninja
-      - BUILD_PARALLEL_JOBS: 3
-      - TEST_PARALLEL_JOBS: 4
-      - CMAKE_OPTIONS: -DTOOLCHAIN=cxx11-pic -DALETH_INTERPRETER_SHARED=ON
-    docker:
-      - image: ethereum/cpp-build-env:2
-    steps:
-      - checkout
-      - *update-submodules
-      - *environment-info
-      - *configure
-      - *build
 
   macos-xcode90:
     environment:
@@ -228,4 +209,3 @@ workflows:
       - macos-xcode90
       - linux-clang6
       - linux-gcc6
-      - linux-interpreter

--- a/cmake/EthCompilerSettings.cmake
+++ b/cmake/EthCompilerSettings.cmake
@@ -50,6 +50,13 @@ if (("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU") OR ("${CMAKE_CXX_COMPILER_ID}" MA
         endif ()
     endif ()
 
+    # Hide all symbols by default.
+    add_compile_options(-fvisibility=hidden)
+    if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+        # Do not export symbols from dependencies.
+        set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--exclude-libs,ALL")
+    endif()
+
     # Check GCC compiler version.
     if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
         if("${CMAKE_CXX_COMPILER_VERSION}" VERSION_LESS 4.8)

--- a/cmake/EthCompilerSettings.cmake
+++ b/cmake/EthCompilerSettings.cmake
@@ -18,103 +18,103 @@ include(EthCheckCXXCompilerFlag)
 
 eth_add_cxx_compiler_flag_if_supported(-fstack-protector-strong have_stack_protector_strong_support)
 if(NOT have_stack_protector_strong_support)
-	eth_add_cxx_compiler_flag_if_supported(-fstack-protector)
+    eth_add_cxx_compiler_flag_if_supported(-fstack-protector)
 endif()
 
 eth_add_cxx_compiler_flag_if_supported(-Wimplicit-fallthrough)
 
 if (("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU") OR ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang"))
-	# Enables all the warnings about constructions that some users consider questionable,
-	# and that are easy to avoid.  Also enable some extra warning flags that are not
-	# enabled by -Wall.   Finally, treat at warnings-as-errors, which forces developers
-	# to fix warnings as they arise, so they don't accumulate "to be fixed later".
-	add_compile_options(-Wall)
-	add_compile_options(-Wextra)
-	add_compile_options(-Werror)
+    # Enables all the warnings about constructions that some users consider questionable,
+    # and that are easy to avoid.  Also enable some extra warning flags that are not
+    # enabled by -Wall.   Finally, treat at warnings-as-errors, which forces developers
+    # to fix warnings as they arise, so they don't accumulate "to be fixed later".
+    add_compile_options(-Wall)
+    add_compile_options(-Wextra)
+    add_compile_options(-Werror)
 
-	# Disable warnings about unknown pragmas (which is enabled by -Wall).
-	add_compile_options(-Wno-unknown-pragmas)
+    # Disable warnings about unknown pragmas (which is enabled by -Wall).
+    add_compile_options(-Wno-unknown-pragmas)
 
-	# Configuration-specific compiler settings.
-	set(CMAKE_CXX_FLAGS_DEBUG          "-Og -g -DETH_DEBUG")
-	set(CMAKE_CXX_FLAGS_MINSIZEREL     "-Os -DNDEBUG")
-	set(CMAKE_CXX_FLAGS_RELEASE        "-O3 -DNDEBUG")
-	set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g")
+    # Configuration-specific compiler settings.
+    set(CMAKE_CXX_FLAGS_DEBUG          "-Og -g -DETH_DEBUG")
+    set(CMAKE_CXX_FLAGS_MINSIZEREL     "-Os -DNDEBUG")
+    set(CMAKE_CXX_FLAGS_RELEASE        "-O3 -DNDEBUG")
+    set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g")
 
-	option(USE_LD_GOLD "Use GNU gold linker" ON)
-	if (USE_LD_GOLD)
-		execute_process(COMMAND ${CMAKE_C_COMPILER} -fuse-ld=gold -Wl,--version ERROR_QUIET OUTPUT_VARIABLE LD_VERSION)
-		if ("${LD_VERSION}" MATCHES "GNU gold")
-			set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fuse-ld=gold")
-			set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -fuse-ld=gold")
-		endif ()
-	endif ()
+    option(USE_LD_GOLD "Use GNU gold linker" ON)
+    if (USE_LD_GOLD)
+        execute_process(COMMAND ${CMAKE_C_COMPILER} -fuse-ld=gold -Wl,--version ERROR_QUIET OUTPUT_VARIABLE LD_VERSION)
+        if ("${LD_VERSION}" MATCHES "GNU gold")
+            set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fuse-ld=gold")
+            set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -fuse-ld=gold")
+        endif ()
+    endif ()
 
-	# Check GCC compiler version.
-	if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
-		if("${CMAKE_CXX_COMPILER_VERSION}" VERSION_LESS 4.8)
-			message(FATAL_ERROR "This compiler ${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION} is not supported. GCC 4.8 or newer is required.")
-		endif()
+    # Check GCC compiler version.
+    if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
+        if("${CMAKE_CXX_COMPILER_VERSION}" VERSION_LESS 4.8)
+            message(FATAL_ERROR "This compiler ${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION} is not supported. GCC 4.8 or newer is required.")
+        endif()
 
-	# Stop if buggy clang compiler detected.
-	elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES AppleClang)
-		if("${CMAKE_CXX_COMPILER_VERSION}" VERSION_LESS 8.4)
-			message(FATAL_ERROR "This compiler ${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION} is not able to compile required libff. Install clang 4+ from Homebrew or XCode 9.")
-		endif()
-	endif()
+    # Stop if buggy clang compiler detected.
+    elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES AppleClang)
+        if("${CMAKE_CXX_COMPILER_VERSION}" VERSION_LESS 8.4)
+            message(FATAL_ERROR "This compiler ${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION} is not able to compile required libff. Install clang 4+ from Homebrew or XCode 9.")
+        endif()
+    endif()
 
 # The major alternative compiler to GCC/Clang is Microsoft's Visual C++ compiler, only available on Windows.
 elseif (MSVC)
 
-	add_compile_options(/MP)						# enable parallel compilation
-	add_compile_options(/EHsc)						# specify Exception Handling Model in msvc
-	add_compile_options(/WX)						# enable warnings-as-errors
-	add_compile_options(/wd4068)					# disable unknown pragma warning (4068)
-	add_compile_options(/wd4996)					# disable unsafe function warning (4996)
-	add_compile_options(/wd4503)					# disable decorated name length exceeded, name was truncated (4503)
-	add_compile_options(/wd4267)					# disable conversion from 'size_t' to 'type', possible loss of data (4267)
-	add_compile_options(/wd4180)					# disable qualifier applied to function type has no meaning; ignored (4180)
-	add_compile_options(/wd4290)					# disable C++ exception specification ignored except to indicate a function is not __declspec(nothrow) (4290)
-	add_compile_options(/wd4297)					# disable <vector>'s function assumed not to throw an exception but does (4297)
-	add_compile_options(/wd4244)					# disable conversion from 'type1' to 'type2', possible loss of data (4244)
-	add_compile_options(/wd4800)					# disable forcing value to bool 'true' or 'false' (performance warning) (4800)
-	add_compile_options(-D_WIN32_WINNT=0x0600)		# declare Windows Vista API requirement
-	add_compile_options(-DNOMINMAX)					# undefine windows.h MAX && MIN macros cause it cause conflicts with std::min && std::max functions
-	add_compile_options(-DMINIUPNP_STATICLIB)		# define miniupnp static library
+    add_compile_options(/MP)                        # enable parallel compilation
+    add_compile_options(/EHsc)                        # specify Exception Handling Model in msvc
+    add_compile_options(/WX)                        # enable warnings-as-errors
+    add_compile_options(/wd4068)                    # disable unknown pragma warning (4068)
+    add_compile_options(/wd4996)                    # disable unsafe function warning (4996)
+    add_compile_options(/wd4503)                    # disable decorated name length exceeded, name was truncated (4503)
+    add_compile_options(/wd4267)                    # disable conversion from 'size_t' to 'type', possible loss of data (4267)
+    add_compile_options(/wd4180)                    # disable qualifier applied to function type has no meaning; ignored (4180)
+    add_compile_options(/wd4290)                    # disable C++ exception specification ignored except to indicate a function is not __declspec(nothrow) (4290)
+    add_compile_options(/wd4297)                    # disable <vector>'s function assumed not to throw an exception but does (4297)
+    add_compile_options(/wd4244)                    # disable conversion from 'type1' to 'type2', possible loss of data (4244)
+    add_compile_options(/wd4800)                    # disable forcing value to bool 'true' or 'false' (performance warning) (4800)
+    add_compile_options(-D_WIN32_WINNT=0x0600)        # declare Windows Vista API requirement
+    add_compile_options(-DNOMINMAX)                    # undefine windows.h MAX && MIN macros cause it cause conflicts with std::min && std::max functions
+    add_compile_options(-DMINIUPNP_STATICLIB)        # define miniupnp static library
 
-	# Always use Release variant of C++ runtime.
-	# We don't want to provide Debug variants of all dependencies. Some default
-	# flags set by CMake must be tweaked.
-	string(REPLACE "/MDd" "/MD" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
-	string(REPLACE "/D_DEBUG" "" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
-	string(REPLACE "/RTC1" "" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
-	string(REPLACE "/MDd" "/MD" CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")
-	string(REPLACE "/D_DEBUG" "" CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")
-	string(REPLACE "/RTC1" "" CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")
-	set_property(GLOBAL PROPERTY DEBUG_CONFIGURATIONS OFF)
+    # Always use Release variant of C++ runtime.
+    # We don't want to provide Debug variants of all dependencies. Some default
+    # flags set by CMake must be tweaked.
+    string(REPLACE "/MDd" "/MD" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
+    string(REPLACE "/D_DEBUG" "" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
+    string(REPLACE "/RTC1" "" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
+    string(REPLACE "/MDd" "/MD" CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")
+    string(REPLACE "/D_DEBUG" "" CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")
+    string(REPLACE "/RTC1" "" CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")
+    set_property(GLOBAL PROPERTY DEBUG_CONFIGURATIONS OFF)
 
-	# disable empty object file warning
-	set(CMAKE_STATIC_LINKER_FLAGS "${CMAKE_STATIC_LINKER_FLAGS} /ignore:4221")
-	# warning LNK4075: ignoring '/EDITANDCONTINUE' due to '/SAFESEH' specification
-	# warning LNK4099: pdb was not found with lib
-	# stack size 16MB
-	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /ignore:4099,4075 /STACK:16777216")
+    # disable empty object file warning
+    set(CMAKE_STATIC_LINKER_FLAGS "${CMAKE_STATIC_LINKER_FLAGS} /ignore:4221")
+    # warning LNK4075: ignoring '/EDITANDCONTINUE' due to '/SAFESEH' specification
+    # warning LNK4099: pdb was not found with lib
+    # stack size 16MB
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /ignore:4099,4075 /STACK:16777216")
 
 # If you don't have GCC, Clang or VC++ then you are on your own.  Good luck!
 else ()
-	message(WARNING "Your compiler is not tested, if you run into any issues, we'd welcome any patches.")
+    message(WARNING "Your compiler is not tested, if you run into any issues, we'd welcome any patches.")
 endif ()
 
 if (SANITIZE)
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-omit-frame-pointer -fsanitize=${SANITIZE}")
-	if (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
-		set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -fsanitize-blacklist=${CMAKE_SOURCE_DIR}/sanitizer-blacklist.txt")
-	endif()
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-omit-frame-pointer -fsanitize=${SANITIZE}")
+    if (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
+        set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -fsanitize-blacklist=${CMAKE_SOURCE_DIR}/sanitizer-blacklist.txt")
+    endif()
 endif()
 
 option(COVERAGE "Build with code coverage support" OFF)
 if(COVERAGE)
-	add_compile_options(-g --coverage)
-	set(CMAKE_SHARED_LINKER_FLAGS "--coverage ${CMAKE_SHARED_LINKER_FLAGS}")
-	set(CMAKE_EXE_LINKER_FLAGS "--coverage ${CMAKE_EXE_LINKER_FLAGS}")
+    add_compile_options(-g --coverage)
+    set(CMAKE_SHARED_LINKER_FLAGS "--coverage ${CMAKE_SHARED_LINKER_FLAGS}")
+    set(CMAKE_EXE_LINKER_FLAGS "--coverage ${CMAKE_EXE_LINKER_FLAGS}")
 endif()

--- a/libaleth-interpreter/CMakeLists.txt
+++ b/libaleth-interpreter/CMakeLists.txt
@@ -5,7 +5,7 @@
 if(ALETH_INTERPRETER_SHARED)
     set(library_type SHARED)
 else()
-    set(library_type STATIC)
+    set(library_type)
 endif()
 
 add_library(

--- a/libaleth-interpreter/CMakeLists.txt
+++ b/libaleth-interpreter/CMakeLists.txt
@@ -2,15 +2,8 @@
 # Copyright 2018 Aleth Autors.
 # Licensed under the GNU General Public License, Version 3. See the LICENSE file.
 
-if(ALETH_INTERPRETER_SHARED)
-    set(library_type SHARED)
-else()
-    set(library_type)
-endif()
-
-add_library(
-    aleth-interpreter
-    ${library_type}
+set(
+    sources
     interpreter.h
     VM.cpp
     VM.h
@@ -18,7 +11,20 @@ add_library(
     VMConfig.h
     VMOpt.cpp
 )
+add_library(aleth-interpreter STATIC ${sources})
 target_link_libraries(aleth-interpreter PRIVATE devcore aleth-buildinfo evmc::evmc evmc::instructions)
+
+if(ALETH_INTERPRETER_SHARED)
+    # Build aleth-interpreter additionally as a shared library to include it in the package
+    add_library(aleth-interpreter-shared SHARED ${sources})
+    target_link_libraries(aleth-interpreter-shared PRIVATE devcore aleth-buildinfo evmc::evmc evmc::instructions)
+    set_target_properties(aleth-interpreter-shared PROPERTIES OUTPUT_NAME aleth-interpreter)
+    install(TARGETS aleth-interpreter-shared EXPORT alethTargets
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    )
+endif()
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL GNU)
     target_compile_options(aleth-interpreter PRIVATE -fstack-usage)

--- a/libaleth-interpreter/interpreter.h
+++ b/libaleth-interpreter/interpreter.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <evmc/evmc.h>
+#include <evmc/utils.h>
 
 #if __cplusplus
 extern "C" {
@@ -15,7 +16,7 @@ extern "C" {
 #define NOEXCEPT
 #endif
 
-struct evmc_instance* evmc_create_interpreter() NOEXCEPT;
+EVMC_EXPORT struct evmc_instance* evmc_create_interpreter() NOEXCEPT;
 
 #if __cplusplus
 }


### PR DESCRIPTION
It adds the `ALETH_INTERPRETER_SHARED` CMake option to additionally build the interpreter as a shared library and include it in the final package. This is useful because this shared library can be used in geth as the VM and people will not have to build it from source.

The interpreter is still linked statically in the aleth client. It's easier to distribute it this way (no install needed on linux, no DLL issue on Windows).