### PR TITLE
Fix incorrect logging of NodeIPEndpoint

### DIFF
--- a/libp2p/Common.cpp
+++ b/libp2p/Common.cpp
@@ -226,12 +226,13 @@ std::string NodeSpec::enode() const
 
 namespace dev
 {
-    
-std::ostream& operator<<(std::ostream& _out, dev::p2p::NodeIPEndpoint const& _ep)
+namespace p2p
 {
-    _out << _ep.address() << _ep.udpPort() << _ep.tcpPort();
+std::ostream& operator<<(std::ostream& _out, NodeIPEndpoint const& _ep)
+{
+    _out << _ep.address() << " UDP " << _ep.udpPort() << " TCP " << _ep.tcpPort();
     return _out;
 }
-
+}  // namespace p2p
 }
 

--- a/libp2p/Common.h
+++ b/libp2p/Common.h
@@ -329,10 +329,10 @@ private:
     std::atomic<bool> m_stopped;
 };
 
+/// Simple stream output for a NodeIPEndpoint.
+std::ostream& operator<<(std::ostream& _out, NodeIPEndpoint const& _ep);
 }
     
-/// Simple stream output for a NodeIPEndpoint.
-std::ostream& operator<<(std::ostream& _out, dev::p2p::NodeIPEndpoint const& _ep);
 }
 
 /// std::hash for asio::adress

--- a/libp2p/NodeTable.cpp
+++ b/libp2p/NodeTable.cpp
@@ -98,11 +98,15 @@ shared_ptr<NodeEntry> NodeTable::addNode(Node const& _node, NodeRelation _relati
     if (!_node.id)
     {
         DEV_GUARDED(x_nodes)
-        LOG(m_logger) << "Sending public key discovery Ping to "
-                      << (bi::udp::endpoint)_node.endpoint
-                      << " (Advertising: " << (bi::udp::endpoint)m_node.endpoint << ")";
+        {
+            LOG(m_logger) << "Sending public key discovery Ping to "
+                          << (bi::udp::endpoint)_node.endpoint
+                          << " (Advertising: " << (bi::udp::endpoint)m_node.endpoint << ")";
+        }
         DEV_GUARDED(x_pubkDiscoverPings)
-        m_pubkDiscoverPings[_node.endpoint.address()] = std::chrono::steady_clock::now();
+        {
+            m_pubkDiscoverPings[_node.endpoint.address()] = std::chrono::steady_clock::now();
+        }
         ping(_node.endpoint);
         return shared_ptr<NodeEntry>();
     }
@@ -113,10 +117,12 @@ shared_ptr<NodeEntry> NodeTable::addNode(Node const& _node, NodeRelation _relati
     
     auto ret = make_shared<NodeEntry>(m_node.id, _node.id, _node.endpoint);
     DEV_GUARDED(x_nodes)
+    {
         m_nodes[_node.id] = ret;
-        LOG(m_logger) << "addNode pending for " << _node.endpoint;
-        ping(_node.endpoint);
-        return ret;
+    }
+    LOG(m_logger) << "addNode pending for " << _node.endpoint;
+    ping(_node.endpoint);
+    return ret;
 }
 
 list<NodeID> NodeTable::nodes() const


### PR DESCRIPTION
Fix is to move `operator<<` for `NodeIPEndpoint` into namespace `dev::p2p`