### PR TITLE
testeth: do not output names section with binaryen for wast2wasm

### DIFF
--- a/test/tools/libtesteth/wast2wasm.cpp
+++ b/test/tools/libtesteth/wast2wasm.cpp
@@ -42,6 +42,7 @@ string wast2wasm(string const& input, bool debug)
 
     wasm::BufferWithRandomAccess buffer(debug);
     wasm::WasmBinaryWriter writer(&module, buffer, debug);
+    writer.setNamesSection(false);
     writer.write();
 
     ostringstream output;


### PR DESCRIPTION
Fixes #5075.