### PR TITLE
Some cleanup in libp2p

### DIFF
--- a/libethereum/BlockChainSync.cpp
+++ b/libethereum/BlockChainSync.cpp
@@ -212,7 +212,7 @@ void BlockChainSync::onPeerStatus(std::shared_ptr<EthereumPeer> _peer)
     char const* disconnectReason = nullptr;
     if (_peer->m_genesisHash != host().chain().genesisHash())
         disconnectReason = "Invalid genesis hash.";
-    else if (_peer->m_protocolVersion != host().protocolVersion() && _peer->m_protocolVersion != EthereumHost::c_oldProtocolVersion)
+    else if (_peer->m_protocolVersion != host().protocolVersion())
         disconnectReason = "Invalid protocol version.";
     else if (_peer->m_networkId != host().networkId())
         disconnectReason = "Invalid network identifier.";

--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -133,12 +133,9 @@ void Client::init(p2p::Host* _extNet, fs::path const& _dbPath, fs::path const& _
     // create Ethereum capability only if we're not downloading the snapshot
     if (_snapshotDownloadPath.empty())
     {
-        auto host = _extNet->registerCapability(
-            make_shared<EthereumHost>(bc(), m_stateDB, m_tq, m_bq, _networkId));
-        m_host = host;
-
-        _extNet->addCapability(host, EthereumHost::staticName(),
-            EthereumHost::c_oldProtocolVersion);  // TODO: remove this once v61+ protocol is common
+        auto ethHostCapability = make_shared<EthereumHost>(bc(), m_stateDB, m_tq, m_bq, _networkId);
+        _extNet->registerCapability(ethHostCapability);
+        m_host = ethHostCapability;
     }
 
     // create Warp capability if we either download snapshot or can give out snapshot
@@ -148,8 +145,10 @@ void Client::init(p2p::Host* _extNet, fs::path const& _dbPath, fs::path const& _
     {
         std::shared_ptr<SnapshotStorageFace> snapshotStorage(
             importedSnapshotExists ? createSnapshotStorage(importedSnapshot) : nullptr);
-        m_warpHost = _extNet->registerCapability(make_shared<WarpHostCapability>(
-            bc(), _networkId, _snapshotDownloadPath, snapshotStorage));
+        auto warpHostCapability = make_shared<WarpHostCapability>(
+            bc(), _networkId, _snapshotDownloadPath, snapshotStorage);
+        _extNet->registerCapability(warpHostCapability);
+        m_warpHost = warpHostCapability;
     }
 
     if (_dbPath.size())

--- a/libethereum/EthereumHost.cpp
+++ b/libethereum/EthereumHost.cpp
@@ -38,7 +38,6 @@ using namespace dev;
 using namespace dev::eth;
 using namespace p2p;
 
-unsigned const EthereumHost::c_oldProtocolVersion = 62; //TODO: remove this once v63+ is common
 static unsigned const c_maxSendTransactions = 256;
 
 char const* const EthereumHost::s_stateNames[static_cast<int>(SyncState::Size)] = {"NotSynced", "Idle", "Waiting", "Blocks", "State"};
@@ -505,12 +504,6 @@ void EthereumHost::foreachPeer(std::function<bool(std::shared_ptr<EthereumPeer>)
     for (auto s: sessions)
         if (!_f(capabilityFromSession<EthereumPeer>(*s.first)))
             return;
-
-    sessions = peerSessions(c_oldProtocolVersion); //TODO: remove once v61+ is common
-    std::sort(sessions.begin(), sessions.end(), sessionLess);
-    for (auto s: sessions)
-        if (!_f(capabilityFromSession<EthereumPeer>(*s.first, c_oldProtocolVersion)))
-            return;
 }
 
 tuple<vector<shared_ptr<EthereumPeer>>, vector<shared_ptr<EthereumPeer>>, vector<shared_ptr<SessionFace>>> EthereumHost::randomSelection(unsigned _percent, std::function<bool(EthereumPeer*)> const& _allow)
@@ -609,8 +602,6 @@ void EthereumHost::onTransactionImported(ImportResult _ir, h256 const& _h, h512 
         return;
 
     std::shared_ptr<EthereumPeer> peer = capabilityFromSession<EthereumPeer>(*session);
-    if (!peer)
-        peer = capabilityFromSession<EthereumPeer>(*session, c_oldProtocolVersion);
     if (!peer)
         return;
 

--- a/libethereum/EthereumPeer.cpp
+++ b/libethereum/EthereumPeer.cpp
@@ -133,13 +133,8 @@ void EthereumPeer::requestStatus(u256 _hostNetworkId, u256 _chainTotalDifficulty
     setAsking(Asking::State);
     m_requireTransactions = true;
     RLPStream s;
-    bool latest = m_peerCapabilityVersion == m_hostProtocolVersion;
-    prep(s, StatusPacket, 5)
-                    << (latest ? m_hostProtocolVersion : EthereumHost::c_oldProtocolVersion)
-                    << _hostNetworkId
-                    << _chainTotalDifficulty
-                    << _chainCurrentHash
-                    << _chainGenesisHash;
+    prep(s, StatusPacket, 5) << m_hostProtocolVersion << _hostNetworkId << _chainTotalDifficulty
+                             << _chainCurrentHash << _chainGenesisHash;
     sealAndSend(s);
 }
 

--- a/libp2p/Host.h
+++ b/libp2p/Host.h
@@ -1,18 +1,18 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file Host.h
  * @author Alex Leverington <nessence@gmail.com>
@@ -48,11 +48,11 @@ namespace std
 {
 template<> struct hash<pair<dev::p2p::NodeID, string>>
 {
-	size_t operator()(pair<dev::p2p::NodeID, string> const& _value) const
-	{
-		size_t ret = hash<dev::p2p::NodeID>()(_value.first);
-		return ret ^ (hash<string>()(_value.second) + 0x9e3779b9 + (ret << 6) + (ret >> 2));
-	}
+    size_t operator()(pair<dev::p2p::NodeID, string> const& _value) const
+    {
+        size_t ret = hash<dev::p2p::NodeID>()(_value.first);
+        return ret ^ (hash<string>()(_value.second) + 0x9e3779b9 + (ret << 6) + (ret >> 2));
+    }
 };
 }
 
@@ -67,55 +67,55 @@ class Host;
 class HostNodeTableHandler: public NodeTableEventHandler
 {
 public:
-	HostNodeTableHandler(Host& _host);
+    HostNodeTableHandler(Host& _host);
 
-	Host const& host() const { return m_host; }
+    Host const& host() const { return m_host; }
 
 private:
-	virtual void processEvent(NodeID const& _n, NodeTableEventType const& _e);
+    virtual void processEvent(NodeID const& _n, NodeTableEventType const& _e);
 
-	Host& m_host;
+    Host& m_host;
 };
 
 struct SubReputation
 {
-	bool isRude = false;
-	int utility = 0;
-	bytes data;
+    bool isRude = false;
+    int utility = 0;
+    bytes data;
 };
 
 struct Reputation
 {
-	std::unordered_map<std::string, SubReputation> subs;
+    std::unordered_map<std::string, SubReputation> subs;
 };
 
 class ReputationManager
 {
 public:
-	ReputationManager();
+    ReputationManager();
 
-	void noteRude(SessionFace const& _s, std::string const& _sub = std::string());
-	bool isRude(SessionFace const& _s, std::string const& _sub = std::string()) const;
-	void setData(SessionFace const& _s, std::string const& _sub, bytes const& _data);
-	bytes data(SessionFace const& _s, std::string const& _subs) const;
+    void noteRude(SessionFace const& _s, std::string const& _sub = std::string());
+    bool isRude(SessionFace const& _s, std::string const& _sub = std::string()) const;
+    void setData(SessionFace const& _s, std::string const& _sub, bytes const& _data);
+    bytes data(SessionFace const& _s, std::string const& _subs) const;
 
 private:
-	std::unordered_map<std::pair<p2p::NodeID, std::string>, Reputation> m_nodes;	///< Nodes that were impolite while syncing. We avoid syncing from these if possible.
-	SharedMutex mutable x_nodes;
+    std::unordered_map<std::pair<p2p::NodeID, std::string>, Reputation> m_nodes;	///< Nodes that were impolite while syncing. We avoid syncing from these if possible.
+    SharedMutex mutable x_nodes;
 };
 
 struct NodeInfo
 {
-	NodeInfo() = default;
-	NodeInfo(NodeID const& _id, std::string const& _address, unsigned _port, std::string const& _version):
-		id(_id), address(_address), port(_port), version(_version) {}
+    NodeInfo() = default;
+    NodeInfo(NodeID const& _id, std::string const& _address, unsigned _port, std::string const& _version):
+        id(_id), address(_address), port(_port), version(_version) {}
 
-	std::string enode() const { return "enode://" + id.hex() + "@" + address + ":" + toString(port); }
+    std::string enode() const { return "enode://" + id.hex() + "@" + address + ":" + toString(port); }
 
-	NodeID id;
-	std::string address;
-	unsigned port;
-	std::string version;
+    NodeID id;
+    std::string address;
+    unsigned port;
+    std::string version;
 };
 
 /**
@@ -127,228 +127,238 @@ struct NodeInfo
  */
 class Host: public Worker
 {
-	friend class HostNodeTableHandler;
-	friend class RLPXHandshake;
-	
-	friend class Session;
-	friend class HostCapabilityFace;
+    friend class HostNodeTableHandler;
+    friend class RLPXHandshake;
+    
+    friend class Session;
+    friend class HostCapabilityFace;
 
 public:
-	/// Start server, listening for connections on the given port.
-	Host(
-		std::string const& _clientVersion,
-		NetworkPreferences const& _n = NetworkPreferences(),
-		bytesConstRef _restoreNetwork = bytesConstRef()
-	);
+    /// Start server, listening for connections on the given port.
+    Host(
+        std::string const& _clientVersion,
+        NetworkPreferences const& _n = NetworkPreferences(),
+        bytesConstRef _restoreNetwork = bytesConstRef()
+    );
 
-	/// Alternative constructor that allows providing the node key directly
-	/// without restoring the network.
-	Host(
-		std::string const& _clientVersion,
-		KeyPair const& _alias,
-		NetworkPreferences const& _n = NetworkPreferences()
-	);
+    /// Alternative constructor that allows providing the node key directly
+    /// without restoring the network.
+    Host(
+        std::string const& _clientVersion,
+        KeyPair const& _alias,
+        NetworkPreferences const& _n = NetworkPreferences()
+    );
 
-	/// Will block on network process events.
-	virtual ~Host();
+    /// Will block on network process events.
+    virtual ~Host();
 
-	/// Default hosts for current version of client.
-	static std::unordered_map<Public, std::string> pocHosts();
+    /// Default hosts for current version of client.
+    static std::unordered_map<Public, std::string> pocHosts();
 
-	/// Register a peer-capability; all new peer connections will have this capability.
-	template <class T> std::shared_ptr<T> registerCapability(std::shared_ptr<T> const& _t) { _t->m_host = this; m_capabilities[std::make_pair(T::staticName(), T::staticVersion())] = _t; return _t; }
-	template <class T> void addCapability(std::shared_ptr<T> const & _p, std::string const& _name, u256 const& _version) { m_capabilities[std::make_pair(_name, _version)] = _p; }
+    /// Register a host capability; all new peer connections will see this capability.
+    void registerCapability(std::shared_ptr<HostCapabilityFace> const& _cap)
+    {
+        registerCapability(_cap, _cap->name(), _cap->version());
+    }
+    /// Register a host capability with arbitrary name and version.
+    /// Might be useful when you want to handle several subprotocol versions with a single
+    /// capability class.
+    void registerCapability(std::shared_ptr<HostCapabilityFace> const& _cap,
+        std::string const& _name, u256 const& _version)
+    {
+        _cap->m_host = this;
+        m_capabilities[std::make_pair(_name, _version)] = _cap;
+    }
 
-	bool haveCapability(CapDesc const& _name) const { return m_capabilities.count(_name) != 0; }
-	CapDescs caps() const { CapDescs ret; for (auto const& i: m_capabilities) ret.push_back(i.first); return ret; }
-	template <class T> std::shared_ptr<T> cap() const { try { return std::static_pointer_cast<T>(m_capabilities.at(std::make_pair(T::staticName(), T::staticVersion()))); } catch (...) { return nullptr; } }
+    bool haveCapability(CapDesc const& _name) const { return m_capabilities.count(_name) != 0; }
+    CapDescs caps() const { CapDescs ret; for (auto const& i: m_capabilities) ret.push_back(i.first); return ret; }
 
-	/// Add a potential peer.
-	void addPeer(NodeSpec const& _s, PeerType _t);
+    /// Add a potential peer.
+    void addPeer(NodeSpec const& _s, PeerType _t);
 
-	/// Add node as a peer candidate. Node is added if discovery ping is successful and table has capacity.
-	void addNode(NodeID const& _node, NodeIPEndpoint const& _endpoint);
-	
-	/// Create Peer and attempt keeping peer connected.
-	void requirePeer(NodeID const& _node, NodeIPEndpoint const& _endpoint);
+    /// Add node as a peer candidate. Node is added if discovery ping is successful and table has capacity.
+    void addNode(NodeID const& _node, NodeIPEndpoint const& _endpoint);
+    
+    /// Create Peer and attempt keeping peer connected.
+    void requirePeer(NodeID const& _node, NodeIPEndpoint const& _endpoint);
 
-	/// Create Peer and attempt keeping peer connected.
-	void requirePeer(NodeID const& _node, bi::address const& _addr, unsigned short _udpPort, unsigned short _tcpPort) { requirePeer(_node, NodeIPEndpoint(_addr, _udpPort, _tcpPort)); }
+    /// Create Peer and attempt keeping peer connected.
+    void requirePeer(NodeID const& _node, bi::address const& _addr, unsigned short _udpPort, unsigned short _tcpPort) { requirePeer(_node, NodeIPEndpoint(_addr, _udpPort, _tcpPort)); }
 
-	/// Note peer as no longer being required.
-	void relinquishPeer(NodeID const& _node);
-	
-	/// Set ideal number of peers.
-	void setIdealPeerCount(unsigned _n) { m_idealPeerCount = _n; }
+    /// Note peer as no longer being required.
+    void relinquishPeer(NodeID const& _node);
+    
+    /// Set ideal number of peers.
+    void setIdealPeerCount(unsigned _n) { m_idealPeerCount = _n; }
 
-	/// Set multipier for max accepted connections.
-	void setPeerStretch(unsigned _n) { m_stretchPeers = _n; }
-	
-	/// Get peer information.
-	PeerSessionInfos peerSessionInfo() const;
+    /// Set multipier for max accepted connections.
+    void setPeerStretch(unsigned _n) { m_stretchPeers = _n; }
+    
+    /// Get peer information.
+    PeerSessionInfos peerSessionInfo() const;
 
-	/// Get number of peers connected.
-	size_t peerCount() const;
+    /// Get number of peers connected.
+    size_t peerCount() const;
 
-	/// Get the address we're listening on currently.
-	std::string listenAddress() const { return m_tcpPublic.address().is_unspecified() ? "0.0.0.0" : m_tcpPublic.address().to_string(); }
+    /// Get the address we're listening on currently.
+    std::string listenAddress() const { return m_tcpPublic.address().is_unspecified() ? "0.0.0.0" : m_tcpPublic.address().to_string(); }
 
-	/// Get the port we're listening on currently.
-	unsigned short listenPort() const { return std::max(0, m_listenPort.load()); }
+    /// Get the port we're listening on currently.
+    unsigned short listenPort() const { return std::max(0, m_listenPort.load()); }
 
-	/// Serialise the set of known peers.
-	bytes saveNetwork() const;
+    /// Serialise the set of known peers.
+    bytes saveNetwork() const;
 
-	// TODO: P2P this should be combined with peers into a HostStat object of some kind; coalesce data, as it's only used for status information.
-	Peers getPeers() const { RecursiveGuard l(x_sessions); Peers ret; for (auto const& i: m_peers) ret.push_back(*i.second); return ret; }
+    // TODO: P2P this should be combined with peers into a HostStat object of some kind; coalesce data, as it's only used for status information.
+    Peers getPeers() const { RecursiveGuard l(x_sessions); Peers ret; for (auto const& i: m_peers) ret.push_back(*i.second); return ret; }
 
-	NetworkPreferences const& networkPreferences() const { return m_netPrefs; }
+    NetworkPreferences const& networkPreferences() const { return m_netPrefs; }
 
-	void setNetworkPreferences(NetworkPreferences const& _p, bool _dropPeers = false) { m_dropPeers = _dropPeers; auto had = isStarted(); if (had) stop(); m_netPrefs = _p; if (had) start(); }
+    void setNetworkPreferences(NetworkPreferences const& _p, bool _dropPeers = false) { m_dropPeers = _dropPeers; auto had = isStarted(); if (had) stop(); m_netPrefs = _p; if (had) start(); }
 
-	/// Start network. @threadsafe
-	void start();
+    /// Start network. @threadsafe
+    void start();
 
-	/// Stop network. @threadsafe
-	/// Resets acceptor, socket, and IO service. Called by deallocator.
-	void stop();
+    /// Stop network. @threadsafe
+    /// Resets acceptor, socket, and IO service. Called by deallocator.
+    void stop();
 
-	/// @returns if network has been started.
-	bool isStarted() const { return isWorking(); }
+    /// @returns if network has been started.
+    bool isStarted() const { return isWorking(); }
 
-	/// @returns our reputation manager.
-	ReputationManager& repMan() { return m_repMan; }
+    /// @returns our reputation manager.
+    ReputationManager& repMan() { return m_repMan; }
 
-	/// @returns if network is started and interactive.
-	bool haveNetwork() const { Guard l(x_runTimer); Guard ll(x_nodeTable); return m_run && !!m_nodeTable; }
-	
-	/// Validates and starts peer session, taking ownership of _io. Disconnects and returns false upon error.
-	void startPeerSession(Public const& _id, RLP const& _hello, std::unique_ptr<RLPXFrameCoder>&& _io, std::shared_ptr<RLPXSocket> const& _s);
+    /// @returns if network is started and interactive.
+    bool haveNetwork() const { Guard l(x_runTimer); Guard ll(x_nodeTable); return m_run && !!m_nodeTable; }
+    
+    /// Validates and starts peer session, taking ownership of _io. Disconnects and returns false upon error.
+    void startPeerSession(Public const& _id, RLP const& _hello, std::unique_ptr<RLPXFrameCoder>&& _io, std::shared_ptr<RLPXSocket> const& _s);
 
-	/// Get session by id
-	std::shared_ptr<SessionFace> peerSession(NodeID const& _id) { RecursiveGuard l(x_sessions); return m_sessions.count(_id) ? m_sessions[_id].lock() : std::shared_ptr<SessionFace>(); }
+    /// Get session by id
+    std::shared_ptr<SessionFace> peerSession(NodeID const& _id) { RecursiveGuard l(x_sessions); return m_sessions.count(_id) ? m_sessions[_id].lock() : std::shared_ptr<SessionFace>(); }
 
-	/// Get our current node ID.
-	NodeID id() const { return m_alias.pub(); }
+    /// Get our current node ID.
+    NodeID id() const { return m_alias.pub(); }
 
-	/// Get the public TCP endpoint.
-	bi::tcp::endpoint const& tcpPublic() const { return m_tcpPublic; }
+    /// Get the public TCP endpoint.
+    bi::tcp::endpoint const& tcpPublic() const { return m_tcpPublic; }
 
-	/// Get the public endpoint information.
-	std::string enode() const { return "enode://" + id().hex() + "@" + (networkPreferences().publicIPAddress.empty() ? m_tcpPublic.address().to_string() : networkPreferences().publicIPAddress) + ":" + toString(m_tcpPublic.port()); }
+    /// Get the public endpoint information.
+    std::string enode() const { return "enode://" + id().hex() + "@" + (networkPreferences().publicIPAddress.empty() ? m_tcpPublic.address().to_string() : networkPreferences().publicIPAddress) + ":" + toString(m_tcpPublic.port()); }
 
-	/// Get the node information.
-	p2p::NodeInfo nodeInfo() const { return NodeInfo(id(), (networkPreferences().publicIPAddress.empty() ? m_tcpPublic.address().to_string() : networkPreferences().publicIPAddress), m_tcpPublic.port(), m_clientVersion); }
+    /// Get the node information.
+    p2p::NodeInfo nodeInfo() const { return NodeInfo(id(), (networkPreferences().publicIPAddress.empty() ? m_tcpPublic.address().to_string() : networkPreferences().publicIPAddress), m_tcpPublic.port(), m_clientVersion); }
 
 protected:
-	void onNodeTableEvent(NodeID const& _n, NodeTableEventType const& _e);
+    void onNodeTableEvent(NodeID const& _n, NodeTableEventType const& _e);
 
-	/// Deserialise the data and populate the set of known peers.
-	void restoreNetwork(bytesConstRef _b);
+    /// Deserialise the data and populate the set of known peers.
+    void restoreNetwork(bytesConstRef _b);
 
 private:
-	enum PeerSlotType { Egress, Ingress };
-	
-	unsigned peerSlots(PeerSlotType _type) { return _type == Egress ? m_idealPeerCount : m_idealPeerCount * m_stretchPeers; }
-	
-	bool havePeerSession(NodeID const& _id) { return !!peerSession(_id); }
+    enum PeerSlotType { Egress, Ingress };
+    
+    unsigned peerSlots(PeerSlotType _type) { return _type == Egress ? m_idealPeerCount : m_idealPeerCount * m_stretchPeers; }
+    
+    bool havePeerSession(NodeID const& _id) { return !!peerSession(_id); }
 
-	/// Determines and sets m_tcpPublic to publicly advertised address.
-	void determinePublic();
+    /// Determines and sets m_tcpPublic to publicly advertised address.
+    void determinePublic();
 
-	void connect(std::shared_ptr<Peer> const& _p);
+    void connect(std::shared_ptr<Peer> const& _p);
 
-	/// Returns true if pending and connected peer count is less than maximum
-	bool peerSlotsAvailable(PeerSlotType _type = Ingress);
-	
-	/// Ping the peers to update the latency information and disconnect peers which have timed out.
-	void keepAlivePeers();
+    /// Returns true if pending and connected peer count is less than maximum
+    bool peerSlotsAvailable(PeerSlotType _type = Ingress);
+    
+    /// Ping the peers to update the latency information and disconnect peers which have timed out.
+    void keepAlivePeers();
 
-	/// Disconnect peers which didn't respond to keepAlivePeers ping prior to c_keepAliveTimeOut.
-	void disconnectLatePeers();
+    /// Disconnect peers which didn't respond to keepAlivePeers ping prior to c_keepAliveTimeOut.
+    void disconnectLatePeers();
 
-	/// Called only from startedWorking().
-	void runAcceptor();
+    /// Called only from startedWorking().
+    void runAcceptor();
 
-	/// Called by Worker. Not thread-safe; to be called only by worker.
-	virtual void startedWorking();
-	/// Called by startedWorking. Not thread-safe; to be called only be Worker.
-	void run(boost::system::error_code const& error);			///< Run network. Called serially via ASIO deadline timer. Manages connection state transitions.
+    /// Called by Worker. Not thread-safe; to be called only by worker.
+    virtual void startedWorking();
+    /// Called by startedWorking. Not thread-safe; to be called only be Worker.
+    void run(boost::system::error_code const& error);			///< Run network. Called serially via ASIO deadline timer. Manages connection state transitions.
 
-	/// Run network. Not thread-safe; to be called only by worker.
-	virtual void doWork();
+    /// Run network. Not thread-safe; to be called only by worker.
+    virtual void doWork();
 
-	/// Shutdown network. Not thread-safe; to be called only by worker.
-	virtual void doneWorking();
+    /// Shutdown network. Not thread-safe; to be called only by worker.
+    virtual void doneWorking();
 
-	/// Get or create host identifier (KeyPair).
-	static KeyPair networkAlias(bytesConstRef _b);
+    /// Get or create host identifier (KeyPair).
+    static KeyPair networkAlias(bytesConstRef _b);
 
-	/// returns true if a member of m_requiredPeers
-	bool isRequiredPeer(NodeID const&) const;
+    /// returns true if a member of m_requiredPeers
+    bool isRequiredPeer(NodeID const&) const;
 
-	bool nodeTableHasNode(Public const& _id) const;
-	Node nodeFromNodeTable(Public const& _id) const;
-	bool addNodeToNodeTable(Node const& _node, NodeTable::NodeRelation _relation = NodeTable::NodeRelation::Unknown);
+    bool nodeTableHasNode(Public const& _id) const;
+    Node nodeFromNodeTable(Public const& _id) const;
+    bool addNodeToNodeTable(Node const& _node, NodeTable::NodeRelation _relation = NodeTable::NodeRelation::Unknown);
 
-	bytes m_restoreNetwork;										///< Set by constructor and used to set Host key and restore network peers & nodes.
+    bytes m_restoreNetwork;										///< Set by constructor and used to set Host key and restore network peers & nodes.
 
-	std::atomic<bool> m_run{false};													///< Whether network is running.
+    std::atomic<bool> m_run{false};													///< Whether network is running.
 
-	std::string m_clientVersion;											///< Our version string.
+    std::string m_clientVersion;											///< Our version string.
 
-	NetworkPreferences m_netPrefs;										///< Network settings.
+    NetworkPreferences m_netPrefs;										///< Network settings.
 
-	/// Interface addresses (private, public)
-	std::set<bi::address> m_ifAddresses;								///< Interface addresses.
+    /// Interface addresses (private, public)
+    std::set<bi::address> m_ifAddresses;								///< Interface addresses.
 
-	std::atomic<int> m_listenPort{-1};												///< What port are we listening on. -1 means binding failed or acceptor hasn't been initialized.
+    std::atomic<int> m_listenPort{-1};												///< What port are we listening on. -1 means binding failed or acceptor hasn't been initialized.
 
-	ba::io_service m_ioService;											///< IOService for network stuff.
-	bi::tcp::acceptor m_tcp4Acceptor;										///< Listening acceptor.
+    ba::io_service m_ioService;											///< IOService for network stuff.
+    bi::tcp::acceptor m_tcp4Acceptor;										///< Listening acceptor.
 
-	std::unique_ptr<boost::asio::deadline_timer> m_timer;					///< Timer which, when network is running, calls scheduler() every c_timerInterval ms.
-	mutable std::mutex x_runTimer;	///< Start/stop mutex.
-	static const unsigned c_timerInterval = 100;							///< Interval which m_timer is run when network is connected.
-	std::condition_variable m_timerReset;
+    std::unique_ptr<boost::asio::deadline_timer> m_timer;					///< Timer which, when network is running, calls scheduler() every c_timerInterval ms.
+    mutable std::mutex x_runTimer;	///< Start/stop mutex.
+    static const unsigned c_timerInterval = 100;							///< Interval which m_timer is run when network is connected.
+    std::condition_variable m_timerReset;
 
-	std::set<Peer*> m_pendingPeerConns;									/// Used only by connect(Peer&) to limit concurrently connecting to same node. See connect(shared_ptr<Peer>const&).
+    std::set<Peer*> m_pendingPeerConns;									/// Used only by connect(Peer&) to limit concurrently connecting to same node. See connect(shared_ptr<Peer>const&).
 
-	bi::tcp::endpoint m_tcpPublic;											///< Our public listening endpoint.
-	KeyPair m_alias;															///< Alias for network communication. Network address is k*G. k is key material. TODO: Replace KeyPair.
-	std::shared_ptr<NodeTable> m_nodeTable;									///< Node table (uses kademlia-like discovery).
-	mutable std::mutex x_nodeTable;
-	std::shared_ptr<NodeTable> nodeTable() const { Guard l(x_nodeTable); return m_nodeTable; }
+    bi::tcp::endpoint m_tcpPublic;											///< Our public listening endpoint.
+    KeyPair m_alias;															///< Alias for network communication. Network address is k*G. k is key material. TODO: Replace KeyPair.
+    std::shared_ptr<NodeTable> m_nodeTable;									///< Node table (uses kademlia-like discovery).
+    mutable std::mutex x_nodeTable;
+    std::shared_ptr<NodeTable> nodeTable() const { Guard l(x_nodeTable); return m_nodeTable; }
 
-	/// Shared storage of Peer objects. Peers are created or destroyed on demand by the Host. Active sessions maintain a shared_ptr to a Peer;
-	std::unordered_map<NodeID, std::shared_ptr<Peer>> m_peers;
-	
-	/// Peers we try to connect regardless of p2p network.
-	std::set<NodeID> m_requiredPeers;
-	mutable Mutex x_requiredPeers;
+    /// Shared storage of Peer objects. Peers are created or destroyed on demand by the Host. Active sessions maintain a shared_ptr to a Peer;
+    std::unordered_map<NodeID, std::shared_ptr<Peer>> m_peers;
+    
+    /// Peers we try to connect regardless of p2p network.
+    std::set<NodeID> m_requiredPeers;
+    mutable Mutex x_requiredPeers;
 
-	/// The nodes to which we are currently connected. Used by host to service peer requests and keepAlivePeers and for shutdown. (see run())
-	/// Mutable because we flush zombie entries (null-weakptrs) as regular maintenance from a const method.
-	mutable std::unordered_map<NodeID, std::weak_ptr<SessionFace>> m_sessions;
-	mutable RecursiveMutex x_sessions;
-	
-	std::list<std::weak_ptr<RLPXHandshake>> m_connecting;					///< Pending connections.
-	Mutex x_connecting;													///< Mutex for m_connecting.
+    /// The nodes to which we are currently connected. Used by host to service peer requests and keepAlivePeers and for shutdown. (see run())
+    /// Mutable because we flush zombie entries (null-weakptrs) as regular maintenance from a const method.
+    mutable std::unordered_map<NodeID, std::weak_ptr<SessionFace>> m_sessions;
+    mutable RecursiveMutex x_sessions;
+    
+    std::list<std::weak_ptr<RLPXHandshake>> m_connecting;					///< Pending connections.
+    Mutex x_connecting;													///< Mutex for m_connecting.
 
-	unsigned m_idealPeerCount = 11;										///< Ideal number of peers to be connected to.
-	unsigned m_stretchPeers = 7;										///< Accepted connection multiplier (max peers = ideal*stretch).
+    unsigned m_idealPeerCount = 11;										///< Ideal number of peers to be connected to.
+    unsigned m_stretchPeers = 7;										///< Accepted connection multiplier (max peers = ideal*stretch).
 
-	std::map<CapDesc, std::shared_ptr<HostCapabilityFace>> m_capabilities;	///< Each of the capabilities we support.
-	
-	/// Deadline timers used for isolated network events. GC'd by run.
-	std::list<std::shared_ptr<boost::asio::deadline_timer>> m_timers;
-	Mutex x_timers;
+    std::map<CapDesc, std::shared_ptr<HostCapabilityFace>> m_capabilities;	///< Each of the capabilities we support.
+    
+    /// Deadline timers used for isolated network events. GC'd by run.
+    std::list<std::shared_ptr<boost::asio::deadline_timer>> m_timers;
+    Mutex x_timers;
 
-	std::chrono::steady_clock::time_point m_lastPing;						///< Time we sent the last ping to all peers.
-	bool m_accepting = false;
-	bool m_dropPeers = false;
+    std::chrono::steady_clock::time_point m_lastPing;						///< Time we sent the last ping to all peers.
+    bool m_accepting = false;
+    bool m_dropPeers = false;
 
-	ReputationManager m_repMan;
+    ReputationManager m_repMan;
 
     Logger m_logger{createLogger(VerbosityDebug, "net")};
 };

--- a/libp2p/HostCapability.h
+++ b/libp2p/HostCapability.h
@@ -1,18 +1,18 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file HostCapability.h
  * @author Gav Wood <i@gavwood.com>
@@ -36,56 +36,55 @@ namespace p2p
 
 class HostCapabilityFace
 {
-	friend class Host;
-	template <class T> friend class HostCapability;
-	friend class Capability;
-	friend class Session;
+    friend class Host;
+    template <class T> friend class HostCapability;
+    friend class Capability;
+    friend class Session;
 
 public:
-	HostCapabilityFace() {}
-	virtual ~HostCapabilityFace() {}
+    HostCapabilityFace() {}
+    virtual ~HostCapabilityFace() {}
 
-	Host* host() const { return m_host; }
+    Host* host() const { return m_host; }
 
-	std::vector<std::pair<std::shared_ptr<SessionFace>, std::shared_ptr<Peer>>> peerSessions() const;
-	std::vector<std::pair<std::shared_ptr<SessionFace>, std::shared_ptr<Peer>>> peerSessions(u256 const& _version) const;
+    std::vector<std::pair<std::shared_ptr<SessionFace>, std::shared_ptr<Peer>>> peerSessions() const;
+    std::vector<std::pair<std::shared_ptr<SessionFace>, std::shared_ptr<Peer>>> peerSessions(u256 const& _version) const;
+
+    virtual std::string name() const = 0;
+    virtual u256 version() const = 0;
 
 protected:
-	virtual std::string name() const = 0;
-	virtual u256 version() const = 0;
-	CapDesc capDesc() const { return std::make_pair(name(), version()); }
-	virtual unsigned messageCount() const = 0;
-	virtual std::shared_ptr<Capability> newPeerCapability(std::shared_ptr<SessionFace> const& _s, unsigned _idOffset, CapDesc const& _cap) = 0;
+    CapDesc capDesc() const { return std::make_pair(name(), version()); }
+    virtual unsigned messageCount() const = 0;
+    virtual std::shared_ptr<Capability> newPeerCapability(std::shared_ptr<SessionFace> const& _s, unsigned _idOffset, CapDesc const& _cap) = 0;
 
-	virtual void onStarting() {}
-	virtual void onStopping() {}
+    virtual void onStarting() {}
+    virtual void onStopping() {}
 
 private:
-	Host* m_host = nullptr;
+    Host* m_host = nullptr;
 };
 
 template<class PeerCap>
 class HostCapability: public HostCapabilityFace
 {
 public:
-	HostCapability() {}
-	virtual ~HostCapability() {}
+    HostCapability() {}
+    virtual ~HostCapability() {}
 
-	static std::string staticName() { return PeerCap::name(); }
-	static u256 staticVersion() { return PeerCap::version(); }
-	static unsigned staticMessageCount() { return PeerCap::messageCount(); }
+    std::string name() const override { return PeerCap::name(); }
+    u256 version() const override { return PeerCap::version(); }
 
 protected:
-	virtual std::string name() const { return PeerCap::name(); }
-	virtual u256 version() const { return PeerCap::version(); }
-	virtual unsigned messageCount() const { return PeerCap::messageCount(); }
+    unsigned messageCount() const override { return PeerCap::messageCount(); }
 
-	virtual std::shared_ptr<Capability> newPeerCapability(std::shared_ptr<SessionFace> const& _s, unsigned _idOffset, CapDesc const& _cap)
-	{
-		auto p = std::make_shared<PeerCap>(_s, this, _idOffset, _cap);
-		_s->registerCapability(_cap, p);
-		return p;
-	}
+    std::shared_ptr<Capability> newPeerCapability(
+        std::shared_ptr<SessionFace> const& _s, unsigned _idOffset, CapDesc const& _cap) override
+    {
+        auto p = std::make_shared<PeerCap>(_s, this, _idOffset, _cap);
+        _s->registerCapability(_cap, p);
+        return p;
+    }
 };
 
 }

--- a/test/unittests/libp2p/capability.cpp
+++ b/test/unittests/libp2p/capability.cpp
@@ -109,8 +109,10 @@ BOOST_AUTO_TEST_CASE(capability)
     NetworkPreferences prefs2(localhost, 0, false);
     Host host1("Test", prefs1);
     Host host2("Test", prefs2);
-    auto thc1 = host1.registerCapability(make_shared<TestHostCapability>());
-    auto thc2 = host2.registerCapability(make_shared<TestHostCapability>());
+    auto thc1 = make_shared<TestHostCapability>();
+    host1.registerCapability(thc1);
+    auto thc2 = make_shared<TestHostCapability>();
+    host2.registerCapability(thc2);
     host1.start();	
     host2.start();
     auto port1 = host1.listenPort();


### PR DESCRIPTION
1. I plan some refactoring of at least `p2p::Host` to hide it behind abstract interface, to make libp2p better isolated. This is the first step, making it's interface simpler by getting rid of template methods.

2. Get rid of support for speaking to `eth` protocol versions earlier than 63. I can see only v63 peers in the network now.