### PR TITLE
README: Fix the URL for opening new issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![GitHub Issues](https://img.shields.io/github/issues-raw/ethereum/cpp-ethereum.svg)](https://github.com/ethereum/cpp-ethereum/issues)
 
 - Chat in [cpp-ethereum channel on Gitter](https://gitter.im/ethereum/cpp-ethereum).
-- Report bugs, issues or feature requests using [GitHub issues](issues/new).
+- Report bugs, issues or feature requests using [GitHub issues](https://github.com/ethereum/cpp-ethereum/issues/new).
 
 
 ## Getting Started


### PR DESCRIPTION
When making url issues/new, address a wrong url(https://github.com/ethereum/cpp-ethereum/blob/develop/issues/new).
So fix the url with https://github.com/ethereum/cpp-ethereum/issues/new.

-- Report bugs, issues or feature requests using [GitHub issues](issues/new).
+- Report bugs, issues or feature requests using [GitHub issues](https://github.com/ethereum/cpp-ethereum/issues/new).