### PR TITLE
Renamed NetworkPreferences to NetworkConfig

### DIFF
--- a/aleth/main.cpp
+++ b/aleth/main.cpp
@@ -839,7 +839,7 @@ int main(int argc, char** argv)
         return getPassword("Enter password for address " + keyManager.accountName(a) + " (" + a.abridged() + "; hint:" + keyManager.passwordHint(a) + "): ");
     };
 
-    auto netPrefs = publicIP.empty() ? NetworkPreferences(listenIP, listenPort, upnp) : NetworkPreferences(publicIP, listenIP ,listenPort, upnp);
+    auto netPrefs = publicIP.empty() ? NetworkConfig(listenIP, listenPort, upnp) : NetworkConfig(publicIP, listenIP ,listenPort, upnp);
     netPrefs.discovery = (privateChain.empty() && !disableDiscovery) || enableDiscovery;
     netPrefs.pin = vm.count("pin") != 0;
 

--- a/libp2p/Host.cpp
+++ b/libp2p/Host.cpp
@@ -98,7 +98,7 @@ bytes ReputationManager::data(SessionFace const& _s, std::string const& _sub) co
     return bytes();
 }
 
-Host::Host(string const& _clientVersion, KeyPair const& _alias, NetworkPreferences const& _n):
+Host::Host(string const& _clientVersion, KeyPair const& _alias, NetworkConfig const& _n):
     Worker("p2p", 0),
     m_clientVersion(_clientVersion),
     m_netPrefs(_n),
@@ -111,7 +111,7 @@ Host::Host(string const& _clientVersion, KeyPair const& _alias, NetworkPreferenc
     cnetnote << "Id: " << id();
 }
 
-Host::Host(string const& _clientVersion, NetworkPreferences const& _n, bytesConstRef _restoreNetwork):
+Host::Host(string const& _clientVersion, NetworkConfig const& _n, bytesConstRef _restoreNetwork):
     Host(_clientVersion, networkAlias(_restoreNetwork), _n)
 {
     m_restoreNetwork = _restoreNetwork.toBytes();

--- a/libp2p/Host.cpp
+++ b/libp2p/Host.cpp
@@ -101,7 +101,7 @@ bytes ReputationManager::data(SessionFace const& _s, std::string const& _sub) co
 Host::Host(string const& _clientVersion, KeyPair const& _alias, NetworkConfig const& _n):
     Worker("p2p", 0),
     m_clientVersion(_clientVersion),
-    m_netPrefs(_n),
+    m_netConfig(_n),
     m_ifAddresses(Network::getInterfaceAddresses()),
     m_ioService(2),
     m_tcp4Acceptor(m_ioService),
@@ -297,7 +297,7 @@ void Host::startPeerSession(Public const& _id, RLP const& _rlp, unique_ptr<RLPXF
         return;
     }
 
-    if (m_netPrefs.pin && !isRequiredPeer(_id))
+    if (m_netConfig.pin && !isRequiredPeer(_id))
     {
         cdebug << "Unexpected identity from peer (got" << _id << ", must be one of " << m_requiredPeers << ")";
         ps->disconnect(UnexpectedIdentity);
@@ -384,26 +384,26 @@ void Host::determinePublic()
     // set m_tcpPublic := listenIP (if public) > public > upnp > unspecified address.
     
     auto ifAddresses = Network::getInterfaceAddresses();
-    auto laddr = m_netPrefs.listenIPAddress.empty() ? bi::address() : bi::address::from_string(m_netPrefs.listenIPAddress);
+    auto laddr = m_netConfig.listenIPAddress.empty() ? bi::address() : bi::address::from_string(m_netConfig.listenIPAddress);
     auto lset = !laddr.is_unspecified();
-    auto paddr = m_netPrefs.publicIPAddress.empty() ? bi::address() : bi::address::from_string(m_netPrefs.publicIPAddress);
+    auto paddr = m_netConfig.publicIPAddress.empty() ? bi::address() : bi::address::from_string(m_netConfig.publicIPAddress);
     auto pset = !paddr.is_unspecified();
     
     bool listenIsPublic = lset && isPublicAddress(laddr);
     bool publicIsHost = !lset && pset && ifAddresses.count(paddr);
     
     bi::tcp::endpoint ep(bi::address(), m_listenPort);
-    if (m_netPrefs.traverseNAT && listenIsPublic)
+    if (m_netConfig.traverseNAT && listenIsPublic)
     {
         cnetnote << "Listen address set to Public address: " << laddr << ". UPnP disabled.";
         ep.address(laddr);
     }
-    else if (m_netPrefs.traverseNAT && publicIsHost)
+    else if (m_netConfig.traverseNAT && publicIsHost)
     {
         cnetnote << "Public address set to Host configured address: " << paddr << ". UPnP disabled.";
         ep.address(paddr);
     }
-    else if (m_netPrefs.traverseNAT)
+    else if (m_netConfig.traverseNAT)
     {
         bi::address natIFAddr;
         ep = Network::traverseNAT(lset && ifAddresses.count(laddr) ? std::set<bi::address>({laddr}) : ifAddresses, m_listenPort, natIFAddr);
@@ -713,7 +713,7 @@ void Host::run(boost::system::error_code const&)
             bool required = p.second->peerType == PeerType::Required;
             if (haveSession && required)
                 reqConn++;
-            else if (!haveSession && p.second->shouldReconnect() && (!m_netPrefs.pin || required))
+            else if (!haveSession && p.second->shouldReconnect() && (!m_netConfig.pin || required))
                 toConnect.push_back(p.second);
         }
     }
@@ -722,7 +722,7 @@ void Host::run(boost::system::error_code const&)
         if (p->peerType == PeerType::Required && reqConn++ < m_idealPeerCount)
             connect(p);
     
-    if (!m_netPrefs.pin)
+    if (!m_netConfig.pin)
     {
         unsigned const maxSlots = m_idealPeerCount + reqConn;
         unsigned occupiedSlots = peerCount() + m_pendingPeerConns.size();
@@ -761,7 +761,7 @@ void Host::startedWorking()
         h.second->onStarting();
     
     // try to open acceptor (todo: ipv6)
-    int port = Network::tcp4Listen(m_tcp4Acceptor, m_netPrefs);
+    int port = Network::tcp4Listen(m_tcp4Acceptor, m_netConfig);
     if (port > 0)
     {
         m_listenPort = port;
@@ -775,7 +775,7 @@ void Host::startedWorking()
         m_ioService,
         m_alias,
         NodeIPEndpoint(bi::address::from_string(listenAddress()), listenPort(), listenPort()),
-        m_netPrefs.discovery
+        m_netConfig.discovery
     );
     nodeTable->setEventHandler(new HostNodeTableHandler(*this));
     DEV_GUARDED(x_nodeTable)

--- a/libp2p/Host.h
+++ b/libp2p/Host.h
@@ -136,7 +136,7 @@ public:
     /// Start server, listening for connections on the given port.
     Host(
         std::string const& _clientVersion,
-        NetworkPreferences const& _n = NetworkPreferences(),
+        NetworkConfig const& _n = NetworkConfig(),
         bytesConstRef _restoreNetwork = bytesConstRef()
     );
 
@@ -145,7 +145,7 @@ public:
     Host(
         std::string const& _clientVersion,
         KeyPair const& _alias,
-        NetworkPreferences const& _n = NetworkPreferences()
+        NetworkConfig const& _n = NetworkConfig()
     );
 
     /// Will block on network process events.
@@ -205,9 +205,9 @@ public:
     // TODO: P2P this should be combined with peers into a HostStat object of some kind; coalesce data, as it's only used for status information.
     Peers getPeers() const { RecursiveGuard l(x_sessions); Peers ret; for (auto const& i: m_peers) ret.push_back(*i.second); return ret; }
 
-    NetworkPreferences const& networkPreferences() const { return m_netPrefs; }
+    NetworkConfig const& networkConfig() const { return m_netPrefs; }
 
-    void setNetworkPreferences(NetworkPreferences const& _p, bool _dropPeers = false) { m_dropPeers = _dropPeers; auto had = isStarted(); if (had) stop(); m_netPrefs = _p; if (had) start(); }
+    void setNetworkConfig(NetworkConfig const& _p, bool _dropPeers = false) { m_dropPeers = _dropPeers; auto had = isStarted(); if (had) stop(); m_netPrefs = _p; if (had) start(); }
 
     /// Start network. @threadsafe
     void start();
@@ -242,10 +242,10 @@ public:
     bi::tcp::endpoint const& tcpPublic() const { return m_tcpPublic; }
 
     /// Get the public endpoint information.
-    std::string enode() const { return "enode://" + id().hex() + "@" + (networkPreferences().publicIPAddress.empty() ? m_tcpPublic.address().to_string() : networkPreferences().publicIPAddress) + ":" + toString(m_tcpPublic.port()); }
+    std::string enode() const { return "enode://" + id().hex() + "@" + (networkConfig().publicIPAddress.empty() ? m_tcpPublic.address().to_string() : networkConfig().publicIPAddress) + ":" + toString(m_tcpPublic.port()); }
 
     /// Get the node information.
-    p2p::NodeInfo nodeInfo() const { return NodeInfo(id(), (networkPreferences().publicIPAddress.empty() ? m_tcpPublic.address().to_string() : networkPreferences().publicIPAddress), m_tcpPublic.port(), m_clientVersion); }
+    p2p::NodeInfo nodeInfo() const { return NodeInfo(id(), (networkConfig().publicIPAddress.empty() ? m_tcpPublic.address().to_string() : networkConfig().publicIPAddress), m_tcpPublic.port(), m_clientVersion); }
 
     /// Get sessions by capability name and version
     std::vector<std::pair<std::shared_ptr<SessionFace>, std::shared_ptr<Peer>>> peerSessions(
@@ -308,7 +308,7 @@ private:
 
     std::string m_clientVersion;											///< Our version string.
 
-    NetworkPreferences m_netPrefs;										///< Network settings.
+    NetworkConfig m_netPrefs;										        ///< Network settings.
 
     /// Interface addresses (private, public)
     std::set<bi::address> m_ifAddresses;								///< Interface addresses.

--- a/libp2p/Host.h
+++ b/libp2p/Host.h
@@ -136,7 +136,7 @@ public:
     /// Start server, listening for connections on the given port.
     Host(
         std::string const& _clientVersion,
-        NetworkConfig const& _n = NetworkConfig(),
+        NetworkConfig const& _n = {},
         bytesConstRef _restoreNetwork = bytesConstRef()
     );
 
@@ -145,7 +145,7 @@ public:
     Host(
         std::string const& _clientVersion,
         KeyPair const& _alias,
-        NetworkConfig const& _n = NetworkConfig()
+        NetworkConfig const& _n = {}
     );
 
     /// Will block on network process events.
@@ -205,9 +205,9 @@ public:
     // TODO: P2P this should be combined with peers into a HostStat object of some kind; coalesce data, as it's only used for status information.
     Peers getPeers() const { RecursiveGuard l(x_sessions); Peers ret; for (auto const& i: m_peers) ret.push_back(*i.second); return ret; }
 
-    NetworkConfig const& networkConfig() const { return m_netPrefs; }
+    NetworkConfig const& networkConfig() const { return m_netConfig; }
 
-    void setNetworkConfig(NetworkConfig const& _p, bool _dropPeers = false) { m_dropPeers = _dropPeers; auto had = isStarted(); if (had) stop(); m_netPrefs = _p; if (had) start(); }
+    void setNetworkConfig(NetworkConfig const& _p, bool _dropPeers = false) { m_dropPeers = _dropPeers; auto had = isStarted(); if (had) stop(); m_netConfig = _p; if (had) start(); }
 
     /// Start network. @threadsafe
     void start();
@@ -308,7 +308,7 @@ private:
 
     std::string m_clientVersion;											///< Our version string.
 
-    NetworkConfig m_netPrefs;										        ///< Network settings.
+    NetworkConfig m_netConfig;										        ///< Network settings.
 
     /// Interface addresses (private, public)
     std::set<bi::address> m_ifAddresses;								///< Interface addresses.

--- a/libp2p/Host.h
+++ b/libp2p/Host.h
@@ -136,7 +136,7 @@ public:
     /// Start server, listening for connections on the given port.
     Host(
         std::string const& _clientVersion,
-        NetworkConfig const& _n = {},
+        NetworkConfig const& _n = NetworkConfig{},
         bytesConstRef _restoreNetwork = bytesConstRef()
     );
 
@@ -145,7 +145,7 @@ public:
     Host(
         std::string const& _clientVersion,
         KeyPair const& _alias,
-        NetworkConfig const& _n = {}
+        NetworkConfig const& _n = NetworkConfig{}
     );
 
     /// Will block on network process events.

--- a/libp2p/Network.cpp
+++ b/libp2p/Network.cpp
@@ -116,7 +116,7 @@ std::set<bi::address> Network::getInterfaceAddresses()
     return addresses;
 }
 
-int Network::tcp4Listen(bi::tcp::acceptor& _acceptor, NetworkConfig const& _netPrefs)
+int Network::tcp4Listen(bi::tcp::acceptor& _acceptor, NetworkConfig const& _config)
 {
     // Due to the complexities of NAT and network environments (multiple NICs, tunnels, etc)
     // and security concerns automation is the enemy of network configuration.
@@ -129,18 +129,18 @@ int Network::tcp4Listen(bi::tcp::acceptor& _acceptor, NetworkConfig const& _netP
     bi::address listenIP;
     try
     {
-        listenIP = _netPrefs.listenIPAddress.empty() ? bi::address_v4() : bi::address::from_string(_netPrefs.listenIPAddress);
+        listenIP = _config.listenIPAddress.empty() ? bi::address_v4() : bi::address::from_string(_config.listenIPAddress);
     }
     catch (...)
     {
-        cwarn << "Couldn't start accepting connections on host. Failed to accept socket on " << listenIP << ":" << _netPrefs.listenPort << ".\n" << boost::current_exception_diagnostic_information();
+        cwarn << "Couldn't start accepting connections on host. Failed to accept socket on " << listenIP << ":" << _config.listenPort << ".\n" << boost::current_exception_diagnostic_information();
         return -1;
     }
-    bool requirePort = (bool)_netPrefs.listenPort;
+    bool requirePort = (bool)_config.listenPort;
 
     for (unsigned i = 0; i < 2; ++i)
     {
-        bi::tcp::endpoint endpoint(listenIP, requirePort ? _netPrefs.listenPort : (i ? 0 : c_defaultListenPort));
+        bi::tcp::endpoint endpoint(listenIP, requirePort ? _config.listenPort : (i ? 0 : c_defaultListenPort));
         try
         {
 #if defined(_WIN32)
@@ -160,7 +160,7 @@ int Network::tcp4Listen(bi::tcp::acceptor& _acceptor, NetworkConfig const& _netP
             if (i || requirePort)
             {
                 // both attempts failed
-                cwarn << "Couldn't start accepting connections on host. Failed to accept socket on " << listenIP << ":" << _netPrefs.listenPort << ".\n" << boost::current_exception_diagnostic_information();
+                cwarn << "Couldn't start accepting connections on host. Failed to accept socket on " << listenIP << ":" << _config.listenPort << ".\n" << boost::current_exception_diagnostic_information();
                 _acceptor.close();
                 return -1;
             }

--- a/libp2p/Network.cpp
+++ b/libp2p/Network.cpp
@@ -116,7 +116,7 @@ std::set<bi::address> Network::getInterfaceAddresses()
     return addresses;
 }
 
-int Network::tcp4Listen(bi::tcp::acceptor& _acceptor, NetworkPreferences const& _netPrefs)
+int Network::tcp4Listen(bi::tcp::acceptor& _acceptor, NetworkConfig const& _netPrefs)
 {
     // Due to the complexities of NAT and network environments (multiple NICs, tunnels, etc)
     // and security concerns automation is the enemy of network configuration.
@@ -124,7 +124,7 @@ int Network::tcp4Listen(bi::tcp::acceptor& _acceptor, NetworkPreferences const& 
     //
     // Preferred IP: Attempt if set, else, try 0.0.0.0 (all interfaces)
     // Preferred Port: Attempt if set, else, try c_defaultListenPort or 0 (random)
-    // TODO: throw instead of returning -1 and rename NetworkPreferences to NetworkConfig
+    // TODO: throw instead of returning -1 
     
     bi::address listenIP;
     try

--- a/libp2p/Network.h
+++ b/libp2p/Network.h
@@ -42,7 +42,7 @@ static const unsigned short c_defaultListenPort = 30303;
 struct NetworkConfig
 {
 	// Default Network Preferences
-	NetworkConfig(unsigned short lp = c_defaultListenPort): listenPort(lp) {}
+	explicit NetworkConfig(unsigned short lp = c_defaultListenPort): listenPort(lp) {}
 
 	// Network Preferences with specific Listen IP
 	NetworkConfig(std::string const& l, unsigned short lp = c_defaultListenPort, bool u = true): publicIPAddress(), listenIPAddress(l), listenPort(lp), traverseNAT(u) {}
@@ -75,7 +75,7 @@ public:
 	static std::set<bi::address> getInterfaceAddresses();
 
 	/// Try to bind and listen on _listenPort, else attempt net-allocated port.
-	static int tcp4Listen(bi::tcp::acceptor& _acceptor, NetworkConfig const& _netPrefs);
+	static int tcp4Listen(bi::tcp::acceptor& _acceptor, NetworkConfig const& _config);
 
 	/// Return public endpoint of upnp interface. If successful o_upnpifaddr will be a private interface address and endpoint will contain public address and port.
 	static bi::tcp::endpoint traverseNAT(std::set<bi::address> const& _ifAddresses, unsigned short _listenPort, bi::address& o_upnpInterfaceAddr);

--- a/libp2p/Network.h
+++ b/libp2p/Network.h
@@ -39,16 +39,16 @@ namespace p2p
 
 static const unsigned short c_defaultListenPort = 30303;
 
-struct NetworkPreferences
+struct NetworkConfig
 {
 	// Default Network Preferences
-	NetworkPreferences(unsigned short lp = c_defaultListenPort): listenPort(lp) {}
+	NetworkConfig(unsigned short lp = c_defaultListenPort): listenPort(lp) {}
 
 	// Network Preferences with specific Listen IP
-	NetworkPreferences(std::string const& l, unsigned short lp = c_defaultListenPort, bool u = true): publicIPAddress(), listenIPAddress(l), listenPort(lp), traverseNAT(u) {}
+	NetworkConfig(std::string const& l, unsigned short lp = c_defaultListenPort, bool u = true): publicIPAddress(), listenIPAddress(l), listenPort(lp), traverseNAT(u) {}
 
 	// Network Preferences with intended Public IP
-	NetworkPreferences(std::string const& publicIP, std::string const& l = std::string(), unsigned short lp = c_defaultListenPort, bool u = true): publicIPAddress(publicIP), listenIPAddress(l), listenPort(lp), traverseNAT(u) { if (!publicIPAddress.empty() && !isPublicAddress(publicIPAddress)) BOOST_THROW_EXCEPTION(InvalidPublicIPAddress()); }
+	NetworkConfig(std::string const& publicIP, std::string const& l = std::string(), unsigned short lp = c_defaultListenPort, bool u = true): publicIPAddress(publicIP), listenIPAddress(l), listenPort(lp), traverseNAT(u) { if (!publicIPAddress.empty() && !isPublicAddress(publicIPAddress)) BOOST_THROW_EXCEPTION(InvalidPublicIPAddress()); }
 
 	/// Addressing
 
@@ -75,7 +75,7 @@ public:
 	static std::set<bi::address> getInterfaceAddresses();
 
 	/// Try to bind and listen on _listenPort, else attempt net-allocated port.
-	static int tcp4Listen(bi::tcp::acceptor& _acceptor, NetworkPreferences const& _netPrefs);
+	static int tcp4Listen(bi::tcp::acceptor& _acceptor, NetworkConfig const& _netPrefs);
 
 	/// Return public endpoint of upnp interface. If successful o_upnpifaddr will be a private interface address and endpoint will contain public address and port.
 	static bi::tcp::endpoint traverseNAT(std::set<bi::address> const& _ifAddresses, unsigned short _listenPort, bi::address& o_upnpInterfaceAddr);

--- a/libwebthree/WebThree.cpp
+++ b/libwebthree/WebThree.cpp
@@ -39,7 +39,7 @@ static_assert(BOOST_VERSION >= 106400, "Wrong boost headers version");
 WebThreeDirect::WebThreeDirect(std::string const& _clientVersion,
     boost::filesystem::path const& _dbPath, boost::filesystem::path const& _snapshotPath,
     eth::ChainParams const& _params, WithExisting _we, std::set<std::string> const& _interfaces,
-    NetworkPreferences const& _n, bytesConstRef _network, bool _testing)
+    NetworkConfig const& _n, bytesConstRef _network, bool _testing)
   : m_clientVersion(_clientVersion), m_net(_clientVersion, _n, _network)
 {
     if (_dbPath.size())
@@ -96,17 +96,17 @@ std::string WebThreeDirect::composeClientVersion(std::string const& _client)
            buildinfo->compiler_id + buildinfo->compiler_version + "/" + buildinfo->build_type;
 }
 
-p2p::NetworkPreferences const& WebThreeDirect::networkPreferences() const
+p2p::NetworkConfig const& WebThreeDirect::networkConfig() const
 {
-    return m_net.networkPreferences();
+    return m_net.networkConfig();
 }
 
-void WebThreeDirect::setNetworkPreferences(p2p::NetworkPreferences const& _n, bool _dropPeers)
+void WebThreeDirect::setNetworkConfig(p2p::NetworkConfig const& _n, bool _dropPeers)
 {
     auto had = isNetworkStarted();
     if (had)
         stopNetwork();
-    m_net.setNetworkPreferences(_n, _dropPeers);
+    m_net.setNetworkConfig(_n, _dropPeers);
     if (had)
         startNetwork();
 }

--- a/libwebthree/WebThree.h
+++ b/libwebthree/WebThree.h
@@ -124,7 +124,7 @@ public:
         boost::filesystem::path const& _snapshotPath, eth::ChainParams const& _params,
         WithExisting _we = WithExisting::Trust,
         std::set<std::string> const& _interfaces = {"eth", "shh", "bzz"},
-        p2p::NetworkConfig const& _n = {},
+        p2p::NetworkConfig const& _n = p2p::NetworkConfig{},
         bytesConstRef _network = bytesConstRef(), bool _testing = false);
 
     /// Destructor.

--- a/libwebthree/WebThree.h
+++ b/libwebthree/WebThree.h
@@ -80,8 +80,8 @@ public:
 
     virtual bool haveNetwork() const = 0;
 
-    virtual p2p::NetworkPreferences const& networkPreferences() const = 0;
-    virtual void setNetworkPreferences(p2p::NetworkPreferences const& _n, bool _dropPeers) = 0;
+    virtual p2p::NetworkConfig const& networkConfig() const = 0;
+    virtual void setNetworkConfig(p2p::NetworkConfig const& _n, bool _dropPeers) = 0;
 
     virtual p2p::NodeID id() const = 0;
 
@@ -124,7 +124,7 @@ public:
         boost::filesystem::path const& _snapshotPath, eth::ChainParams const& _params,
         WithExisting _we = WithExisting::Trust,
         std::set<std::string> const& _interfaces = {"eth", "shh", "bzz"},
-        p2p::NetworkPreferences const& _n = p2p::NetworkPreferences(),
+        p2p::NetworkConfig const& _n = p2p::NetworkConfig(),
         bytesConstRef _network = bytesConstRef(), bool _testing = false);
 
     /// Destructor.
@@ -184,9 +184,9 @@ public:
     
     bool haveNetwork() const override { return m_net.haveNetwork(); }
 
-    p2p::NetworkPreferences const& networkPreferences() const override;
+    p2p::NetworkConfig const& networkConfig() const override;
 
-    void setNetworkPreferences(p2p::NetworkPreferences const& _n, bool _dropPeers = false) override;
+    void setNetworkConfig(p2p::NetworkConfig const& _n, bool _dropPeers = false) override;
 
     p2p::NodeInfo nodeInfo() const override { return m_net.nodeInfo(); }
 

--- a/libwebthree/WebThree.h
+++ b/libwebthree/WebThree.h
@@ -124,7 +124,7 @@ public:
         boost::filesystem::path const& _snapshotPath, eth::ChainParams const& _params,
         WithExisting _we = WithExisting::Trust,
         std::set<std::string> const& _interfaces = {"eth", "shh", "bzz"},
-        p2p::NetworkConfig const& _n = p2p::NetworkConfig(),
+        p2p::NetworkConfig const& _n = {},
         bytesConstRef _network = bytesConstRef(), bool _testing = false);
 
     /// Destructor.

--- a/test/unittests/libethereum/ClientTest.cpp
+++ b/test/unittests/libethereum/ClientTest.cpp
@@ -44,7 +44,7 @@ public:
 
         string listenIP = "127.0.0.1";
         unsigned short listenPort = 30303;
-        auto netPrefs = NetworkPreferences(listenIP, listenPort, false);
+        auto netPrefs = NetworkConfig(listenIP, listenPort, false);
         netPrefs.discovery = false;
         netPrefs.pin = false;
 

--- a/test/unittests/libp2p/capability.cpp
+++ b/test/unittests/libp2p/capability.cpp
@@ -107,8 +107,8 @@ BOOST_AUTO_TEST_CASE(capability)
 
     int const step = 10;
     const char* const localhost = "127.0.0.1";
-    NetworkPreferences prefs1(localhost, 0, false);
-    NetworkPreferences prefs2(localhost, 0, false);
+    NetworkConfig prefs1(localhost, 0, false);
+    NetworkConfig prefs2(localhost, 0, false);
     Host host1("Test", prefs1);
     Host host2("Test", prefs2);
     auto thc1 = make_shared<TestHostCapability>(host1);

--- a/test/unittests/libp2p/peer.cpp
+++ b/test/unittests/libp2p/peer.cpp
@@ -65,12 +65,12 @@ BOOST_FIXTURE_TEST_SUITE(p2p, P2PPeerFixture)
 
 BOOST_AUTO_TEST_CASE(host)
 {
-    Host host1("Test", NetworkPreferences("127.0.0.1", 0, false));
+    Host host1("Test", NetworkConfig("127.0.0.1", 0, false));
     host1.start();
     auto host1port = host1.listenPort();
     BOOST_REQUIRE(host1port);
 
-    Host host2("Test", NetworkPreferences("127.0.0.1", 0, false));
+    Host host2("Test", NetworkConfig("127.0.0.1", 0, false));
     host2.start();
     auto host2port = host2.listenPort();
     BOOST_REQUIRE(host2port);
@@ -121,10 +121,10 @@ BOOST_AUTO_TEST_CASE(host)
 
 BOOST_AUTO_TEST_CASE(networkConfig)
 {
-    Host save("Test", NetworkPreferences(false));
+    Host save("Test", NetworkConfig(false));
     bytes store(save.saveNetwork());
     
-    Host restore("Test", NetworkPreferences(false), bytesConstRef(&store));
+    Host restore("Test", NetworkConfig(false), bytesConstRef(&store));
     BOOST_REQUIRE(save.id() == restore.id());
 }
 
@@ -138,7 +138,7 @@ BOOST_AUTO_TEST_CASE(saveNodes)
 
     for (unsigned i = 0; i < c_nodes; ++i)
     {
-        Host* h = new Host("Test", NetworkPreferences("127.0.0.1", 0, false));
+        Host* h = new Host("Test", NetworkConfig("127.0.0.1", 0, false));
         h->setIdealPeerCount(10);		
         h->start(); // starting host is required so listenport is available
         while (!h->haveNetwork())
@@ -196,8 +196,8 @@ BOOST_AUTO_TEST_CASE(requirePeer)
 {
     unsigned const step = 10;
     const char* const localhost = "127.0.0.1";
-    NetworkPreferences prefs1(localhost, 0, false);
-    NetworkPreferences prefs2(localhost, 0, false);
+    NetworkConfig prefs1(localhost, 0, false);
+    NetworkConfig prefs2(localhost, 0, false);
     Host host1("Test", prefs1);
     Host host2("Test", prefs2);
     host1.start();
@@ -308,7 +308,7 @@ int peerTest(int argc, char** argv)
             remoteHost = argv[i];
     }
 
-    Host ph("Test", NetworkPreferences(listenPort));
+    Host ph("Test", NetworkConfig(listenPort));
 
     if (!remoteHost.empty() && !remoteAlias)
         ph.addNode(remoteAlias, NodeIPEndpoint(bi::address::from_string(remoteHost), remotePort, remotePort));

--- a/test/unittests/libweb3jsonrpc/Client.cpp
+++ b/test/unittests/libweb3jsonrpc/Client.cpp
@@ -67,7 +67,7 @@ BOOST_AUTO_TEST_CASE(Personal)
     chainParams.gasLimit = chainParams.maxGasLimit;
     
     dev::WebThreeDirect web3(WebThreeDirect::composeClientVersion("eth"), getDataDir(), string(),
-        chainParams, WithExisting::Kill, set<string>{"eth"}, p2p::NetworkPreferences(0));
+        chainParams, WithExisting::Kill, set<string>{"eth"}, p2p::NetworkConfig(0));
     web3.stopNetwork();
     web3.ethereum()->stopSealing();
     

--- a/test/unittests/libweb3jsonrpc/jsonrpc.cpp
+++ b/test/unittests/libweb3jsonrpc/jsonrpc.cpp
@@ -120,7 +120,7 @@ struct JsonRpcFixture : public TestOutputHelperFixture
 {
     JsonRpcFixture()
     {
-        dev::p2p::NetworkPreferences nprefs;
+        dev::p2p::NetworkConfig nprefs;
         ChainParams chainParams;
         chainParams.sealEngineName = NoProof::name();
         chainParams.allowFutureBlocks = true;


### PR DESCRIPTION
I have renamed a NetworkPreferences to NetworkConfig which was listed in a TODO in `libp2p/Network.cpp`