### PR TITLE
style changes for ClientTest and test rpc

### DIFF
--- a/libethereum/ClientTest.cpp
+++ b/libethereum/ClientTest.cpp
@@ -109,7 +109,7 @@ void ClientTest::onNewBlocks(h256s const& _blocks, h256Hash& io_changed)
 {
     Client::onNewBlocks(_blocks, io_changed);
 
-    if(--m_blocksToMine <= 0)
+    if (--m_blocksToMine <= 0)
         stopSealing();
 }
 

--- a/libethereum/ClientTest.h
+++ b/libethereum/ClientTest.h
@@ -1,18 +1,18 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file ClientTest.h
  * @author Kholhlov Dimitry <dimitry@ethdev.com>
@@ -36,28 +36,24 @@ DEV_SIMPLE_EXCEPTION(ImportBlockFailed);
 class ClientTest: public Client
 {
 public:
-	/// Trivial forwarding constructor.
-	ClientTest(
-		ChainParams const& _params,
-		int _networkID,
-		p2p::Host* _host,
-		std::shared_ptr<GasPricer> _gpForAdoption,
-		boost::filesystem::path const& _dbPath = boost::filesystem::path(),
-		WithExisting _forceAction = WithExisting::Trust,
-		TransactionQueue::Limits const& _l = TransactionQueue::Limits{1024, 1024}
-	);
-	~ClientTest();
+    /// Trivial forwarding constructor.
+    ClientTest(ChainParams const& _params, int _networkID, p2p::Host* _host,
+        std::shared_ptr<GasPricer> _gpForAdoption,
+        boost::filesystem::path const& _dbPath = boost::filesystem::path(),
+        WithExisting _forceAction = WithExisting::Trust,
+        TransactionQueue::Limits const& _l = TransactionQueue::Limits{1024, 1024});
+    ~ClientTest();
 
-	void setChainParams(std::string const& _genesis);
-	void mineBlocks(unsigned _count);
-	void modifyTimestamp(int64_t _timestamp);
-	void rewindToBlock(unsigned _number);
+    void setChainParams(std::string const& _genesis);
+    void mineBlocks(unsigned _count);
+    void modifyTimestamp(int64_t _timestamp);
+    void rewindToBlock(unsigned _number);
     h256 importRawBlock(std::string const& _blockRLP);
     bool completeSync();
 
 protected:
-	unsigned m_blocksToMine;
-	virtual void onNewBlocks(h256s const& _blocks, h256Hash& io_changed) override;
+    unsigned m_blocksToMine;
+    virtual void onNewBlocks(h256s const& _blocks, h256Hash& io_changed) override;
 };
 
 ClientTest& asClientTest(Interface& _c);

--- a/libweb3jsonrpc/Test.cpp
+++ b/libweb3jsonrpc/Test.cpp
@@ -45,22 +45,25 @@ string logEntriesToLogHash(eth::LogEntries const& _logs)
         l.streamRLP(s);
     return toJS(sha3(s.out()));
 }
+
+h256 stringToHash(string const& _hashString)
+{
+    try
+    {
+        return h256(_hashString);
+    }
+    catch (BadHexCharacter const&)
+    {
+        throw JsonRpcException(Errors::ERROR_RPC_INVALID_PARAMS);
+    }
+}
 }
 
 string Test::test_getLogHash(string const& _txHash)
 {
     try
     {
-        h256 txHash;
-        try
-        {
-            txHash = h256(_txHash);
-        }
-        catch (BadHexCharacter const&)
-        {
-            throw JsonRpcException(Errors::ERROR_RPC_INVALID_PARAMS);
-        }
-
+        h256 txHash = stringToHash(_txHash);
         if (m_eth.blockChain().isKnownTransaction(txHash))
         {
             LocalisedTransaction t = m_eth.localisedTransaction(txHash);
@@ -85,14 +88,13 @@ bool Test::test_setChainParams(Json::Value const& param1)
         std::string output = fastWriter.write(param1);
         asClientTest(m_eth).setChainParams(output);
         asClientTest(m_eth).completeSync();  // set sync state to idle for mining
+        return true;
     }
     catch (std::exception const& ex)
     {
         cwarn << ex.what();
         throw JsonRpcException(Errors::ERROR_RPC_INTERNAL_ERROR, ex.what());
     }
-
-    return true;
 }
 
 bool Test::test_mineBlocks(int _number)

--- a/libweb3jsonrpc/TestFace.h
+++ b/libweb3jsonrpc/TestFace.h
@@ -14,26 +14,18 @@ namespace dev {
             public:
                 TestFace()
                 {
-                    this->bindAndAddMethod(
-                        jsonrpc::Procedure("test_getLogHash", jsonrpc::PARAMS_BY_POSITION,
-                            jsonrpc::JSON_BOOLEAN, "param1", jsonrpc::JSON_STRING, NULL),
-                        &dev::rpc::TestFace::test_getLogHashI);
-                    this->bindAndAddMethod(
-                        jsonrpc::Procedure("test_importRawBlock", jsonrpc::PARAMS_BY_POSITION,
-                            jsonrpc::JSON_STRING, "param1", jsonrpc::JSON_STRING, NULL),
-                        &dev::rpc::TestFace::test_importRawBlockI);
+                    this->bindAndAddMethod(jsonrpc::Procedure("test_getLogHash", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_STRING, "param1", jsonrpc::JSON_STRING, NULL), &dev::rpc::TestFace::test_getLogHashI);
+                    this->bindAndAddMethod(jsonrpc::Procedure("test_importRawBlock", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_STRING, "param1", jsonrpc::JSON_STRING, NULL), &dev::rpc::TestFace::test_importRawBlockI);
                     this->bindAndAddMethod(jsonrpc::Procedure("test_setChainParams", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_BOOLEAN, "param1",jsonrpc::JSON_OBJECT, NULL), &dev::rpc::TestFace::test_setChainParamsI);
                     this->bindAndAddMethod(jsonrpc::Procedure("test_mineBlocks", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_BOOLEAN, "param1",jsonrpc::JSON_INTEGER, NULL), &dev::rpc::TestFace::test_mineBlocksI);
                     this->bindAndAddMethod(jsonrpc::Procedure("test_modifyTimestamp", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_BOOLEAN, "param1",jsonrpc::JSON_INTEGER, NULL), &dev::rpc::TestFace::test_modifyTimestampI);
                     this->bindAndAddMethod(jsonrpc::Procedure("test_rewindToBlock", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_BOOLEAN, "param1",jsonrpc::JSON_INTEGER, NULL), &dev::rpc::TestFace::test_rewindToBlockI);
                 }
-                inline virtual void test_getLogHashI(
-                    const Json::Value& request, Json::Value& response)
+                inline virtual void test_getLogHashI(const Json::Value& request, Json::Value& response)
                 {
                     response = this->test_getLogHash(request[0u].asString());
                 }
-                inline virtual void test_importRawBlockI(
-                    const Json::Value& request, Json::Value& response)
+                inline virtual void test_importRawBlockI(const Json::Value& request, Json::Value& response)
                 {
                     response = this->test_importRawBlock(request[0u].asString());
                 }


### PR DESCRIPTION
remove tabs from ClientTest.cpp/h
clang format ClientTest.cpp/h
minor style changes in libweb3jsonrpc test methods
undo clang on web3jsonrpc of auto generated files 