### PR TITLE
make test_mineBlocks synchronous

### DIFF
--- a/libethereum/ClientTest.h
+++ b/libethereum/ClientTest.h
@@ -45,7 +45,7 @@ public:
     ~ClientTest();
 
     void setChainParams(std::string const& _genesis);
-    bool mineBlocks(unsigned _count);
+    bool mineBlocks(unsigned _count) noexcept;
     void modifyTimestamp(int64_t _timestamp);
     void rewindToBlock(unsigned _number);
     h256 importRawBlock(std::string const& _blockRLP);

--- a/libethereum/ClientTest.h
+++ b/libethereum/ClientTest.h
@@ -45,15 +45,14 @@ public:
     ~ClientTest();
 
     void setChainParams(std::string const& _genesis);
-    void mineBlocks(unsigned _count);
+    bool mineBlocks(unsigned _count);
     void modifyTimestamp(int64_t _timestamp);
     void rewindToBlock(unsigned _number);
     h256 importRawBlock(std::string const& _blockRLP);
     bool completeSync();
 
 protected:
-    unsigned m_blocksToMine;
-    virtual void onNewBlocks(h256s const& _blocks, h256Hash& io_changed) override;
+    unsigned const m_singleBlockMaxMiningTimeInSeconds = 5;
 };
 
 ClientTest& asClientTest(Interface& _c);

--- a/libweb3jsonrpc/Test.cpp
+++ b/libweb3jsonrpc/Test.cpp
@@ -101,14 +101,13 @@ bool Test::test_mineBlocks(int _number)
 {
     try
     {
-        asClientTest(m_eth).mineBlocks(_number);
+        return asClientTest(m_eth).mineBlocks(_number);  // Synchronous
     }
-    catch (std::exception const&)
+    catch (std::exception const& ex)
     {
-        BOOST_THROW_EXCEPTION(JsonRpcException(Errors::ERROR_RPC_INTERNAL_ERROR));
+        cwarn << ex.what();
+        throw JsonRpcException(Errors::ERROR_RPC_INTERNAL_ERROR, ex.what());
     }
-
-    return true;
 }
 
 bool Test::test_modifyTimestamp(int _timestamp)

--- a/libweb3jsonrpc/Test.cpp
+++ b/libweb3jsonrpc/Test.cpp
@@ -99,15 +99,9 @@ bool Test::test_setChainParams(Json::Value const& param1)
 
 bool Test::test_mineBlocks(int _number)
 {
-    try
-    {
-        return asClientTest(m_eth).mineBlocks(_number);  // Synchronous
-    }
-    catch (std::exception const& ex)
-    {
-        cwarn << ex.what();
-        throw JsonRpcException(Errors::ERROR_RPC_INTERNAL_ERROR, ex.what());
-    }
+    if (!asClientTest(m_eth).mineBlocks(_number))  // Synchronous
+        throw JsonRpcException("Mining failed.");
+    return true;
 }
 
 bool Test::test_modifyTimestamp(int _timestamp)


### PR DESCRIPTION
wait for blocks to be successfully imported in the test mode. 
so no need to call for a block number in order to get the information that the blocks were mined