### PR TITLE
Fix unexpected sync start

### DIFF
--- a/libp2p/Capability.cpp
+++ b/libp2p/Capability.cpp
@@ -35,6 +35,12 @@ Capability::Capability(std::shared_ptr<SessionFace> _s, HostCapabilityFace* _h, 
                 << "; idOffset: " << m_idOffset;
 }
 
+void Capability::disconnect()
+{
+    if (auto s = session())
+        s->disconnect(UserReason);
+}
+
 void Capability::disable(std::string const& _problem)
 {
     cnetdetails << "DISABLE: Disabling capability '" << m_hostCap->name()

--- a/libp2p/Capability.h
+++ b/libp2p/Capability.h
@@ -44,6 +44,11 @@ public:
     static u256 version() { return 0; }
     static unsigned messageCount() { return 0; }
 */
+
+    bool enabled() const { return m_enabled; }
+
+    void disconnect();
+
 protected:
     std::shared_ptr<SessionFace> session() const { return m_session.lock(); }
     HostCapabilityFace* hostCapability() const { return m_hostCap; }

--- a/libp2p/Session.cpp
+++ b/libp2p/Session.cpp
@@ -129,7 +129,8 @@ bool Session::readPacket(uint16_t _capId, PacketType _t, RLP const& _r)
 
         for (auto const& i: m_capabilities)
             if (_t >= (int)i.second->m_idOffset && _t - i.second->m_idOffset < i.second->hostCapability()->messageCount())
-                return i.second->m_enabled ? i.second->interpret(_t - i.second->m_idOffset, _r) : true;
+                return i.second->enabled() ? i.second->interpret(_t - i.second->m_idOffset, _r) :
+                                             true;
 
         return false;
     }


### PR DESCRIPTION
Continuing to fix issues from https://github.com/ethereum/cpp-ethereum/issues/5091

Sometimes `BlockChainSync::continueSync()` is called after we determined that peer is not suitable for sync (e.g. different genesis hash) and disabled it, but before it is actually dropped - then it tries to start the sync from it anyway.

Here I change it to immediately disconnect from peer if it's not suitable for sync. Just disabling "eth" capability doesn't make much sense, as `BlockChainSync` works only with it and with no other capability, so we could just disconnect.