### PR TITLE
Expose all collected errors as proper EVMC error codes in aleth-interpreter

### DIFF
--- a/libaleth-interpreter/VM.cpp
+++ b/libaleth-interpreter/VM.cpp
@@ -57,6 +57,26 @@ evmc_result execute(evmc_instance* _instance, evmc_context* _context, evmc_revis
     {
         result.status_code = EVMC_UNDEFINED_INSTRUCTION;
     }
+    catch (dev::eth::OutOfStack const&)
+    {
+        result.status_code = EVMC_STACK_OVERFLOW;
+    }
+    catch (dev::eth::StackUnderflow const&)
+    {
+        result.status_code = EVMC_STACK_UNDERFLOW;
+    }
+    catch (dev::eth::BufferOverrun const&)
+    {
+        result.status_code = EVMC_INVALID_MEMORY_ACCESS;
+    }
+    catch (dev::eth::OutOfGas const&)
+    {
+        result.status_code = EVMC_OUT_OF_GAS;
+    }
+    catch (dev::eth::BadJumpDestination const&)
+    {
+        result.status_code = EVMC_BAD_JUMP_DESTINATION;
+    }
     catch (dev::eth::DisallowedStateChange const&)
     {
         result.status_code = EVMC_STATIC_MODE_VIOLATION;

--- a/libevm/EVMC.cpp
+++ b/libevm/EVMC.cpp
@@ -54,6 +54,7 @@ owning_bytes_ref EVMC::exec(u256& io_gas, ExtVMFace& _ext, const OnOpFunc& _onOp
     case EVMC_FAILURE:
         BOOST_THROW_EXCEPTION(OutOfGas());
 
+    case EVMC_INVALID_INSTRUCTION: // NOTE: this could have its own exception
     case EVMC_UNDEFINED_INSTRUCTION:
         BOOST_THROW_EXCEPTION(BadInstruction());
 
@@ -65,6 +66,9 @@ owning_bytes_ref EVMC::exec(u256& io_gas, ExtVMFace& _ext, const OnOpFunc& _onOp
 
     case EVMC_STACK_UNDERFLOW:
         BOOST_THROW_EXCEPTION(StackUnderflow());
+
+    case EVMC_INVALID_MEMORY_ACCESS:
+        BOOST_THROW_EXCEPTION(BufferOverrun());
 
     case EVMC_STATIC_MODE_VIOLATION:
         BOOST_THROW_EXCEPTION(DisallowedStateChange());


### PR DESCRIPTION
Two error codes which could be added:
- `EVMC_CALL_DEPTH_EXCEEDED`
- `EVMC_INVALID_INSTRUCTION` (on 0xfe)
