### PR TITLE
fix filler hash check

### DIFF
--- a/test/tools/libtesteth/TestSuite.cpp
+++ b/test/tools/libtesteth/TestSuite.cpp
@@ -82,10 +82,15 @@ void addClientInfo(json_spirit::mValue& _v, fs::path const& _testSource, h256 co
 void checkFillerHash(fs::path const& _compiledTest, fs::path const& _sourceTest)
 {
 	json_spirit::mValue v;
-	string const s = asString(dev::contents(_compiledTest));
+	string s = asString(dev::contents(_compiledTest));
 	BOOST_REQUIRE_MESSAGE(s.length() > 0, "Contents of " + _compiledTest.string() + " is empty.");
 	json_spirit::read_string(s, v);
-	h256 const fillerHash = sha3(dev::contents(_sourceTest));
+
+	json_spirit::mValue v2;
+	s = asString(dev::contents(_sourceTest));
+	BOOST_REQUIRE_MESSAGE(s.length() > 0, "Contents of " + _sourceTest.string() + " is empty.");
+	json_spirit::read_string(s, v2);
+	h256 const fillerHash = sha3(json_spirit::write_string(v2, true));
 
 	for (auto& i: v.get_obj())
 	{


### PR DESCRIPTION
git might change the file contents depending on the OS (probably line endings)
that leads to wrong test source hash error check in testeth sometimes.

this pr change check to the hash of a json structure rather than the hash of filler.json file.
requrires all tests update. (which is coming anyway with new hardfork. filling Constantinople rule)