### PR TITLE
Fix debug_traceTransaction

### DIFF
--- a/aleth-vm/main.cpp
+++ b/aleth-vm/main.cpp
@@ -385,7 +385,7 @@ int main(int argc, char** argv)
         }
     }
     else if (mode == Mode::Trace)
-        cout << st.json(styledJson);
+        cout << (styledJson ? st.styledJson() : st.multilineTrace());
     else if (mode == Mode::OutputOnly)
         cout << toHex(output) << '\n';
     else if (mode == Mode::Test)

--- a/libethereum/Executive.cpp
+++ b/libethereum/Executive.cpp
@@ -163,14 +163,17 @@ void StandardTrace::operator()(uint64_t _steps, uint64_t PC, Instruction inst, b
     m_trace.append(r);
 }
 
-string StandardTrace::json(bool _styled) const
+std::string StandardTrace::styledJson() const
+{
+    return Json::StyledWriter().write(m_trace);
+}
+
+string StandardTrace::multilineTrace() const
 {
     if (m_trace.empty())
         return {};
 
-    if (_styled)
-        return Json::StyledWriter().write(m_trace);
-
+    // Each opcode trace on a separate line
     return std::accumulate(std::next(m_trace.begin()), m_trace.end(),
         Json::FastWriter().write(m_trace[0]),
         [](std::string a, Json::Value b) { return a + Json::FastWriter().write(b); });

--- a/libethereum/Executive.h
+++ b/libethereum/Executive.h
@@ -61,8 +61,9 @@ public:
     void setShowMnemonics() { m_showMnemonics = true; }
     void setOptions(DebugOptions _options) { m_options = _options; }
 
-    std::string json(bool _styled = false) const;
     Json::Value jsonValue() const { return m_trace; }
+    std::string styledJson() const;
+    std::string multilineTrace() const;
 
     OnOpFunc onOp()
     {

--- a/libethereum/Executive.h
+++ b/libethereum/Executive.h
@@ -62,6 +62,7 @@ public:
     void setOptions(DebugOptions _options) { m_options = _options; }
 
     std::string json(bool _styled = false) const;
+    Json::Value jsonValue() const { return m_trace; }
 
     OnOpFunc onOp()
     {

--- a/libweb3jsonrpc/AdminEth.cpp
+++ b/libweb3jsonrpc/AdminEth.cpp
@@ -13,283 +13,283 @@ using namespace dev::rpc;
 using namespace dev::eth;
 
 AdminEth::AdminEth(eth::Client& _eth, eth::TrivialGasPricer& _gp, eth::KeyManager& _keyManager, SessionManager& _sm):
-	m_eth(_eth),
-	m_gp(_gp),
-	m_keyManager(_keyManager),
-	m_sm(_sm)
+    m_eth(_eth),
+    m_gp(_gp),
+    m_keyManager(_keyManager),
+    m_sm(_sm)
 {}
 
 bool AdminEth::admin_eth_setMining(bool _on, string const& _session)
 {
-	RPC_ADMIN;
-	if (_on)
-		m_eth.startSealing();
-	else
-		m_eth.stopSealing();
-	return true;
+    RPC_ADMIN;
+    if (_on)
+        m_eth.startSealing();
+    else
+        m_eth.stopSealing();
+    return true;
 }
 
 Json::Value AdminEth::admin_eth_blockQueueStatus(string const& _session)
 {
-	RPC_ADMIN;
-	Json::Value ret;
-	BlockQueueStatus bqs = m_eth.blockQueue().status();
-	ret["importing"] = (int)bqs.importing;
-	ret["verified"] = (int)bqs.verified;
-	ret["verifying"] = (int)bqs.verifying;
-	ret["unverified"] = (int)bqs.unverified;
-	ret["future"] = (int)bqs.future;
-	ret["unknown"] = (int)bqs.unknown;
-	ret["bad"] = (int)bqs.bad;
-	return ret;
+    RPC_ADMIN;
+    Json::Value ret;
+    BlockQueueStatus bqs = m_eth.blockQueue().status();
+    ret["importing"] = (int)bqs.importing;
+    ret["verified"] = (int)bqs.verified;
+    ret["verifying"] = (int)bqs.verifying;
+    ret["unverified"] = (int)bqs.unverified;
+    ret["future"] = (int)bqs.future;
+    ret["unknown"] = (int)bqs.unknown;
+    ret["bad"] = (int)bqs.bad;
+    return ret;
 }
 
 bool AdminEth::admin_eth_setAskPrice(string const& _wei, string const& _session)
 {
-	RPC_ADMIN;
-	m_gp.setAsk(jsToU256(_wei));
-	return true;
+    RPC_ADMIN;
+    m_gp.setAsk(jsToU256(_wei));
+    return true;
 }
 
 bool AdminEth::admin_eth_setBidPrice(string const& _wei, string const& _session)
 {
-	RPC_ADMIN;
-	m_gp.setBid(jsToU256(_wei));
-	return true;
+    RPC_ADMIN;
+    m_gp.setBid(jsToU256(_wei));
+    return true;
 }
 
 Json::Value AdminEth::admin_eth_findBlock(string const& _blockHash, string const& _session)
 {
-	RPC_ADMIN;
-	h256 h(_blockHash);
-	if (m_eth.blockChain().isKnown(h))
-		return toJson(m_eth.blockChain().info(h));
-	switch(m_eth.blockQueue().blockStatus(h))
-	{
-		case QueueStatus::Ready:
-			return "ready";
-		case QueueStatus::Importing:
-			return "importing";
-		case QueueStatus::UnknownParent:
-			return "unknown parent";
-		case QueueStatus::Bad:
-			return "bad";
-		default:
-			return "unknown";
-	}
+    RPC_ADMIN;
+    h256 h(_blockHash);
+    if (m_eth.blockChain().isKnown(h))
+        return toJson(m_eth.blockChain().info(h));
+    switch(m_eth.blockQueue().blockStatus(h))
+    {
+        case QueueStatus::Ready:
+            return "ready";
+        case QueueStatus::Importing:
+            return "importing";
+        case QueueStatus::UnknownParent:
+            return "unknown parent";
+        case QueueStatus::Bad:
+            return "bad";
+        default:
+            return "unknown";
+    }
 }
 
 string AdminEth::admin_eth_blockQueueFirstUnknown(string const& _session)
 {
-	RPC_ADMIN;
-	return m_eth.blockQueue().firstUnknown().hex();
+    RPC_ADMIN;
+    return m_eth.blockQueue().firstUnknown().hex();
 }
 
 bool AdminEth::admin_eth_blockQueueRetryUnknown(string const& _session)
 {
-	RPC_ADMIN;
-	m_eth.retryUnknown();
-	return true;
+    RPC_ADMIN;
+    m_eth.retryUnknown();
+    return true;
 }
 
 Json::Value AdminEth::admin_eth_allAccounts(string const& _session)
 {
-	RPC_ADMIN;
-	Json::Value ret;
-	u256 total = 0;
-	u256 pendingtotal = 0;
-	Address beneficiary;
-	for (auto const& address: m_keyManager.accounts())
-	{
-		auto pending = m_eth.balanceAt(address, PendingBlock);
-		auto latest = m_eth.balanceAt(address, LatestBlock);
-		Json::Value a;
-		if (address == beneficiary)
-			a["beneficiary"] = true;
-		a["address"] = toJS(address);
-		a["balance"] = toJS(latest);
-		a["nicebalance"] = formatBalance(latest);
-		a["pending"] = toJS(pending);
-		a["nicepending"] = formatBalance(pending);
-		ret["accounts"][m_keyManager.accountName(address)] = a;
-		total += latest;
-		pendingtotal += pending;
-	}
-	ret["total"] = toJS(total);
-	ret["nicetotal"] = formatBalance(total);
-	ret["pendingtotal"] = toJS(pendingtotal);
-	ret["nicependingtotal"] = formatBalance(pendingtotal);
-	return ret;
+    RPC_ADMIN;
+    Json::Value ret;
+    u256 total = 0;
+    u256 pendingtotal = 0;
+    Address beneficiary;
+    for (auto const& address: m_keyManager.accounts())
+    {
+        auto pending = m_eth.balanceAt(address, PendingBlock);
+        auto latest = m_eth.balanceAt(address, LatestBlock);
+        Json::Value a;
+        if (address == beneficiary)
+            a["beneficiary"] = true;
+        a["address"] = toJS(address);
+        a["balance"] = toJS(latest);
+        a["nicebalance"] = formatBalance(latest);
+        a["pending"] = toJS(pending);
+        a["nicepending"] = formatBalance(pending);
+        ret["accounts"][m_keyManager.accountName(address)] = a;
+        total += latest;
+        pendingtotal += pending;
+    }
+    ret["total"] = toJS(total);
+    ret["nicetotal"] = formatBalance(total);
+    ret["pendingtotal"] = toJS(pendingtotal);
+    ret["nicependingtotal"] = formatBalance(pendingtotal);
+    return ret;
 }
 
 Json::Value AdminEth::admin_eth_newAccount(Json::Value const& _info, string const& _session)
 {
-	RPC_ADMIN;
-	if (!_info.isMember("name"))
-		throw jsonrpc::JsonRpcException("No member found: name");
-	string name = _info["name"].asString();
-	KeyPair kp = KeyPair::create();
-	h128 uuid;
-	if (_info.isMember("password"))
-	{
-		string password = _info["password"].asString();
-		string hint = _info["passwordHint"].asString();
-		uuid = m_keyManager.import(kp.secret(), name, password, hint);
-	}
-	else
-		uuid = m_keyManager.import(kp.secret(), name);
-	Json::Value ret;
-	ret["account"] = toJS(kp.pub());
-	ret["uuid"] = toUUID(uuid);
-	return ret;
+    RPC_ADMIN;
+    if (!_info.isMember("name"))
+        throw jsonrpc::JsonRpcException("No member found: name");
+    string name = _info["name"].asString();
+    KeyPair kp = KeyPair::create();
+    h128 uuid;
+    if (_info.isMember("password"))
+    {
+        string password = _info["password"].asString();
+        string hint = _info["passwordHint"].asString();
+        uuid = m_keyManager.import(kp.secret(), name, password, hint);
+    }
+    else
+        uuid = m_keyManager.import(kp.secret(), name);
+    Json::Value ret;
+    ret["account"] = toJS(kp.pub());
+    ret["uuid"] = toUUID(uuid);
+    return ret;
 }
 
 bool AdminEth::admin_eth_setMiningBenefactor(string const& _uuidOrAddress, string const& _session)
 {
-	RPC_ADMIN;
-	return miner_setEtherbase(_uuidOrAddress);
+    RPC_ADMIN;
+    return miner_setEtherbase(_uuidOrAddress);
 }
 
 Json::Value AdminEth::admin_eth_inspect(string const& _address, string const& _session)
 {
-	RPC_ADMIN;
-	if (!isHash<Address>(_address))
-		throw jsonrpc::JsonRpcException("Invalid address given.");
-	
-	Json::Value ret;
-	auto h = Address(fromHex(_address));
-	ret["storage"] = toJson(m_eth.storageAt(h, PendingBlock));
-	ret["balance"] = toJS(m_eth.balanceAt(h, PendingBlock));
-	ret["nonce"] = toJS(m_eth.countAt(h, PendingBlock));
-	ret["code"] = toJS(m_eth.codeAt(h, PendingBlock));
-	return ret;
+    RPC_ADMIN;
+    if (!isHash<Address>(_address))
+        throw jsonrpc::JsonRpcException("Invalid address given.");
+    
+    Json::Value ret;
+    auto h = Address(fromHex(_address));
+    ret["storage"] = toJson(m_eth.storageAt(h, PendingBlock));
+    ret["balance"] = toJS(m_eth.balanceAt(h, PendingBlock));
+    ret["nonce"] = toJS(m_eth.countAt(h, PendingBlock));
+    ret["code"] = toJS(m_eth.codeAt(h, PendingBlock));
+    return ret;
 }
 
 h256 AdminEth::blockHash(string const& _blockNumberOrHash) const
 {
-	if (isHash<h256>(_blockNumberOrHash))
-		return h256(_blockNumberOrHash.substr(_blockNumberOrHash.size() - 64, 64));
-	try
-	{
-		return m_eth.blockChain().numberHash(stoul(_blockNumberOrHash));
-	}
-	catch (...)
-	{
-		throw jsonrpc::JsonRpcException("Invalid argument");
-	}
+    if (isHash<h256>(_blockNumberOrHash))
+        return h256(_blockNumberOrHash.substr(_blockNumberOrHash.size() - 64, 64));
+    try
+    {
+        return m_eth.blockChain().numberHash(stoul(_blockNumberOrHash));
+    }
+    catch (...)
+    {
+        throw jsonrpc::JsonRpcException("Invalid argument");
+    }
 }
 
 Json::Value AdminEth::admin_eth_reprocess(string const& _blockNumberOrHash, string const& _session)
 {
-	RPC_ADMIN;
-	Json::Value ret;
-	PopulationStatistics ps;
-	m_eth.block(blockHash(_blockNumberOrHash), &ps);
-	ret["enact"] = ps.enact;
-	ret["verify"] = ps.verify;
-	ret["total"] = ps.verify + ps.enact;
-	return ret;
+    RPC_ADMIN;
+    Json::Value ret;
+    PopulationStatistics ps;
+    m_eth.block(blockHash(_blockNumberOrHash), &ps);
+    ret["enact"] = ps.enact;
+    ret["verify"] = ps.verify;
+    ret["total"] = ps.verify + ps.enact;
+    return ret;
 }
 
 Json::Value AdminEth::admin_eth_vmTrace(string const& _blockNumberOrHash, int _txIndex, string const& _session)
 {
-	RPC_ADMIN;
-	
-	Json::Value ret;
-	
-	if (_txIndex < 0)
-		throw jsonrpc::JsonRpcException("Negative index");
-	Block block = m_eth.block(blockHash(_blockNumberOrHash));
-	if ((unsigned)_txIndex < block.pending().size())
-	{
-		Transaction t = block.pending()[_txIndex];
-		State s(State::Null);
-		Executive e(s, block, _txIndex, m_eth.blockChain());
-		try
-		{
-			StandardTrace st;
-			st.setShowMnemonics();
-			e.initialize(t);
-			if (!e.execute())
-				e.go(st.onOp());
-			e.finalize();
-			Json::Reader().parse(st.json(), ret);
-		}
-		catch(Exception const& _e)
-		{
-			cwarn << diagnostic_information(_e);
-		}
-	}
-	
-	return ret;
+    RPC_ADMIN;
+    
+    Json::Value ret;
+    
+    if (_txIndex < 0)
+        throw jsonrpc::JsonRpcException("Negative index");
+    Block block = m_eth.block(blockHash(_blockNumberOrHash));
+    if ((unsigned)_txIndex < block.pending().size())
+    {
+        Transaction t = block.pending()[_txIndex];
+        State s(State::Null);
+        Executive e(s, block, _txIndex, m_eth.blockChain());
+        try
+        {
+            StandardTrace st;
+            st.setShowMnemonics();
+            e.initialize(t);
+            if (!e.execute())
+                e.go(st.onOp());
+            e.finalize();
+            ret["structLogs"] = st.jsonValue();
+        }
+        catch(Exception const& _e)
+        {
+            cwarn << diagnostic_information(_e);
+        }
+    }
+    
+    return ret;
 }
 
 Json::Value AdminEth::admin_eth_getReceiptByHashAndIndex(string const& _blockNumberOrHash, int _txIndex, string const& _session)
 {
-	RPC_ADMIN;
-	if (_txIndex < 0)
-		throw jsonrpc::JsonRpcException("Negative index");
-	auto h = blockHash(_blockNumberOrHash);
-	if (!m_eth.blockChain().isKnown(h))
-		throw jsonrpc::JsonRpcException("Invalid/unknown block.");
-	auto rs = m_eth.blockChain().receipts(h);
-	if ((unsigned)_txIndex >= rs.receipts.size())
-		throw jsonrpc::JsonRpcException("Index too large.");
-	return toJson(rs.receipts[_txIndex]);
+    RPC_ADMIN;
+    if (_txIndex < 0)
+        throw jsonrpc::JsonRpcException("Negative index");
+    auto h = blockHash(_blockNumberOrHash);
+    if (!m_eth.blockChain().isKnown(h))
+        throw jsonrpc::JsonRpcException("Invalid/unknown block.");
+    auto rs = m_eth.blockChain().receipts(h);
+    if ((unsigned)_txIndex >= rs.receipts.size())
+        throw jsonrpc::JsonRpcException("Index too large.");
+    return toJson(rs.receipts[_txIndex]);
 }
 
 bool AdminEth::miner_start(int)
 {
-	m_eth.startSealing();
-	return true;
+    m_eth.startSealing();
+    return true;
 }
 
 bool AdminEth::miner_stop()
 {
-	m_eth.stopSealing();
-	return true;
+    m_eth.stopSealing();
+    return true;
 }
 
 bool AdminEth::miner_setEtherbase(string const& _uuidOrAddress)
 {
-	Address a;
-	h128 uuid = fromUUID(_uuidOrAddress);
-	if (uuid)
-		a = m_keyManager.address(uuid);
-	else if (isHash<Address>(_uuidOrAddress))
-		a = Address(_uuidOrAddress);
-	else
-		throw jsonrpc::JsonRpcException("Invalid UUID or address");
+    Address a;
+    h128 uuid = fromUUID(_uuidOrAddress);
+    if (uuid)
+        a = m_keyManager.address(uuid);
+    else if (isHash<Address>(_uuidOrAddress))
+        a = Address(_uuidOrAddress);
+    else
+        throw jsonrpc::JsonRpcException("Invalid UUID or address");
 
-	if (m_setMiningBenefactor)
-		m_setMiningBenefactor(a);
-	else
-		m_eth.setAuthor(a);
-	return true;
+    if (m_setMiningBenefactor)
+        m_setMiningBenefactor(a);
+    else
+        m_eth.setAuthor(a);
+    return true;
 }
 
 bool AdminEth::miner_setExtra(string const& _extraData)
 {
-	m_eth.setExtraData(asBytes(_extraData));
-	return true;
+    m_eth.setExtraData(asBytes(_extraData));
+    return true;
 }
 
 bool AdminEth::miner_setGasPrice(string const& _gasPrice)
 {
-	m_gp.setAsk(jsToU256(_gasPrice));
-	return true;
+    m_gp.setAsk(jsToU256(_gasPrice));
+    return true;
 }
 
 string AdminEth::miner_hashrate()
 {
-	EthashClient const* client = nullptr;
-	try
-	{
-		client = asEthashClient(&m_eth);
-	}
-	catch (...)
-	{
-		throw jsonrpc::JsonRpcException("Hashrate not available - blockchain does not support mining.");
-	}
-	return toJS(client->hashrate());
+    EthashClient const* client = nullptr;
+    try
+    {
+        client = asEthashClient(&m_eth);
+    }
+    catch (...)
+    {
+        throw jsonrpc::JsonRpcException("Hashrate not available - blockchain does not support mining.");
+    }
+    return toJS(client->hashrate());
 }

--- a/libweb3jsonrpc/Debug.cpp
+++ b/libweb3jsonrpc/Debug.cpp
@@ -67,7 +67,6 @@ State Debug::stateAt(std::string const& _blockHashOrNumber, int _txIndex) const
 
 Json::Value Debug::traceTransaction(Executive& _e, Transaction const& _t, Json::Value const& _json)
 {
-    Json::Value trace;
     StandardTrace st;
     st.setShowMnemonics();
     st.setOptions(debugOptions(_json));
@@ -75,8 +74,7 @@ Json::Value Debug::traceTransaction(Executive& _e, Transaction const& _t, Json::
     if (!_e.execute())
         _e.go(st.onOp());
     _e.finalize();
-    Json::Reader().parse(st.json(), trace);
-    return trace;
+    return st.jsonValue();
 }
 
 Json::Value Debug::traceBlock(Block const& _block, Json::Value const& _json)

--- a/test/tools/libtesteth/ImportTest.cpp
+++ b/test/tools/libtesteth/ImportTest.cpp
@@ -278,7 +278,7 @@ std::tuple<eth::State, ImportTest::ExecOutput, eth::ChangeLog> ImportTest::execu
             st.setShowMnemonics();
             st.setOptions(Options::get().jsontraceOptions);
             out = initialState.execute(_env, *se.get(), _tr, Permanence::Committed, st.onOp());
-            cout << st.json();
+            cout << st.multilineTrace();
             cout << "{\"stateRoot\": \"" << initialState.rootHash().hex() << "\"}";
         }
         else

--- a/test/unittests/libweb3jsonrpc/jsonrpc.cpp
+++ b/test/unittests/libweb3jsonrpc/jsonrpc.cpp
@@ -655,7 +655,7 @@ BOOST_AUTO_TEST_CASE(debugStorageRangeAtFinalBlockState)
     BOOST_CHECK_EQUAL(result["storage"][keyHash]["value"].asString(), "0x07");
 }
 
-BOOST_AUTO_TEST_CASE(debugTraceTranaction)
+BOOST_AUTO_TEST_CASE(debugTraceTransaction)
 {
     // mine to get some balance at coinbase
     dev::eth::mine(*(web3->ethereum()), 1);
@@ -677,8 +677,34 @@ BOOST_AUTO_TEST_CASE(debugTraceTranaction)
     Json::Value result = rpcClient->debug_traceTransaction(txHash, Json::Value(Json::objectValue));
     BOOST_REQUIRE(result.isObject());
     BOOST_REQUIRE(result["structLogs"].isArray());
+    BOOST_REQUIRE_GT(result["structLogs"].size(), 0u);
 }
 
+BOOST_AUTO_TEST_CASE(adminEthVmTrace)
+{
+    // mine to get some balance at coinbase
+    dev::eth::mine(*(web3->ethereum()), 1);
+
+    // send some transaction requiring execution
+    string initCode =
+        "608060405260076000553415601357600080fd5b60358060206000396000"
+        "f3006080604052600080fd00a165627a7a7230582006db0551577963b544"
+        "3e9501b4b10880e186cff876cd360e9ad6e4181731fcdd0029";
+
+    Json::Value tx;
+    tx["code"] = initCode;
+    tx["from"] = toJS(coinbase.address());
+    string txHash = rpcClient->eth_sendTransaction(tx);
+    BOOST_REQUIRE(!txHash.empty());
+
+    dev::eth::mine(*(web3->ethereum()), 1);
+
+    // get trace for 0th transaction in 2nd block
+    Json::Value result = rpcClient->admin_eth_vmTrace("2", 0, adminSession);
+    BOOST_REQUIRE(result.isObject());
+    BOOST_REQUIRE(result["structLogs"].isArray());
+    BOOST_REQUIRE_GT(result["structLogs"].size(), 0u);
+}
 
 BOOST_AUTO_TEST_CASE(test_setChainParams)
 {

--- a/test/unittests/libweb3jsonrpc/jsonrpc.cpp
+++ b/test/unittests/libweb3jsonrpc/jsonrpc.cpp
@@ -655,6 +655,31 @@ BOOST_AUTO_TEST_CASE(debugStorageRangeAtFinalBlockState)
     BOOST_CHECK_EQUAL(result["storage"][keyHash]["value"].asString(), "0x07");
 }
 
+BOOST_AUTO_TEST_CASE(debugTraceTranaction)
+{
+    // mine to get some balance at coinbase
+    dev::eth::mine(*(web3->ethereum()), 1);
+
+    // send some transaction requiring execution
+    string initCode =
+        "608060405260076000553415601357600080fd5b60358060206000396000"
+        "f3006080604052600080fd00a165627a7a7230582006db0551577963b544"
+        "3e9501b4b10880e186cff876cd360e9ad6e4181731fcdd0029";
+
+    Json::Value tx;
+    tx["code"] = initCode;
+    tx["from"] = toJS(coinbase.address());
+    string txHash = rpcClient->eth_sendTransaction(tx);
+    BOOST_REQUIRE(!txHash.empty());
+
+    dev::eth::mine(*(web3->ethereum()), 1);
+
+    Json::Value result = rpcClient->debug_traceTransaction(txHash, Json::Value(Json::objectValue));
+    BOOST_REQUIRE(result.isObject());
+    BOOST_REQUIRE(result["structLogs"].isArray());
+}
+
+
 BOOST_AUTO_TEST_CASE(test_setChainParams)
 {
     Json::Value ret;


### PR DESCRIPTION
- Rename `StandardTrace::json()` to `multilineTrace()`, because it's not a valid json now, but json objects for each opcode trace concantenated as seaparate line each.
- Move styled json option into separate `styledJson()` method.
- Add `jsonValue()` method to return json without converting to string.