### PR TITLE
Include version.json file in docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 /build
 /deps
-/test/jsontests
+/hera
+/test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,6 +149,9 @@ if (TESTS)
 endif()
 
 
+install(FILES ${PROJECT_BINARY_DIR}/aleth/buildinfo.json DESTINATION ${CMAKE_INSTALL_DATADIR}/aleth)
+
+
 if(WIN32)
     set(CPACK_GENERATOR ZIP)
 else()

--- a/scripts/docker/aleth.dockerfile
+++ b/scripts/docker/aleth.dockerfile
@@ -3,6 +3,7 @@
 # Build stage
 FROM alpine:latest as builder
 RUN apk add --no-cache \
+        git \
         cmake \
         g++ \
         make \
@@ -20,5 +21,7 @@ RUN apk add --no-cache \
         libstdc++ \
         leveldb --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing/
 COPY --from=builder /usr/bin/aleth /source/scripts/aleth.py /source/scripts/jsonrpcproxy.py /usr/bin/
+COPY --from=builder /usr/share/aleth/ /usr/share/aleth/
+RUN ln -s /usr/share/aleth/buildinfo.json /version.json
 EXPOSE 8545
 ENTRYPOINT ["/usr/bin/aleth.py"]


### PR DESCRIPTION
- Upgrades EVMC to get the latest Cable which is capable of generating buildinfo.json file.
- Aleth now installs buildinfo.json file to /usr/share/aleth/buildinfo.json.
- In docker image /version.json points to /usr/share/aleth/buildinfo.json.
- This also fixes the lack of git information in the docker build (by installing git).