### PR TITLE
Rename MinerCLI variable to miner

### DIFF
--- a/aleth/main.cpp
+++ b/aleth/main.cpp
@@ -260,7 +260,7 @@ int main(int argc, char** argv)
     }
 
 
-    MinerCLI m(MinerCLI::OperationMode::None);
+    MinerCLI miner(MinerCLI::OperationMode::None);
 
     bool listenSet = false;
     bool chainConfigIsSet = false;
@@ -417,7 +417,7 @@ int main(int argc, char** argv)
         return -1;
     }
     for (size_t i = 0; i < unrecognisedOptions.size(); ++i)
-        if (!m.interpretOption(i, unrecognisedOptions))
+        if (!miner.interpretOption(i, unrecognisedOptions))
         {
             cerr << "Invalid argument: " << unrecognisedOptions[i] << "\n";
             return -1;
@@ -794,7 +794,7 @@ int main(int argc, char** argv)
     if (loggingOptions.verbosity > 0)
         cout << EthGrayBold "aleth, a C++ Ethereum client" EthReset << "\n";
 
-    m.execute();
+    miner.execute();
 
     fs::path secretsPath;
     if (testingMode)
@@ -1015,7 +1015,7 @@ int main(int argc, char** argv)
     if (c)
     {
         c->setGasPricer(gasPricer);
-        c->setSealer(m.minerType());
+        c->setSealer(miner.minerType());
         c->setAuthor(author);
         if (networkID != NoNetworkID)
             c->setNetworkId(networkID);


### PR DESCRIPTION
`m` is changed to `miner` for reading code easier, especially when there're many line of code between its declaration and where it's used. And there're already many local scope `m` variables for other purposes.